### PR TITLE
fix(users): account delete drops the Postgres _pgadmin shadow role (JAB-289)

### DIFF
--- a/panel-api/internal/userops/userops_cascade_pgshadow_test.go
+++ b/panel-api/internal/userops/userops_cascade_pgshadow_test.go
@@ -1,0 +1,106 @@
+package userops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// recCascadeAgent records agent calls and can fail selected verbs.
+type recCascadeAgent struct {
+	calls  []string
+	params []map[string]any
+	failOn map[string]bool
+}
+
+func (a *recCascadeAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.calls = append(a.calls, method)
+	m, _ := params.(map[string]any)
+	a.params = append(a.params, m)
+	if a.failOn[method] {
+		return nil, errors.New(method + " boom")
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// fakeCascadeUsers records the row delete; all other UserRepository methods are
+// unused (embedded interface panics on unexpected use).
+type fakeCascadeUsers struct {
+	repository.UserRepository
+	deleted string
+}
+
+func (f *fakeCascadeUsers) Delete(_ context.Context, id string) error {
+	f.deleted = id
+	return nil
+}
+
+func cascadeCalledWith(a *recCascadeAgent, method, key, val string) bool {
+	for i, c := range a.calls {
+		if c == method && i < len(a.params) && a.params[i][key] == val {
+			return true
+		}
+	}
+	return false
+}
+
+// JAB-289: deleting a tenant who used the Adminer SSO bridge against Postgres
+// must drop their <osuser>_pgadmin shadow LOGIN role, or a live credential is
+// orphaned on the engine.
+func TestDeleteCascade_DropsPgShadowRole(t *testing.T) {
+	ag := &recCascadeAgent{}
+	users := &fakeCascadeUsers{}
+	target := &models.User{ID: "u1", Username: strptr("alice"), PgadminUsername: strptr("alice_pgadmin")}
+
+	if err := DeleteCascade(context.Background(), Deps{Users: users, Agent: ag}, DeleteDeps{}, target, "test"); err != nil {
+		t.Fatalf("cascade: %v", err)
+	}
+	if !cascadeCalledWith(ag, "db.postgres.drop_role", "role", "alice_pgadmin") {
+		t.Fatalf("PG shadow role not dropped; calls=%v params=%v", ag.calls, ag.params)
+	}
+	// The MariaDB shadow is still reaped too.
+	if !cascadeCalledWith(ag, "db_user.drop", "db_user_name", "alice_mysqladmin") {
+		t.Errorf("MariaDB shadow reap regressed; calls=%v", ag.calls)
+	}
+	if users.deleted != "u1" {
+		t.Errorf("user row should be deleted after a clean cascade, got %q", users.deleted)
+	}
+}
+
+// No PG shadow provisioned → no drop_role attempted (also avoids hitting the
+// optional Postgres engine on MariaDB-only boxes).
+func TestDeleteCascade_NoPgShadow_NoRoleDrop(t *testing.T) {
+	ag := &recCascadeAgent{}
+	users := &fakeCascadeUsers{}
+	target := &models.User{ID: "u1", Username: strptr("alice")} // PgadminUsername nil
+
+	if err := DeleteCascade(context.Background(), Deps{Users: users, Agent: ag}, DeleteDeps{}, target, "test"); err != nil {
+		t.Fatalf("cascade: %v", err)
+	}
+	for _, c := range ag.calls {
+		if c == "db.postgres.drop_role" {
+			t.Fatalf("must not attempt a PG role drop with no shadow provisioned; calls=%v", ag.calls)
+		}
+	}
+}
+
+// A failed shadow-role drop aborts the cascade with DBCleanupError and keeps the
+// user row as the only handle on the orphaned role — never a silent delete.
+func TestDeleteCascade_PgShadowDropFails_AbortsBeforeRowDelete(t *testing.T) {
+	ag := &recCascadeAgent{failOn: map[string]bool{"db.postgres.drop_role": true}}
+	users := &fakeCascadeUsers{}
+	target := &models.User{ID: "u1", Username: strptr("alice"), PgadminUsername: strptr("alice_pgadmin")}
+
+	err := DeleteCascade(context.Background(), Deps{Users: users, Agent: ag}, DeleteDeps{}, target, "test")
+	var ce *DBCleanupError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected DBCleanupError, got %v", err)
+	}
+	if users.deleted != "" {
+		t.Errorf("user row must NOT be deleted when a shadow drop failed, got %q", users.deleted)
+	}
+}

--- a/panel-api/internal/userops/userops_lifecycle.go
+++ b/panel-api/internal/userops/userops_lifecycle.go
@@ -49,21 +49,22 @@ func (e *DockerTeardownError) Error() string {
 	return "userops: docker app teardown failed for " + strings.Join(e.Slugs, ", ")
 }
 
-// DBCleanupError reports MariaDB objects (schemas, logins, the mysqladmin
-// shadow) whose host-side drop failed during DeleteCascade. The user row is NOT
-// deleted when this is returned: deleting it CASCADEs the databases/
-// database_users metadata away, so a failed drop would strand the MariaDB
-// object on the host with no panel row left to name it — invisible to
-// `jabali db list`, excluded from backups, grants still live (#1010 / db fix
-// 541612543+4d455c150, originally inline in the delete handler; kept here so the
-// automation delete path gets the same guarantee). Retrying the delete is safe:
-// the domain/docker/ACL steps are idempotent and re-list empty on the retry.
+// DBCleanupError reports database engine objects (MariaDB schemas + logins and
+// the _mysqladmin shadow, plus the PostgreSQL _pgadmin shadow role) whose
+// host-side drop failed during DeleteCascade. The user row is NOT deleted when
+// this is returned: deleting it CASCADEs the databases/database_users metadata
+// away, so a failed drop would strand the engine object on the host with no
+// panel row left to name it — invisible to `jabali db list`, excluded from
+// backups, grants still live (#1010 / db fix 541612543+4d455c150, originally
+// inline in the delete handler; kept here so the automation delete path gets the
+// same guarantee; JAB-289 added the PG shadow role). Retrying the delete is
+// safe: the domain/docker/ACL steps are idempotent and re-list empty on the retry.
 type DBCleanupError struct {
 	Objects []string
 }
 
 func (e *DBCleanupError) Error() string {
-	return "userops: host-side MariaDB drop failed for " + strings.Join(e.Objects, ", ")
+	return "userops: host-side database engine drop failed for " + strings.Join(e.Objects, ", ")
 }
 
 // RotatePassword rotates a user's auth password. Order is load-bearing
@@ -378,6 +379,30 @@ func DeleteCascade(ctx context.Context, d Deps, dd DeleteDeps, target *models.Us
 			undropped = append(undropped, shadowUser)
 			logError(d, "cascade delete: mysqladmin shadow drop failed — aborting so the login is not orphaned",
 				"user_id", id, "mysqladmin_user", shadowUser, "err", dropErr)
+		}
+	}
+
+	// Drop the per-user PostgreSQL shadow-admin ROLE (<osuser>_pgadmin) — the
+	// Adminer-SSO counterpart to the MariaDB _mysqladmin shadow above (JAB-289).
+	// Like it, the role is not a database_users row, so the reap loop never
+	// touches it; unlike it, it lives on Postgres, so db_user.drop (MariaDB)
+	// would never reach it. Left unreaped, deleting a tenant who used Adminer
+	// SSO against Postgres orphaned a live LOGIN role with a decryptable
+	// password (pgadmin_password_enc) — the same orphan class this guards.
+	//
+	// Guarded on a provisioned pgadmin_username: only PG-SSO tenants have one,
+	// and the guard also avoids calling db.postgres.drop_role on boxes where the
+	// optional Postgres engine isn't installed. db.postgres.drop_role is an
+	// idempotent DROP ROLE IF EXISTS.
+	if d.Agent != nil && target.PgadminUsername != nil && *target.PgadminUsername != "" {
+		pgShadow := *target.PgadminUsername
+		agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		_, dropErr := d.Agent.Call(agentCtx, "db.postgres.drop_role", map[string]any{"role": pgShadow})
+		cancel()
+		if dropErr != nil {
+			undropped = append(undropped, pgShadow)
+			logError(d, "cascade delete: pgadmin shadow role drop failed — aborting so the login is not orphaned",
+				"user_id", id, "pgadmin_user", pgShadow, "err", dropErr)
 		}
 	}
 


