### PR TITLE
feat(users): rename a tenant's username in place (GH #1238)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -5417,6 +5417,18 @@ jabali user password <email|username|user-id> [flags]
 - `--password` — explicit new password (omit to auto-generate)
 - `--password-stdin` — read new password from stdin (no prompt, no echo)
 
+#### `jabali user rename`
+
+Rename a tenant's Linux/login username in place (GH #1238)
+
+```
+jabali user rename <email|username|user-id> <new-username> [flags]
+```
+
+**Flags:**
+
+- `--yes` — skip the confirmation prompt
+
 #### `jabali user reprovision`
 
 Re-run OS provisioning for a user + sync the panel password

--- a/panel-agent/internal/commands/user_rename.go
+++ b/panel-agent/internal/commands/user_rename.go
@@ -1,0 +1,149 @@
+// user.rename — rename a tenant's Linux account in place (GH #1238).
+//
+// The uid is the stable anchor: usermod -l keeps it, so NO file re-chown is
+// needed — only the account NAME and the home PATH change. Both homes live under
+// /home, so the `usermod -m` move is always same-filesystem (instant rename(2)).
+//
+// Sequence: quiesce every name-keyed per-user service (FPM pools, nspawn unit,
+// slice), disable linger, kill lingering processes, THEN usermod -l / groupmod -n
+// / usermod -d -m, reap the orphaned crontab (usermod does not move it), and
+// re-provision the slice + FPM drop-ins under the new name. Idempotent: if the new
+// name already exists and the old is gone, it is a no-op success.
+//
+// The panel side (userops.RenameUser) refuses the rename up front when the tenant
+// has isolated FTP jails (bind-mounts under the home) or app installs — those need
+// the mount/credential handling that a later version will add. This verb assumes
+// that gate has passed.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type userRenameParams struct {
+	OldUsername string `json:"old_username"`
+	NewUsername string `json:"new_username"`
+	UID         int    `json:"uid"`
+}
+
+type userRenameResponse struct {
+	OldUsername string `json:"old_username"`
+	NewUsername string `json:"new_username"`
+	UID         int    `json:"uid"`
+	NewHome     string `json:"new_home"`
+	AlreadyDone bool   `json:"already_done"`
+}
+
+// runCombined runs a command through the exec seam and returns trimmed combined
+// output plus the error — for surfacing usermod/groupmod stderr in AgentErrors.
+func runCombined(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := execCommandContext(ctx, name, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func userRenameHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p userRenameParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if !usernameRegex.MatchString(p.OldUsername) || !usernameRegex.MatchString(p.NewUsername) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "old_username and new_username must match ^[a-z_][a-z0-9_-]{0,31}$"}
+	}
+	if p.OldUsername == p.NewUsername {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "old and new username are identical"}
+	}
+	newHome := "/home/" + p.NewUsername
+
+	oldExists := execCommandContext(ctx, "id", p.OldUsername).Run() == nil
+	newExists := execCommandContext(ctx, "id", p.NewUsername).Run() == nil
+
+	// Idempotent: the rename already happened.
+	if newExists && !oldExists {
+		return userRenameResponse{OldUsername: p.OldUsername, NewUsername: p.NewUsername, UID: p.UID, NewHome: newHome, AlreadyDone: true}, nil
+	}
+	if !oldExists {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeNotFound, Message: fmt.Sprintf("user %q not found", p.OldUsername)}
+	}
+	if newExists {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeAlreadyExists, Message: fmt.Sprintf("target user %q already exists", p.NewUsername)}
+	}
+
+	// --- Quiesce every name-keyed per-user service under the OLD name, while the
+	// old name still resolves (slice removal needs the UID resolvable) ---
+	reapUserFPMPools(ctx, p.OldUsername)
+	reapUserNspawnPHPUnit(ctx, p.OldUsername)
+	sliceParams, _ := json.Marshal(map[string]string{"username": p.OldUsername})
+	if _, err := userSliceRemoveHandler(ctx, sliceParams); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("could not remove the old per-user slice before rename: %v", err)}
+	}
+	// Disable linger so no user-manager holds the account; best-effort.
+	if err := execCommandContext(ctx, "loginctl", "disable-linger", p.OldUsername).Run(); err != nil {
+		slog.InfoContext(ctx, "user.rename: loginctl disable-linger failed (best-effort)", "username", p.OldUsername, "err", err)
+	}
+	// Kill any remaining tenant processes so usermod -l is not refused
+	// ("user is currently used by process N"). uid-scoped: only the tenant's own
+	// processes, never the agent or panel. TERM, brief settle, then KILL.
+	if p.UID > 0 {
+		_ = execCommandContext(ctx, "pkill", "-TERM", "-u", strconv.Itoa(p.UID)).Run()
+		time.Sleep(500 * time.Millisecond)
+		_ = execCommandContext(ctx, "pkill", "-KILL", "-u", strconv.Itoa(p.UID)).Run()
+	}
+
+	// --- Rename the account, its primary group, and move the home ---
+	if out, err := runCombined(ctx, "usermod", "-l", p.NewUsername, p.OldUsername); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod -l failed (account still %q; re-run to resume): %v: %s", p.OldUsername, err, out)}
+	}
+	// Debian useradd creates a per-user group named after the user; rename it too
+	// so the group name tracks the account. Best-effort: if no such group exists
+	// (shared-group setups), skip without failing the rename.
+	if execCommandContext(ctx, "getent", "group", p.OldUsername).Run() == nil {
+		if out, err := runCombined(ctx, "groupmod", "-n", p.NewUsername, p.OldUsername); err != nil {
+			slog.WarnContext(ctx, "user.rename: groupmod -n failed (best-effort)", "old", p.OldUsername, "new", p.NewUsername, "err", err, "out", out)
+		}
+	}
+	// Move the home dir. Same filesystem (both under /home) → instant.
+	if out, err := runCombined(ctx, "usermod", "-d", newHome, "-m", p.NewUsername); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod -d -m failed (account renamed to %q but home not moved; re-run to resume): %v: %s", p.NewUsername, err, out)}
+	}
+
+	// usermod does not move the crontab spool file; reap the orphan (cron
+	// reconcile re-applies the jobs under the new name).
+	if err := os.Remove("/var/spool/cron/crontabs/" + p.OldUsername); err != nil && !os.IsNotExist(err) {
+		slog.InfoContext(ctx, "user.rename: could not remove old crontab spool (best-effort)", "username", p.OldUsername, "err", err)
+	}
+
+	// --- Re-provision per-user services under the NEW name ---
+	newSliceParams, _ := json.Marshal(map[string]string{"username": p.NewUsername})
+	if _, err := userSliceEnsureHandler(ctx, newSliceParams); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("account renamed to %q but re-provisioning its slice failed (re-run to resume): %v", p.NewUsername, err)}
+	}
+	if err := execCommandContext(ctx, "loginctl", "enable-linger", p.NewUsername).Run(); err != nil {
+		slog.InfoContext(ctx, "user.rename: loginctl enable-linger failed (best-effort)", "username", p.NewUsername, "err", err)
+	}
+
+	// Confirm the uid is unchanged (the whole design depends on it).
+	uid := p.UID
+	if out, err := execCommandContext(ctx, "id", "-u", p.NewUsername).Output(); err == nil {
+		if got, perr := strconv.Atoi(strings.TrimSpace(string(out))); perr == nil {
+			uid = got
+			if p.UID > 0 && got != p.UID {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("uid changed during rename (%d → %d) — aborting; this must never happen", p.UID, got)}
+			}
+		}
+	}
+
+	return userRenameResponse{OldUsername: p.OldUsername, NewUsername: p.NewUsername, UID: uid, NewHome: newHome}, nil
+}
+
+func init() {
+	Default.Register("user.rename", userRenameHandler)
+}

