### PR TITLE
feat(domains): change a domain's owner (GH #1238)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1925,6 +1925,18 @@ Print the current catch-all target
 jabali domain catchall show <domain-name-or-id>
 ```
 
+#### `jabali domain chown`
+
+Reassign a domain to a different owner, moving its docroot (GH #1238)
+
+```
+jabali domain chown <domain> <new-owner> [flags]
+```
+
+**Flags:**
+
+- `--yes` — skip the confirmation prompt
+
 #### `jabali domain create`
 
 Create a new domain (direct DB; bypasses HTTP auth — M20-safe)

--- a/panel-agent/internal/commands/domain_reown.go
+++ b/panel-agent/internal/commands/domain_reown.go
@@ -1,0 +1,122 @@
+// domain.reown — move a domain's served docroot tree from the old owner's home
+// to the new owner's home and re-own it to the new uid (GH #1238 owner-change).
+//
+// Same-filesystem move (both docroots live under /home) so os.Rename is instant
+// and preserves the docroot's setgid bit; chownTreeRecursive then repoints every
+// entry to new_uid:www-data (Lchown-based, symlink-safe — never follows a tenant
+// -planted symlink out of the tree). The uid change is the point here: after the
+// move the old owner owns nothing in the tree and cannot traverse into the new
+// owner's home, so the domain's files are isolated to the new owner.
+//
+// v1 moves the docroot directory itself (the served tree). The panel refuses the
+// owner-change when the domain has an app install (its config would carry the old
+// owner's DB credentials), so this verb assumes that gate has passed.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type domainReownParams struct {
+	OldDocRoot string `json:"old_doc_root"`
+	NewDocRoot string `json:"new_doc_root"`
+	NewUID     int    `json:"new_uid"`
+}
+
+type domainReownResponse struct {
+	NewDocRoot  string `json:"new_doc_root"`
+	AlreadyDone bool   `json:"already_done"`
+}
+
+func domainReownHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p domainReownParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse: %v", err)}
+	}
+	if !strings.HasPrefix(p.OldDocRoot, "/home/") || !strings.HasPrefix(p.NewDocRoot, "/home/") {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "old_doc_root and new_doc_root must be under /home/"}
+	}
+	// Reject traversal / relative segments — the panel builds these by prefix
+	// swap, so a clean absolute path is expected.
+	if filepath.Clean(p.OldDocRoot) != p.OldDocRoot || filepath.Clean(p.NewDocRoot) != p.NewDocRoot {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "doc_root paths must be clean absolute paths"}
+	}
+	if p.NewUID <= 0 {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "new_uid must be a positive uid"}
+	}
+	wwwGID, err := lookupGroup("www-data")
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "lookup www-data: " + err.Error()}
+	}
+
+	_, oldErr := os.Lstat(p.OldDocRoot)
+	_, newErr := os.Lstat(p.NewDocRoot)
+	oldExists := oldErr == nil
+	newExists := newErr == nil
+
+	// Idempotent: already moved.
+	if !oldExists && newExists {
+		return domainReownResponse{NewDocRoot: p.NewDocRoot, AlreadyDone: true}, nil
+	}
+	if !oldExists {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeNotFound, Message: fmt.Sprintf("source docroot %q not found", p.OldDocRoot)}
+	}
+	if newExists {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeAlreadyExists, Message: fmt.Sprintf("target docroot %q already exists", p.NewDocRoot)}
+	}
+
+	// Ensure the destination's parent chain under the new owner's home exists and
+	// is owned new_uid:www-data + setgid (matching a normally-created docroot
+	// wrapper). Re-owning an already-correct dir is a no-op.
+	parent := filepath.Dir(p.NewDocRoot) // /home/<new>/domains/<name>
+	grandparent := filepath.Dir(parent)  // /home/<new>/domains
+	for _, d := range []string{grandparent, parent} {
+		if err := ensureOwnedSetgidDir(d, p.NewUID, wwwGID); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("prepare destination dir %q: %v", d, err)}
+		}
+	}
+
+	// Move (same fs → instant; preserves the docroot's own setgid), then re-own.
+	if err := os.Rename(p.OldDocRoot, p.NewDocRoot); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("move docroot %q -> %q: %v", p.OldDocRoot, p.NewDocRoot, err)}
+	}
+	if err := chownTreeRecursive(p.NewDocRoot, p.NewUID, wwwGID); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("re-own moved tree (docroot moved to %q; re-run to resume): %v", p.NewDocRoot, err)}
+	}
+	// Re-assert setgid 2750 on the docroot itself so new files keep inheriting the
+	// www-data group (rename preserved it, but be explicit).
+	if err := os.Chmod(p.NewDocRoot, os.ModeSetgid|0o750); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("set docroot mode: %v", err)}
+	}
+
+	return domainReownResponse{NewDocRoot: p.NewDocRoot}, nil
+}
+
+// ensureOwnedSetgidDir creates dir (if absent) and sets it to uid:gid + setgid
+// 2750. If it already exists as a directory it is left untouched.
+func ensureOwnedSetgidDir(path string, uid, gid int) error {
+	if fi, err := os.Lstat(path); err == nil {
+		if fi.IsDir() {
+			return nil
+		}
+		return fmt.Errorf("%s exists but is not a directory", path)
+	}
+	if err := os.Mkdir(path, 0o750); err != nil {
+		return err
+	}
+	if err := os.Chown(path, uid, gid); err != nil {
+		return err
+	}
+	return os.Chmod(path, os.ModeSetgid|0o750)
+}
+
+func init() {
+	Default.Register("domain.reown", domainReownHandler)
+}

--- a/panel-agent/internal/commands/domain_reown_test.go
+++ b/panel-agent/internal/commands/domain_reown_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestDomainReown_ValidatesInput covers the guards that reject before any
+// filesystem mutation; the move + re-own path is covered by the .86 drill.
+func TestDomainReown_ValidatesInput(t *testing.T) {
+	cases := []struct {
+		name      string
+		old, newp string
+		uid       int
+	}{
+		{"old not under /home", "/etc/passwd", "/home/bob/d/public_html", 1002},
+		{"new not under /home", "/home/alice/d/public_html", "/tmp/x", 1002},
+		{"traversal in old", "/home/alice/../../etc", "/home/bob/d/public_html", 1002},
+		{"non-positive uid", "/home/alice/d/public_html", "/home/bob/d/public_html", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, _ := json.Marshal(domainReownParams{OldDocRoot: tc.old, NewDocRoot: tc.newp, NewUID: tc.uid})
+			if _, err := domainReownHandler(context.Background(), raw); err == nil {
+				t.Errorf("expected a validation error for old=%q new=%q uid=%d", tc.old, tc.newp, tc.uid)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/domain_chown_cmd.go
+++ b/panel-api/cmd/server/domain_chown_cmd.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+func newDomainChownCmd() *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "chown <domain> <new-owner>",
+		Short: "Reassign a domain to a different owner, moving its docroot (GH #1238)",
+		Long: `Reassign a domain to a different tenant.
+
+The domain row is preserved (its SSL lineage, DNS zone, and mailboxes stay); its
+docroot tree is moved into the new owner's home and re-owned to the new uid, then
+the reconciler re-binds the PHP pool and re-renders the vhost under the new owner.
+
+v1 refuses a domain that has an app install: its config carries the current
+owner's database credentials, so it must be detached/migrated to the new owner
+first (a cross-tenant credential leak otherwise).`,
+		Args:    cobra.ExactArgs(2),
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+			defer cancel()
+
+			dom, err := resolveDomainCLI(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			newOwner, err := resolveUser(ctx, args[1])
+			if err != nil {
+				return err
+			}
+
+			if !yes {
+				ok, cerr := confirm(fmt.Sprintf(
+					"Reassign %q to %q? This moves its docroot into the new owner's home and re-owns the files.",
+					dom.Name, args[1]))
+				if cerr != nil {
+					return cerr
+				}
+				if !ok {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			d := userops.Deps{
+				Users:   userRepo(),
+				Domains: domainRepoFromDB(),
+				Log:     slog.Default(),
+			}
+			if sharedAgent != nil {
+				d.Agent = sharedAgent
+			}
+			cd := userops.ChownDeps{
+				AppInstalls: repository.NewApplicationInstallRepository(sharedDB),
+				// Reconciler nil: the CLI is a separate process; the running panel's
+				// periodic reconcile re-binds the pool + re-renders the vhost.
+			}
+			if err := userops.ChangeDomainOwner(ctx, d, cd, dom, newOwner); err != nil {
+				cliAuditErr(ctx, "domain.chown", "domain", dom.ID, &dom.UserID)
+				return err
+			}
+			cliAuditOK(ctx, "domain.chown", "domain", dom.ID, &newOwner.ID)
+			fmt.Printf("Reassigned %q to %q.\nThe reconciler re-renders it under the new owner within ~a minute.\n", dom.Name, *newOwner.Username)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
+	return cmd
+}

--- a/panel-api/cmd/server/domain_cmd.go
+++ b/panel-api/cmd/server/domain_cmd.go
@@ -31,6 +31,7 @@ func newDomainCmd() *cobra.Command {
 		newDomainEnableCmd(),
 		newDomainDisableCmd(),
 		newDomainDeleteCmd(),
+		newDomainChownCmd(),
 		newDomainPruneOrphansCmd(),
 	)
 	// M6 email-* leaves live in their own file (domain_email_cmd.go).

--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -558,3 +558,4 @@ func (*fakeDomainRepo) DetachDockerApp(context.Context, string, bool) error {
 func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
 	return 0, nil
 }
+func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -1266,3 +1266,4 @@ func (*mockDomainRepo) DetachDockerApp(context.Context, string, bool) error {
 func (r *mockDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
 	return 0, nil
 }
+func (r *mockDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }

--- a/panel-api/internal/api/docker_apps_user_test.go
+++ b/panel-api/internal/api/docker_apps_user_test.go
@@ -440,4 +440,5 @@ func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 	return 0, nil
 }
 
-func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error          { return nil }
+func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -853,3 +853,6 @@ func (m *MockSSLCertificateRepository) ResetForRetry(ctx context.Context, id str
 func (m *MockDomainRepository) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
 	return 0, nil
 }
+func (r *MockDomainRepository) TransferOwner(context.Context, string, string, string) error {
+	return nil
+}

--- a/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
@@ -297,3 +297,4 @@ func TestTTLOrDefault(t *testing.T) {
 func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
 	return 0, nil
 }
+func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }

--- a/panel-api/internal/migrate/directadmin/restore_forwarders_preserve_test.go
+++ b/panel-api/internal/migrate/directadmin/restore_forwarders_preserve_test.go
@@ -84,3 +84,4 @@ func TestImportForwarders_InertByDefault(t *testing.T) {
 func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {
 	return 0, nil
 }
+func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2333,4 +2333,5 @@ func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 	return 0, nil
 }
 
-func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error          { return nil }
+func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -27,6 +27,10 @@ type DomainRepository interface {
 	// Prefix-anchored + user-scoped, so it can never touch another tenant's
 	// paths. Returns the number of rows changed.
 	RewriteDocRootPrefix(ctx context.Context, userID, oldPrefix, newPrefix string) (int64, error)
+	// TransferOwner reassigns a domain to a new owner and repoints its docroot
+	// (GH #1238 owner-change). Dedicated method: the Update allowlist excludes
+	// user_id, so a full-model Update would silently drop the transfer.
+	TransferOwner(ctx context.Context, domainID, newUserID, newDocRoot string) error
 	// BulkSetEnabledByUserID flips domains.is_enabled for every row
 	// owned by the user. Returns the count of changed rows. Used by
 	// the admin user-suspend handler so a single API call takes every
@@ -353,6 +357,13 @@ func (r *domainRepo) RewriteDocRootPrefix(ctx context.Context, userID, oldPrefix
 		Where("user_id = ? AND doc_root LIKE ?", userID, oldPrefix+"%").
 		Update("doc_root", gorm.Expr("CONCAT(?, SUBSTRING(doc_root, ?))", newPrefix, len(oldPrefix)+1))
 	return res.RowsAffected, res.Error
+}
+
+func (r *domainRepo) TransferOwner(ctx context.Context, domainID, newUserID, newDocRoot string) error {
+	return r.db.WithContext(ctx).
+		Model(&models.Domain{}).
+		Where("id = ?", domainID).
+		Updates(map[string]any{"user_id": newUserID, "doc_root": newDocRoot}).Error
 }
 
 func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {

--- a/panel-api/internal/userops/userops_domain_chown.go
+++ b/panel-api/internal/userops/userops_domain_chown.go
@@ -1,0 +1,92 @@
+package userops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ChownReconciler re-renders a domain after its owner — and thus its docroot and
+// PHP pool binding — changed. Satisfied by *reconciler.Reconciler.
+type ChownReconciler interface {
+	Schedule(domainID string)
+}
+
+// ChownDeps carries the extra repos ChangeDomainOwner needs beyond the core Deps.
+type ChownDeps struct {
+	AppInstalls repository.ApplicationInstallRepository
+	Reconciler  ChownReconciler
+}
+
+// ChangeDomainOwner reassigns a domain to a new tenant, moving its docroot into
+// the new owner's home and re-owning the files to the new uid (GH #1238).
+//
+// The domain row is never deleted/recreated — domain_id survives, so tombstones,
+// the SSL lineage, the DNS zone, and mailboxes all stay. Files move first (agent
+// domain.reown), then the DB repoints owner + docroot; the running reconciler
+// re-binds the PHP pool and re-renders the vhost under the new owner.
+//
+// v1 REFUSES a domain that has an app install: its config (e.g. WordPress
+// wp-config) carries the OLD owner's database credentials, so handing the files
+// to the new owner would leak a live cross-tenant credential. Detach or migrate
+// the app + its database to the new owner first.
+func ChangeDomainOwner(ctx context.Context, d Deps, cd ChownDeps, domain *models.Domain, newOwner *models.User) error {
+	if domain == nil || newOwner == nil {
+		return fmt.Errorf("chown: nil domain or new owner")
+	}
+	if newOwner.IsAdmin || newOwner.Username == nil || *newOwner.Username == "" {
+		return fmt.Errorf("chown: the new owner must be a tenant with a Linux username")
+	}
+	if newOwner.LinuxUID == nil {
+		return fmt.Errorf("chown: new owner %q has no linux_uid yet (account not fully provisioned)", *newOwner.Username)
+	}
+	if domain.UserID == newOwner.ID {
+		return fmt.Errorf("chown: %q is already owned by %q", domain.Name, *newOwner.Username)
+	}
+	if d.Users == nil || d.Domains == nil || d.Agent == nil {
+		return fmt.Errorf("chown: users, domains, and agent must be wired")
+	}
+
+	// Refuse when an app install is present (cross-tenant DB-credential leak).
+	if cd.AppInstalls != nil {
+		if inst, err := cd.AppInstalls.FindByDomainID(ctx, domain.ID); err == nil && inst != nil {
+			return fmt.Errorf("chown: %q has an app install (%s) whose config holds the current owner's database credentials — detach or migrate it to the new owner first", domain.Name, inst.AppType)
+		}
+	}
+
+	// Resolve the old owner to derive the /home/<old>/ prefix embedded in the docroot.
+	oldOwner, err := d.Users.FindByID(ctx, domain.UserID)
+	if err != nil || oldOwner == nil || oldOwner.Username == nil || *oldOwner.Username == "" {
+		return fmt.Errorf("chown: could not resolve the current owner of %q: %w", domain.Name, err)
+	}
+	oldPrefix := "/home/" + *oldOwner.Username + "/"
+	newPrefix := "/home/" + *newOwner.Username + "/"
+	if !strings.HasPrefix(domain.DocRoot, oldPrefix) {
+		return fmt.Errorf("chown: docroot %q is not under the current owner's home %q — refusing (needs manual review)", domain.DocRoot, oldPrefix)
+	}
+	newDocRoot := newPrefix + strings.TrimPrefix(domain.DocRoot, oldPrefix)
+
+	// Move + re-own the docroot tree on the box.
+	if _, err := d.Agent.Call(ctx, "domain.reown", map[string]any{
+		"old_doc_root": domain.DocRoot,
+		"new_doc_root": newDocRoot,
+		"new_uid":      int(*newOwner.LinuxUID),
+	}); err != nil {
+		return fmt.Errorf("chown: agent domain.reown failed: %w", err)
+	}
+
+	// Repoint the DB (files already moved past this line).
+	if err := d.Domains.TransferOwner(ctx, domain.ID, newOwner.ID, newDocRoot); err != nil {
+		return fmt.Errorf("chown: persist new owner (files already moved to %q — re-run to resync the DB): %w", newDocRoot, err)
+	}
+
+	if cd.Reconciler != nil {
+		cd.Reconciler.Schedule(domain.ID)
+	}
+	domain.UserID = newOwner.ID
+	domain.DocRoot = newDocRoot
+	return nil
+}

--- a/panel-api/internal/userops/userops_domain_chown_test.go
+++ b/panel-api/internal/userops/userops_domain_chown_test.go
@@ -1,0 +1,141 @@
+package userops
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type chownUsers struct {
+	repository.UserRepository
+	byID map[string]*models.User
+}
+
+func (f *chownUsers) FindByID(_ context.Context, id string) (*models.User, error) {
+	if u, ok := f.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type chownDomains struct {
+	repository.DomainRepository
+	transferredTo, newDocRoot string
+	transferCalled            bool
+}
+
+func (f *chownDomains) TransferOwner(_ context.Context, _ string, newUserID, newDocRoot string) error {
+	f.transferCalled = true
+	f.transferredTo, f.newDocRoot = newUserID, newDocRoot
+	return nil
+}
+
+type chownAgent struct {
+	called     bool
+	lastMethod string
+	lastParams map[string]any
+}
+
+func (a *chownAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.called = true
+	a.lastMethod = method
+	if m, ok := params.(map[string]any); ok {
+		a.lastParams = m
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type chownApps struct {
+	repository.ApplicationInstallRepository
+	install *models.ApplicationInstall
+}
+
+func (f *chownApps) FindByDomainID(_ context.Context, _ string) (*models.ApplicationInstall, error) {
+	if f.install != nil {
+		return f.install, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func cuidptr(u uint32) *uint32 { return &u }
+
+func chownFixture() (Deps, ChownDeps, *models.Domain, *models.User, *chownDomains, *chownAgent) {
+	oldOwner := &models.User{ID: "old", Username: strptr("alice"), LinuxUID: cuidptr(1001)}
+	newOwner := &models.User{ID: "new", Username: strptr("bob"), LinuxUID: cuidptr(1002)}
+	users := &chownUsers{byID: map[string]*models.User{"old": oldOwner, "new": newOwner}}
+	doms := &chownDomains{}
+	ag := &chownAgent{}
+	d := Deps{Users: users, Domains: doms, Agent: ag}
+	cd := ChownDeps{AppInstalls: &chownApps{}}
+	domain := &models.Domain{ID: "d1", Name: "site.example", UserID: "old", DocRoot: "/home/alice/domains/site.example/public_html"}
+	return d, cd, domain, newOwner, doms, ag
+}
+
+func TestChangeDomainOwner_HappyPath(t *testing.T) {
+	d, cd, domain, newOwner, doms, ag := chownFixture()
+
+	if err := ChangeDomainOwner(context.Background(), d, cd, domain, newOwner); err != nil {
+		t.Fatalf("chown: %v", err)
+	}
+	if !ag.called || ag.lastMethod != "domain.reown" {
+		t.Fatalf("agent domain.reown not called; called=%v method=%q", ag.called, ag.lastMethod)
+	}
+	wantNew := "/home/bob/domains/site.example/public_html"
+	if ag.lastParams["old_doc_root"] != "/home/alice/domains/site.example/public_html" || ag.lastParams["new_doc_root"] != wantNew {
+		t.Errorf("agent docroots wrong: %v", ag.lastParams)
+	}
+	if ag.lastParams["new_uid"] != 1002 {
+		t.Errorf("agent new_uid = %v, want 1002", ag.lastParams["new_uid"])
+	}
+	if !doms.transferCalled || doms.transferredTo != "new" || doms.newDocRoot != wantNew {
+		t.Errorf("TransferOwner wrong: called=%v to=%q docroot=%q", doms.transferCalled, doms.transferredTo, doms.newDocRoot)
+	}
+	if domain.UserID != "new" || domain.DocRoot != wantNew {
+		t.Errorf("domain not updated in place: owner=%q docroot=%q", domain.UserID, domain.DocRoot)
+	}
+}
+
+func TestChangeDomainOwner_Refusals(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Deps, *ChownDeps, *models.Domain, *models.User)
+		want   string
+	}{
+		{"app install present", func(_ *Deps, cd *ChownDeps, _ *models.Domain, _ *models.User) {
+			cd.AppInstalls.(*chownApps).install = &models.ApplicationInstall{AppType: "wordpress"}
+		}, "app install"},
+		{"new owner is admin", func(_ *Deps, _ *ChownDeps, _ *models.Domain, no *models.User) {
+			no.IsAdmin = true
+		}, "must be a tenant"},
+		{"already owned", func(_ *Deps, _ *ChownDeps, dom *models.Domain, no *models.User) {
+			dom.UserID = no.ID
+		}, "already owned"},
+		{"docroot not under owner home", func(_ *Deps, _ *ChownDeps, dom *models.Domain, _ *models.User) {
+			dom.DocRoot = "/home/someoneelse/x/public_html"
+		}, "not under the current owner"},
+		{"new owner no uid", func(_ *Deps, _ *ChownDeps, _ *models.Domain, no *models.User) {
+			no.LinuxUID = nil
+		}, "no linux_uid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, cd, domain, newOwner, _, ag := chownFixture()
+			tc.mutate(&d, &cd, domain, newOwner)
+
+			err := ChangeDomainOwner(context.Background(), d, cd, domain, newOwner)
+			if err == nil {
+				t.Fatalf("expected refusal, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.want)
+			}
+			if ag.called {
+				t.Errorf("agent must NOT be called on a refused owner-change (files must stay put)")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What (GH #1238, part 2 of 2)

Adds `jabali domain chown <domain> <new-owner>` — a confirm-gated, CLI-first reassignment of a domain to a different tenant. (Part 1, user rename, is PR #1305.)

The domain row is **never deleted or recreated** — `domain_id` survives, so tombstones, the SSL lineage, the DNS zone, and mailboxes all stay.

### Sequence
- **agent `domain.reown`**: same-filesystem `os.Rename` of the docroot tree into the new owner's home (instant; preserves the docroot's setgid), then `chownTreeRecursive` (Lchown-based, symlink-safe) repoints every entry to `new_uid:www-data`. The uid change is the point — the old owner can no longer traverse into the files. Idempotent; aborts with a resume hint.
- **panel `userops.ChangeDomainOwner`**: preflight refusals, then repoint the DB via a dedicated `DomainRepository.TransferOwner` (the allowlisted `Update` excludes `user_id`); the running reconciler re-binds the PHP pool and re-renders the vhost under the new owner.

### v1 constraint — security (refused loudly)
Refuses a domain that has an **app install**: its config (e.g. WordPress `wp-config`) carries the CURRENT owner's database credentials, so handing the files to the new owner would leak a live cross-tenant credential. Detach or migrate the app + its DB to the new owner first. Also refuses a non-tenant new owner, a docroot not under the current owner's home, and a no-op self-transfer.

## Tests
- `ChangeDomainOwner` happy-path (docroot prefix swap, agent params incl. new_uid, DB transfer, in-place update) + every refusal.
- `domain.reown` input validation.
- cli-reference golden regenerated. No migrations.

## Live drill on the smoke host (.86) — verified by behavior
Created a domain under owner A with a marker file, then `domain chown ... B`:
- file content moved **intact** to `/home/B/domains/.../public_html`; **re-owned to B's uid (1502)**; docroot **setgid + www-data group preserved**; old path **gone** (moved, not copied — isolation).
- `domains.user_id` → B, `doc_root` → `/home/B/...`.
- the running reconciler re-rendered the nginx vhost: `root /home/B/...` (serves under the new owner).

GH #1238 (part 2: change domain owner)
