### PR TITLE
fix(users): reprovision persists uid + CLI malware-monitor parity (JAB-287)

### DIFF
--- a/panel-api/cmd/server/user_reprovision_cmd.go
+++ b/panel-api/cmd/server/user_reprovision_cmd.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 )
 
 func newUserReprovisionCmd() *cobra.Command {
@@ -86,12 +88,13 @@ Password: --password <pwd> | --password-stdin | (omitted → auto-generate + pri
 			// side fails, the DB password is left untouched.
 			agentCtx, cancel2 := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel2()
-			if _, aerr := sharedAgent.Call(agentCtx, "user.create", map[string]any{
+			raw, aerr := sharedAgent.Call(agentCtx, "user.create", map[string]any{
 				"username": username,
 				"home_dir": "/home/" + username,
 				"shell":    "/usr/local/bin/jabali-ssh-shell",
 				"password": newPwd,
-			}); aerr != nil {
+			})
+			if aerr != nil {
 				var ae *agent.AgentError
 				if errors.As(aerr, &ae) && ae.Code == agent.CodeAlreadyExists {
 					return fmt.Errorf("OS user %q already exists — sync the password only with `jabali user password %s` instead of reprovisioning", username, target.ID)
@@ -106,9 +109,24 @@ Password: --password <pwd> | --password-stdin | (omitted → auto-generate + pri
 				return fmt.Errorf("bcrypt hash: %w", err)
 			}
 			target.PasswordHash = string(hash)
+			// JAB-287: persist the freshly-allocated uid (parity with the REST
+			// handler) so users.linux_uid tracks the real OS uid after useradd.
+			if uid := userops.ParseReprovisionedUID(raw); uid != nil {
+				target.LinuxUID = uid
+			}
 			if err := repository.NewUserRepository(sharedDB).Update(ctx, target); err != nil {
 				return fmt.Errorf("update panel password hash: %w", err)
 			}
+
+			// JAB-287: re-evaluate maldet inotify watches (the reprovision may have
+			// recreated the home dir) — the REST handler does this; the CLI must too,
+			// or CLI-reprovisioned homes go unwatched until the next full reconcile.
+			// Best-effort, matching the REST path's fire-and-forget.
+			monCtx, monCancel := context.WithTimeout(ctx, 10*time.Second)
+			if _, mErr := sharedAgent.Call(monCtx, "security.malware.monitor.reload", map[string]any{}); mErr != nil {
+				slog.Debug("malware monitor reload skipped", "err", mErr)
+			}
+			monCancel()
 
 			if jsonOutput {
 				out := map[string]any{"user_id": target.ID, "username": username, "reprovisioned": true}

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -648,7 +648,7 @@ func (h *userHandler) reprovision(c *gin.Context) {
 	}
 	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	_, agentErr := h.cfg.Agent.Call(agentCtx, "user.create", map[string]any{
+	raw, agentErr := h.cfg.Agent.Call(agentCtx, "user.create", map[string]any{
 		"username": username,
 		"home_dir": "/home/" + username,
 		"shell":    "/usr/local/bin/jabali-ssh-shell",
@@ -680,6 +680,14 @@ func (h *userHandler) reprovision(c *gin.Context) {
 		return
 	}
 	user.PasswordHash = string(hash)
+	// JAB-287: useradd allocated a fresh uid (the verb pins none), so persist it
+	// or users.linux_uid drifts from the real OS uid — quota, nft skuid egress
+	// dispatch, and SFTP all map the panel row through linux_uid. Best-effort:
+	// the password sync (the load-bearing effect) is written in the same full-row
+	// Update regardless (no partial-model clobber — cf. JAB-280).
+	if uid := userops.ParseReprovisionedUID(raw); uid != nil {
+		user.LinuxUID = uid
+	}
 	if err := h.cfg.Repo.Update(ctx, user); err != nil {
 		h.translateErr(c, err)
 		return

--- a/panel-api/internal/userops/userops_reprovision.go
+++ b/panel-api/internal/userops/userops_reprovision.go
@@ -1,0 +1,27 @@
+package userops
+
+import "encoding/json"
+
+// ParseReprovisionedUID extracts the freshly-allocated uid from a user.create
+// agent response and returns it as a *uint32 to persist into users.linux_uid.
+//
+// Reprovisioning recreates the OS account with useradd, which allocates a NEW
+// uid (the verb accepts no uid to pin), so the value the DB recorded at first
+// provisioning goes stale. Everything that maps the panel row through
+// linux_uid — POSIX quota, the nft skuid egress-dispatch rules, SFTP/FTP jails —
+// then targets the wrong uid. Both the REST handler and the operator CLI call
+// this so they persist the reprovisioned uid identically (JAB-287).
+//
+// Best-effort by design: a malformed response or a non-positive uid returns nil,
+// and the caller keeps the prior value rather than failing an OS reprovision
+// that already succeeded.
+func ParseReprovisionedUID(raw []byte) *uint32 {
+	var pr struct {
+		UID int `json:"uid"`
+	}
+	if err := json.Unmarshal(raw, &pr); err != nil || pr.UID <= 0 {
+		return nil
+	}
+	uid := uint32(pr.UID)
+	return &uid
+}

--- a/panel-api/internal/userops/userops_reprovision_test.go
+++ b/panel-api/internal/userops/userops_reprovision_test.go
@@ -1,0 +1,36 @@
+package userops
+
+import "testing"
+
+func TestParseReprovisionedUID(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want uint32 // 0 means "expect nil"
+	}{
+		{"valid uid", `{"username":"alice","uid":1042,"home_dir":"/home/alice"}`, 1042},
+		{"uid only", `{"uid":1007}`, 1007},
+		{"zero uid ignored", `{"uid":0}`, 0},
+		{"negative uid ignored", `{"uid":-1}`, 0},
+		{"missing uid", `{"username":"alice"}`, 0},
+		{"malformed json", `not json`, 0},
+		{"empty", ``, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseReprovisionedUID([]byte(tc.raw))
+			if tc.want == 0 {
+				if got != nil {
+					t.Fatalf("expected nil (keep prior uid), got %d", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected uid %d, got nil", tc.want)
+			}
+			if *got != tc.want {
+				t.Fatalf("uid = %d, want %d", *got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Two concrete gaps in the account reprovision paths (REST `POST /users/:id/reprovision`
and `jabali user reprovision`), both in JAB-287's "same ... UID, and monitoring
sequence" criterion. The full "extract ONE operation" refactor stays on the parent.

### 1. The reprovisioned uid was never persisted (drift)
Reprovision recreates the OS account with `useradd`, which allocates a **new**
uid (the `user.create` verb pins none and returns the allocated uid). Neither the
REST handler nor the CLI captured it, so `users.linux_uid` drifted from the real
OS uid after any reprovision. Everything that maps the panel row through
`linux_uid` — POSIX quota, the **nft skuid egress-dispatch** rules, SFTP/FTP
jails — then targeted the wrong uid.

Both paths now persist the returned uid via a shared
`userops.ParseReprovisionedUID` helper. Best-effort: a malformed/zero uid keeps
the prior value, and the password sync still writes in the same full-row `Update`
(no partial-model clobber, cf. JAB-280).

### 2. CLI skipped the malware-monitor reload
The REST handler fires `security.malware.monitor.reload` after reprovision (the
home dir may have been recreated); the CLI did not, so a CLI-reprovisioned home
went unwatched by maldet until the next full reconcile. The CLI now issues the
same best-effort reload.

## Tests
`TestParseReprovisionedUID` — valid / uid-only / zero / negative / missing /
malformed / empty (nil = keep prior uid). Full `userops` + `internal/api` +
`cmd/server` suites and `go vet` green.

## Out of scope (parent module ticket)
One shared REST+CLI reprovision operation and a retryable management handle at
every external step.

GH JAB-287
