### PR TITLE
fix(automation): route user disable/enable through the full account lifecycle (JAB-281)

### DIFF
--- a/panel-api/internal/api/automation_write_routes.go
+++ b/panel-api/internal/api/automation_write_routes.go
@@ -20,6 +20,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 )
 
 // capability describes one mounted write action for GET /automation/capabilities.
@@ -133,9 +134,21 @@ func userSuspendHandler(cfg AutomationConfig, suspend bool) gin.HandlerFunc {
 			autoErr(c, http.StatusConflict, "conflict", "refusing to disable an admin user")
 			return
 		}
-		// SetSuspended is the same repo method the GUI calls; the reconciler
-		// converges the OS/service state (DB-is-truth). Idempotent by target state.
-		if err := cfg.Users.SetSuspended(ctx, id, suspend, "automation:"+tok.ID); err != nil {
+		// JAB-281: route through the full User Account Lifecycle transition —
+		// the SAME userops.Suspend/Unsuspend the admin GUI/API and CLI use, not a
+		// bare suspended-flag flip. Beyond the load-bearing DB flag this
+		// deactivates the Kratos identity + invalidates cached sessions, disables
+		// owned domains, stops Docker apps, and locks OS + FTP credentials.
+		// Steps 2-5 are best-effort warnings inside userops; a returned error is
+		// only the hard DB-write failure. Idempotent by target state.
+		reason := "automation:" + tok.ID
+		var opErr error
+		if suspend {
+			_, opErr = userops.Suspend(ctx, billingUserOpsDeps(cfg), u, reason)
+		} else {
+			_, opErr = userops.Unsuspend(ctx, billingUserOpsDeps(cfg), u)
+		}
+		if opErr != nil {
 			auditWrite(c, cfg.Audits, tok, action, "user", id, models.AuditResultError)
 			autoErr(c, http.StatusBadGateway, "internal", "suspend failed")
 			return

--- a/panel-api/internal/api/automation_write_routes_test.go
+++ b/panel-api/internal/api/automation_write_routes_test.go
@@ -157,6 +157,56 @@ func TestUserDisable_NotFound(t *testing.T) {
 	}
 }
 
+// TestUserDisable_RoutesLifecycle proves automation disable runs the full
+// User Account Lifecycle transition (JAB-281) — not a bare suspended-flag flip.
+// With a Linux username + agent wired, userops.Suspend must lock OS + FTP
+// credentials; a bare SetSuspended would leave agent.calls empty.
+func TestUserDisable_RoutesLifecycle(t *testing.T) {
+	uname := "alice"
+	users := &awUsers{u: &models.User{ID: "u1", Email: "a@x.tld", Username: &uname}}
+	ag := &awAgent{}
+	aud := &awAudit{}
+	r := awRouter(AutomationConfig{Users: users, Agent: ag, Audits: aud}, writeTok())
+	w := awPost(r, "/users/u1/disable")
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if users.suspended == nil || !*users.suspended {
+		t.Fatal("suspended flag was not set true")
+	}
+	if !awCalled(ag, "user.suspend") || !awCalled(ag, "ftpaccount.lock_tenant") {
+		t.Fatalf("lifecycle OS/FTP lock did not fire; agent calls = %v", ag.calls)
+	}
+}
+
+// TestUserEnable_RoutesLifecycle is the unsuspend mirror: the OS unlock agent
+// command must fire, proving enable also routes through userops.Unsuspend.
+func TestUserEnable_RoutesLifecycle(t *testing.T) {
+	uname := "alice"
+	users := &awUsers{u: &models.User{ID: "u1", Email: "a@x.tld", Username: &uname, Suspended: true}}
+	ag := &awAgent{}
+	r := awRouter(AutomationConfig{Users: users, Agent: ag, Audits: &awAudit{}}, writeTok())
+	w := awPost(r, "/users/u1/enable")
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if users.suspended == nil || *users.suspended {
+		t.Fatal("suspended flag was not cleared")
+	}
+	if !awCalled(ag, "user.unsuspend") {
+		t.Fatalf("lifecycle OS unlock did not fire; agent calls = %v", ag.calls)
+	}
+}
+
+func awCalled(a *awAgent, cmd string) bool {
+	for _, c := range a.calls {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
 func TestDomainSuspend_IdempotentNoop(t *testing.T) {
 	// Domain already disabled → suspend is a no-op 200, no Update call.
 	dom := &awDomains{d: &models.Domain{ID: "d1", Name: "x.test", IsEnabled: false}}


### PR DESCRIPTION
## What

Automation `POST /automation/users/:id/disable` and `/enable` flipped only the
`users.suspended` DB column via a bare `SetSuspended`. That skipped the rest of
the documented one-write-path suspend cascade:

- Kratos identity stayed **active** and cached whoami sessions stayed **valid**
- owned domains kept **serving** (never disabled)
- Docker apps kept **running**
- OS + FTP credentials stayed **unlocked** (SSH/SFTP still worked)

Net effect: an account "suspended" via the automation API was **not actually
locked out** — it could still sign in to the panel and use SSH/SFTP. Security gap.

## Fix

Route both verbs through `userops.Suspend` / `userops.Unsuspend` — the exact same
lifecycle transition the admin GUI/API (`users_suspend.go`) and the `jabali user
suspend/unsuspend` CLI already use — wired from the existing `billingUserOpsDeps`
in the automation package. `userops` is now the **only** writer of the suspended
flag; the admin-guard and audit/notify behaviour is unchanged. Steps 2–5 remain
best-effort warnings inside `userops`; a returned error is still only the hard
DB-write failure (mapped 502).

## Tests

- `TestUserDisable_RoutesLifecycle` — disable flips the flag **and** fires the OS
  (`user.suspend`) + FTP (`ftpaccount.lock_tenant`) lock agent commands, which a
  bare `SetSuspended` never would.
- `TestUserEnable_RoutesLifecycle` — enable clears the flag and fires
  `user.unsuspend`.
- Existing admin-conflict / not-found / domain-suspend tests unchanged & green.

`go build ./...`, `go test ./internal/api/ ./internal/userops/`, `go vet` — all pass.

GH JAB-281
