### PR TITLE
fix(malware): CLI scans create a tracking row via the shared Scan Lifecycle Start (JAB-320)

### DIFF
--- a/panel-api/cmd/server/malware_cmd.go
+++ b/panel-api/cmd/server/malware_cmd.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -57,11 +58,21 @@ func newMalwareScanCmd() *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 			defer cancel()
-			err := csCall(ctx, verb, params)
-			if err == nil {
-				cliAuditOK(ctx, "malware.scan", "malware_scan", path+user, nil)
+			raw, err := sharedAgent.Call(ctx, verb, params)
+			if err != nil {
+				return err
 			}
-			return err
+			os.Stdout.Write(raw)
+			os.Stdout.Write([]byte{'\n'})
+			cliAuditOK(ctx, "malware.scan", "malware_scan", path+user, nil)
+			// JAB-320: persist the per-user scan tracking row through the same
+			// shared Malware Scan Lifecycle Start the REST handler uses, so a
+			// CLI-started scan is visible in the panel's scan history (it was
+			// previously untracked). Best-effort — the scan already ran + audited.
+			if _, rerr := api.RecordMalwareScanStart(ctx, repository.NewMalwareUserScanRepository(sharedDB), repository.NewUserRepository(sharedDB), raw, path, user); rerr != nil {
+				fmt.Fprintf(os.Stderr, "warning: scan started but tracking row not recorded: %v\n", rerr)
+			}
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&path, "path", "", "absolute path to scan")

