### PR TITLE
fix(automation): surface lifecycle suspend warnings in the response (JAB-281)

### DIFF
--- a/panel-api/internal/api/automation_write.go
+++ b/panel-api/internal/api/automation_write.go
@@ -30,6 +30,36 @@ func autoOK(c *gin.Context, msg string) {
 	c.JSON(http.StatusOK, gin.H{"ok": true, "status": "done", "message": msg})
 }
 
+// autoOKWarnings is autoOK plus a non-empty `warnings` map (step-named,
+// best-effort failures from a multi-step lifecycle op). Empty map → omitted, so
+// the clean-path envelope is byte-identical to autoOK.
+func autoOKWarnings(c *gin.Context, msg string, warnings map[string]string) {
+	body := gin.H{"ok": true, "status": "done", "message": msg}
+	if len(warnings) > 0 {
+		body["warnings"] = warnings
+	}
+	c.JSON(http.StatusOK, body)
+}
+
+// lifecycleWarnings collapses the userops kratos/domain/os warning strings into a
+// keyed map, dropping the empties. Returns nil when every step succeeded.
+func lifecycleWarnings(kratos, domain, os string) map[string]string {
+	w := map[string]string{}
+	if kratos != "" {
+		w["kratos"] = kratos
+	}
+	if domain != "" {
+		w["domain"] = domain
+	}
+	if os != "" {
+		w["os"] = os
+	}
+	if len(w) == 0 {
+		return nil
+	}
+	return w
+}
+
 func autoAsync(c *gin.Context, opID, msg string) {
 	c.JSON(http.StatusAccepted, gin.H{"ok": true, "operation_id": opID, "status": "pending", "message": msg})
 }

--- a/panel-api/internal/api/automation_write_routes.go
+++ b/panel-api/internal/api/automation_write_routes.go
@@ -142,11 +142,18 @@ func userSuspendHandler(cfg AutomationConfig, suspend bool) gin.HandlerFunc {
 		// Steps 2-5 are best-effort warnings inside userops; a returned error is
 		// only the hard DB-write failure. Idempotent by target state.
 		reason := "automation:" + tok.ID
-		var opErr error
+		var (
+			opErr    error
+			warnings map[string]string
+		)
 		if suspend {
-			_, opErr = userops.Suspend(ctx, billingUserOpsDeps(cfg), u, reason)
+			res, err := userops.Suspend(ctx, billingUserOpsDeps(cfg), u, reason)
+			opErr = err
+			warnings = lifecycleWarnings(res.KratosWarning, res.DomainWarning, res.OSWarning)
 		} else {
-			_, opErr = userops.Unsuspend(ctx, billingUserOpsDeps(cfg), u)
+			res, err := userops.Unsuspend(ctx, billingUserOpsDeps(cfg), u)
+			opErr = err
+			warnings = lifecycleWarnings(res.KratosWarning, res.DomainWarning, res.OSWarning)
 		}
 		if opErr != nil {
 			auditWrite(c, cfg.Audits, tok, action, "user", id, models.AuditResultError)
@@ -158,7 +165,10 @@ func userSuspendHandler(cfg AutomationConfig, suspend bool) gin.HandlerFunc {
 			"warning", "Automation "+verbDone(suspend, "disabled", "enabled")+" a user",
 			"User "+u.Email+" was "+verbDone(suspend, "disabled", "enabled")+" via the automation API.",
 			"/jabali-admin/users")
-		autoOK(c, "user "+id+" "+verbDone(suspend, "disabled", "enabled"))
+		// JAB-281 criterion: surface the lifecycle's best-effort warnings
+		// (kratos/domain/os) in the automation response without reimplementing
+		// the orchestration — the userops result is the single source.
+		autoOKWarnings(c, "user "+id+" "+verbDone(suspend, "disabled", "enabled"), warnings)
 	}
 }
 

--- a/panel-api/internal/api/automation_write_routes_test.go
+++ b/panel-api/internal/api/automation_write_routes_test.go
@@ -207,6 +207,31 @@ func awCalled(a *awAgent, cmd string) bool {
 	return false
 }
 
+// TestUserDisable_ExposesLifecycleWarnings proves best-effort lifecycle failures
+// (JAB-281 criterion) surface in the automation response as a keyed `warnings`
+// map — here a failing OS lock agent call becomes warnings.os — while the write
+// still succeeds (the DB flag is the load-bearing gate).
+func TestUserDisable_ExposesLifecycleWarnings(t *testing.T) {
+	uname := "alice"
+	users := &awUsers{u: &models.User{ID: "u1", Email: "a@x.tld", Username: &uname}}
+	ag := &awAgent{err: context.DeadlineExceeded} // OS lock fails → os warning
+	r := awRouter(AutomationConfig{Users: users, Agent: ag, Audits: &awAudit{}}, writeTok())
+	w := awPost(r, "/users/u1/disable")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 (best-effort failure is not fatal), got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		OK       bool              `json:"ok"`
+		Warnings map[string]string `json:"warnings"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK || body.Warnings["os"] == "" {
+		t.Fatalf("expected ok with an os warning, got %s", w.Body.String())
+	}
+}
+
 func TestDomainSuspend_IdempotentNoop(t *testing.T) {
 	// Domain already disabled → suspend is a no-op 200, no Update call.
 	dom := &awDomains{d: &models.Domain{ID: "d1", Name: "x.test", IsEnabled: false}}


### PR DESCRIPTION
## What

Follow-up to #1292 completing the final JAB-281 acceptance criterion:
**"Automation responses expose lifecycle warnings without reimplementing orchestration."**

The automation `POST /users/:id/disable` + `/enable` handler now captures the
`userops.Suspend`/`Unsuspend` result and surfaces its best-effort step warnings
(`kratos` / `domain` / `os`) in the response as a keyed `warnings` map — the
same warnings the admin REST handler already returns, sourced from the single
`userops` result (no re-orchestration).

Clean-path responses are byte-identical to before (`warnings` omitted when the
map is empty), so no contract break for existing callers.

## Test

`TestUserDisable_ExposesLifecycleWarnings` — a failing OS-lock agent call becomes
`warnings.os` while the write still returns 200 (the DB flag is the load-bearing
gate; steps 2-5 are best-effort). Full `internal/api` suite + `go vet` green.

GH JAB-281
