### PR TITLE
fix(backups): CLI SFTP destination validation rejects shell metacharacters too (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_parity_cmd.go
+++ b/panel-api/cmd/server/backup_destination_parity_cmd.go
@@ -30,6 +30,13 @@ func validateSFTPOpts(s *models.SFTPOptions) error {
 	if s.Host == "" || s.User == "" {
 		return errors.New("sftp host and user are required")
 	}
+	// JAB-310: the REST handler rejects whitespace/shell metacharacters in the
+	// host/user (they flow into restic's sftp.command); the CLI omitted this,
+	// so a CLI-created SFTP destination could carry an injectable host/user.
+	// Both adapters now call the one shared rule so they cannot drift.
+	if err := models.ValidateSFTPHostUser(s.Host, s.User); err != nil {
+		return err
+	}
 	if s.Path == "" {
 		return errors.New("sftp path is required")
 	}

--- a/panel-api/cmd/server/backup_destination_parity_cmd_test.go
+++ b/panel-api/cmd/server/backup_destination_parity_cmd_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-310: the CLI destination validator omitted the REST handler's
+// shell-metacharacter rule, so a CLI-created SFTP destination could carry an
+// injectable host/user that flows into restic's sftp.command. validateSFTPOpts
+// now enforces the same shared boundary rule.
+func TestValidateSFTPOpts_RejectsUnsafeHostUser(t *testing.T) {
+	if err := validateSFTPOpts(&models.SFTPOptions{Host: "h;rm -rf /", User: "u", Path: "/backups"}); err == nil {
+		t.Error("CLI must reject shell metacharacters in the sftp host")
+	}
+	if err := validateSFTPOpts(&models.SFTPOptions{Host: "h", User: "restic user", Path: "/backups"}); err == nil {
+		t.Error("CLI must reject whitespace in the sftp user")
+	}
+	// A well-formed destination still validates.
+	if err := validateSFTPOpts(&models.SFTPOptions{Host: "backup.example.com", User: "restic", Path: "/backups"}); err != nil {
+		t.Errorf("a plain sftp destination must be accepted, got %v", err)
+	}
+}

--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -283,11 +282,6 @@ func (h *backupDestinationHandler) create(c *gin.Context) {
 	c.JSON(http.StatusCreated, toDestDTO(d))
 }
 
-// sftpUnsafeRe matches anything that must never appear in an SSH host or
-// username: whitespace (which would split the sftp.command into extra argv
-// entries) plus the usual shell metacharacters.
-var sftpUnsafeRe = regexp.MustCompile("[\\s'\"\\\\;|&$<>()`]")
-
 // validateSFTPInputs enforces non-empty host+user, non-empty path, and
 // auth ∈ {key, password}. Key path absolute when auth=key.
 func validateSFTPInputs(s *sftpRequestOptions) error {
@@ -295,13 +289,11 @@ func validateSFTPInputs(s *sftpRequestOptions) error {
 		return errors.New("host and user are required")
 	}
 	// Host and user end up inside the restic `-o sftp.command=...` string,
-	// which restic tokenizes on whitespace and executes. SFTPCommandFlag quotes
-	// them, but validate here too: a value carrying whitespace or shell
-	// metacharacters has no legitimate meaning as an SSH host or username, and
-	// CONVENTIONS.md asks for the check at the boundary rather than relying on
-	// one downstream helper staying correct forever.
-	if sftpUnsafeRe.MatchString(s.Host) || sftpUnsafeRe.MatchString(s.User) {
-		return errors.New("host and user must not contain whitespace or shell metacharacters")
+	// which restic tokenizes on whitespace and executes. Reject whitespace and
+	// shell metacharacters at the boundary via the shared rule (JAB-310), the
+	// single owner both the REST and CLI validators call.
+	if err := models.ValidateSFTPHostUser(s.Host, s.User); err != nil {
+		return err
 	}
 	if s.Path == "" {
 		return errors.New("path is required")

--- a/panel-api/internal/models/backup_destination.go
+++ b/panel-api/internal/models/backup_destination.go
@@ -7,7 +7,9 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -96,6 +98,24 @@ type SFTPOptions struct {
 	Path    string `json:"path"`
 	Auth    string `json:"auth"` // SFTPAuthKey | SFTPAuthPassword
 	KeyPath string `json:"key_path,omitempty"`
+}
+
+// sftpUnsafeRe matches anything that must never appear in an SSH host or
+// username: whitespace (which would split restic's `-o sftp.command=...` into
+// extra argv entries) plus the usual shell metacharacters.
+var sftpUnsafeRe = regexp.MustCompile("[\\s'\"\\\\;|&$<>()`]")
+
+// ValidateSFTPHostUser rejects a host or user carrying whitespace or shell
+// metacharacters — values with no legitimate meaning as an SSH host/username
+// that would otherwise flow into restic's sftp.command and split or inject.
+// The single owner of this boundary rule so the REST and CLI destination
+// validators cannot drift (JAB-310); the check lives here even though
+// SFTPCommandFlag also quotes downstream, per CONVENTIONS.md's boundary rule.
+func ValidateSFTPHostUser(host, user string) error {
+	if sftpUnsafeRe.MatchString(host) || sftpUnsafeRe.MatchString(user) {
+		return errors.New("host and user must not contain whitespace or shell metacharacters")
+	}
+	return nil
 }
 
 type BackupDestination struct {

--- a/panel-api/internal/models/backup_destination_sftp_test.go
+++ b/panel-api/internal/models/backup_destination_sftp_test.go
@@ -1,0 +1,35 @@
+package models
+
+import "testing"
+
+// ValidateSFTPHostUser is the single boundary rule both the REST and CLI
+// destination validators call (JAB-310): host/user carrying whitespace or shell
+// metacharacters must be rejected before they reach restic's sftp.command.
+func TestValidateSFTPHostUser(t *testing.T) {
+	if err := ValidateSFTPHostUser("backup.example.com", "resticuser"); err != nil {
+		t.Fatalf("a plain host/user must be accepted, got %v", err)
+	}
+
+	bad := []struct {
+		name, host, user string
+	}{
+		{"semicolon host", "h;rm -rf /", "u"},
+		{"pipe user", "h", "u|nc"},
+		{"space host", "bad host", "u"},
+		{"tab host", "h\tx", "u"},
+		{"ampersand host", "a&b", "u"},
+		{"dollar user", "h", "u$IFS"},
+		{"backtick host", "h`id`", "u"},
+		{"redirect user", "h", "u>f"},
+		{"single quote host", "h'", "u"},
+		{"double quote host", "h\"", "u"},
+		{"backslash host", "h\\x", "u"},
+		{"paren user", "h", "u(x)"},
+		{"newline host", "h\nx", "u"},
+	}
+	for _, tc := range bad {
+		if err := ValidateSFTPHostUser(tc.host, tc.user); err == nil {
+			t.Errorf("%s: host=%q user=%q must be rejected", tc.name, tc.host, tc.user)
+		}
+	}
+}


### PR DESCRIPTION
## What

The REST destination handler rejects whitespace + shell metacharacters in an
SFTP host/user (they end up inside restic's `-o sftp.command=...`, which restic
tokenizes on whitespace and executes). The CLI validator (`validateSFTPOpts`,
called by the `jabali backup destination` create/update overlays) mirrored the
REST checks but **omitted this one** — so a CLI-created SFTP destination could
carry a host/user with metacharacters or spaces that split the `sftp.command`
or inject. The ticket flags this parity gap directly.

## Fix

Move the rule to **one owner**: `models.ValidateSFTPHostUser`. Both the REST
handler (`validateSFTPInputs`) and the CLI (`validateSFTPOpts`) call it, so the
boundary check cannot drift between adapters again — which is exactly how the
CLI ended up without it. No behavior change on the REST side (same regex, now
shared); the CLI gains the check.

## Tests

- `models.TestValidateSFTPHostUser` — safe case + every metacharacter and
  whitespace form (`;` `|` space tab `&` `$` backtick `>` quotes `\` parens newline).
- `cmd/server` `TestValidateSFTPOpts_RejectsUnsafeHostUser` — the CLI now rejects
  an injectable host/user and still accepts a plain one.

Full `models` + `internal/api` + `cmd/server` suites and `go vet` green.

## Scope

The cross-adapter unsafe-character parity criterion. The rest of the Backup
Destination Lifecycle module — create-failure credential-file compensation,
structured SFTP option round-trips, and one shared Materialize/Test/RotatePassword
surface — stays on the parent ticket.

GH JAB-310