--- a/panel-agent/internal/commands/user_rename_test.go
+++ b/panel-agent/internal/commands/user_rename_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestUserRename_ValidatesInput covers the input guards that reject before any
+// host mutation (bad/identical names) — the exec-driven happy path is covered by
+// the .86 rename drill under JABALI_ALLOW_HOST_MUTATION.
+func TestUserRename_ValidatesInput(t *testing.T) {
+	cases := []struct {
+		name, oldU, newU string
+	}{
+		{"identical names", "alice", "alice"},
+		{"invalid new (spaces)", "alice", "Bad Name"},
+		{"invalid new (uppercase)", "alice", "Bob"},
+		{"invalid old", "Bad", "bob"},
+		{"empty new", "alice", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(userRenameParams{OldUsername: tc.oldU, NewUsername: tc.newU, UID: 1001})
+			if _, err := userRenameHandler(context.Background(), params); err == nil {
+				t.Errorf("expected a validation error for %q -> %q", tc.oldU, tc.newU)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -554,3 +554,7 @@ func (*fakeDomainRepo) AttachDockerApp(context.Context, string, string, models.N
 func (*fakeDomainRepo) DetachDockerApp(context.Context, string, bool) error {
 	return nil
 }
+
+func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}

--- a/panel-api/cmd/server/kratos_rebuild_cmd_test.go
+++ b/panel-api/cmd/server/kratos_rebuild_cmd_test.go
@@ -370,3 +370,5 @@ func TestRebuildOne_ProbeNotFoundTriggersRebuild(t *testing.T) {
 		t.Errorf("newID = %q, want new-kratos-uuid", newID)
 	}
 }
+
+func (r *fakeRebuildUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/cmd/server/user.go
+++ b/panel-api/cmd/server/user.go
@@ -28,6 +28,7 @@ func newUserCmd() *cobra.Command {
 	cmd.AddCommand(
 		newUserListCmd(),
 		newUserCreateCmd(),
+		newUserRenameCmd(),
 		newUserDeleteCmd(),
 		newUserPasswordCmd(),
 		newUserReprovisionCmd(),

--- a/panel-api/cmd/server/user_rename_cmd.go
+++ b/panel-api/cmd/server/user_rename_cmd.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+// cliRenameDeps wires userops.Deps for `user rename` from the CLI singletons.
+func cliRenameDeps() userops.Deps {
+	var kc *kratosclient.Client
+	if sharedCfg != nil {
+		kc = kratosclient.NewClient(sharedCfg.Auth.Kratos.PublicURL, sharedCfg.Auth.Kratos.AdminURL)
+	}
+	d := userops.Deps{
+		Users:        userRepo(),
+		Domains:      domainRepoFromDB(),
+		KratosClient: kc,
+		Log:          slog.Default(),
+	}
+	if sharedAgent != nil {
+		d.Agent = sharedAgent
+	}
+	return d
+}
+
+func newUserRenameCmd() *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "rename <email|username|user-id> <new-username>",
+		Short: "Rename a tenant's Linux/login username in place (GH #1238)",
+		Long: `Rename a tenant's Linux account (and Kratos login identifier) in place.
+
+The uid is preserved, so file ownership is unchanged; the account name and the
+home directory (/home/<old> -> /home/<new>) move, and every owned domain's docroot
+is repointed and re-rendered.
+
+v1 refuses the rename when the tenant has FTP/SFTP subaccounts or Python apps
+(their jails/app-roots need move handling a later version adds). Their databases
+and DB SSO shadow roles keep the old-username prefix (the panel keys them by id).`,
+		Args:    cobra.ExactArgs(2),
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+			defer cancel()
+
+			target, err := resolveUser(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			newName := args[1]
+			old := ""
+			if target.Username != nil {
+				old = *target.Username
+			}
+
+			if !yes {
+				ok, cerr := confirm(fmt.Sprintf(
+					"Rename user %q -> %q? This renames the Linux account, moves /home/%s -> /home/%s, and re-renders their sites.",
+					old, newName, old, newName))
+				if cerr != nil {
+					return cerr
+				}
+				if !ok {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			rd := userops.RenameDeps{
+				FtpAccounts: repository.NewFtpAccountRepository(sharedDB),
+				PythonApps:  pythonAppRepoFromDB(),
+				// Reconciler is nil: the CLI is a separate process, so the running
+				// panel's periodic reconcile re-renders the owned domains.
+			}
+			if err := userops.RenameUser(ctx, cliRenameDeps(), rd, target, newName); err != nil {
+				cliAuditErr(ctx, "user.rename", "user", target.ID, &target.ID)
+				return err
+			}
+			cliAuditOK(ctx, "user.rename", "user", target.ID, &target.ID)
+			fmt.Printf("Renamed %q -> %q.\nThe reconciler re-renders their sites within ~a minute; verify with a page load or `jabali domain list`.\n", old, newName)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
+	return cmd
+}

--- a/panel-api/internal/api/cron_admin_list_test.go
+++ b/panel-api/internal/api/cron_admin_list_test.go
@@ -182,3 +182,7 @@ func (u *userRepoAdapterForCronAdminTest) SetSuspended(context.Context, string, 
 	return nil
 }
 func (u *userRepoAdapterForCronAdminTest) Delete(context.Context, string) error { return nil }
+
+func (r *userRepoAdapterForCronAdminTest) UpdateUsername(context.Context, string, string) error {
+	return nil
+}

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -800,3 +800,5 @@ type pgUserFake struct {
 func (f *pgUserFake) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
 	return f.users[id], nil
 }
+
+func (r *mockUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -1262,3 +1262,7 @@ func (*mockDomainRepo) AttachDockerApp(context.Context, string, string, models.N
 func (*mockDomainRepo) DetachDockerApp(context.Context, string, bool) error {
 	return nil
 }
+
+func (r *mockDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}

--- a/panel-api/internal/api/docker_apps_user_test.go
+++ b/panel-api/internal/api/docker_apps_user_test.go
@@ -435,3 +435,9 @@ func TestTenantDocker_StopOverQuotaNeverGated(t *testing.T) {
 		t.Fatalf("stop of over-quota app = %d, want 200 — blocking stop would be perverse (%s)", rec.Code, rec.Body.String())
 	}
 }
+
+func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}
+
+func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -849,3 +849,7 @@ func (m *MockSSLCertificateRepository) ResetForRetry(ctx context.Context, id str
 	args := m.Called(ctx, id, now)
 	return args.Error(0)
 }
+
+func (m *MockDomainRepository) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}

--- a/panel-api/internal/api/sso_phpmyadmin_validate_test.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate_test.go
@@ -419,3 +419,5 @@ func TestValidate_OwnerMismatchRefused(t *testing.T) {
 	h, tok := jab8Setup(t, user, db)
 	assert.Equal(t, http.StatusUnauthorized, jab8Run(t, h, tok))
 }
+
+func (m *mockUserRepoValidate) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/api/users_test.go
+++ b/panel-api/internal/api/users_test.go
@@ -1147,3 +1147,5 @@ func TestUsers_Patch_MalformedEmailRejected(t *testing.T) {
 	})
 	assert.Equal(t, http.StatusBadRequest, rec.Code, "malformed non-empty email must 400")
 }
+
+func (r *memUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/auth/testhelpers_test.go
+++ b/panel-api/internal/auth/testhelpers_test.go
@@ -154,3 +154,5 @@ func seedUser(t *testing.T, users *fakeUserRepo, email, password string, admin b
 	require.NoError(t, users.Create(context.Background(), u))
 	return u
 }
+
+func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/middleware/auth_kratos_test.go
+++ b/panel-api/internal/middleware/auth_kratos_test.go
@@ -327,3 +327,5 @@ func TestRequireKratosSession_KratosUnreachable_Returns503(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	assert.Contains(t, rec.Body.String(), "identity_service_unavailable")
 }
+
+func (r *fakeUsersRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
@@ -293,3 +293,7 @@ func TestTTLOrDefault(t *testing.T) {
 		t.Errorf("ttlOrDefault(14400,0) = %d, want 14400 (no default keeps source)", got)
 	}
 }
+
+func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}

--- a/panel-api/internal/migrate/directadmin/restore_forwarders_preserve_test.go
+++ b/panel-api/internal/migrate/directadmin/restore_forwarders_preserve_test.go
@@ -80,3 +80,7 @@ func TestImportForwarders_InertByDefault(t *testing.T) {
 		})
 	}
 }
+
+func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2328,3 +2328,9 @@ func TestReconcileVersionedPHPPools(t *testing.T) {
 	}
 	require.Equal(t, "phpuser-php8.0", rp["slug"], "only the OLD orphan should be reaped, not the fresh one")
 }
+
+func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}
+
+func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -22,6 +22,11 @@ type DomainRepository interface {
 	List(ctx context.Context, opts ListOptions) ([]models.Domain, int64, error)
 	ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.Domain, int64, error)
 	Update(ctx context.Context, d *models.Domain) error
