### PR TITLE
fix(cli): enforce db-user quota + compensate orphaned engine credential on create (JAB-282)

### DIFF
--- a/panel-api/cmd/server/db_user_cmd.go
+++ b/panel-api/cmd/server/db_user_cmd.go
@@ -107,15 +107,6 @@ func newDBUserCreateCmd() *cobra.Command {
 			if userLookup == "" || name == "" {
 				return errors.New("--user and --name are required")
 			}
-			if engine == "" {
-				engine = "mariadb"
-			}
-			if engine != "mariadb" && engine != "postgres" {
-				return fmt.Errorf("--engine must be 'mariadb' or 'postgres' (got %q)", engine)
-			}
-			if !dbUserNameRe.MatchString(name) {
-				return fmt.Errorf("invalid db_user name %q — must match ^[a-zA-Z][a-zA-Z0-9_]{0,30}$", name)
-			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
 
@@ -123,74 +114,24 @@ func newDBUserCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if !asAdmin && (panelUser.Username == nil || *panelUser.Username == "") {
-				return fmt.Errorf("user %s has no Linux username — cannot prefix db user name", panelUser.ID)
-			}
 
-			finalName := name
-			if !asAdmin {
-				finalName = *panelUser.Username + "_" + name
-			}
-
-			repo := dbUserRepoFromDB()
-			exists, err := repo.ExistsByUserAndUsername(ctx, panelUser.ID, finalName)
+			du, pw, err := dbUserCreate(ctx, dbUserCreateDeps{
+				agent:          sharedAgent,
+				dbUsers:        dbUserRepoFromDB(),
+				packages:       packageRepoFromDB(),
+				serverSettings: repository.NewServerSettingsRepository(sharedDB),
+			}, dbUserCreateInput{
+				panelUser: panelUser,
+				name:      name,
+				engine:    engine,
+				asAdmin:   asAdmin,
+				password:  password,
+			})
 			if err != nil {
-				return fmt.Errorf("collision check: %w", err)
-			}
-			if exists {
-				return fmt.Errorf("db user %q already exists for panel user %s", finalName, *panelUser.Username)
-			}
-
-			if engine == "postgres" {
-				ssRepo := repository.NewServerSettingsRepository(sharedDB)
-				ss, sErr := ssRepo.Get(ctx)
-				if sErr != nil {
-					return fmt.Errorf("server_settings: %w", sErr)
-				}
-				if ss == nil || !ss.PostgresEnabled {
-					return errors.New("postgres engine requested but server_settings.postgres_enabled=false")
-				}
-			}
-
-			pw := password
-			if pw == "" {
-				pw = ids.NewSecret()
-			}
-			hash, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
-			if err != nil {
-				return fmt.Errorf("bcrypt: %w", err)
-			}
-
-			if engine == "mariadb" {
-				_, err = sharedAgent.Call(ctx, "db_user.create", map[string]any{
-					"db_user_name": finalName,
-					"password":     pw,
-				})
-			} else {
-				_, err = sharedAgent.Call(ctx, "db.postgres.create_role", map[string]any{
-					"role":     finalName,
-					"password": pw,
-				})
-			}
-			if err != nil {
-				return fmt.Errorf("agent.%s create: %w", engine, err)
-			}
-
-			now := time.Now().UTC()
-			du := &models.DatabaseUser{
-				ID:           ids.NewULID(),
-				UserID:       panelUser.ID,
-				Username:     finalName,
-				Engine:       engine,
-				PasswordHash: string(hash),
-				CreatedAt:    now,
-				UpdatedAt:    now,
-			}
-			if err := repo.Create(ctx, du); err != nil {
-				return fmt.Errorf("db_user row insert: %w", err)
+				return err
 			}
 			cliAuditOK(ctx, "db_user.create", "database_user", du.ID, &panelUser.ID)
-			fmt.Fprintf(os.Stdout, "Created db user %s (id=%s, engine=%s)\n", finalName, du.ID, engine)
+			fmt.Fprintf(os.Stdout, "Created db user %s (id=%s, engine=%s)\n", du.Username, du.ID, du.Engine)
 			if password == "" {
 				fmt.Fprintf(os.Stdout, "Generated password: %s\n", pw)
 				fmt.Fprintln(os.Stdout, "Save it now — not stored in plaintext anywhere.")
@@ -204,6 +145,157 @@ func newDBUserCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&password, "password", "", "Password (auto-generated ULID if omitted; revealed once)")
 	cmd.Flags().BoolVar(&asAdmin, "as-admin", false, "Skip the panel-username prefix (admin-only DB user names)")
 	return cmd
+}
+
+// dbUserCreateDeps is the narrow slice of collaborators dbUserCreate needs, so
+// the cobra RunE stays a thin wire-up over globals and the logic is unit-testable
+// with fakes (mirrors dbGrantDeps).
+type dbUserCreateDeps struct {
+	agent          agent.AgentInterface
+	dbUsers        repository.DatabaseUserRepository
+	packages       repository.PackageRepository
+	serverSettings repository.ServerSettingsRepository
+}
+
+// dbUserCreateInput is the request for one database-identity creation.
+type dbUserCreateInput struct {
+	panelUser *models.User
+	name      string // bare name, without the panel-username prefix
+	engine    string // "" defaults to mariadb
+	asAdmin   bool   // skip the panel-username prefix
+	password  string // "" auto-generates a reveal-once secret
+}
+
+// dbUserCreateAgentCall / dbUserDropAgentCall centralise the engine-specific
+// command + param mapping the ticket flags as copied across REST, CLI, and
+// teardown. Param shapes match the REST handler (dbUserCmd/dbUserDropParams):
+// MariaDB uses db_user_name, Postgres uses role.
+func dbUserCreateAgentCall(engine, finalName, pw string) (string, map[string]any) {
+	if engine == "postgres" {
+		return "db.postgres.create_role", map[string]any{"role": finalName, "password": pw}
+	}
+	return "db_user.create", map[string]any{"db_user_name": finalName, "password": pw}
+}
+
+func dbUserDropAgentCall(engine, finalName string) (string, map[string]any) {
+	if engine == "postgres" {
+		return "db.postgres.drop_role", map[string]any{"role": finalName}
+	}
+	return "db_user.drop", map[string]any{"db_user_name": finalName}
+}
+
+// dbUserCreate is the shared CLI database-identity creation operation (JAB-282
+// slice). It closes two divergences from the REST create handler that this CLI
+// path had:
+//
+//   - it skipped the package max_database_users quota, so an operator could push
+//     a tenant past its limit;
+//   - a row-insert failure returned the error but left the freshly-created engine
+//     credential live — an orphaned MariaDB user / PostgreSQL role with no panel
+//     row, invisible to the reconciler and delete-cascade.
+//
+// Returns the persisted row and the plaintext password (revealed once). The
+// remaining module work (one shared REST+CLI operation, a single documented
+// name-length matrix) stays on the parent ticket.
+func dbUserCreate(ctx context.Context, d dbUserCreateDeps, in dbUserCreateInput) (*models.DatabaseUser, string, error) {
+	engine := in.engine
+	if engine == "" {
+		engine = "mariadb"
+	}
+	if engine != "mariadb" && engine != "postgres" {
+		return nil, "", fmt.Errorf("--engine must be 'mariadb' or 'postgres' (got %q)", engine)
+	}
+	if !dbUserNameRe.MatchString(in.name) {
+		return nil, "", fmt.Errorf("invalid db_user name %q — must match %s", in.name, dbUserNameRe.String())
+	}
+	if in.panelUser == nil {
+		return nil, "", errors.New("panel user required")
+	}
+	if !in.asAdmin && (in.panelUser.Username == nil || *in.panelUser.Username == "") {
+		return nil, "", fmt.Errorf("user %s has no Linux username — cannot prefix db user name", in.panelUser.ID)
+	}
+
+	finalName := in.name
+	if !in.asAdmin {
+		finalName = *in.panelUser.Username + "_" + in.name
+	}
+
+	exists, err := d.dbUsers.ExistsByUserAndUsername(ctx, in.panelUser.ID, finalName)
+	if err != nil {
+		return nil, "", fmt.Errorf("collision check: %w", err)
+	}
+	if exists {
+		return nil, "", fmt.Errorf("db user %q already exists for panel user %s", finalName, in.panelUser.ID)
+	}
+
+	// Package quota parity with the REST handler (JAB-282): enforce
+	// max_database_users when the owner has a package. A package-load error is
+	// non-fatal — matches REST, which skips the quota and proceeds.
+	if in.panelUser.PackageID != nil && *in.panelUser.PackageID != "" && d.packages != nil {
+		if pkg, pErr := d.packages.FindByID(ctx, *in.panelUser.PackageID); pErr == nil && pkg.MaxDatabaseUsers > 0 {
+			count, cErr := d.dbUsers.CountByUserID(ctx, in.panelUser.ID)
+			if cErr != nil {
+				return nil, "", fmt.Errorf("quota count: %w", cErr)
+			}
+			if count >= int64(pkg.MaxDatabaseUsers) {
+				return nil, "", fmt.Errorf("quota exceeded: package allows %d database users, %s already has %d",
+					pkg.MaxDatabaseUsers, in.panelUser.ID, count)
+			}
+		}
+	}
+
+	if engine == "postgres" {
+		if d.serverSettings == nil {
+			return nil, "", errors.New("server settings unavailable")
+		}
+		ss, sErr := d.serverSettings.Get(ctx)
+		if sErr != nil {
+			return nil, "", fmt.Errorf("server_settings: %w", sErr)
+		}
+		if ss == nil || !ss.PostgresEnabled {
+			return nil, "", errors.New("postgres engine requested but server_settings.postgres_enabled=false")
+		}
+	}
+
+	pw := in.password
+	if pw == "" {
+		pw = ids.NewSecret()
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, "", fmt.Errorf("bcrypt: %w", err)
+	}
+
+	createCmd, createParams := dbUserCreateAgentCall(engine, finalName, pw)
+	if _, err := d.agent.Call(ctx, createCmd, createParams); err != nil {
+		return nil, "", fmt.Errorf("agent.%s create: %w", engine, err)
+	}
+
+	now := time.Now().UTC()
+	du := &models.DatabaseUser{
+		ID:           ids.NewULID(),
+		UserID:       in.panelUser.ID,
+		Username:     finalName,
+		Engine:       engine,
+		PasswordHash: string(hash),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := d.dbUsers.Create(ctx, du); err != nil {
+		// Compensate: the engine credential is already live. Drop it so a failed
+		// row insert never leaves an orphaned MariaDB user / PostgreSQL role —
+		// the exact bug this closes. Background ctx so a near-deadline create ctx
+		// can't starve the rollback.
+		dropCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		dropCmd, dropParams := dbUserDropAgentCall(engine, finalName)
+		_, derr := d.agent.Call(dropCtx, dropCmd, dropParams)
+		cancel()
+		if derr != nil {
+			return nil, "", fmt.Errorf("db_user row insert failed (%v) AND the compensating engine drop ALSO failed (%v) — a live %s credential %q is now orphaned; drop it directly on the engine", err, derr, engine, finalName)
+		}
+		return nil, "", fmt.Errorf("db_user row insert: %w (engine credential rolled back)", err)
+	}
+	return du, pw, nil
 }
 
 func newDBUserDeleteCmd() *cobra.Command {

--- a/panel-api/cmd/server/db_user_create_test.go
+++ b/panel-api/cmd/server/db_user_create_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes (JAB-282 CLI db-identity creation) ---
+
+type recCreateAgent struct {
+	calls  []string
+	params []map[string]any
+	failOn map[string]bool // command name -> return an error
+}
+
+func (a *recCreateAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	a.calls = append(a.calls, cmd)
+	m, _ := params.(map[string]any)
+	a.params = append(a.params, m)
+	if a.failOn[cmd] {
+		return nil, errors.New(cmd + " boom")
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type fakeCreateDBUsers struct {
+	repository.DatabaseUserRepository
+	count      int64
+	exists     bool
+	failCreate bool
+	created    *models.DatabaseUser
+}
+
+func (f *fakeCreateDBUsers) ExistsByUserAndUsername(_ context.Context, _, _ string) (bool, error) {
+	return f.exists, nil
+}
+func (f *fakeCreateDBUsers) CountByUserID(_ context.Context, _ string) (int64, error) {
+	return f.count, nil
+}
+func (f *fakeCreateDBUsers) Create(_ context.Context, du *models.DatabaseUser) error {
+	if f.failCreate {
+		return errors.New("row insert boom")
+	}
+	f.created = du
+	return nil
+}
+
+type fakeCreatePackages struct {
+	repository.PackageRepository
+	pkg *models.HostingPackage
+}
+
+func (f fakeCreatePackages) FindByID(_ context.Context, _ string) (*models.HostingPackage, error) {
+	if f.pkg != nil {
+		return f.pkg, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func packagedUser() *models.User {
+	return &models.User{ID: "u1", Username: strp("alice"), PackageID: strp("pkgA")}
+}
+
+func createDeps(a *recCreateAgent, dbu *fakeCreateDBUsers, pkgs repository.PackageRepository) dbUserCreateDeps {
+	return dbUserCreateDeps{agent: a, dbUsers: dbu, packages: pkgs}
+}
+
+// Happy path: engine credential created, row persisted, password revealed.
+func TestDBUserCreate_HappyPath(t *testing.T) {
+	ag := &recCreateAgent{}
+	dbu := &fakeCreateDBUsers{}
+	du, pw, err := dbUserCreate(context.Background(), createDeps(ag, dbu, fakeCreatePackages{}),
+		dbUserCreateInput{panelUser: packagedUser(), name: "app"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(ag.calls) != 1 || ag.calls[0] != "db_user.create" {
+		t.Fatalf("expected one db_user.create call, got %v", ag.calls)
+	}
+	if du.Username != "alice_app" || pw == "" || dbu.created == nil {
+		t.Fatalf("unexpected result: du=%+v pw=%q created=%v", du, pw, dbu.created)
+	}
+}
+
+// JAB-282 bug #1: package max_database_users quota must be enforced (CLI parity
+// with REST). At-limit → error BEFORE any engine credential is created.
+func TestDBUserCreate_QuotaExceeded_NoEngineCall(t *testing.T) {
+	ag := &recCreateAgent{}
+	dbu := &fakeCreateDBUsers{count: 3}
+	pkgs := fakeCreatePackages{pkg: &models.HostingPackage{MaxDatabaseUsers: 3}}
+	_, _, err := dbUserCreate(context.Background(), createDeps(ag, dbu, pkgs),
+		dbUserCreateInput{panelUser: packagedUser(), name: "app"})
+	if err == nil {
+		t.Fatal("expected quota_exceeded error at the limit")
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("quota must be enforced BEFORE creating the engine credential, got %v", ag.calls)
+	}
+}
+
+// Under the limit still creates.
+func TestDBUserCreate_UnderQuota_Creates(t *testing.T) {
+	ag := &recCreateAgent{}
+	dbu := &fakeCreateDBUsers{count: 2}
+	pkgs := fakeCreatePackages{pkg: &models.HostingPackage{MaxDatabaseUsers: 3}}
+	if _, _, err := dbUserCreate(context.Background(), createDeps(ag, dbu, pkgs),
+		dbUserCreateInput{panelUser: packagedUser(), name: "app"}); err != nil {
+		t.Fatalf("under quota should succeed: %v", err)
+	}
+	if len(ag.calls) != 1 || ag.calls[0] != "db_user.create" {
+		t.Fatalf("expected create call, got %v", ag.calls)
+	}
+}
+
+// JAB-282 bug #2: a row-insert failure must compensate by dropping the live
+// engine credential — never leave an orphaned MariaDB user / PostgreSQL role.
+func TestDBUserCreate_RowInsertFails_CompensatesDrop(t *testing.T) {
+	ag := &recCreateAgent{}
+	dbu := &fakeCreateDBUsers{failCreate: true}
+	_, _, err := dbUserCreate(context.Background(), createDeps(ag, dbu, fakeCreatePackages{}),
+		dbUserCreateInput{panelUser: packagedUser(), name: "app"})
+	if err == nil {
+		t.Fatal("expected row-insert error")
+	}
+	if len(ag.calls) != 2 || ag.calls[0] != "db_user.create" || ag.calls[1] != "db_user.drop" {
+		t.Fatalf("row-insert failure must compensate with a drop, got %v", ag.calls)
+	}
+	if ag.params[1]["db_user_name"] != "alice_app" {
+		t.Errorf("drop must target the created credential, got %v", ag.params[1])
+	}
+}
+
+// Postgres row-insert failure compensates with the role-drop verb + role param.
+func TestDBUserCreate_Postgres_RowInsertFails_CompensatesRoleDrop(t *testing.T) {
+	ag := &recCreateAgent{}
+	dbu := &fakeCreateDBUsers{failCreate: true}
+	ss := okServerSettings{enabled: true}
+	deps := createDeps(ag, dbu, fakeCreatePackages{})
+	deps.serverSettings = ss
+	_, _, err := dbUserCreate(context.Background(), deps,
+		dbUserCreateInput{panelUser: packagedUser(), name: "app", engine: "postgres"})
+	if err == nil {
+		t.Fatal("expected row-insert error")
+	}
+	if len(ag.calls) != 2 || ag.calls[0] != "db.postgres.create_role" || ag.calls[1] != "db.postgres.drop_role" {
+		t.Fatalf("postgres compensation must drop the role, got %v", ag.calls)
+	}
+	if ag.params[1]["role"] != "alice_app" {
+		t.Errorf("role-drop must target the created role, got %v", ag.params[1])
+	}
+}
+
+type okServerSettings struct {
+	repository.ServerSettingsRepository
+	enabled bool
+}
+
+func (s okServerSettings) Get(_ context.Context) (*models.ServerSettings, error) {
+	return &models.ServerSettings{PostgresEnabled: s.enabled}, nil
+}


### PR DESCRIPTION
## What

The `jabali db user create` CLI diverged from the REST create handler
(`databaseUserHandler.create`) in two ways this slice closes — both flagged in
JAB-282.

### 1. Package quota was skipped
REST enforces the owner package's `max_database_users`; the CLI created
unboundedly, so an operator could push a tenant past its limit. The CLI now runs
the **same** at-limit check (package present → count vs `MaxDatabaseUsers`)
**before** it touches the engine. A package-load error is non-fatal, matching
REST.

### 2. A row-insert failure orphaned a live engine credential (drift/security)
The MariaDB user / PostgreSQL role is created on the engine **before** the panel
row insert. When the insert failed, the CLI returned the error but left that
credential **live** — with no panel row it is invisible to the reconciler and
the delete-cascade. It now **compensates** by dropping the engine credential (on
a background ctx so a near-deadline request ctx cannot starve the rollback) and
reports a distinct error if the drop itself also fails. This mirrors REST's
compensation and the JAB-284 grant fix.

## How
- Extracted the create core into a testable `dbUserCreate` helper with a narrow
  `dbUserCreateDeps` struct (mirrors `dbUserGrantCreate`).
- Centralised engine command+param mapping in `dbUserCreateAgentCall` /
  `dbUserDropAgentCall` (param shapes match REST's `dbUserCmd`/`dbUserDropParams`:
  MariaDB `db_user_name`, Postgres `role`).

## Tests
- `TestDBUserCreate_QuotaExceeded_NoEngineCall` — at-limit errors with **no**
  engine call.
- `TestDBUserCreate_RowInsertFails_CompensatesDrop` /
  `..._Postgres_..._CompensatesRoleDrop` — insert failure drops the created
  credential via `db_user.drop` / `db.postgres.drop_role`.
- Happy-path + under-quota still create. Full `cmd/server` suite + `go vet` green.

## Out of scope (stays on the parent module ticket)
One shared REST+CLI creation operation and a single documented name-length matrix
(CLI `^[a-zA-Z][a-zA-Z0-9_]{0,30}$` vs REST `^[a-z][a-z0-9_]{0,63}$`).

GH JAB-282
