### PR TITLE
fix(ssl): unblock stuck ACME certs — jabali ssl retry, real budget reset, route-cache + UI (GH #1221)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4965,6 +4965,14 @@ jabali ssl renew <domain> [flags]
 
 - `--force` — force renewal even if cert is not due
 
+#### `jabali ssl retry`
+
+Reset a stuck cert (failed / pending_acme_retry) and re-attempt ACME issuance now
+
+```
+jabali ssl retry <domain>
+```
+
 #### `jabali ssl set-custom`
 
 Install an operator-supplied SSL cert + key (JAB-128)

--- a/panel-api/cmd/server/ssl_cmd.go
+++ b/panel-api/cmd/server/ssl_cmd.go
@@ -31,6 +31,7 @@ func newSSLCmd() *cobra.Command {
 		newSSLEnableCmd(),
 		newSSLDisableCmd(),
 		newSSLRenewCmd(),
+		newSSLRetryCmd(),
 		newSSLSetCustomCmd(),
 		newSSLSharedCmd(),
 		newSSLReadinessCmd(),
@@ -251,7 +252,11 @@ func newSSLRenewCmd() *cobra.Command {
 				return fmt.Errorf("no cert for %s — run `jabali ssl enable %s` first to create + issue", dom.Name, dom.Name)
 			}
 			if cert.Status != models.SSLStatusIssued && cert.Status != models.SSLStatusRenewing {
-				return fmt.Errorf("cert for %s is in status %q (expected 'issued') — wait for reconciler to finish issuing or check `jabali ssl list`", dom.Name, cert.Status)
+				hint := "wait for the reconciler to finish issuing, or check `jabali ssl list`"
+				if cert.Status == models.SSLStatusPendingACMERetry || cert.Status == models.SSLStatusFailed {
+					hint = fmt.Sprintf("run `jabali ssl retry %s` to reset the certificate and re-attempt issuance now", dom.Name)
+				}
+				return fmt.Errorf("cert for %s is in status %q (expected 'issued') — %s", dom.Name, cert.Status, hint)
 			}
 			raw, err := sharedAgent.Call(ctx, "ssl.renew", map[string]any{
 				"domain": dom.Name,
@@ -283,4 +288,51 @@ func newSSLRenewCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "force renewal even if cert is not due")
 	return cmd
+}
+
+// newSSLRetryCmd unblocks a certificate stuck in 'failed' or 'pending_acme_retry'
+// — e.g. a migrated domain that could not pass a challenge until its DNS
+// delegation was corrected (GH #1221). It resets the row to pending with a fresh
+// retry budget (repo.ResetForRetry); the long-lived reconciler's retry ticker
+// picks a 'pending' row up on its next pass and re-attempts ACME. DB-only: this
+// is a separate process from the running panel, so it never calls the agent or
+// the in-process reconciler directly.
+func newSSLRetryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "retry <domain>",
+		Short:   "Reset a stuck cert (failed / pending_acme_retry) and re-attempt ACME issuance now",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			dom, err := domainRepoFromDB().FindByName(ctx, args[0])
+			if err != nil {
+				if errors.Is(err, repository.ErrNotFound) {
+					return fmt.Errorf("domain %q not found", args[0])
+				}
+				return fmt.Errorf("lookup domain: %w", err)
+			}
+			cert, cerr := sslRepoFromDB().FindByDomainID(ctx, dom.ID)
+			if cerr != nil {
+				if errors.Is(cerr, repository.ErrNotFound) {
+					return fmt.Errorf("no cert for %s — run `jabali ssl enable %s` first to create + issue", dom.Name, dom.Name)
+				}
+				return fmt.Errorf("lookup cert: %w", cerr)
+			}
+			if cert.Status != models.SSLStatusFailed && cert.Status != models.SSLStatusPendingACMERetry {
+				return fmt.Errorf("cert for %s is in status %q — retry only applies to 'failed' or 'pending_acme_retry' (an issued cert renews with `jabali ssl renew`)", dom.Name, cert.Status)
+			}
+			if err := sslRepoFromDB().ResetForRetry(ctx, cert.ID, time.Now().UTC()); err != nil {
+				return fmt.Errorf("reset cert for retry: %w", err)
+			}
+			cliAuditOK(ctx, "ssl.retry", "domain", dom.ID, &dom.UserID)
+			if jsonOutput {
+				return printJSON(map[string]any{"domain": dom.Name, "status": models.SSLStatusPending, "queued": true})
+			}
+			fmt.Printf("Reset %s for re-issuance (status → pending, retry budget restored).\n"+
+				"The reconciler will attempt ACME on its next pass — watch `jabali ssl list`.\n", dom.Name)
+			return nil
+		},
+	}
 }

