### PR TITLE
test(users): fix data race in the delete-cascade agent mock (JAB-289 follow-up)

### DIFF
--- a/panel-api/internal/userops/userops_cascade_pgshadow_test.go
+++ b/panel-api/internal/userops/userops_cascade_pgshadow_test.go
@@ -4,27 +4,53 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// recCascadeAgent records agent calls and can fail selected verbs.
+// recCascadeAgent records agent calls and can fail selected verbs. DeleteCascade
+// fires the user.delete reap in a background goroutine (fire-and-forget), so this
+// mock is written from that goroutine as well as the test one — mu guards the
+// recorded slices, and every reader below takes it too (JAB-289 test race).
 type recCascadeAgent struct {
+	mu     sync.Mutex
 	calls  []string
 	params []map[string]any
 	failOn map[string]bool
 }
 
 func (a *recCascadeAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.mu.Lock()
 	a.calls = append(a.calls, method)
 	m, _ := params.(map[string]any)
 	a.params = append(a.params, m)
+	a.mu.Unlock()
 	if a.failOn[method] {
 		return nil, errors.New(method + " boom")
 	}
 	return json.RawMessage(`{}`), nil
+}
+
+// hasCall reports whether method was recorded. Locked (see recCascadeAgent.mu).
+func (a *recCascadeAgent) hasCall(method string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, c := range a.calls {
+		if c == method {
+			return true
+		}
+	}
+	return false
+}
+
+// callsSnapshot returns a copy of the recorded call list for failure messages.
+func (a *recCascadeAgent) callsSnapshot() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.calls...)
 }
 
 // fakeCascadeUsers records the row delete; all other UserRepository methods are
@@ -40,6 +66,8 @@ func (f *fakeCascadeUsers) Delete(_ context.Context, id string) error {
 }
 
 func cascadeCalledWith(a *recCascadeAgent, method, key, val string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	for i, c := range a.calls {
 		if c == method && i < len(a.params) && a.params[i][key] == val {
 			return true
@@ -60,11 +88,11 @@ func TestDeleteCascade_DropsPgShadowRole(t *testing.T) {
 		t.Fatalf("cascade: %v", err)
 	}
 	if !cascadeCalledWith(ag, "db.postgres.drop_role", "role", "alice_pgadmin") {
-		t.Fatalf("PG shadow role not dropped; calls=%v params=%v", ag.calls, ag.params)
+		t.Fatalf("PG shadow role not dropped; calls=%v", ag.callsSnapshot())
 	}
 	// The MariaDB shadow is still reaped too.
 	if !cascadeCalledWith(ag, "db_user.drop", "db_user_name", "alice_mysqladmin") {
-		t.Errorf("MariaDB shadow reap regressed; calls=%v", ag.calls)
+		t.Errorf("MariaDB shadow reap regressed; calls=%v", ag.callsSnapshot())
 	}
 	if users.deleted != "u1" {
 		t.Errorf("user row should be deleted after a clean cascade, got %q", users.deleted)
@@ -81,10 +109,8 @@ func TestDeleteCascade_NoPgShadow_NoRoleDrop(t *testing.T) {
 	if err := DeleteCascade(context.Background(), Deps{Users: users, Agent: ag}, DeleteDeps{}, target, "test"); err != nil {
 		t.Fatalf("cascade: %v", err)
 	}
-	for _, c := range ag.calls {
-		if c == "db.postgres.drop_role" {
-			t.Fatalf("must not attempt a PG role drop with no shadow provisioned; calls=%v", ag.calls)
-		}
+	if ag.hasCall("db.postgres.drop_role") {
+		t.Fatalf("must not attempt a PG role drop with no shadow provisioned; calls=%v", ag.callsSnapshot())
 	}
 }
 


### PR DESCRIPTION
## Problem

`go test -race` (the **Go tests + vet** CI job) has been failing on **every open PR** since #1296 (JAB-289) landed. The failure is a data race in the test mock, not production code:

- `DeleteCascade` fires the `user.delete` reap in a background goroutine (userops_lifecycle.go, "fire-and-forget").
- The JAB-289 mock `recCascadeAgent` recorded calls into **unsynchronized** slices (`calls`/`params`).
- That goroutine's `Call()` therefore raced the test's own `range ag.calls` reads → `race detected`, non-deterministically across `TestDeleteCascade_*`.

## Fix

Test-only. Guard the mock's recorded slices with a `sync.Mutex` and route every reader through it (`hasCall` / `callsSnapshot` / the now-locked `cascadeCalledWith`). The production fire-and-forget is correct — a real agent `Call` over the socket is already concurrency-safe.

## Verification

```
go test -race -count=10 ./internal/userops/   # green
```

Repeated 10× per test plus 3× full-package, all clean.

GH — unblocks CI (`Go tests + vet`) for all open PRs.