--- a/panel-api/internal/api/malware_scan_op.go
+++ b/panel-api/internal/api/malware_scan_op.go
@@ -1,0 +1,58 @@
+// malware_scan_op.go — the shared "Start" of the Malware Scan Lifecycle
+// (JAB-320). Both the REST handler (startScan) and the `jabali malware scan`
+// CLI persist the per-user scan tracking row through RecordMalwareScanStart, so
+// a scan started from EITHER surface is visible in the panel's scan history —
+// the CLI previously called the agent and only audited, leaving CLI-started
+// scans untracked.
+package api
+
+import (
+	"context"
+	"encoding/json"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// RecordMalwareScanStart decodes a security.malware.scan_* agent reply and, when
+// it carries a session_id and resolves to a hosting user, writes the tracking
+// row (mig 000097).
+//
+// Best-effort by design and identical to the REST handler's prior inline logic:
+// a missing/malformed session_id, or a path that is not under a user's /home,
+// leaves no row — the scan is still running, it just won't appear in the
+// per-user history until the next resolvable scan. It never fails the caller.
+// A malformed/absent session_id therefore cannot masquerade as a recorded
+// (successful) scan: no row is written. Returns the recorded session_id (or "")
+// and any repository error (which the caller logs but does not surface as a
+// scan failure — the scan already started).
+func RecordMalwareScanStart(ctx context.Context, scans repository.MalwareUserScanRepository, users repository.UserRepository, rawReply []byte, path, user string) (sessionID string, err error) {
+	if scans == nil {
+		return "", nil
+	}
+	var startResp struct {
+		SessionID string `json:"session_id"`
+	}
+	if jerr := json.Unmarshal(rawReply, &startResp); jerr != nil || startResp.SessionID == "" {
+		return "", nil
+	}
+
+	username := user
+	targetPath := path
+	if username != "" {
+		targetPath = "/home/" + username
+	} else {
+		username = userFromPath(path)
+	}
+	if username == "" {
+		return startResp.SessionID, nil
+	}
+
+	var userID *string
+	if users != nil {
+		if u, lerr := users.FindByUsername(ctx, username); lerr == nil && u != nil {
+			id := u.ID
+			userID = &id
+		}
+	}
+	return startResp.SessionID, scans.StartScan(ctx, username, startResp.SessionID, targetPath, userID)
+}

--- a/panel-api/internal/api/malware_scan_op_test.go
+++ b/panel-api/internal/api/malware_scan_op_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type scanRow struct {
+	username, sessionID, targetPath string
+	userID                          *string
+}
+
+type fakeUserScans struct {
+	repository.MalwareUserScanRepository
+	calls []scanRow
+}
+
+func (f *fakeUserScans) StartScan(_ context.Context, username, sessionID, targetPath string, userID *string) error {
+	f.calls = append(f.calls, scanRow{username, sessionID, targetPath, userID})
+	return nil
+}
+
+type fakeScanUsers struct {
+	repository.UserRepository
+	byName map[string]*models.User
+}
+
+func (f fakeScanUsers) FindByUsername(_ context.Context, n string) (*models.User, error) {
+	if u, ok := f.byName[n]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func scanUsers() fakeScanUsers {
+	return fakeScanUsers{byName: map[string]*models.User{"alice": {ID: "u1"}, "bob": {ID: "u2"}}}
+}
+
+// A --user scan with a valid session writes a tracking row scoped to that user's
+// home, with the resolved user_id — the criterion "every accepted CLI scan has a
+// tracking row".
+func TestRecordMalwareScanStart_UserScanCreatesRow(t *testing.T) {
+	scans := &fakeUserScans{}
+	sid, err := RecordMalwareScanStart(context.Background(), scans, scanUsers(),
+		[]byte(`{"session_id":"s1"}`), "", "alice")
+	if err != nil || sid != "s1" {
+		t.Fatalf("sid=%q err=%v", sid, err)
+	}
+	if len(scans.calls) != 1 {
+		t.Fatalf("expected one tracking row, got %d", len(scans.calls))
+	}
+	r := scans.calls[0]
+	if r.username != "alice" || r.sessionID != "s1" || r.targetPath != "/home/alice" || r.userID == nil || *r.userID != "u1" {
+		t.Fatalf("row wrong: %+v (userID=%v)", r, r.userID)
+	}
+}
+
+// A --path scan under a home resolves the owning user and still records a row.
+func TestRecordMalwareScanStart_PathResolvesUser(t *testing.T) {
+	scans := &fakeUserScans{}
+	sid, err := RecordMalwareScanStart(context.Background(), scans, scanUsers(),
+		[]byte(`{"session_id":"s2"}`), "/home/bob/public_html", "")
+	if err != nil || sid != "s2" {
+		t.Fatalf("sid=%q err=%v", sid, err)
+	}
+	if len(scans.calls) != 1 || scans.calls[0].username != "bob" || scans.calls[0].targetPath != "/home/bob/public_html" {
+		t.Fatalf("path scan row wrong: %+v", scans.calls)
+	}
+}
+
+// A missing or malformed session id cannot masquerade as a recorded scan: no row
+// is written (the criterion "malformed/missing Agent session IDs cannot produce
+// success").
+func TestRecordMalwareScanStart_NoSessionID_NoRow(t *testing.T) {
+	for _, reply := range [][]byte{[]byte(`{"session_id":""}`), []byte(`{}`), []byte(`not json`), nil} {
+		scans := &fakeUserScans{}
+		sid, err := RecordMalwareScanStart(context.Background(), scans, scanUsers(), reply, "", "alice")
+		if err != nil {
+			t.Fatalf("reply %q: unexpected err %v", reply, err)
+		}
+		if sid != "" || len(scans.calls) != 0 {
+			t.Fatalf("reply %q: must write no row (sid=%q calls=%d)", reply, sid, len(scans.calls))
+		}
+	}
+}
+
+// A path not under any user's home records no per-user row (parity with the REST
+// handler) but still surfaces the session id.
+func TestRecordMalwareScanStart_PathNotUnderHome_NoRow(t *testing.T) {
+	scans := &fakeUserScans{}
+	sid, err := RecordMalwareScanStart(context.Background(), scans, scanUsers(),
+		[]byte(`{"session_id":"s3"}`), "/tmp/elsewhere", "")
+	if err != nil || sid != "s3" {
+		t.Fatalf("sid=%q err=%v", sid, err)
+	}
+	if len(scans.calls) != 0 {
+		t.Fatalf("a non-home path must not create a per-user row, got %+v", scans.calls)
+	}
+}
+
+func TestRecordMalwareScanStart_NilScans_NoOp(t *testing.T) {
+	if sid, err := RecordMalwareScanStart(context.Background(), nil, scanUsers(),
+		[]byte(`{"session_id":"s1"}`), "", "alice"); sid != "" || err != nil {
+		t.Fatalf("nil scans repo must be a no-op, got sid=%q err=%v", sid, err)
+	}
+}

--- a/panel-api/internal/api/security_malware.go
+++ b/panel-api/internal/api/security_malware.go
@@ -327,39 +327,16 @@ func (h *securityMalwareHandler) startScan(c *gin.Context) {
 	if h.cfg.Log != nil {
 		h.cfg.Log.Info("malware: scan agent ok", "raw_len", len(raw), "raw_head", string(raw[:min(120, len(raw))]))
 	}
-	// Track per-user scan job (mig 000097). Decode the agent reply to
-	// recover the session_id; on parse failure we still return 202 since
-	// the scan IS running — the table just won't show this row until the
-	// next manual scan.
-	if h.cfg.UserScans != nil {
-		var startResp struct {
-			SessionID string `json:"session_id"`
-		}
-		if jerr := json.Unmarshal(raw, &startResp); jerr == nil && startResp.SessionID != "" {
-			username := body.User
-			targetPath := body.Path
-			if username != "" {
-				targetPath = "/home/" + username
-			} else {
-				username = userFromPath(body.Path)
-			}
-			if username != "" {
-				var userID *string
-				if h.cfg.Users != nil {
-					if u, lerr := h.cfg.Users.FindByUsername(c.Request.Context(), username); lerr == nil && u != nil {
-						id := u.ID
-						userID = &id
-					}
-				}
-				uerr := h.cfg.UserScans.StartScan(c.Request.Context(), username, startResp.SessionID, targetPath, userID)
-				if h.cfg.Log != nil {
-					if uerr != nil {
-						h.cfg.Log.Warn("malware: track user scan failed", "username", username, "session_id", startResp.SessionID, "err", uerr)
-					} else {
-						h.cfg.Log.Info("malware: track user scan started", "username", username, "session_id", startResp.SessionID, "user_id", userID)
-					}
-				}
-			}
+	// Track per-user scan job (mig 000097) through the shared Malware Scan
+	// Lifecycle Start (JAB-320), the same op the CLI uses. On parse failure we
+	// still return 202 since the scan IS running — the table just won't show
+	// this row until the next resolvable scan.
+	sid, uerr := RecordMalwareScanStart(c.Request.Context(), h.cfg.UserScans, h.cfg.Users, raw, body.Path, body.User)
+	if h.cfg.Log != nil {
+		if uerr != nil {
+			h.cfg.Log.Warn("malware: track user scan failed", "session_id", sid, "err", uerr)
+		} else if sid != "" {
+			h.cfg.Log.Info("malware: track user scan started", "session_id", sid)
 		}
 	}
 	c.Data(http.StatusAccepted, "application/json; charset=utf-8", raw)


### PR DESCRIPTION
## What

The REST handler persisted a per-user scan tracking row (mig 000097) after
starting an agent scan — parse the `session_id` from the agent reply, resolve
the owning user, write the row. The `jabali malware scan` CLI only called the
agent and audited, so **CLI-started scans were invisible** to the panel's scan
history/tracking.

## Fix

Extract that logic into a shared, gin-free `api.RecordMalwareScanStart` — the
"Start" of the Malware Scan Lifecycle. The REST handler now routes through it
(behaviour unchanged) and the CLI calls it after a successful scan, so a scan
started from either surface has a tracking row.

Best-effort and fail-closed: a missing/malformed `session_id`, or a path not
under a user's `/home`, writes no row (the scan still runs) — a malformed
session can't masquerade as a recorded scan. The CLI returns early on agent
failure, so a failed scan never creates a row.

## Tests

- a `--user` scan writes a row scoped to `/home/<user>` with the resolved
  `user_id`;
- a `--path` scan resolves the owner from the home path;
- missing / empty / malformed / absent session ids write no row;
- a non-home path records no per-user row but still surfaces the session id;
- a nil repo is a no-op.

Full `internal/api` + `cmd/server` suites green.

## Acceptance criteria

- ✅ Every accepted HTTP or CLI scan has a tracking row (for a user-resolvable
  target — parity with the REST handler).
- ✅ Malformed/missing agent session IDs cannot produce a recorded scan.
- ✅ Agent failure does not create a running row (CLI returns early).
- ✅ The row-write facts are now identical across adapters (shared op).

## Scope

The wider Malware Scan Lifecycle Module (a first-class `Status` surface + unified
failure state) stays on the parent ticket.

GH JAB-320