--- a/panel-api/cmd/server/ssl_cmd.go
+++ b/panel-api/cmd/server/ssl_cmd.go
@@ -331,7 +331,7 @@ func newSSLRetryCmd() *cobra.Command {
 				return printJSON(map[string]any{"domain": dom.Name, "status": models.SSLStatusPending, "queued": true})
 			}
 			fmt.Printf("Reset %s for re-issuance (status → pending, retry budget restored).\n"+
-				"The reconciler will attempt ACME on its next pass — watch `jabali ssl list`.\n", dom.Name)
+				"The reconciler will attempt ACME within about a minute — watch `jabali ssl list`.\n", dom.Name)
 			return nil
 		},
 	}

--- a/panel-api/internal/api/domains_ssl_badge_test.go
+++ b/panel-api/internal/api/domains_ssl_badge_test.go
@@ -220,3 +220,4 @@ func (m *mockSSLCertsForBadge) ListExhaustedForSSLEnabledDomains(context.Context
 }
 
 func (m *mockSSLCertsForBadge) RearmACME(context.Context, string, int, time.Time) error { return nil }
+func (m *mockSSLCertsForBadge) ResetForRetry(context.Context, string, time.Time) error  { return nil }

--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -347,16 +347,13 @@ func (h *sslHandler) retrySSL(c *gin.Context) {
 		return
 	}
 
