### PR TITLE
fix(backups): admin account backup keeps the dest password alive for the async job (JAB-302)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -512,10 +512,16 @@ func (h *backupHandler) createForUser(c *gin.Context) {
 		}
 		ctx, cancel := context.WithTimeout(c.Request.Context(), backupCallTimeout)
 		defer cancel()
-		// M30.2.x: per-destination password file is provisioned by
-		// the agent's write_temp on demand; cleanup runs after
-		// dispatch completes (or fails).
-		callErr := backupwrapperhelpers.WithDestPasswordFile(ctx, dest, h.cfg.Agent, h.cfg.SSOKey,
+		// JAB-302: backup.create is ASYNC — the agent spawns the backup
+		// goroutine and returns immediately. So this dispatch must NOT unlink
+		// the per-destination password tempfile when the Call returns: the
+		// background restic/borg run still needs it to authenticate to the
+		// destination. Use the async variant (like the scheduler); the agent's
+		// backup.create goroutine owns the tempfile's lifetime and removes it
+		// when the job finishes (backup_create.go: defer removePasswordTempFile).
+		// The old sync WithDestPasswordFile raced its cleanup_temp against the
+		// live backup — the exact bug the agent comment records as "used to".
+		callErr := backupwrapperhelpers.WithDestPasswordFileAsync(ctx, dest, h.cfg.Agent, h.cfg.SSOKey,
 			func(passwordFile string) error {
 				if passwordFile != "" {
 					params["password_file"] = passwordFile

--- a/panel-api/internal/api/backups_async_password_test.go
+++ b/panel-api/internal/api/backups_async_password_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// recBackupAgent records the agent method names a dispatch issues.
+type recBackupAgent struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (a *recBackupAgent) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
+	a.mu.Lock()
+	a.calls = append(a.calls, method)
+	a.mu.Unlock()
+	if method == "backup.repo.password.write_temp" {
+		return json.RawMessage(`{"path":"/run/jabali/restic-pw/abc"}`), nil
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (a *recBackupAgent) has(method string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, m := range a.calls {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+type stubBackupUsers struct {
+	repository.UserRepository
+	u *models.User
+}
+
+func (s stubBackupUsers) FindByID(_ context.Context, id string) (*models.User, error) {
+	if s.u != nil && s.u.ID == id {
+		return s.u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type stubBackupDests struct {
+	repository.BackupDestinationRepository
+	d *models.BackupDestination
+}
+
+func (s stubBackupDests) Get(_ context.Context, id string) (*models.BackupDestination, error) {
+	if s.d != nil && s.d.ID == id {
+		return s.d, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type stubBackupJobs struct {
+	repository.BackupJobRepository
+}
+
+func (stubBackupJobs) Create(_ context.Context, _ *models.BackupJob) error { return nil }
+func (stubBackupJobs) MarkStarted(_ context.Context, _ string) error       { return nil }
+
+// JAB-302: backup.create is async — the agent spawns the backup goroutine and
+// self-cleans the per-destination password tempfile when the job finishes. The
+// admin account-backup dispatch must therefore use the async password helper and
+// must NOT unlink the tempfile itself, or it races cleanup_temp against the live
+// backup (the exact regression the agent comment records). This pins that the
+// dispatch provisions the password + fires backup.create but issues no
+// cleanup_temp.
+func TestCreateForUser_AsyncDestPassword_NoCleanupRace(t *testing.T) {
+	key := ssokey.Key{}
+	enc, err := key.Seal([]byte("dest-secret"))
+	require.NoError(t, err)
+	dest := &models.BackupDestination{ID: "d1", Enabled: true, Kind: "sftp", PasswordEnc: enc}
+
+	uname := "alice"
+	ag := &recBackupAgent{}
+	h := &backupHandler{cfg: BackupHandlerConfig{
+		Users:        stubBackupUsers{u: &models.User{ID: "u1", Username: &uname, Email: "a@x.tld"}},
+		Destinations: stubBackupDests{d: dest},
+		Jobs:         stubBackupJobs{},
+		Agent:        ag,
+		SSOKey:       &key,
+	}}
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "u1"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/admin/users/u1/backups",
+		strings.NewReader(`{"destination_id":"d1","content":"full","compression":"off"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.createForUser(c)
+
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	require.True(t, ag.has("backup.repo.password.write_temp"),
+		"must provision the per-destination password tempfile; calls=%v", ag.calls)
+	require.True(t, ag.has("backup.create"), "must dispatch the backup; calls=%v", ag.calls)
+	require.False(t, ag.has("backup.repo.password.cleanup_temp"),
+		"admin account backup must NOT unlink the password tempfile — backup.create is async and the agent owns its lifetime (JAB-302); calls=%v", ag.calls)
+}


### PR DESCRIPTION
## What

The admin account-backup dispatch (`createForUser`) provisioned the
per-destination restic/borg password via the agent's `write_temp`, then wrapped
the dispatch in the **synchronous** `WithDestPasswordFile` helper — which unlinks
that tempfile (`cleanup_temp`) as soon as the `Call` returns.

But `backup.create` is **asynchronous**: the agent spawns the backup goroutine
and returns immediately (`backup_create.go` `go func`), so the panel's cleanup
raced the live backup, which still needed the password to authenticate to the
destination. The agent code comment already records this exact failure mode as
one it *"used to"* hit before the tempfile lifetime was moved agent-side:

> panel-api's deferred cleanup used to unlink it seconds in, while the
> orchestrator below still needed it

## Fix

Every other async dispatch (the scheduler) already uses
`WithDestPasswordFileAsync`, which leaves the tempfile in place; the agent's
`backup.create` goroutine owns its lifetime and removes it when the job finishes
(`defer removePasswordTempFile`). Align the admin path with that. The synchronous
helper stays correct for the genuinely synchronous ops — `backup.forget` and
`backup.restore` neither spawn a goroutine — so **only this one call site**
changes.

## Test

`TestCreateForUser_AsyncDestPassword_NoCleanupRace` drives `createForUser` with a
sealed-password destination and a recording agent, asserting it issues
`write_temp` + `backup.create` but **not** `cleanup_temp`. Full `internal/api` +
`backupscheduler` suites and `go vet` green.

## Scope

The account-caller slice of the Backup Job Intake module. Unifying the five
dispatch paths (admin / tenant / system / scheduled / automation), rotated-
credential lifetime across all of them, and failure classification stays on the
parent ticket.

GH JAB-302
