### PR TITLE
perf(reconciler): skip unchanged domain.create dispatches with a per-domain cache (JAB-369)

### DIFF
--- a/panel-api/internal/reconciler/domain_dispatch_gate.go
+++ b/panel-api/internal/reconciler/domain_dispatch_gate.go
@@ -1,0 +1,78 @@
+package reconciler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+)
+
+// domainDispatchState is what each domain's domainDispatchCache entry holds.
+// Hash covers the fully-assembled domain.create wire payload — everything the
+// agent renders the vhost from. At is when we last dispatched.
+type domainDispatchState struct {
+	Hash string
+	At   time.Time
+}
+
+// domainReDispatchInterval forces a domain.create even when the payload hash
+// matches, so out-of-band drift (an operator hand-editing the vhost, a partial
+// apply, an agent binary whose template changed without a panel restart) is
+// still corrected on a bounded schedule. Same self-healing contract as
+// dnsZoneReDispatchInterval / sshKeysReDispatchInterval / ftpAccountsReDispatchInterval.
+const domainReDispatchInterval = 15 * time.Minute
+
+// desiredDomainDispatchHash hashes the fully-assembled domain.create params so
+// an unchanged domain skips the per-tick agent round-trip (the agent's own
+// content compare already no-ops an unchanged vhost; this stops the panel
+// asserting it ~60 times an hour per domain — JAB-369). params is exactly what
+// the agent receives as JSON, so hashing its JSON encoding hashes what the agent
+// acts on; json.Marshal sorts map keys, so the encoding is stable for a given
+// payload. On a marshal error it returns "" and the caller never skips.
+func desiredDomainDispatchHash(params map[string]any) string {
+	b, err := json.Marshal(params)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// domainDispatchNeeded reports whether domain.create should run this tick. True
+// when the payload changed, when this PROCESS has not dispatched the domain yet,
+// or when the self-heal interval elapsed.
+//
+// The cache is process-local (sync.Map on the Reconciler) by design: after a
+// panel restart the cache is empty, so every domain is re-dispatched and the
+// host re-converged; and a promoted DR standby can never inherit a stale
+// "already applied on this host" decision from replicated database state,
+// because that decision lives only in the previous primary's memory. An empty
+// hash (marshal failure) always dispatches.
+func (r *Reconciler) domainDispatchNeeded(domainID, hash string, now time.Time) bool {
+	if hash == "" {
+		return true
+	}
+	v, ok := r.domainDispatchCache.Load(domainID)
+	if !ok {
+		return true
+	}
+	st, okT := v.(domainDispatchState)
+	if !okT {
+		return true
+	}
+	if st.Hash != hash {
+		return true
+	}
+	return now.Sub(st.At) >= domainReDispatchInterval
+}
+
+// domainDispatched records a SUCCESSFUL dispatch so the next tick can
+// short-circuit. A failed domain.create is never recorded — the domain stays
+// "dirty" and retries next tick, never stamped as applied. An empty hash is not
+// recorded (the caller then never short-circuits on it).
+func (r *Reconciler) domainDispatched(domainID, hash string, now time.Time) {
+	if hash == "" {
+		return
+	}
+	r.domainDispatchCache.Store(domainID, domainDispatchState{Hash: hash, At: now})
+}

--- a/panel-api/internal/reconciler/domain_dispatch_gate_test.go
+++ b/panel-api/internal/reconciler/domain_dispatch_gate_test.go
@@ -1,0 +1,132 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func countDomainCreate(ag *fakeAgent) int {
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	n := 0
+	for _, c := range ag.calls {
+		if c.method == "domain.create" {
+			n++
+		}
+	}
+	return n
+}
+
+// The headline JAB-369 win: an unchanged domain on a second periodic tick makes
+// no domain.create agent call, while force paths always re-dispatch.
+func TestCreateDomainOnAgent_UnchangedSecondTickSkips(t *testing.T) {
+	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
+
+	// First periodic tick (force=false) — dispatches.
+	r.createDomainOnAgent(context.Background(), dom, false)
+	if got := countDomainCreate(ag); got != 1 {
+		t.Fatalf("first tick must dispatch domain.create once, got %d", got)
+	}
+
+	// Second periodic tick, nothing changed — must skip the agent call.
+	r.createDomainOnAgent(context.Background(), dom, false)
+	if got := countDomainCreate(ag); got != 1 {
+		t.Fatalf("unchanged second tick must NOT re-dispatch domain.create, got %d", got)
+	}
+
+	// A force run re-dispatches even when unchanged.
+	r.createDomainOnAgent(context.Background(), dom, true)
+	if got := countDomainCreate(ag); got != 2 {
+		t.Fatalf("force must re-dispatch domain.create, got %d", got)
+	}
+
+	// After the force dispatch stamped the cache, the next unchanged periodic
+	// tick skips again.
+	r.createDomainOnAgent(context.Background(), dom, false)
+	if got := countDomainCreate(ag); got != 2 {
+		t.Fatalf("unchanged tick after a force must skip again, got %d", got)
+	}
+}
+
+// A failed dispatch is never stamped: the next tick re-attempts.
+func TestCreateDomainOnAgent_FailedDispatchRetries(t *testing.T) {
+	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
+	ag.failMethod = "domain.create"
+
+	r.createDomainOnAgent(context.Background(), dom, false)
+	r.createDomainOnAgent(context.Background(), dom, false)
+	if got := countDomainCreate(ag); got != 2 {
+		t.Fatalf("a failed dispatch must stay dirty and retry next tick (expected 2 attempts), got %d", got)
+	}
+}
+
+func TestDesiredDomainDispatchHash_StableAndSensitive(t *testing.T) {
+	a := map[string]any{"domain_id": "d1", "serve_https": true, "custom_directives": "x"}
+	// Same content, different key insertion order — json.Marshal sorts keys, so
+	// the hash must be identical.
+	b := map[string]any{"custom_directives": "x", "serve_https": true, "domain_id": "d1"}
+	if desiredDomainDispatchHash(a) != desiredDomainDispatchHash(b) {
+		t.Fatal("hash must be independent of map key order")
+	}
+	// Any field change flips the hash.
+	c := map[string]any{"domain_id": "d1", "serve_https": false, "custom_directives": "x"}
+	if desiredDomainDispatchHash(a) == desiredDomainDispatchHash(c) {
+		t.Fatal("a changed field must change the hash")
+	}
+	if desiredDomainDispatchHash(a) == "" {
+		t.Fatal("a marshalable payload must hash non-empty")
+	}
+}
+
+func TestDomainDispatchNeeded(t *testing.T) {
+	r := &Reconciler{}
+	now := time.Now()
+	const hash = "abc"
+
+	// Never dispatched → needed.
+	if !r.domainDispatchNeeded("d1", hash, now) {
+		t.Fatal("an un-dispatched domain must be needed")
+	}
+
+	// Record a dispatch; an unchanged payload within the interval is NOT needed.
+	r.domainDispatched("d1", hash, now)
+	if r.domainDispatchNeeded("d1", hash, now.Add(time.Minute)) {
+		t.Fatal("an unchanged, recently-dispatched domain must be skipped")
+	}
+
+	// A changed payload is needed even within the interval.
+	if !r.domainDispatchNeeded("d1", "def", now.Add(time.Minute)) {
+		t.Fatal("a changed payload must be needed")
+	}
+
+	// The self-heal interval forces a re-dispatch of unchanged content.
+	if !r.domainDispatchNeeded("d1", hash, now.Add(domainReDispatchInterval+time.Second)) {
+		t.Fatal("past the re-dispatch interval an unchanged domain must be re-dispatched (drift repair)")
+	}
+
+	// An empty hash (marshal failure) always dispatches and is never stamped.
+	if !r.domainDispatchNeeded("d2", "", now) {
+		t.Fatal("an empty hash must always dispatch")
+	}
+	r.domainDispatched("d2", "", now)
+	if _, ok := r.domainDispatchCache.Load("d2"); ok {
+		t.Fatal("an empty hash must not be recorded")
+	}
+}
+
+// A failed dispatch must never be stamped: the domain stays dirty and the next
+// tick still treats it as needed.
+func TestDomainDispatch_FailedNotStamped(t *testing.T) {
+	r := &Reconciler{}
+	now := time.Now()
+	// Simulate the createDomainOnAgent failure path: hash computed, but
+	// domainDispatched is NOT called. Needed must remain true.
+	if !r.domainDispatchNeeded("d1", "h", now) {
+		t.Fatal("precondition")
+	}
+	// (no domainDispatched call)
+	if !r.domainDispatchNeeded("d1", "h", now.Add(time.Second)) {
+		t.Fatal("a domain whose dispatch failed (never stamped) must stay needed")
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -272,6 +272,15 @@ type Reconciler struct {
 	// every pass, the payload could never converge, so no downstream gate
 	// could ever fire. Keyed by zone ID; value type dnsZoneDispatchState.
 	dnsZoneDispatchCache sync.Map
+
+	// domainDispatchCache: per-domain hash of the last-dispatched domain.create
+	// wire payload + timestamp, same shape and rationale as the caches above
+	// (JAB-369). Without it the reconciler re-sent domain.create for EVERY
+	// enabled domain every ~60s tick — a full per-domain params assembly plus an
+	// agent round-trip (nginx -t + content compare) that no-ops when nothing
+	// changed. Keyed by domain ID; value type domainDispatchState. Process-local
+	// so a restart or DR-standby promotion re-dispatches everything.
+	domainDispatchCache sync.Map
 }
 
 // WithPanelCertificate injects the M32 panel-cert repo + routability
@@ -956,7 +965,7 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 		if agentSites[name] {
 			r.log.Info("reconcile: disabling unwanted domain", "domain", name)
 			r.reconcileDNSZone(ctx, domain)
-			r.createDomainOnAgent(ctx, domain)
+			r.createDomainOnAgent(ctx, domain, false)
 		}
 	}
 
@@ -1137,7 +1146,7 @@ func (r *Reconciler) ReconcileOne(ctx context.Context, domainID string) error {
 	// The agent handles both enabled and disabled via the is_enabled parameter.
 	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	r.createDomainOnAgent(agentCtx, domain)
+	r.createDomainOnAgent(agentCtx, domain, true) // ReconcileOne: event-driven, always dispatch
 
 	return nil
 }
@@ -1169,7 +1178,7 @@ func (r *Reconciler) ReconcileAllForce(ctx context.Context) error {
 		sslCancel()
 
 		agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		r.createDomainOnAgent(agentCtx, d)
+		r.createDomainOnAgent(agentCtx, d, true) // Force run: always dispatch
 		cancel()
 	}
 
@@ -1627,7 +1636,9 @@ func (r *Reconciler) regenerateNginxForPool(ctx context.Context, pool *models.PH
 	for i := range allDomains {
 		domain := &allDomains[i]
 		if domain.PHPPoolID != nil && *domain.PHPPoolID == pool.ID {
-			r.createDomainOnAgent(ctx, domain)
+			// force: the pool config changed, which is out-of-band to the
+			// per-domain payload hash — the cache would otherwise skip it.
+			r.createDomainOnAgent(ctx, domain, true)
 		}
 	}
 }
@@ -1701,7 +1712,13 @@ func (r *Reconciler) effectiveInterceptErrors(ctx context.Context, domain *model
 	return false
 }
 
-func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Domain) {
+// createDomainOnAgent assembles and dispatches domain.create for a domain.
+// When force is false (the periodic tick) an unchanged, recently-dispatched
+// domain is skipped via the process-local domainDispatchCache (JAB-369); force
+// is true for the event-driven ReconcileOne, ReconcileAllForce, and the
+// pool-regeneration pass, which must re-dispatch regardless of the cache
+// (a pool config change is out-of-band to the per-domain payload hash).
+func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Domain, force bool) {
 	user, err := r.users.FindByID(ctx, domain.UserID)
 	if err != nil {
 		r.log.Error("failed to fetch user for domain", "domain_id", domain.ID, "user_id", domain.UserID, "err", err)
@@ -1999,16 +2016,28 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 		params[k] = v
 	}
 
+	// JAB-369: skip the agent round-trip when the fully-assembled payload is
+	// byte-identical to the last successful dispatch for this domain AND we're
+	// within the drift-repair interval. force paths (ReconcileOne / Force /
+	// pool-regen) always dispatch. params is exactly what the agent receives.
+	hash := desiredDomainDispatchHash(params)
+	if !force && !r.domainDispatchNeeded(domain.ID, hash, time.Now()) {
+		return
+	}
+
 	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	_, err = r.agent.Call(callCtx, "domain.create", params)
-	if err != nil {
+	if _, err = r.agent.Call(callCtx, "domain.create", params); err != nil {
+		// Left unstamped so the domain stays dirty and retries next tick — a
+		// failed apply is never recorded as applied.
 		r.log.Error("domain create failed on agent",
 			"domain_id", domain.ID,
 			"domain", domain.Name,
 			"err", err)
+		return
 	}
+	r.domainDispatched(domain.ID, hash, time.Now())
 }
 
 // redirectHTTPSForCert decides whether the agent should render the :80→:443
@@ -3563,7 +3592,7 @@ func (r *Reconciler) reconcileEnabledDomain(ctx context.Context, name string, do
 	// code shipped (or whose insert failed mid-flight). No-op when
 	// the rows already exist; safe on every tick.
 	r.ensureTenantDKIMRecords(ctx, domain)
-	r.createDomainOnAgent(ctx, domain)
+	r.createDomainOnAgent(ctx, domain, false)
 	// M6.3: ensure the recursor has a forwarder for this zone so
 	// local resolution hits pdns-server on loopback :5300. Idempotent.
 	r.reconcileRecursorForward(ctx, name)

--- a/panel-api/internal/reconciler/ssl_fronted_vhost_test.go
+++ b/panel-api/internal/reconciler/ssl_fronted_vhost_test.go
@@ -80,7 +80,7 @@ func vhostHTTPSParams(t *testing.T, ag *fakeAgent) (redirect, serve bool) {
 func TestFrontedVhost_SelfSignedServes443NoRedirect(t *testing.T) {
 	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
 
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 
 	redirect, serve := vhostHTTPSParams(t, ag)
 	if !serve {
@@ -95,7 +95,7 @@ func TestFrontedVhost_IssuedServes443NoRedirect(t *testing.T) {
 	r, ag, dom, sc := frontedVhostFixture(t, letsEncryptCertPath, letsEncryptKeyPath, cfEdgeAddrs, true)
 	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
 
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 
 	redirect, serve := vhostHTTPSParams(t, ag)
 	if !serve || redirect {
@@ -106,7 +106,7 @@ func TestFrontedVhost_IssuedServes443NoRedirect(t *testing.T) {
 func TestDirectVhost_SelfSignedBootstrapStaysHTTPOnly(t *testing.T) {
 	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, []string{frontedTestOwnIP}, true)
 
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 
 	redirect, serve := vhostHTTPSParams(t, ag)
 	if redirect || serve {
@@ -118,7 +118,7 @@ func TestDirectVhost_IssuedRedirectsAndServes(t *testing.T) {
 	r, ag, dom, sc := frontedVhostFixture(t, letsEncryptCertPath, letsEncryptKeyPath, []string{frontedTestOwnIP}, true)
 	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
 
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 
 	redirect, serve := vhostHTTPSParams(t, ag)
 	if !redirect || !serve {
@@ -138,7 +138,7 @@ func TestDirectVhost_SelfSignedToLETransitionReRenders(t *testing.T) {
 	r, ag, dom, sc := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, []string{frontedTestOwnIP}, true)
 
 	// Tick 1: still on the self-signed bootstrap placeholder.
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 	if redirect, serve := vhostHTTPSParams(t, ag); redirect || serve {
 		t.Fatalf("pre-transition: (redirect=%v, serve=%v), want (false, false)", redirect, serve)
 	}
@@ -154,7 +154,7 @@ func TestDirectVhost_SelfSignedToLETransitionReRenders(t *testing.T) {
 	ag.mu.Unlock()
 
 	// Tick 2: the very next dispatch must reflect the trusted cert.
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 	if redirect, serve := vhostHTTPSParams(t, ag); !redirect || !serve {
 		t.Fatalf("post-transition: (redirect=%v, serve=%v), want (true, true) — the :80 shape must update the tick a real cert lands", redirect, serve)
 	}
@@ -164,7 +164,7 @@ func TestFrontedVhost_InconclusiveLookupKeepsCachedValue(t *testing.T) {
 	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
 
 	// First render: definitive fronted answer, cached.
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 	// Expire the entry, then blind the resolvers.
 	r.frontedMu.Lock()
 	e := r.frontedCache[dom.Name]
@@ -176,7 +176,7 @@ func TestFrontedVhost_InconclusiveLookupKeepsCachedValue(t *testing.T) {
 	ag.mu.Lock()
 	ag.calls = nil
 	ag.mu.Unlock()
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 
 	redirect, serve := vhostHTTPSParams(t, ag)
 	if !serve || redirect {
@@ -191,7 +191,7 @@ func TestFrontedVhost_DNS01IssueMethodImpliesFronted(t *testing.T) {
 	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
 	sc.byDomain[dom.ID].IssueMethod = issueMethodDNS01
 
-	r.createDomainOnAgent(context.Background(), dom)
+	r.createDomainOnAgent(context.Background(), dom, true)
 
 	redirect, serve := vhostHTTPSParams(t, ag)
 	if !serve || redirect {


### PR DESCRIPTION
## What

The reconciler re-sent `domain.create` for **every enabled domain on every ~60s
tick** — a full per-domain params assembly plus an agent round-trip (`nginx -t`
+ content compare) that no-ops when nothing changed. The DNS, SSH-key, and FTP
passes already gate their dispatches behind a process-local desired-hash cache;
the domain pass was the one major resource still asserting itself sixty times an
hour per domain.

## Fix

`domainDispatchCache` (`sync.Map` on the Reconciler), mirroring the existing
DNS/SSH/FTP gates exactly: hash the fully-assembled `domain.create` payload —
which is precisely what the agent receives as JSON, so `json.Marshal`'s
sorted-key encoding is a faithful, stable fingerprint — and skip the dispatch
when it matches the last successful one **and** we are within a 15-minute
drift-repair interval.

`createDomainOnAgent` takes a `force` flag:
- periodic enabled/disabled loops → `false` (the win),
- event-driven `ReconcileOne`, the `Force` run, and the **pool-regeneration**
  pass → `true` (a pool config change is out-of-band to the per-domain payload
  hash and must re-dispatch regardless).

**DR-safe by construction:** the cache is process-local, so a panel restart or a
promoted DR standby starts empty and re-dispatches every domain — a promoted
standby can never inherit a stale "already applied on this host" decision from
replicated DB state. A **failed** dispatch is never stamped, so it stays dirty
and retries next tick.

## Tests

- hash is order-independent + change-sensitive;
- the gate returns *needed* for un-dispatched / changed / past-interval, and
  *skips* for unchanged-within-interval; empty-hash (marshal failure) always
  dispatches and is never recorded;
- behavioral: `createDomainOnAgent` twice → the unchanged second tick makes **no**
  `domain.create` call, `force` re-dispatches, and a failed dispatch retries.

Full reconciler suite green. **Box-verified** on the smoke host: deployed, ran
multiple ticks with no `domain.create` errors, existing domains still serve their
real certs (openssl), baseline restored.

## Scope

The highest-frequency dispatch of the Reconciliation Planner ticket. The full
typed-planner Module (`ResourceKey`, coalescing `Schedule`, phase dependency
graph, Normal/Audit/Force run modes, per-phase fingerprints) stays on the parent.

GH JAB-369
