### PR TITLE
fix(mail): stop selecting mailbox secrets into inventory/directory rows (JAB-370)

### DIFF
--- a/panel-api/internal/repository/mailbox_inventory_internal_test.go
+++ b/panel-api/internal/repository/mailbox_inventory_internal_test.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"strings"
+	"testing"
+)
+
+// The mailbox inventory / directory projection must never select the
+// secret-bearing columns into memory (JAB-370): the bcrypt password_hash and
+// the AES-encrypted password_enc are irrelevant to every inventory consumer and
+// were being pulled by `SELECT m.*` on admin- and fleet-polled paths. Both
+// ListAllWithDomain and ListByOwnerWithDomain build from this one constant, so
+// guarding it guards both.
+func TestMailboxInventorySelect_ExcludesSecretColumns(t *testing.T) {
+	for _, secret := range []string{"password_hash", "password_enc"} {
+		if strings.Contains(mailboxInventorySelect, secret) {
+			t.Fatalf("mailbox inventory projection must not select %q; got %q", secret, mailboxInventorySelect)
+		}
+	}
+	if strings.Contains(mailboxInventorySelect, "m.*") {
+		t.Fatalf("mailbox inventory projection must be an explicit allowlist, not a wildcard: %q", mailboxInventorySelect)
+	}
+	// The safe columns every inventory consumer relies on must still be present.
+	for _, col := range []string{
+		"m.id", "m.domain_id", "m.local_part", "m.email_cached", "m.display_name",
+		"m.quota_bytes", "m.is_disabled", "m.send_only", "m.system",
+		"m.last_usage_bytes", "m.last_usage_at", "domain_name", "owner_user_id",
+	} {
+		if !strings.Contains(mailboxInventorySelect, col) {
+			t.Errorf("mailbox inventory projection is missing expected safe column %q", col)
+		}
+	}
+}

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -138,13 +138,25 @@ func (r *mailboxRepo) CountAll(ctx context.Context) (int64, error) {
 	return n, err
 }
 
+// mailboxInventorySelect is the safe column projection for the WithDomain list
+// reads (JAB-370): every mailboxes column EXCEPT the secret-bearing
+// password_hash and the AES-encrypted password_enc. The inventory/directory
+// views never need either, and `SELECT m.*` was pulling both into memory (bcrypt
+// hash + up to 512 bytes of ciphertext per row) on admin- and fleet-polled
+// paths. An explicit allowlist also fails safe: a future secret column is not
+// materialised unless it is deliberately added here.
+const mailboxInventorySelect = "m.id, m.domain_id, m.local_part, m.email_cached, " +
+	"m.display_name, m.quota_bytes, m.is_disabled, m.send_only, m.system, " +
+	"m.last_usage_bytes, m.last_usage_at, m.created_at, m.updated_at, " +
+	"d.name AS domain_name, d.user_id AS owner_user_id, COALESCE(u.username, '') AS user_username"
+
 // ListAllWithDomain returns every mailbox on the server joined with its
 // domain name + owning user's username, ordered by email. Admin-only path.
 func (r *mailboxRepo) ListAllWithDomain(ctx context.Context) ([]MailboxWithDomain, error) {
 	var rows []MailboxWithDomain
 	err := r.db.WithContext(ctx).
 		Table("mailboxes m").
-		Select("m.*, d.name AS domain_name, d.user_id AS owner_user_id, COALESCE(u.username, '') AS user_username").
+		Select(mailboxInventorySelect).
 		Joins("JOIN domains d ON d.id = m.domain_id").
 		Joins("LEFT JOIN users u ON u.id = d.user_id").
 		Order("m.email_cached ASC").
@@ -158,7 +170,7 @@ func (r *mailboxRepo) ListByOwnerWithDomain(ctx context.Context, userID string) 
 	var rows []MailboxWithDomain
 	err := r.db.WithContext(ctx).
 		Table("mailboxes m").
-		Select("m.*, d.name AS domain_name, d.user_id AS owner_user_id, COALESCE(u.username, '') AS user_username").
+		Select(mailboxInventorySelect).
 		Joins("JOIN domains d ON d.id = m.domain_id").
 		Joins("LEFT JOIN users u ON u.id = d.user_id").
 		Where("d.user_id = ?", userID).


### PR DESCRIPTION
## What

The admin Mail directory (`ListAllWithDomain`) and the owner-scoped Mail view
(`ListByOwnerWithDomain`) projected `SELECT m.*`, materialising **every**
`mailboxes` column — including the bcrypt `password_hash` and the AES-256-GCM
`password_enc` envelope — into memory on every read, even though both are
`json:"-"` and never reach the browser.

These are admin-facing paths, and one is reachable from the **fleet-polled**
automation mail summary. Pulling a 512-byte ciphertext + a bcrypt hash per row
purely to list addresses is needless secret exposure — the existing `CountAll`
fix already called out the same waste for the count case.

## Fix

Replace `m.*` with an explicit safe-column allowlist (`mailboxInventorySelect`)
shared by both projections. No inventory consumer reads the secret fields
(verified: usage ticker, admin directory, tenant workspace, automation summary
all read email/quota/usage only), so wire output is unchanged. The allowlist
also **fails safe**: a future secret column is not materialised unless
deliberately added.

## Test

`TestMailboxInventorySelect_ExcludesSecretColumns` (internal `package repository`
test) asserts the projection never contains `password_hash` / `password_enc` /
a wildcard, and still carries the safe columns. Full `go test ./...` green.

## Scope

This is JAB-370's `No password hash or encrypted password material is selected
into inventory rows` criterion. The broader Mail Inventory Module
(server-paginated Directory/Workspace/Recent/Selection projections, constant
query count wrt domain count, authoritative totals, >200-row/domain
non-truncation) stays on the parent ticket.

GH JAB-370