-	// Reset retry count and clear next_retry_at to allow immediate retry
-	if err := h.cfg.SSLCerts.UpdateStatus(ctx, cert.ID, cert.Status, cert.LastError); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-
-	// For pending_acme_retry, reset retry_count to 0
-	// We'll do this via a direct update since we don't have a dedicated method
-	// Actually, let's just mark it as pending to trigger immediate retry
-	if err := h.cfg.SSLCerts.UpdateStatus(ctx, cert.ID, models.SSLStatusPending, nil); err != nil {
+	// Flip to pending with a fresh budget: retry_count=0, next_retry_at + last_error
+	// cleared. A manual Retry is a deliberate operator action, so it resets the
+	// counter (matching the documented contract) rather than handing the cert its
+	// last one attempt — a pending_acme_retry cert that had already burned its
+	// budget would otherwise re-cap to 'failed' on the next tick. LE's own
+	// per-hostname failed-validation limit is the backstop against abuse.
+	if err := h.cfg.SSLCerts.ResetForRetry(ctx, cert.ID, time.Now().UTC()); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -390,6 +390,66 @@ func TestListAllSSL_Success(t *testing.T) {
 	mockSSLCerts.AssertCalled(t, "ListAll", mock.MatchedBy(func(ctx context.Context) bool { return true }))
 }
 
+// retryTestScheduler records Schedule() calls for the retrySSL tests.
+type retryTestScheduler struct{ scheduled []string }
+
+func (r *retryTestScheduler) Schedule(domainID string) { r.scheduled = append(r.scheduled, domainID) }
+
+// TestRetrySSL covers the manual "Retry" path (GH #1221): a stuck cert
+// (pending_acme_retry / failed) is reset for a fresh-budget re-issuance and the
+// reconciler is scheduled; issued certs and non-admins are refused.
+func TestRetrySSL(t *testing.T) {
+	makeHandler := func(cert *models.SSLCertificate) (*sslHandler, *MockSSLCertificateRepository, *retryTestScheduler) {
+		mockCerts := new(MockSSLCertificateRepository)
+		sched := &retryTestScheduler{}
+		mockCerts.On("FindByDomainID", mock.Anything, "domain-1").Return(cert, nil)
+		mockCerts.On("ResetForRetry", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		cfg := SSLHandlerConfig{SSLCerts: mockCerts, Reconciler: sched}
+		return newSSLHandler(cfg), mockCerts, sched
+	}
+	// c.Writer.Status() is used rather than w.Code: the success path replies with
+	// c.Status(202) and no body, which gin does not flush to the httptest recorder
+	// on direct handler invocation (no Write). c.Writer.Status() reflects the code
+	// the handler set in every case.
+	do := func(h *sslHandler, admin bool) *gin.Context {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Params = gin.Params{{Key: "id", Value: "domain-1"}}
+		c.Request = httptest.NewRequest("POST", "/api/v1/domains/domain-1/ssl/retry", nil)
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "admin", IsAdmin: admin})
+		h.retrySSL(c)
+		return c
+	}
+
+	t.Run("pending_acme_retry resets and schedules", func(t *testing.T) {
+		h, mockCerts, sched := makeHandler(&models.SSLCertificate{ID: "cert-1", DomainID: "domain-1", Status: models.SSLStatusPendingACMERetry, RetryCount: 12})
+		c := do(h, true)
+		require.Equal(t, http.StatusAccepted, c.Writer.Status())
+		mockCerts.AssertCalled(t, "ResetForRetry", mock.Anything, "cert-1", mock.Anything)
+		require.Equal(t, []string{"domain-1"}, sched.scheduled)
+	})
+
+	t.Run("failed is retryable", func(t *testing.T) {
+		h, mockCerts, _ := makeHandler(&models.SSLCertificate{ID: "cert-1", DomainID: "domain-1", Status: models.SSLStatusFailed})
+		c := do(h, true)
+		require.Equal(t, http.StatusAccepted, c.Writer.Status())
+		mockCerts.AssertCalled(t, "ResetForRetry", mock.Anything, "cert-1", mock.Anything)
+	})
+
+	t.Run("issued is not retryable", func(t *testing.T) {
+		h, mockCerts, _ := makeHandler(&models.SSLCertificate{ID: "cert-1", DomainID: "domain-1", Status: models.SSLStatusIssued})
+		c := do(h, true)
+		require.Equal(t, http.StatusConflict, c.Writer.Status())
+		mockCerts.AssertNotCalled(t, "ResetForRetry", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("non-admin forbidden", func(t *testing.T) {
+		h, _, _ := makeHandler(&models.SSLCertificate{ID: "cert-1", DomainID: "domain-1", Status: models.SSLStatusPendingACMERetry})
+		c := do(h, false)
+		require.Equal(t, http.StatusForbidden, c.Writer.Status())
+	})
+}
+
 // TestListAllSSL_AdminOnly tests non-admin users get 403
 func TestListAllSSL_AdminOnly(t *testing.T) {
 	mockSSLCerts := new(MockSSLCertificateRepository)
@@ -783,4 +843,9 @@ func (m *MockSSLCertificateRepository) ListExhaustedForSSLEnabledDomains(context
 
 func (m *MockSSLCertificateRepository) RearmACME(context.Context, string, int, time.Time) error {
 	return nil
+}
+
+func (m *MockSSLCertificateRepository) ResetForRetry(ctx context.Context, id string, now time.Time) error {
+	args := m.Called(ctx, id, now)
+	return args.Error(0)
 }

--- a/panel-api/internal/reconciler/dns01_routing.go
+++ b/panel-api/internal/reconciler/dns01_routing.go
@@ -41,6 +41,14 @@ const (
 	// cert row as the ticket sketched): it survives across ticks in the
 	// long-lived reconciler process and self-heals after NS changes.
 	dns01RouteCacheTTL = time.Hour
+	// dns01RouteNegativeCacheTTL is the shorter TTL for a "no provider" result.
+	// ProviderNone is the transient "operator is mid-fix" state — they're moving
+	// NS to our PowerDNS or adding a Cloudflare token — so it must be re-checked
+	// soon, not held stale for the full hour. GH #1221: after correcting a DNS
+	// delegation an operator runs `jabali ssl retry`; without a short negative
+	// TTL the retry re-resolves to the cached ProviderNone and silently re-parks
+	// the cert for another day. A POSITIVE route is stable and keeps the 1h TTL.
+	dns01RouteNegativeCacheTTL = 5 * time.Minute
 )
 
 // IssueMethod values recorded on ssl_certificates rows.
@@ -107,11 +115,15 @@ func (r *Reconciler) dns01Route(ctx context.Context, srv *models.ServerSettings,
 	route := dns01.AuthoritativeRoute(routeCtx, cfg, name)
 	cancel()
 
+	ttl := dns01RouteCacheTTL
+	if route.Provider == dns01.ProviderNone {
+		ttl = dns01RouteNegativeCacheTTL // re-check a mid-fix delegation soon (GH #1221)
+	}
 	r.dns01RouteMu.Lock()
 	if r.dns01RouteCache == nil {
 		r.dns01RouteCache = map[string]dns01CachedRoute{}
 	}
-	r.dns01RouteCache[name] = dns01CachedRoute{route: route, expires: time.Now().Add(dns01RouteCacheTTL)}
+	r.dns01RouteCache[name] = dns01CachedRoute{route: route, expires: time.Now().Add(ttl)}
 	r.dns01RouteMu.Unlock()
 	return route
 }

--- a/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
+++ b/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
@@ -139,3 +139,7 @@ func (f *fakeSSLCertRepo) RearmACME(_ context.Context, id string, retryCount int
 	f.rearmed[id] = retryCount
 	return nil
 }
+
+func (f *fakeSSLCertRepo) ResetForRetry(_ context.Context, _ string, _ time.Time) error {
+	return nil
+}

--- a/panel-api/internal/reconciler/ssl_dns01_routing_test.go
+++ b/panel-api/internal/reconciler/ssl_dns01_routing_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dns01"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
@@ -179,5 +180,43 @@ func TestDNS01_FrontedPDNSZone_IssuesViaDNS01(t *testing.T) {
 
 	if !agentCalled(ag, "ssl.issue_dns01") {
 		t.Fatal("fronted + jabali-authoritative must issue via DNS-01 through pdns")
+	}
+}
+
+// TestDNS01_NegativeRouteCachedBriefly pins the GH #1221 fix: a "no provider"
+// route (operator mid-delegation-fix) is cached only briefly, so `jabali ssl
+// retry` right after the fix re-resolves instead of re-parking on a stale
+// ProviderNone. A positive route keeps the full 1h TTL.
+func TestDNS01_NegativeRouteCachedBriefly(t *testing.T) {
+	ctx := context.Background()
+
+	// No provider: Cloudflare NS but the token doesn't cover the zone.
+	rNeg, _, _, _ := dns01Fixture(t, []string{"kip.ns.cloudflare.com"}, "")
+	rNeg.dns01ZoneFinder = fixedZoneFinder{id: ""}
+	srvNeg, err := rNeg.serverSettings.Get(ctx)
+	if err != nil {
+		t.Fatalf("get settings: %v", err)
+	}
+	if route := rNeg.dns01Route(ctx, srvNeg, "example.com"); route.Provider != dns01.ProviderNone {
+		t.Fatalf("expected ProviderNone, got %v", route.Provider)
+	}
+	negTTL := time.Until(rNeg.dns01RouteCache["example.com"].expires)
+	if negTTL > dns01RouteNegativeCacheTTL+time.Minute {
+		t.Errorf("no-provider route cached for %v, want <= ~%v (a mid-fix delegation must be re-checked soon)", negTTL, dns01RouteNegativeCacheTTL)
+	}
+
+	// Positive: our PowerDNS is authoritative → provider available, long TTL.
+	rPos, _, _, _ := dns01Fixture(t, []string{"ns1.panel.example"}, "")
+	rPos.serverSettings.(*fakeServerSettingsRepo).settings.NS1Name = "ns1.panel.example"
+	srvPos, err := rPos.serverSettings.Get(ctx)
+	if err != nil {
+		t.Fatalf("get settings: %v", err)
+	}
+	if route := rPos.dns01Route(ctx, srvPos, "example.com"); route.Provider == dns01.ProviderNone {
+		t.Fatalf("expected a real provider for a jabali-authoritative zone, got ProviderNone")
+	}
+	posTTL := time.Until(rPos.dns01RouteCache["example.com"].expires)
+	if posTTL < dns01RouteCacheTTL-2*time.Minute {
+		t.Errorf("positive route cached for %v, want ~%v", posTTL, dns01RouteCacheTTL)
 	}
 }

--- a/panel-api/internal/repository/ssl_certificate_repository.go
+++ b/panel-api/internal/repository/ssl_certificate_repository.go
@@ -79,6 +79,11 @@ type SSLCertificateRepository interface {
 	ListExhaustedForSSLEnabledDomains(ctx context.Context, before time.Time, limit int) ([]models.SSLCertificate, error)
 	// RearmACME puts an exhausted certificate back in the retry queue.
 	RearmACME(ctx context.Context, id string, retryCount int, now time.Time) error
+	// ResetForRetry unblocks a stuck certificate for an immediate, full-budget
+	// re-issuance attempt: status=pending, retry_count=0, next_retry_at + last_error
+	// cleared. Deliberate operator/tenant action ("Retry" button / `jabali ssl
+	// retry`), so a fresh budget is intended — unlike RearmACME's metered re-arm.
+	ResetForRetry(ctx context.Context, id string, now time.Time) error
 }
 
 type sslCertificateRepo struct{ db *gorm.DB }
@@ -433,6 +438,24 @@ func (r *sslCertificateRepo) RearmACME(ctx context.Context, id string, retryCoun
 			"status":        models.SSLStatusPendingACMERetry,
 			"retry_count":   retryCount,
 			"next_retry_at": now,
+			"updated_at":    now,
+		}).Error
+}
+
+// ResetForRetry unblocks a stuck cert for an immediate full-budget re-issuance:
+// status=pending (picked up by ListDueForACMERetry case 1 regardless of
+// next_retry_at), retry_count zeroed for a fresh budget, next_retry_at and
+// last_error cleared. gorm skips zero-valued struct fields on Updates, so the
+// map form is used to force retry_count=0 and the NULLs to persist.
+func (r *sslCertificateRepo) ResetForRetry(ctx context.Context, id string, now time.Time) error {
+	return r.db.WithContext(ctx).
+		Model(&models.SSLCertificate{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"status":        models.SSLStatusPending,
+			"retry_count":   0,
+			"next_retry_at": nil,
+			"last_error":    nil,
 			"updated_at":    now,
 		}).Error
 }

--- a/panel-api/internal/repository/ssl_certificate_repository_test.go
+++ b/panel-api/internal/repository/ssl_certificate_repository_test.go
@@ -163,6 +163,38 @@ func TestSSLCertificateRepository_UpdateStatus(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSSLCertificateRepository_ResetForRetry(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := repository.NewSSLCertificateRepository(gdb)
+	ctx := context.Background()
+
+	certID := "01ARWX4FRYXZ73AK7EQQ69G5NV"
+	now := time.Now().UTC()
+
+	mock.ExpectBegin()
+	// One UPDATE: status=pending, retry_count=0, next_retry_at=NULL, last_error=NULL,
+	// updated_at=now. Map-ordered SET columns -> AnyArg for every value; the WHERE
+	// binds certID.
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE `ssl_certificates` SET")).
+		WithArgs(
+			sqlmock.AnyArg(), // last_error (NULL)
+			sqlmock.AnyArg(), // next_retry_at (NULL)
+			sqlmock.AnyArg(), // retry_count (0)
+			sqlmock.AnyArg(), // status (pending)
+			sqlmock.AnyArg(), // updated_at
+			certID,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := repo.ResetForRetry(ctx, certID, now)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSSLCertificateRepository_UpdateAfterIssuance(t *testing.T) {
 	t.Parallel()
 	gdb, mock, raw := newMockDB(t)

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -301,7 +301,31 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
           type="warning"
           showIcon
           title={t("domainsslsection.using_self_signed_certificate")}
-          description={t("domainsslsection.this_domain_is_using_a_self_signed_certifica")}
+          description={
+            <>
+              {t("domainsslsection.this_domain_is_using_a_self_signed_certifica")}
+              {/* GH #1221: a parked (pending_acme_retry) cert is serving the
+                  self-signed fallback while Let's Encrypt retries on a slow
+                  cadence. Surface the reason + a manual Retry so an operator
+                  who just fixed DNS/delegation can re-attempt immediately,
+                  instead of waiting for the daily recheck. */}
+              {status === "pending_acme_retry" && (
+                <>
+                  {cert?.last_error && (
+                    <div style={{ marginTop: 8 }}>Reason: {cert.last_error}</div>
+                  )}
+                  <Button
+                    type="primary"
+                    loading={renewing}
+                    onClick={onRetry}
+                    style={{ marginTop: 8 }}
+                  >
+                    Retry now
+                  </Button>
+                </>
+              )}
+            </>
+          }
         />
       ) : null}
 


### PR DESCRIPTION
## Problem (GH #1221)

A migrated domain's cert got stuck in `pending_acme_retry` after the reporter corrected its DNS delegation, with no obvious way to force re-issuance:

- `sudo jabali ssl renew` **refuses** any non-issued cert (a parked cert has no lineage to renew) and gave a dead-end "wait for the reconciler" message.
- The admin UI showed the **Retry button only for `status=failed`** — a `pending_acme_retry` cert got a warning with no action, so the reporter resorted to toggling self-signed→LE to force issuance.
- Even the existing Retry path could silently re-park for 24h (stale DNS-01 route cache) and never actually reset the retry budget.

## Fix

1. **New `jabali ssl retry <domain>`** — resets a stuck cert (`failed` / `pending_acme_retry`) to `pending` with a fresh budget via a new `repo.ResetForRetry`; the reconciler's 1-min SSL retry ticker picks it up. DB-only (separate process; no agent / in-process reconciler call).
2. **`retrySSL` API actually resets `retry_count` now** — it previously flipped to pending but left the counter (its own comment admitted the reset was unimplemented, plus a no-op self-status update). A cert that had burned its budget no longer re-caps to `failed` after one attempt — matching the documented "Retry resets retry_count" contract.
3. **Short-TTL the DNS-01 "no provider" route cache** (1h → 5m for `ProviderNone`). A CDN-fronted domain caches `ProviderNone` while delegated elsewhere; without this, a retry right after a delegation fix re-resolves to the stale cache and re-parks +24h — the exact reported scenario. Positive routes keep the 1h TTL. Covers the CLI, the UI, and the automatic daily recheck.
4. **UI Retry button for `pending_acme_retry`** — surfaces the parked reason (`last_error`) + a "Retry now" button on the admin SSL section, reusing the existing `POST /ssl/retry`.
5. `jabali ssl renew` now points a stuck cert at `jabali ssl retry <domain>` instead of the dead-end message.

## Tests

- `repo.ResetForRetry` (sqlmock).
- `retrySSL` handler: `pending_acme_retry` + `failed` reset & schedule, `issued` → 409, non-admin → 403.
- DNS-01 route cache: a no-provider route caches ≤ ~5m, a jabali-authoritative route keeps ~1h.
- CLI reference golden regenerated for `jabali ssl retry`.

Backend verified locally (`go build ./...`, `go vet`, package tests green); UI type-checks (`tsc -b`) and builds. Live box-verify on the smoke host to follow.

GH #1221