### PR TITLE
fix(automation): give the suspend cascade room past a 10s ceiling (JAB-281)

### DIFF
--- a/panel-api/internal/api/automation_write_routes.go
+++ b/panel-api/internal/api/automation_write_routes.go
@@ -120,7 +120,14 @@ func userSuspendHandler(cfg AutomationConfig, suspend bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tok := middleware.AutomationToken(c)
 		id := c.Param("id")
-		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		// JAB-281: the suspend path now runs the full userops.Suspend cascade,
+		// which stops the tenant's Docker apps (budgeted up to 2m each) BEFORE it
+		// locks OS + FTP credentials. A 10s ceiling would expire mid-cascade on a
+		// Docker-heavy tenant and hand the credential-lock agent calls a dead ctx —
+		// leaving SSH/FTP live until the next reconcile tick. Give the cascade room
+		// (the DB flag + Kratos invalidation, the load-bearing gate, run first
+		// regardless; the reconciler is the durable backstop for the rest).
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Minute)
 		defer cancel()
 		u, err := cfg.Users.FindByID(ctx, id)
 		if err != nil || u == nil {


### PR DESCRIPTION
Follow-up to #1292 / #1293. Routing automation user disable through `userops.Suspend` means the handler's 10s request ctx now bounds the **whole cascade**, which stops the tenant's Docker apps (budgeted up to 2m each) **before** it locks OS + FTP credentials. On a Docker-heavy tenant the 10s clock expired mid-cascade and handed `user.suspend` / `ftpaccount.lock_tenant` a cancelled ctx — leaving SSH/FTP live until the next reconcile tick.

Raise the disable/enable route ceiling to 3m so the credential lock actually runs. The suspended flag + Kratos invalidation (the load-bearing login gate) still run first regardless, and the reconciler remains the durable backstop. The domain suspend handler (a fast `is_enabled` flip, no cascade) keeps its 10s ceiling.

GH JAB-281