### PR DESCRIPTION
## What

`DeleteCascade` (the shared account-delete path behind REST, CLI, and billing
cancel) reaped the per-user **MariaDB** `_mysqladmin` shadow login but never the
**PostgreSQL** counterpart.

The Adminer SSO bridge provisions a persistent shadow **LOGIN role** named
`<osuser>_pgadmin` (stored in `users.pgadmin_username`, password encrypted at
rest in `pgadmin_password_enc`) the first time a tenant opens a Postgres
database. It is **not** a `database_users` row, so the reap loop never touched
it, and `db_user.drop` only reaches MariaDB — so deleting such a tenant left a
**live Postgres role with a decryptable password orphaned on the engine**,
invisible to the panel. This is the same orphaned-live-credential class as
JAB-282 / JAB-284.

## Fix

The cascade now drops it via `db.postgres.drop_role` (`DROP ROLE IF EXISTS`),
placed right after the MariaDB shadow drop and guarded on a provisioned
`pgadmin_username` so it neither fires needlessly nor touches the **optional**
Postgres engine on MariaDB-only boxes. A failed drop joins the same abort set as
the MariaDB shadow (`DBCleanupError`): the user row is **kept** as the only
handle on the orphan rather than silently deleted, so a retry converges.

## Tests

Drive `DeleteCascade` with a recording agent:
- PG role dropped by the correct verb (`db.postgres.drop_role`) + `role` param;
- no drop attempted when no shadow was provisioned (MariaDB-only tenants);
- a failed drop returns `DBCleanupError` and leaves the user row intact.

Full `userops` + `internal/api` suites and `go vet` green.

## Out of scope (parent module ticket)
One shared REST+CLI+cascade delete operation with per-step retry handles.

GH JAB-289
