### PR TITLE
perf(dns): batched DNS Zone inventory replaces the overview fan-out (JAB-377)

### DIFF
--- a/panel-api/cmd/server/dns_cmd_test.go
+++ b/panel-api/cmd/server/dns_cmd_test.go
@@ -39,6 +39,15 @@ func (f *memDNSZoneRepo) FindByDomainID(context.Context, string) (*models.DNSZon
 	return nil, repository.ErrNotFound
 }
 func (f *memDNSZoneRepo) ListAll(context.Context) ([]models.DNSZone, error) { return nil, nil }
+func (f *memDNSZoneRepo) FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DNSZone, error) {
+	var out []models.DNSZone
+	for _, id := range domainIDs {
+		if z, err := f.FindByDomainID(ctx, id); err == nil && z != nil {
+			out = append(out, *z)
+		}
+	}
+	return out, nil
+}
 
 type memDNSRecordRepo struct{ byID map[string]*models.DNSRecord }
 
@@ -81,6 +90,16 @@ func (f *memDNSRecordRepo) ListByZoneID(_ context.Context, zoneID string) ([]mod
 	return out, nil
 }
 func (f *memDNSRecordRepo) DeleteByZoneID(context.Context, string) error { return nil }
+func (f *memDNSRecordRepo) CountByZoneIDs(ctx context.Context, zoneIDs []string) (map[string]int64, error) {
+	out := make(map[string]int64)
+	for _, zid := range zoneIDs {
+		recs, _ := f.ListByZoneID(ctx, zid)
+		if len(recs) > 0 {
+			out[zid] = int64(len(recs))
+		}
+	}
+	return out, nil
+}
 func (f *memDNSRecordRepo) DeleteByZoneIDAndManagedBy(context.Context, string, string) error {
 	return nil
 }

