### PR TITLE
fix(limits): CLI limit-override set enforces the same bounds as REST (JAB-309)

### DIFF
--- a/internal/limits/override_bounds_test.go
+++ b/internal/limits/override_bounds_test.go
@@ -1,0 +1,38 @@
+package limits
+
+import "testing"
+
+func u32(v uint32) *uint32 { return &v }
+
+// ValidateOverrideBounds is the single bounds check both the REST handler and
+// the operator CLI call (JAB-309): a present value over its ceiling is rejected;
+// nil fields and in-range values pass.
+func TestValidateOverrideBounds(t *testing.T) {
+	// All nil → valid (a no-op override).
+	if err := ValidateOverrideBounds(nil, nil, nil, nil, nil); err != nil {
+		t.Fatalf("all-nil override must be valid, got %v", err)
+	}
+	// In-range values → valid.
+	if err := ValidateOverrideBounds(u32(200), u32(2048), u32(500), u32(500), u32(1000)); err != nil {
+		t.Fatalf("in-range override must be valid, got %v", err)
+	}
+
+	cases := []struct {
+		name                             string
+		cpu, mem, ioRead, ioWrite, tasks *uint32
+	}{
+		{"cpu over", u32(MaxCPUQuotaPercent + 1), nil, nil, nil, nil},
+		{"mem over", nil, u32(MaxMemoryLimitMB + 1), nil, nil, nil},
+		{"io-read over", nil, nil, u32(MaxIOMbps + 1), nil, nil},
+		{"io-write over", nil, nil, nil, u32(MaxIOMbps + 1), nil},
+		{"tasks over", nil, nil, nil, nil, u32(MaxTasks + 1)},
+		{"one bad among good", u32(100), u32(2048), u32(MaxIOMbps + 1), u32(100), u32(50)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateOverrideBounds(tc.cpu, tc.mem, tc.ioRead, tc.ioWrite, tc.tasks); err == nil {
+				t.Errorf("%s: an out-of-range override must be rejected", tc.name)
+			}
+		})
+	}
+}

--- a/internal/limits/resolve.go
+++ b/internal/limits/resolve.go
@@ -124,6 +124,31 @@ const (
 // Validate rejects out-of-range values. Non-zero values above the cap
 // fail; zero always passes (unlimited is always legal). Returns the
 // first violation or nil.
+// ValidateOverrideBounds runs each present (non-nil) per-user override value
+// through the same bounds check EffectiveLimits.Validate applies, treating each
+// as a field-of-one so any combination of NULLs is allowed. Shared by the REST
+// handler and the operator CLI so a CLI-set override cannot bypass the bounds
+// (JAB-309). DiskQuotaMB has no upper bound and is not checked, matching Validate.
+func ValidateOverrideBounds(cpu, mem, ioRead, ioWrite, maxTasks *uint32) error {
+	e := EffectiveLimits{}
+	if cpu != nil {
+		e.CPUQuotaPercent = *cpu
+	}
+	if mem != nil {
+		e.MemoryLimitMB = *mem
+	}
+	if ioRead != nil {
+		e.IOReadMbps = *ioRead
+	}
+	if ioWrite != nil {
+		e.IOWriteMbps = *ioWrite
+	}
+	if maxTasks != nil {
+		e.MaxTasks = *maxTasks
+	}
+	return e.Validate()
+}
+
 func (e EffectiveLimits) Validate() error {
 	if e.CPUQuotaPercent > MaxCPUQuotaPercent {
 		return &BoundError{Field: "cpu_quota_percent", Value: e.CPUQuotaPercent, Max: MaxCPUQuotaPercent}

--- a/panel-api/cmd/server/wave4_cmd.go
+++ b/panel-api/cmd/server/wave4_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/limits"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/htaccess"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -161,6 +162,12 @@ func newLimitsOverrideCmd() *cobra.Command {
 			}
 			if !set {
 				return fmt.Errorf("specify at least one override (--disk-mb/--cpu/--memory-mb/--io-read-mbps/--io-write-mbps/--max-tasks)")
+			}
+			// JAB-309: enforce the same bounds the REST handler does — the CLI
+			// previously wrote overrides unvalidated, so an out-of-range value
+			// could be persisted and dispatched to the agent.
+			if err := limits.ValidateOverrideBounds(o.CPUQuotaPercent, o.MemoryLimitMB, o.IOReadMbps, o.IOWriteMbps, o.MaxTasks); err != nil {
+				return fmt.Errorf("invalid override: %w", err)
 			}
 			if err := repository.NewUserLimitOverrideRepository(sharedDB).Upsert(ctx, o); err != nil {
 				return fmt.Errorf("upsert override: %w", err)

--- a/panel-api/internal/api/user_limits.go
+++ b/panel-api/internal/api/user_limits.go
@@ -311,25 +311,10 @@ func (h *userLimitsHandler) upsertOverride(c *gin.Context) {
 // the bundle-style Validate() on EffectiveLimits because an override
 // can have any combination of NULL values.
 func validateOverrideBounds(req overrideRequest) error {
-	// Treat each present value as an EffectiveLimits field-of-one and
-	// let the central validator decide.
-	e := limits.EffectiveLimits{}
-	if req.CPUQuotaPercent != nil {
-		e.CPUQuotaPercent = *req.CPUQuotaPercent
-	}
-	if req.MemoryLimitMB != nil {
-		e.MemoryLimitMB = *req.MemoryLimitMB
-	}
-	if req.IOReadMbps != nil {
-		e.IOReadMbps = *req.IOReadMbps
-	}
-	if req.IOWriteMbps != nil {
-		e.IOWriteMbps = *req.IOWriteMbps
-	}
-	if req.MaxTasks != nil {
-		e.MaxTasks = *req.MaxTasks
-	}
-	return e.Validate()
+	// Shared with the operator CLI (JAB-309) so both enforce the identical
+	// bounds; each present value is validated as an EffectiveLimits field-of-one.
+	return limits.ValidateOverrideBounds(
+		req.CPUQuotaPercent, req.MemoryLimitMB, req.IOReadMbps, req.IOWriteMbps, req.MaxTasks)
 }
 
 func (h *userLimitsHandler) clearOverride(c *gin.Context) {


### PR DESCRIPTION
## What

The REST override handler validated each present override value against its
ceiling (`validateOverrideBounds` → `EffectiveLimits.Validate`) before
persisting. The operator CLI (`jabali user limits override set`) built the
override from flags and went straight to `Upsert` **with no validation**, so an
out-of-range value (e.g. `--cpu 99999`) could be persisted and then dispatched
to the agent.

## Fix

Move the check to **one owner**: `limits.ValidateOverrideBounds(cpu, mem, ioRead,
ioWrite, maxTasks)`. The REST handler's `validateOverrideBounds` now delegates
to it, and the CLI calls it before `Upsert`, so both adapters enforce the
identical bounds and cannot drift — the same consolidation as the SFTP-metachar
rule (JAB-310). `DiskQuotaMB` is unbounded and unchecked, matching `Validate`.
No behaviour change on the REST side (same check, now shared); the CLI gains it.

## Test

`limits.TestValidateOverrideBounds` — all-nil (valid), in-range (valid), and each
field over its ceiling rejected (cpu / mem / io-read / io-write / tasks), plus one
bad value among good. Full `limits` + `internal/api` + `cmd/server` suites green.

## Scope

The concrete "CLI overrides skip bounds validation" bug. The rest of the
Effective Resource Limits module — a shared typed Apply/Clear plan so the CLI
**clears** (not always applies) when policy disappears and honours the
disk-quota gate — stays on the parent ticket.

GH JAB-309