+	// RewriteDocRootPrefix rewrites the leading /home/<old> of every doc_root
+	// owned by userID to /home/<new> when a user is renamed (GH #1238).
+	// Prefix-anchored + user-scoped, so it can never touch another tenant's
+	// paths. Returns the number of rows changed.
+	RewriteDocRootPrefix(ctx context.Context, userID, oldPrefix, newPrefix string) (int64, error)
 	// BulkSetEnabledByUserID flips domains.is_enabled for every row
 	// owned by the user. Returns the count of changed rows. Used by
 	// the admin user-suspend handler so a single API call takes every
@@ -337,6 +342,17 @@ func (r *domainRepo) ListByUserID(ctx context.Context, userID string, opts ListO
 		return nil, 0, err
 	}
 	return domains, total, nil
+}
+
+func (r *domainRepo) RewriteDocRootPrefix(ctx context.Context, userID, oldPrefix, newPrefix string) (int64, error) {
+	// Prefix-anchored (LIKE oldPrefix%) AND user-scoped, so it only ever rewrites
+	// this tenant's own docroots — CONCAT the new prefix onto the tail after the
+	// old prefix. MariaDB SUBSTRING is 1-indexed, so start at len(oldPrefix)+1.
+	res := r.db.WithContext(ctx).
+		Model(&models.Domain{}).
+		Where("user_id = ? AND doc_root LIKE ?", userID, oldPrefix+"%").
+		Update("doc_root", gorm.Expr("CONCAT(?, SUBSTRING(doc_root, ?))", newPrefix, len(oldPrefix)+1))
+	return res.RowsAffected, res.Error
 }
 
 func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {

--- a/panel-api/internal/repository/user_repository.go
+++ b/panel-api/internal/repository/user_repository.go
@@ -37,6 +37,10 @@ type UserRepository interface {
 	// Dedicated method: the Select-allowlist Update would silently drop it, and
 	// a *string lets NULL (auto) be written.
 	UpdateCLIPHPVersion(ctx context.Context, id string, version *string) error
+	// UpdateUsername renames the tenant's login/Linux username (GH #1238).
+	// Dedicated method: the Select-allowlist Update excludes username, so a
+	// full-model Update would silently drop the rename.
+	UpdateUsername(ctx context.Context, id string, username string) error
 	// LinkKratosIdentity writes kratos_identity_id on the row. Deliberately
 	// separate from Update — Update's column allowlist excludes this field so
 	// a profile-edit handler can't accidentally overwrite it, but the M20
@@ -162,6 +166,16 @@ func (r *userRepo) List(ctx context.Context, opts ListOptions) ([]models.User, i
 		return nil, 0, translate(err)
 	}
 	return out, total, nil
+}
+
+// UpdateUsername renames the tenant's username in isolation (GH #1238). Returns
+// a translated duplicate-key error if the new username is already taken (the
+// ux_users_username unique index), so the caller can surface a clean conflict.
+func (r *userRepo) UpdateUsername(ctx context.Context, id string, username string) error {
+	return translate(r.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("id = ?", id).
+		Update("username", username).Error)
 }
 
 func (r *userRepo) UpdateCLIPHPVersion(ctx context.Context, id string, version *string) error {

--- a/panel-api/internal/sso/sso_test.go
+++ b/panel-api/internal/sso/sso_test.go
@@ -188,3 +188,5 @@ func (m *mockTokensForSSO) PurgeExpired(ctx context.Context) (int64, error) {
 func ptrString(s string) *string {
 	return &s
 }
+
+func (r *mockUsersForSSO) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/userops/userops_rename.go
+++ b/panel-api/internal/userops/userops_rename.go
@@ -1,0 +1,125 @@
+package userops
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// renameUsernameRegex mirrors the agent-side validation (POSIX username).
+var renameUsernameRegex = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
+
+// RenameReconciler re-renders a domain's config after its owner's username — and
+// thus its docroot path — changed. Satisfied by *reconciler.Reconciler.
+type RenameReconciler interface {
+	Schedule(domainID string)
+}
+
+// RenameDeps carries the extra repos RenameUser needs for its preflight refusals
+// and post-rename reconcile, beyond the core Deps.
+type RenameDeps struct {
+	FtpAccounts repository.FtpAccountRepository
+	PythonApps  repository.PythonAppRepository
+	Reconciler  RenameReconciler
+}
+
+// RenameUser renames a tenant's Linux/login username in place (GH #1238).
+//
+// uid is the stable anchor, so no file re-chown is needed — the agent's
+// user.rename does usermod -l / -d -m; here the panel repoints the DB (username
+// + every docroot's /home/<old> prefix), re-keys the Kratos login identifier, and
+// reconciles the owned domains so their vhosts re-render under the new path/pool.
+//
+// v1 REFUSES a rename when the tenant has FTP/SFTP subaccounts (their jails are
+// bind-mounted under the home) or Python apps (app-root paths + services) — those
+// need move handling a later version will add. Shadow DB roles and tenant database
+// names deliberately keep their old-username prefix: the panel keys them by
+// user_id, so they keep working; MariaDB has no RENAME DATABASE.
+//
+// Idempotent + abort-with-resume: the OS account is renamed first, then the DB.
+// A failure after the agent step leaves the box ahead of the DB; re-running the
+// command recovers (the agent no-ops, the DB steps retry).
+func RenameUser(ctx context.Context, d Deps, rd RenameDeps, target *models.User, newName string) error {
+	if target == nil {
+		return fmt.Errorf("rename: nil target user")
+	}
+	if target.IsAdmin || target.Username == nil || *target.Username == "" {
+		return fmt.Errorf("rename: only tenant accounts with a Linux username can be renamed")
+	}
+	old := *target.Username
+	if newName == old {
+		return fmt.Errorf("rename: new username is the same as the current one")
+	}
+	if !renameUsernameRegex.MatchString(newName) {
+		return fmt.Errorf("rename: invalid new username %q (must match ^[a-z_][a-z0-9_-]{0,31}$)", newName)
+	}
+	if target.LinuxUID == nil {
+		return fmt.Errorf("rename: %q has no linux_uid yet (account not fully provisioned)", old)
+	}
+	if d.Users == nil || d.Agent == nil {
+		return fmt.Errorf("rename: users repository and agent must be wired")
+	}
+
+	// --- Preflight refusals, BEFORE the agent mutates the box ---
+	if existing, err := d.Users.FindByUsername(ctx, newName); err == nil && existing != nil {
+		return fmt.Errorf("rename: username %q is already taken", newName)
+	}
+	if rd.FtpAccounts != nil {
+		n, err := rd.FtpAccounts.CountByUserID(ctx, target.ID)
+		if err != nil {
+			return fmt.Errorf("rename: checking FTP subaccounts: %w", err)
+		}
+		if n > 0 {
+			return fmt.Errorf("rename: %q has %d FTP/SFTP subaccount(s) — remove them first (v1 does not move their jails)", old, n)
+		}
+	}
+	if rd.PythonApps != nil {
+		apps, err := rd.PythonApps.ListByUser(ctx, target.ID)
+		if err != nil {
+			return fmt.Errorf("rename: checking Python apps: %w", err)
+		}
+		if len(apps) > 0 {
+			return fmt.Errorf("rename: %q has %d Python app(s) — remove them first (v1 does not move their app roots)", old, len(apps))
+		}
+	}
+
+	// --- Rename the OS account on the box ---
+	uid := int(*target.LinuxUID)
+	if _, err := d.Agent.Call(ctx, "user.rename", map[string]any{
+		"old_username": old,
+		"new_username": newName,
+		"uid":          uid,
+	}); err != nil {
+		return fmt.Errorf("rename: agent user.rename failed: %w", err)
+	}
+
+	// --- Repoint the DB (box already renamed past this line) ---
+	if err := d.Users.UpdateUsername(ctx, target.ID, newName); err != nil {
+		return fmt.Errorf("rename: persist new username (box already renamed to %q — re-run to resync the DB): %w", newName, err)
+	}
+	if d.Domains != nil {
+		if _, err := d.Domains.RewriteDocRootPrefix(ctx, target.ID, "/home/"+old, "/home/"+newName); err != nil {
+			return fmt.Errorf("rename: rewrite docroots (re-run to resume): %w", err)
+		}
+	}
+	if d.KratosClient != nil && target.KratosIdentityID != nil && *target.KratosIdentityID != "" {
+		if err := d.KratosClient.UpdateUsernameTrait(ctx, *target.KratosIdentityID, newName); err != nil {
+			logWarn(d, "rename: could not update the Kratos username trait (login identifier may lag until next set)", "user_id", target.ID, "err", err)
+		}
+	}
+
+	// --- Reconcile owned domains so vhosts re-render under the new path/pool ---
+	if rd.Reconciler != nil && d.Domains != nil {
+		if doms, _, err := d.Domains.ListByUserID(ctx, target.ID, repository.ListOptions{Limit: 10000}); err == nil {
+			for i := range doms {
+				rd.Reconciler.Schedule(doms[i].ID)
+			}
+		}
+	}
+
+	target.Username = &newName
+	return nil
+}

--- a/panel-api/internal/userops/userops_rename_test.go
+++ b/panel-api/internal/userops/userops_rename_test.go
@@ -1,0 +1,179 @@
+package userops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- minimal fakes (embed the interface; only the used methods are real) ---
+
+type renameUsers struct {
+	repository.UserRepository
+	existing     map[string]*models.User // by username, for FindByUsername
+	renamedTo    string
+	renameCalled bool
+}
+
+func (f *renameUsers) FindByUsername(_ context.Context, u string) (*models.User, error) {
+	if m, ok := f.existing[u]; ok {
+		return m, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (f *renameUsers) UpdateUsername(_ context.Context, _ string, username string) error {
+	f.renameCalled = true
+	f.renamedTo = username
+	return nil
+}
+
+type renameDomains struct {
+	repository.DomainRepository
+	rewroteFrom, rewroteTo string
+	rewriteCalled          bool
+}
+
+func (f *renameDomains) RewriteDocRootPrefix(_ context.Context, _ string, oldP, newP string) (int64, error) {
+	f.rewriteCalled = true
+	f.rewroteFrom, f.rewroteTo = oldP, newP
+	return 1, nil
+}
+func (f *renameDomains) ListByUserID(_ context.Context, _ string, _ repository.ListOptions) ([]models.Domain, int64, error) {
+	return nil, 0, nil
+}
+
+type renameAgent struct {
+	called     bool
+	lastMethod string
+	lastParams map[string]any
+	returnErr  error
+}
+
+func (a *renameAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.called = true
+	a.lastMethod = method
+	if m, ok := params.(map[string]any); ok {
+		a.lastParams = m
+	}
+	if a.returnErr != nil {
+		return nil, a.returnErr
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type renameFtp struct {
+	repository.FtpAccountRepository
+	count int64
+}
+
+func (f *renameFtp) CountByUserID(_ context.Context, _ string) (int64, error) { return f.count, nil }
+
+type renamePython struct {
+	repository.PythonAppRepository
+	apps []*models.PythonApp
+}
+
+func (f *renamePython) ListByUser(_ context.Context, _ string) ([]*models.PythonApp, error) {
+	return f.apps, nil
+}
+
+func uidptr(u uint32) *uint32 { return &u }
+
+func baseTarget() *models.User {
+	return &models.User{ID: "u1", Username: strptr("alice"), LinuxUID: uidptr(1001)}
+}
+
+func TestRenameUser_HappyPath(t *testing.T) {
+	users := &renameUsers{existing: map[string]*models.User{}}
+	doms := &renameDomains{}
+	ag := &renameAgent{}
+	d := Deps{Users: users, Domains: doms, Agent: ag}
+	rd := RenameDeps{FtpAccounts: &renameFtp{}, PythonApps: &renamePython{}}
+	target := baseTarget()
+
+	if err := RenameUser(context.Background(), d, rd, target, "bob"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if !ag.called || ag.lastMethod != "user.rename" {
+		t.Fatalf("agent user.rename not called; called=%v method=%q", ag.called, ag.lastMethod)
+	}
+	if ag.lastParams["old_username"] != "alice" || ag.lastParams["new_username"] != "bob" {
+		t.Errorf("agent params wrong: %v", ag.lastParams)
+	}
+	if !users.renameCalled || users.renamedTo != "bob" {
+		t.Errorf("UpdateUsername not applied: called=%v to=%q", users.renameCalled, users.renamedTo)
+	}
+	if !doms.rewriteCalled || doms.rewroteFrom != "/home/alice" || doms.rewroteTo != "/home/bob" {
+		t.Errorf("docroot rewrite wrong: called=%v %q->%q", doms.rewriteCalled, doms.rewroteFrom, doms.rewroteTo)
+	}
+	if target.Username == nil || *target.Username != "bob" {
+		t.Errorf("target.Username not updated: %v", target.Username)
+	}
+}
+
+func TestRenameUser_Refusals(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Deps, *RenameDeps, **models.User)
+		want   string // substring
+	}{
+		{"name taken", func(d *Deps, _ *RenameDeps, _ **models.User) {
+			d.Users.(*renameUsers).existing["bob"] = &models.User{ID: "u2"}
+		}, "already taken"},
+		{"has ftp subaccounts", func(_ *Deps, rd *RenameDeps, _ **models.User) {
+			rd.FtpAccounts.(*renameFtp).count = 3
+		}, "FTP/SFTP subaccount"},
+		{"has python apps", func(_ *Deps, rd *RenameDeps, _ **models.User) {
+			rd.PythonApps.(*renamePython).apps = []*models.PythonApp{{}}
+		}, "Python app"},
+		{"admin", func(_ *Deps, _ *RenameDeps, tp **models.User) {
+			(*tp).IsAdmin = true
+		}, "tenant accounts"},
+		{"same name", func(_ *Deps, _ *RenameDeps, tp **models.User) {
+			(*tp).Username = strptr("bob")
+		}, "same as the current"},
+		{"no linux_uid", func(_ *Deps, _ *RenameDeps, tp **models.User) {
+			(*tp).LinuxUID = nil
+		}, "no linux_uid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			users := &renameUsers{existing: map[string]*models.User{}}
+			ag := &renameAgent{}
+			d := Deps{Users: users, Domains: &renameDomains{}, Agent: ag}
+			rd := RenameDeps{FtpAccounts: &renameFtp{}, PythonApps: &renamePython{}}
+			target := baseTarget()
+			tc.mutate(&d, &rd, &target)
+
+			err := RenameUser(context.Background(), d, rd, target, "bob")
+			if err == nil {
+				t.Fatalf("expected refusal, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.want)
+			}
+			if ag.called {
+				t.Errorf("agent must NOT be called on a refused rename (box must stay untouched)")
+			}
+		})
+	}
+}
+
+func TestRenameUser_AgentFailureStopsBeforeDB(t *testing.T) {
+	users := &renameUsers{existing: map[string]*models.User{}}
+	ag := &renameAgent{returnErr: errors.New("usermod boom")}
+	d := Deps{Users: users, Domains: &renameDomains{}, Agent: ag}
+	rd := RenameDeps{FtpAccounts: &renameFtp{}, PythonApps: &renamePython{}}
+
+	if err := RenameUser(context.Background(), d, rd, baseTarget(), "bob"); err == nil {
+		t.Fatal("expected agent failure to propagate")
+	}
+	if users.renameCalled {
+		t.Error("DB username must NOT be updated when the agent rename failed")
+	}
+}


### PR DESCRIPTION
## What (GH #1238, part 1 of 2)

Adds `jabali user rename <user> <new-username>` — a confirm-gated, CLI-first rename of a tenant's Linux account **and** Kratos login identifier, in place.

The uid is the stable anchor, so **no files are re-chowned** — only the account NAME and the home PATH change.

### Sequence
- **agent `user.rename`**: quiesce every name-keyed per-user service (FPM pools, nspawn unit, slice), disable linger, `pkill -u <uid>` the tenant's remaining processes, then `usermod -l` / `groupmod -n` / `usermod -d -m` (same-fs move under `/home`), reap the orphaned crontab spool, and re-provision the slice + FPM drop-ins under the new name. Idempotent (no-op if already renamed); aborts with a resume hint.
- **panel `userops.RenameUser`**: preflight refusals, then repoint the DB — new username (dedicated `UpdateUsername`, since the allowlisted `Update` silently drops it) and every owned docroot's `/home/<old>` prefix (`DomainRepository.RewriteDocRootPrefix`, prefix-anchored + user-scoped) — re-key the Kratos username trait, and let the running reconciler re-render the owned domains under the new path/pool.

### v1 constraints (refused loudly)
- No FTP/SFTP subaccounts (jail bind-mounts) and no Python apps (app-root paths) — those need move handling part 2 / a follow-up adds.
- Tenant databases and DB SSO shadow roles keep their old-username prefix (the panel keys them by `user_id`; MariaDB has no `RENAME DATABASE`).
- Mail is unaffected (Stalwart keys on the address, not the Linux user).

## Tests
- `RenameUser` happy-path + every refusal (taken name, FTP subaccounts, Python apps, admin, same-name, no-uid) + agent-failure-stops-before-DB.
- Agent verb input validation.
- cli-reference golden regenerated. No migrations.

## Live drill on the smoke host (.86) — verified by behavior
Renamed a throwaway tenant with a domain, a home file, and a crontab:
- `id` shows the new name at the **same uid (1501)**; old name gone; group renamed.
- home dir moved with its file intact; old home gone; **crontab reaped**; **slice re-keyed** to the new name (old slice gone).
- `users.username` updated; `domains.doc_root` rewritten `/home/old/...` → `/home/new/...`.
- the running reconciler re-rendered the nginx vhost: `root /home/<new>/...` (site serves from the new home).
- rename to an already-taken name is refused.

GH #1238 (part 1: rename user — domain-owner-change follows in a second PR)