--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -195,6 +195,15 @@ func (*fakeDNSZoneRepo) FindByName(context.Context, string) (*models.DNSZone, er
 func (*fakeDNSZoneRepo) ListAll(context.Context) ([]models.DNSZone, error) {
 	return nil, nil
 }
+func (f *fakeDNSZoneRepo) FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DNSZone, error) {
+	var out []models.DNSZone
+	for _, id := range domainIDs {
+		if z, err := f.FindByDomainID(ctx, id); err == nil && z != nil {
+			out = append(out, *z)
+		}
+	}
+	return out, nil
+}
 
 type fakeDNSRecordRepo struct {
 	records     map[string][]models.DNSRecord // zoneID → rows
@@ -205,6 +214,15 @@ type fakeDNSRecordRepo struct {
 
 func (f *fakeDNSRecordRepo) ListByZoneID(_ context.Context, zoneID string) ([]models.DNSRecord, error) {
 	return f.records[zoneID], nil
+}
+func (f *fakeDNSRecordRepo) CountByZoneIDs(_ context.Context, zoneIDs []string) (map[string]int64, error) {
+	out := make(map[string]int64)
+	for _, zid := range zoneIDs {
+		if n := len(f.records[zid]); n > 0 {
+			out[zid] = int64(n)
+		}
+	}
+	return out, nil
 }
 func (f *fakeDNSRecordRepo) Create(_ context.Context, rec *models.DNSRecord) error {
 	if f.createErr != nil {

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -27,7 +28,11 @@ type DNSHandlerConfig struct {
 	Zones          repository.DNSZoneRepository
 	Records        repository.DNSRecordRepository
 	ServerSettings repository.ServerSettingsRepository
-	Reconciler     DNSScheduler
+	// Users resolves owner display names for the admin-scope zone inventory
+	// (JAB-377). Optional: nil drops the owner column, leaving user_id on the
+	// wire as the fallback (mirrors the domains list).
+	Users      repository.UserRepository
+	Reconciler DNSScheduler
 }
 
 func RegisterDNSRoutes(g *gin.RouterGroup, cfg DNSHandlerConfig) {
@@ -43,6 +48,10 @@ func RegisterDNSRoutes(g *gin.RouterGroup, cfg DNSHandlerConfig) {
 	// dns_records). Expose them read-only so operators can verify the
 	// zone-level bits without reaching for `dig`.
 	d.GET("/system-records", h.listSystemRecords)
+
+	// Batched DNS Zone overview inventory (JAB-377) — one request replaces the
+	// per-domain GET /domains/:id/dns/zone fan-out both overview pages issued.
+	g.GET("/dns/zones", h.listZoneInventory)
 
 	// Record-level operations don't need the domain id in the path
 	rec := g.Group("/dns/records")
@@ -110,6 +119,144 @@ func (h *dnsHandler) loadDomainOwned(c *gin.Context, domainID string) *models.Do
 	}
 
 	return domain
+}
+
+// dnsZoneInventoryRow is one row of the batched DNS Zone overview (JAB-377):
+// the domain plus its provisioning state, user-record count, effective default
+// TTL, DNSSEC state, and registrar expiry. Username is populated for admin
+// scope only.
+type dnsZoneInventoryRow struct {
+	ID                 string     `json:"id"`
+	Name               string     `json:"name"`
+	UserID             string     `json:"user_id"`
+	Username           *string    `json:"username,omitempty"`
+	Provisioned        bool       `json:"provisioned"`
+	RecordCount        int64      `json:"record_count"`
+	EffectiveTTL       int        `json:"effective_ttl"`
+	DNSSECEnabled      bool       `json:"dnssec_enabled"`
+	RegistrarExpiresAt *time.Time `json:"registrar_expires_at,omitempty"`
+}
+
+// listZoneInventory serves GET /dns/zones — the batched DNS Zone overview
+// inventory (JAB-377). One request with a query budget independent of page
+// size: the scoped + paginated domain page, one zones-by-domain read, one
+// COUNT(*) GROUP BY zone_id aggregate, one settings read for the effective TTL,
+// and (admin) one owner-username batch. It replaces the per-row
+// GET /domains/:id/dns/zone fan-out both overview pages issued — a fan-out that
+// also silently rendered any transient failure as "Not provisioned". Here a
+// lookup failure is an honest 500; a success carries accurate provisioned state.
+func (h *dnsHandler) listZoneInventory(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+
+	page, pageSize, opts := parseListOptions(c, defaultDomainsPageSize, maxDomainsPageSize)
+	opts.OmitHeavyColumns = true
+
+	var (
+		domains []models.Domain
+		total   int64
+		err     error
+	)
+	if claims.IsAdmin {
+		// Admins may scope to one owner via ?user_id (mirrors the domains list);
+		// tenants are always owner-scoped and cannot select another owner.
+		if uid := c.Query("user_id"); uid != "" {
+			if !ids.IsValidULID(uid) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user_id"})
+				return
+			}
+			domains, total, err = h.cfg.Domains.ListByUserID(c.Request.Context(), uid, opts)
+		} else {
+			domains, total, err = h.cfg.Domains.List(c.Request.Context(), opts)
+		}
+	} else {
+		domains, total, err = h.cfg.Domains.ListByUserID(c.Request.Context(), claims.UserID, opts)
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	ttl := h.defaultRecordTTL(c.Request.Context())
+	rows := make([]dnsZoneInventoryRow, len(domains))
+	for i := range domains {
+		rows[i] = dnsZoneInventoryRow{
+			ID:                 domains[i].ID,
+			Name:               domains[i].Name,
+			UserID:             domains[i].UserID,
+			EffectiveTTL:       ttl,
+			DNSSECEnabled:      domains[i].DNSSECEnabled,
+			RegistrarExpiresAt: domains[i].RegistrarExpiresAt,
+		}
+	}
+
+	if len(domains) > 0 {
+		domainIDs := make([]string, len(domains))
+		for i := range domains {
+			domainIDs[i] = domains[i].ID
+		}
+
+		// Provisioned + zone id: one read. A DB error is a real 500, never
+		// silently collapsed to "not provisioned" (the fan-out's bug).
+		zones, zErr := h.cfg.Zones.FindByDomainIDs(c.Request.Context(), domainIDs)
+		if zErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		zoneByDomain := make(map[string]models.DNSZone, len(zones))
+		zoneIDs := make([]string, 0, len(zones))
+		for i := range zones {
+			zoneByDomain[zones[i].DomainID] = zones[i]
+			zoneIDs = append(zoneIDs, zones[i].ID)
+		}
+
+		// Record counts: one COUNT(*) GROUP BY zone_id aggregate — no record
+		// payload is loaded merely to count.
+		counts, cErr := h.cfg.Records.CountByZoneIDs(c.Request.Context(), zoneIDs)
+		if cErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		for i := range rows {
+			if z, ok := zoneByDomain[rows[i].ID]; ok {
+				rows[i].Provisioned = true
+				rows[i].RecordCount = counts[z.ID]
+			}
+		}
+
+		// Owner username (admin scope only): one batch lookup, non-fatal —
+		// user_id stays on the wire as the fallback (mirrors the domains list).
+		if claims.IsAdmin && h.cfg.Users != nil {
+			userIDs := make([]string, 0, len(domains))
+			seen := make(map[string]struct{}, len(domains))
+			for i := range domains {
+				if _, ok := seen[domains[i].UserID]; ok {
+					continue
+				}
+				seen[domains[i].UserID] = struct{}{}
+				userIDs = append(userIDs, domains[i].UserID)
+			}
+			if users, uErr := h.cfg.Users.FindByIDs(c.Request.Context(), userIDs); uErr == nil {
+				nameByID := make(map[string]*string, len(users))
+				for i := range users {
+					nameByID[users[i].ID] = users[i].Username
+				}
+				for i := range rows {
+					rows[i].Username = nameByID[rows[i].UserID]
+				}
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data":      rows,
+		"total":     total,
+		"page":      page,
+		"page_size": pageSize,
+	})
 }
 
 func (h *dnsHandler) getZone(c *gin.Context) {

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -299,6 +299,16 @@ func (m *mockDNSZoneRepo) FindByDomainID(ctx context.Context, domainID string) (
 	return nil, repository.ErrNotFound
 }
 
+func (m *mockDNSZoneRepo) FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DNSZone, error) {
+	var out []models.DNSZone
+	for _, id := range domainIDs {
+		if z, err := m.FindByDomainID(ctx, id); err == nil && z != nil {
+			out = append(out, *z)
+		}
+	}
+	return out, nil
+}
+
 func (m *mockDNSZoneRepo) ListAll(ctx context.Context) ([]models.DNSZone, error) {
 	var zones []models.DNSZone
 	for _, z := range m.zones {
@@ -345,6 +355,17 @@ func (m *mockDNSRecordRepo) ListByZoneID(ctx context.Context, zoneID string) ([]
 		}
 	}
 	return records, nil
+}
+
+func (m *mockDNSRecordRepo) CountByZoneIDs(ctx context.Context, zoneIDs []string) (map[string]int64, error) {
+	out := make(map[string]int64)
+	for _, zid := range zoneIDs {
+		recs, _ := m.ListByZoneID(ctx, zid)
+		if len(recs) > 0 {
+			out[zid] = int64(len(recs))
+		}
+	}
+	return out, nil
 }
 
 func (m *mockDNSRecordRepo) DeleteByZoneID(ctx context.Context, zoneID string) error {

--- a/panel-api/internal/api/dns_zone_inventory_test.go
+++ b/panel-api/internal/api/dns_zone_inventory_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Counting fakes for the JAB-377 zone-inventory query budget. Each embeds its
+// repository interface so only the methods the handler calls are implemented;
+// any other call would panic (guard against scope creep).
+
+type countingDomainRepo struct {
+	repository.DomainRepository
+	listCalls       int
+	listByUserCalls int
+	domains         []models.Domain
+}
+
+func (c *countingDomainRepo) List(_ context.Context, _ repository.ListOptions) ([]models.Domain, int64, error) {
+	c.listCalls++
+	return c.domains, int64(len(c.domains)), nil
+}
+func (c *countingDomainRepo) ListByUserID(_ context.Context, _ string, _ repository.ListOptions) ([]models.Domain, int64, error) {
+	c.listByUserCalls++
+	return c.domains, int64(len(c.domains)), nil
+}
+
+type countingZoneRepo struct {
+	repository.DNSZoneRepository
+	calls int
+}
+
+func (c *countingZoneRepo) FindByDomainIDs(_ context.Context, ids []string) ([]models.DNSZone, error) {
+	c.calls++
+	out := make([]models.DNSZone, 0, len(ids))
+	for i, id := range ids {
+		out = append(out, models.DNSZone{ID: "z" + strconv.Itoa(i), DomainID: id})
+	}
+	return out, nil
+}
+
+type countingRecordRepo struct {
+	repository.DNSRecordRepository
+	calls int
+}
+
+func (c *countingRecordRepo) CountByZoneIDs(_ context.Context, zoneIDs []string) (map[string]int64, error) {
+	c.calls++
+	out := make(map[string]int64, len(zoneIDs))
+	for _, z := range zoneIDs {
+		out[z] = 3
+	}
+	return out, nil
+}
+
+type countingSettingsRepo struct {
+	repository.ServerSettingsRepository
+	calls int
+}
+
+func (c *countingSettingsRepo) Get(_ context.Context) (*models.ServerSettings, error) {
+	c.calls++
+	return &models.ServerSettings{DefaultDNSTTL: 300}, nil
+}
+
+type countingUserRepo struct {
+	repository.UserRepository
+	calls int
+}
+
+func (c *countingUserRepo) FindByIDs(_ context.Context, ids []string) ([]models.User, error) {
+	c.calls++
+	out := make([]models.User, 0, len(ids))
+	for _, id := range ids {
+		name := "owner-" + id
+		out = append(out, models.User{ID: id, Username: &name})
+	}
+	return out, nil
+}
+
+func inventoryHandler(dr *countingDomainRepo) (*dnsHandler, *countingZoneRepo, *countingRecordRepo, *countingSettingsRepo, *countingUserRepo) {
+	zr := &countingZoneRepo{}
+	rr := &countingRecordRepo{}
+	sr := &countingSettingsRepo{}
+	ur := &countingUserRepo{}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr, Zones: zr, Records: rr, ServerSettings: sr, Users: ur}}
+	return h, zr, rr, sr, ur
+}
+
+func invGet(h *dnsHandler, url, userID string, isAdmin bool) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, url, nil)
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: isAdmin})
+	h.listZoneInventory(c)
+	return w
+}
+
+// The query budget is bounded and independent of page size: one domain list,
+// one zones-by-domain read, one COUNT(*) GROUP BY aggregate, one settings read,
+// one owner-username batch — the same counts at 1, 10, and 100 rows (JAB-377).
+func TestZoneInventory_ConstantQueryBudget(t *testing.T) {
+	for _, n := range []int{1, 10, 100} {
+		doms := make([]models.Domain, n)
+		for i := range doms {
+			doms[i] = models.Domain{ID: "d" + strconv.Itoa(i), Name: fmt.Sprintf("ex%d.com", i), UserID: "u1"}
+		}
+		dr := &countingDomainRepo{domains: doms}
+		h, zr, rr, sr, ur := inventoryHandler(dr)
+
+		w := invGet(h, "/dns/zones?page=1&page_size=200", "admin", true)
+
+		require.Equal(t, http.StatusOK, w.Code, "n=%d body=%s", n, w.Body.String())
+		require.Equal(t, 1, dr.listCalls, "domain list exactly once (n=%d)", n)
+		require.Equal(t, 1, zr.calls, "zones batched exactly once (n=%d)", n)
+		require.Equal(t, 1, rr.calls, "record counts aggregated exactly once (n=%d)", n)
+		require.Equal(t, 1, sr.calls, "settings/effective-TTL read exactly once (n=%d)", n)
+		require.Equal(t, 1, ur.calls, "owner usernames batched exactly once (n=%d)", n)
+
+		var resp struct {
+			Data  []dnsZoneInventoryRow `json:"data"`
+			Total int64                 `json:"total"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Len(t, resp.Data, n)
+		require.Equal(t, int64(n), resp.Total)
+		require.True(t, resp.Data[0].Provisioned)
+		require.EqualValues(t, 3, resp.Data[0].RecordCount)
+		require.Equal(t, 300, resp.Data[0].EffectiveTTL)
+		require.NotNil(t, resp.Data[0].Username, "admin scope carries owner username")
+	}
+}
+
+// A tenant is always owner-scoped and cannot select another owner: the handler
+// ignores ?user_id for non-admins and never issues the all-domains List. Owner
+// username is admin-only.
+func TestZoneInventory_TenantScopedCannotSelectOwner(t *testing.T) {
+	dr := &countingDomainRepo{domains: []models.Domain{{ID: "d1", Name: "t.com", UserID: "u1"}}}
+	h, _, _, _, ur := inventoryHandler(dr)
+
+	w := invGet(h, "/dns/zones?user_id=someone-else", "u1", false)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, 0, dr.listCalls, "tenant must never call the all-domains List")
+	require.Equal(t, 1, dr.listByUserCalls, "tenant scoped via ListByUserID")
+	require.Equal(t, 0, ur.calls, "owner-username enrich is admin-only")
+
+	var resp struct {
+		Data []dnsZoneInventoryRow `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	require.Nil(t, resp.Data[0].Username, "tenant scope must not expose owner username")
+}
+
+// A not-yet-provisioned domain (no zone row) reports provisioned=false with a
+// zero record count — distinct from an error (which is a 500, never rendered as
+// "not provisioned").
+func TestZoneInventory_NotProvisioned(t *testing.T) {
+	dr := &countingDomainRepo{domains: []models.Domain{{ID: "d1", Name: "np.com", UserID: "u1"}}}
+	zr := &noZoneRepo{}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr, Zones: zr, Records: &countingRecordRepo{}, ServerSettings: &countingSettingsRepo{}}}
+
+	w := invGet(h, "/dns/zones", "admin", true)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp struct {
+		Data []dnsZoneInventoryRow `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	require.False(t, resp.Data[0].Provisioned)
+	require.EqualValues(t, 0, resp.Data[0].RecordCount)
+}
+
+type noZoneRepo struct {
+	repository.DNSZoneRepository
+}
+
+func (noZoneRepo) FindByDomainIDs(_ context.Context, _ []string) ([]models.DNSZone, error) {
+	return nil, nil
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2832,6 +2832,26 @@ paths:
 
   # --- Dns (auto) ---
 
+  /dns/zones:
+    get:
+      tags: [Dns]
+      summary: List DNS zone inventory
+      description: >-
+        Batched DNS Zone overview — one row per domain with provisioning state,
+        record count, effective default TTL, DNSSEC state, and registrar expiry
+        (owner shown for admin scope). One request replaces the per-domain
+        GET /domains/{id}/dns/zone fan-out. Bounded query budget independent of
+        page size.
+      security: [ { KratosSession: [] } ]
+      parameters:
+        - { in: query, name: page, schema: { type: integer } }
+        - { in: query, name: page_size, schema: { type: integer } }
+        - { in: query, name: q, schema: { type: string } }
+        - { in: query, name: sort, schema: { type: string } }
+        - { in: query, name: order, schema: { type: string, enum: [asc, desc] } }
+        - { in: query, name: user_id, description: "admin-only owner scope", schema: { type: string } }
+      responses: { "200": { description: OK } }
+
   /dns/policy:
     get:
       tags: [Dns]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -924,6 +924,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Zones:          deps.DNSZones,
 				Records:        deps.DNSRecords,
 				ServerSettings: deps.ServerSettings,
+				Users:          deps.Users,
 				Reconciler:     deps.Reconciler,
 			})
 		}

--- a/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
@@ -27,6 +27,9 @@ func (f *fakeDNSZoneRepo) FindByDomainID(context.Context, string) (*models.DNSZo
 	return nil, nil
 }
 func (f *fakeDNSZoneRepo) ListAll(context.Context) ([]models.DNSZone, error) { return nil, nil }
+func (f *fakeDNSZoneRepo) FindByDomainIDs(context.Context, []string) ([]models.DNSZone, error) {
+	return nil, nil
+}
 
 type fakeDNSRecordRepo struct {
 	existing []models.DNSRecord
@@ -46,6 +49,9 @@ func (f *fakeDNSRecordRepo) FindByID(context.Context, string) (*models.DNSRecord
 	return nil, nil
 }
 func (f *fakeDNSRecordRepo) DeleteByZoneID(context.Context, string) error { return nil }
+func (f *fakeDNSRecordRepo) CountByZoneIDs(context.Context, []string) (map[string]int64, error) {
+	return map[string]int64{}, nil
+}
 func (f *fakeDNSRecordRepo) DeleteByZoneIDAndManagedBy(context.Context, string, string) error {
 	return nil
 }

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -374,6 +374,16 @@ func (f *fakeDNSZoneRepo) FindByDomainID(ctx context.Context, domainID string) (
 	return nil, repository.ErrNotFound
 }
 
+func (f *fakeDNSZoneRepo) FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DNSZone, error) {
+	var out []models.DNSZone
+	for _, id := range domainIDs {
+		if z, err := f.FindByDomainID(ctx, id); err == nil && z != nil {
+			out = append(out, *z)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeDNSZoneRepo) ListAll(ctx context.Context) ([]models.DNSZone, error) {
 	var result []models.DNSZone
 	for _, z := range f.zones {
@@ -418,6 +428,17 @@ func (f *fakeDNSRecordRepo) ListByZoneID(ctx context.Context, zoneID string) ([]
 		}
 	}
 	return result, nil
+}
+
+func (f *fakeDNSRecordRepo) CountByZoneIDs(ctx context.Context, zoneIDs []string) (map[string]int64, error) {
+	out := make(map[string]int64)
+	for _, zid := range zoneIDs {
+		recs, _ := f.ListByZoneID(ctx, zid)
+		if len(recs) > 0 {
+			out[zid] = int64(len(recs))
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeDNSRecordRepo) DeleteByZoneID(ctx context.Context, zoneID string) error {

--- a/panel-api/internal/repository/dns_repository.go
+++ b/panel-api/internal/repository/dns_repository.go
@@ -19,6 +19,11 @@ type DNSZoneRepository interface {
 	FindByID(ctx context.Context, id string) (*models.DNSZone, error)
 	FindByName(ctx context.Context, name string) (*models.DNSZone, error)
 	FindByDomainID(ctx context.Context, domainID string) (*models.DNSZone, error)
+	// FindByDomainIDs returns the zones for the given domain IDs in one query —
+	// the DNS Zone inventory's provisioned + zone-id lookup (JAB-377). Domains
+	// without a zone simply have no entry; the caller treats absence as
+	// not-provisioned. Empty input returns nil without a query.
+	FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DNSZone, error)
 	ListAll(ctx context.Context) ([]models.DNSZone, error)
 }
 
@@ -30,6 +35,12 @@ type DNSRecordRepository interface {
 	Delete(ctx context.Context, id string) error
 	FindByID(ctx context.Context, id string) (*models.DNSRecord, error)
 	ListByZoneID(ctx context.Context, zoneID string) ([]models.DNSRecord, error)
+	// CountByZoneIDs returns the user-record count per zone in one aggregate
+	// query (COUNT(*) GROUP BY zone_id) — the DNS Zone inventory's record-count
+	// column without loading a single record payload (JAB-377). Zones with no
+	// records are absent from the map (caller defaults to 0). Empty input
+	// returns an empty map without a query.
+	CountByZoneIDs(ctx context.Context, zoneIDs []string) (map[string]int64, error)
 	DeleteByZoneID(ctx context.Context, zoneID string) error
 	// DeleteByZoneIDAndManagedBy removes every row in the given zone
 	// whose managed_by column matches exactly — NULL values are never
@@ -93,6 +104,17 @@ func (r *dnsZoneRepo) FindByDomainID(ctx context.Context, domainID string) (*mod
 	return &z, nil
 }
 
+func (r *dnsZoneRepo) FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DNSZone, error) {
+	if len(domainIDs) == 0 {
+		return nil, nil
+	}
+	var zs []models.DNSZone
+	if err := r.db.WithContext(ctx).Where("domain_id IN ?", domainIDs).Find(&zs).Error; err != nil {
+		return nil, err
+	}
+	return zs, nil
+}
+
 func (r *dnsZoneRepo) ListAll(ctx context.Context) ([]models.DNSZone, error) {
 	var zs []models.DNSZone
 	if err := r.db.WithContext(ctx).Find(&zs).Error; err != nil {
@@ -141,6 +163,30 @@ func (r *dnsRecordRepo) ListByZoneID(ctx context.Context, zoneID string) ([]mode
 		return nil, err
 	}
 	return recs, nil
+}
+
+func (r *dnsRecordRepo) CountByZoneIDs(ctx context.Context, zoneIDs []string) (map[string]int64, error) {
+	out := make(map[string]int64, len(zoneIDs))
+	if len(zoneIDs) == 0 {
+		return out, nil
+	}
+	type countRow struct {
+		ZoneID string `gorm:"column:zone_id"`
+		Cnt    int64  `gorm:"column:cnt"`
+	}
+	var rows []countRow
+	if err := r.db.WithContext(ctx).
+		Model(&models.DNSRecord{}).
+		Select("zone_id, COUNT(*) AS cnt").
+		Where("zone_id IN ?", zoneIDs).
+		Group("zone_id").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, x := range rows {
+		out[x.ZoneID] = x.Cnt
+	}
+	return out, nil
 }
 
 func (r *dnsRecordRepo) DeleteByZoneID(ctx context.Context, zoneID string) error {

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
@@ -1,16 +1,13 @@
 // DNSZonesOverviewPage — admin landing for DNS. Card.tabList splits
-// into "Zones" (per-domain provisioning) and "DNSSEC" (signing state
-// + DS export). Mirrors the UserList tab style — a count Tag in each
-// label, controlled activeTabKey, panel-attached strip. Both tabs
-// view the same `domains` list so the badge total matches on both.
+// into "Zones" (per-domain provisioning, the batched /dns/zones inventory)
+// and "DNSSEC" (signing state + DS export). Mirrors the UserList tab style —
+// controlled activeTabKey, panel-attached strip.
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { Alert, Button, Card, Spin, Table, Tag, Tooltip, Typography } from "antd";
 import { ServerOutlined } from "@icons";
 import { useNavigate } from "react-router";
 
-import { apiClient } from "../../../apiClient";
 import { columnSearchProps } from "../../../components/columnSearch";
 import { DNSSECTable } from "../../../components/dnssec/DNSSECTable";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
@@ -18,87 +15,44 @@ import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { sorterToParams } from "../../../utils/tableSorter";
 
-interface Domain {
+// DnsZoneRow is one row of the batched GET /dns/zones inventory (JAB-377):
+// the domain plus its provisioning state, record count, and effective TTL,
+// resolved server-side in one request instead of a per-row zone fan-out.
+interface DnsZoneRow {
   id: string;
   user_id: string;
   username?: string | null;
   name: string;
-  created_at: string;
-  updated_at: string;
+  provisioned: boolean;
+  record_count: number;
+  effective_ttl?: number | null;
   dnssec_enabled?: boolean;
   registrar_expires_at?: string | null;
-}
-
-interface ZoneStatus {
-  provisioned: boolean;
-  recordCount?: number;
-  ttl?: number | null;
 }
 
 const ZonesTab = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [zoneStatuses, setZoneStatuses] = useState<Map<string, ZoneStatus>>(
-    new Map(),
-  );
 
-  const query = useTableURL<Domain>({
-    resource: "domains",
+  // One batched request (JAB-377): the endpoint returns provisioning state +
+  // record count + effective TTL per row, so there is no per-domain zone fetch
+  // and a transient failure surfaces as an error, not a false "Not provisioned".
+  const query = useTableURL<DnsZoneRow>({
+    resource: "dns/zones",
     defaultSort: "name",
     defaultOrder: "asc",
   });
-
-  useEffect(() => {
-    const domains = query.items;
-    if (domains.length === 0) return;
-
-    Promise.all(
-      domains.map(async (domain) => {
-        try {
-          const res = await apiClient.get(`/domains/${domain.id}/dns/zone`);
-          return {
-            domainId: domain.id,
-            provisioned: !!res.data?.zone?.id,
-            recordCount: res.data?.record_count as number | undefined,
-            // GH #527: show the effective default record TTL (what records
-            // use), not the SOA minimum_ttl (negative-cache timer, fixed 3600).
-            ttl: (res.data?.effective_ttl ?? null) as number | null,
-          };
-        } catch {
-          return { domainId: domain.id, provisioned: false, recordCount: undefined, ttl: null };
-        }
-      }),
-    ).then((results) => {
-      const statusMap = new Map<string, ZoneStatus>();
-      results.forEach(({ domainId, provisioned, recordCount, ttl }) => {
-        statusMap.set(domainId, { provisioned, recordCount, ttl });
-      });
-      setZoneStatuses(statusMap);
-    });
-  }, [query.items]);
-
-  const getZoneStatusTag = (domainId: string) => {
-    const status = zoneStatuses.get(domainId);
-    if (status === undefined) {
-      return <Spin />;
-    }
-    return status.provisioned ? (
-      <Tag color="green">Provisioned</Tag>
-    ) : (
-      <Tag>Not provisioned</Tag>
-    );
-  };
 
   // Project AntD's sorter into the URL params so the server does the
   // ORDER BY. Without an onChange the sort arrows rendered but changed
   // nothing — the columns declared a server-side sorter and nothing was
   // listening for it.
-  const handleTableChange: React.ComponentProps<typeof Table<Domain>>["onChange"] = (
+  const handleTableChange: React.ComponentProps<typeof Table<DnsZoneRow>>["onChange"] = (
     _pagination,
     _filters,
     sorter,
   ) => {
-    const { sort, order } = sorterToParams<Domain>(sorter);
+    const { sort, order } = sorterToParams<DnsZoneRow>(sorter);
     query.setParams({ sort, order, page: 1 });
   };
 
@@ -112,10 +66,19 @@ const ZonesTab = () => {
       />
       {query.isLoading ? (
         <Spin />
+      ) : query.isError ? (
+        // A load failure is an error, never rendered as an empty list or a false
+        // "Not provisioned" (JAB-377 — the fan-out swallowed exactly this).
+        <Alert
+          type="error"
+          showIcon
+          message="Failed to load DNS zones"
+          description="The zone inventory could not be loaded. This is usually temporary — retry shortly."
+        />
       ) : query.items.length === 0 ? (
         <EmptyWithCTA description={t("dnszonesoverviewpage.no_dns_zones_yet_create_a_domain_to_manage_i")} ctaLabel="Create domain" onCta={() => navigate("/jabali-admin/domains/create")} />
       ) : (
-        <SearchableTableStringQ<Domain>
+        <SearchableTableStringQ<DnsZoneRow>
           onChange={handleTableChange}
           rowKey="id"
           loading={query.isLoading}
@@ -130,55 +93,55 @@ const ZonesTab = () => {
             onChange: (page, pageSize) => query.setParams({ page, pageSize }),
           }}
         >
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             dataIndex="name"
             title={t("dnszonesoverviewpage.domain_name")}
             key="name"
             sorter
             defaultSortOrder="ascend"
-            {...columnSearchProps<Domain>({
+            {...columnSearchProps<DnsZoneRow>({
               placeholder: "Search by domain name",
               currentQ: query.params.q,
               onSearch: (v) => query.setParams({ q: v, page: 1 }),
             })}
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             dataIndex="username"
             title={t("dnszonesoverviewpage.owner")}
             key="username"
             sorter
-            render={(username: string | null | undefined, record: Domain) =>
+            render={(username: string | null | undefined, record: DnsZoneRow) =>
               username ?? record.user_id.substring(0, 8)
             }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.zone_status")}
-            render={(_, record) => getZoneStatusTag(record.id)}
+            render={(_, record) =>
+              record.provisioned ? (
+                <Tag color="green">Provisioned</Tag>
+              ) : (
+                <Tag>Not provisioned</Tag>
+              )
+            }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.records")}
-            render={(_, record) => {
-              const s = zoneStatuses.get(record.id);
-              if (s === undefined) return <Spin size="small" />;
-              return s.recordCount ?? 0;
-            }}
+            render={(_, record) => record.record_count ?? 0}
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.ttl")}
-            render={(_, record) => {
-              const s = zoneStatuses.get(record.id);
-              if (s === undefined) return <Spin size="small" />;
-              return s.ttl != null ? `${s.ttl}s` : "—";
-            }}
+            render={(_, record) =>
+              record.effective_ttl != null ? `${record.effective_ttl}s` : "—"
+            }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.dnssec")}
             dataIndex="dnssec_enabled"
             render={(enabled: boolean | undefined) =>
               enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
             }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.expiration")}
             dataIndex="registrar_expires_at"
             render={(d: string | null | undefined) =>
@@ -191,7 +154,7 @@ const ZonesTab = () => {
               )
             }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.actions")}
             render={(_, record) => (
               <Button

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
@@ -1,101 +1,55 @@
 // UserDNSZonesOverviewPage — tenant landing for DNS. Card.tabList
 // pattern matches admin DNS + UserList — controlled activeTabKey,
-// count Tag in each tab label, panel-attached strip. Both tabs view
-// the same `domains` list.
+// panel-attached strip. The Zones tab is the batched /dns/zones inventory.
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { Alert, Button, Card, Empty, Spin, Table, Tag, Tooltip, Typography } from "antd";
 import { CloudServerOutlined } from "@icons";
 import { useNavigate } from "react-router";
 
-import { apiClient } from "../../../apiClient";
 import { columnSearchProps } from "../../../components/columnSearch";
 import { DNSSECTable } from "../../../components/dnssec/DNSSECTable";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { sorterToParams } from "../../../utils/tableSorter";
 
-interface Domain {
+// DnsZoneRow is one row of the batched GET /dns/zones inventory (JAB-377):
+// the domain plus its provisioning state, record count, and effective TTL,
+// resolved server-side in one request instead of a per-row zone fan-out.
+interface DnsZoneRow {
   id: string;
   user_id: string;
   name: string;
-  created_at: string;
-  updated_at: string;
+  provisioned: boolean;
+  record_count: number;
+  effective_ttl?: number | null;
   dnssec_enabled?: boolean;
   registrar_expires_at?: string | null;
-}
-
-interface ZoneStatus {
-  provisioned: boolean;
-  recordCount?: number;
-  ttl?: number | null;
 }
 
 const ZonesTab = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [zoneStatuses, setZoneStatuses] = useState<Map<string, ZoneStatus>>(
-    new Map(),
-  );
 
-  const query = useTableURL<Domain>({
-    resource: "domains",
+  // One batched request (JAB-377): the endpoint returns provisioning state +
+  // record count + effective TTL per row, so there is no per-domain zone fetch
+  // and a transient failure surfaces as an error, not a false "Not provisioned".
+  const query = useTableURL<DnsZoneRow>({
+    resource: "dns/zones",
     defaultSort: "name",
     defaultOrder: "asc",
   });
-
-  useEffect(() => {
-    const domains = query.items;
-    if (domains.length === 0) return;
-
-    Promise.all(
-      domains.map(async (domain) => {
-        try {
-          const res = await apiClient.get(`/domains/${domain.id}/dns/zone`);
-          return {
-            domainId: domain.id,
-            provisioned: !!res.data?.zone?.id,
-            recordCount: res.data?.record_count as number | undefined,
-            // GH #527: show the effective default record TTL (what records
-            // use), not the SOA minimum_ttl (negative-cache timer, fixed 3600).
-            ttl: (res.data?.effective_ttl ?? null) as number | null,
-          };
-        } catch {
-          return { domainId: domain.id, provisioned: false, recordCount: undefined, ttl: null };
-        }
-      }),
-    ).then((results) => {
-      const statusMap = new Map<string, ZoneStatus>();
-      results.forEach(({ domainId, provisioned, recordCount, ttl }) => {
-        statusMap.set(domainId, { provisioned, recordCount, ttl });
-      });
-      setZoneStatuses(statusMap);
-    });
-  }, [query.items]);
-
-  const getZoneStatusTag = (domainId: string) => {
-    const status = zoneStatuses.get(domainId);
-    if (status === undefined) {
-      return <Spin />;
-    }
-    return status.provisioned ? (
-      <Tag color="green">Provisioned</Tag>
-    ) : (
-      <Tag>Not provisioned</Tag>
-    );
-  };
 
   // Project AntD's sorter into the URL params so the server does the
   // ORDER BY. Without an onChange the sort arrows rendered but changed
   // nothing — the columns declared a server-side sorter and nothing was
   // listening for it.
-  const handleTableChange: React.ComponentProps<typeof Table<Domain>>["onChange"] = (
+  const handleTableChange: React.ComponentProps<typeof Table<DnsZoneRow>>["onChange"] = (
     _pagination,
     _filters,
     sorter,
   ) => {
-    const { sort, order } = sorterToParams<Domain>(sorter);
+    const { sort, order } = sorterToParams<DnsZoneRow>(sorter);
     query.setParams({ sort, order, page: 1 });
   };
 
@@ -109,10 +63,19 @@ const ZonesTab = () => {
       />
       {query.isLoading ? (
         <Spin />
+      ) : query.isError ? (
+        // A load failure is an error, never rendered as an empty list or a false
+        // "Not provisioned" (JAB-377 — the fan-out swallowed exactly this).
+        <Alert
+          type="error"
+          showIcon
+          message="Failed to load DNS zones"
+          description="The zone inventory could not be loaded. This is usually temporary — retry shortly."
+        />
       ) : query.items.length === 0 ? (
         <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userdnszonesoverviewpage.no_domains_found")} />
       ) : (
-        <SearchableTableStringQ<Domain>
+        <SearchableTableStringQ<DnsZoneRow>
           onChange={handleTableChange}
           rowKey="id"
           loading={query.isLoading}
@@ -127,46 +90,46 @@ const ZonesTab = () => {
             onChange: (page, pageSize) => query.setParams({ page, pageSize }),
           }}
         >
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             dataIndex="name"
             title={t("userdnszonesoverviewpage.domain_name")}
             key="name"
             sorter
             defaultSortOrder="ascend"
-            {...columnSearchProps<Domain>({
+            {...columnSearchProps<DnsZoneRow>({
               placeholder: "Search by domain name",
               currentQ: query.params.q,
               onSearch: (v) => query.setParams({ q: v, page: 1 }),
             })}
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("userdnszonesoverviewpage.zone_status")}
-            render={(_, record) => getZoneStatusTag(record.id)}
+            render={(_, record) =>
+              record.provisioned ? (
+                <Tag color="green">Provisioned</Tag>
+              ) : (
+                <Tag>Not provisioned</Tag>
+              )
+            }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("userdnszonesoverviewpage.records")}
-            render={(_, record) => {
-              const s = zoneStatuses.get(record.id);
-              if (s === undefined) return <Spin size="small" />;
-              return s.recordCount ?? 0;
-            }}
+            render={(_, record) => record.record_count ?? 0}
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("userdnszonesoverviewpage.ttl")}
-            render={(_, record) => {
-              const s = zoneStatuses.get(record.id);
-              if (s === undefined) return <Spin size="small" />;
-              return s.ttl != null ? `${s.ttl}s` : "—";
-            }}
+            render={(_, record) =>
+              record.effective_ttl != null ? `${record.effective_ttl}s` : "—"
+            }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("userdnszonesoverviewpage.dnssec")}
             dataIndex="dnssec_enabled"
             render={(enabled: boolean | undefined) =>
               enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
             }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("userdnszonesoverviewpage.expiration")}
             dataIndex="registrar_expires_at"
             render={(d: string | null | undefined) =>
@@ -179,7 +142,7 @@ const ZonesTab = () => {
               )
             }
           />
-          <Table.Column<Domain>
+          <Table.Column<DnsZoneRow>
             title={t("userdnszonesoverviewpage.actions")}
             render={(_, record) => (
               <Button


### PR DESCRIPTION
## What

Both DNS Zone overview pages (admin + tenant) listed domains, then issued one
`GET /domains/:id/dns/zone` **per visible row** (`Promise.all(domains.map(...))`).
A 10-row page cost 1 + 10 HTTP requests and ~40 DB reads, scaling linearly with
page size. Each per-row `catch` also collapsed **any** failure (including
transient 5xx) into a false **"Not provisioned"**, hiding real errors.

## Backend

New `GET /dns/zones` returns the scoped, paginated domain page enriched in a
**bounded, page-size-independent** query budget:
- 1 domain list (reuses the existing scoped/paginated/searched `Domains.List` /
  `ListByUserID` — same auth, same `OmitHeavyColumns`),
- 1 zones-by-domain read (`DNSZoneRepository.FindByDomainIDs`),
- 1 `COUNT(*) GROUP BY zone_id` aggregate (`DNSRecordRepository.CountByZoneIDs`
  — no record payload loaded to count),
- 1 settings read for the effective TTL,
- (admin only) 1 owner-username batch.

Admin scope carries owner data and honors `?user_id` (ULID-validated); tenant
scope is owner-locked and **cannot** select another owner. A lookup failure is
an honest 500. The single-zone `GET /domains/:id/dns/zone` Interface is unchanged
for the record-management page.

## Frontend

Both overview pages now issue one `useTableURL({resource: "dns/zones"})` request
and render provisioning state / record count / TTL straight from the row,
deleting the fan-out and its per-cell spinners. A load failure renders a distinct
error `Alert` — never an empty list or a false "Not provisioned" (**criterion 5,
both halves**). Search, sort (name/username, server-side), pagination, DNSSEC, and
expiry are unchanged.

## Tests

- `TestZoneInventory_ConstantQueryBudget` — identical repo-call counts at
  **1 / 10 / 100** rows (the query-budget guarantee).
- `TestZoneInventory_TenantScopedCannotSelectOwner` — tenant never hits the
  all-domains `List`; no owner column.
- `TestZoneInventory_NotProvisioned` — provisioned vs not-provisioned distinct.
- `openapi.yaml` documents the route (golden green, documented not `-update`d).
- Full panel-api `go test ./...` + panel-ui vitest (294) + `tsc -b` + eslint green.

## Deferred (parent module ticket)

Merging the two overview pages into one shared UI Module with thin admin/tenant
adapters — the pages stay separate, both pointed at the new endpoint. All nine
listed acceptance criteria are met.

GH JAB-377
