### PR TITLE
fix(notifications): smart-group ssh.login to stop noisy-account inbox flooding

### DIFF
--- a/panel-api/internal/eventsources/ssh_login.go
+++ b/panel-api/internal/eventsources/ssh_login.go
@@ -8,13 +8,13 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 )
 
-// runSSHLogin tails the systemd journal for sshd Accepted lines and
-// publishes one ssh.login envelope per successful authentication.
+// runSSHLogin tails the systemd journal for sshd Accepted lines and publishes
+// ssh.login notifications through a smart grouper (ssh_login_group.go): the first
+// login from a (user, IP, method) fires immediately, repeats within the window
+// are suppressed and counted into periodic summaries, and a new IP/method fires
+// fresh. This stops a noisy per-minute account from flooding the admin inbox.
 //
 // We shell out to journalctl --follow rather than linking against
 // libsystemd's sd_journal: the panel-api binary already statics-builds
@@ -38,6 +38,27 @@ func runSSHLogin(ctx context.Context, d Deps) {
 		return
 	}
 
+	// One grouper for the life of the source (survives journalctl restarts), so
+	// login bursts collapse into counted summaries instead of one notification
+	// per login (the "drfeed spam"). A ticker flushes quiet/rolling summaries.
+	gr := newSSHLoginGrouper(d.Now)
+	go func() {
+		t := time.NewTicker(sshFlushInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				for _, env := range gr.flush() {
+					if _, err := d.Queue.Publish(ctx, env); err != nil {
+						d.Log.Warn("eventsources: publish ssh.login summary failed", "err", err)
+					}
+				}
+			}
+		}
+	}()
+
 	// Keep retrying with a backoff so a transient journalctl exit
 	// (rotated journal, OOM kill) doesn't permanently silence ssh
 	// notifications. Cap the backoff so we don't drift toward minute-
@@ -49,7 +70,7 @@ func runSSHLogin(ctx context.Context, d Deps) {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := tailSSHJournal(ctx, d); err != nil && ctx.Err() == nil {
+		if err := tailSSHJournal(ctx, d, gr); err != nil && ctx.Err() == nil {
 			// SIGTERM to the journalctl child races our ctx propagation
 			// at shutdown — the child returns "signal: terminated" before
 			// our ctx.Done() fires. Treat that as graceful and exit silently
@@ -79,7 +100,7 @@ func runSSHLogin(ctx context.Context, d Deps) {
 // tailSSHJournal runs journalctl in JSON-follow mode until ctx is
 // cancelled or the process exits. Each Accepted line is parsed and
 // published as ssh.login.
-func tailSSHJournal(ctx context.Context, d Deps) error {
+func tailSSHJournal(ctx context.Context, d Deps, gr *sshLoginGrouper) error {
 	cmd := exec.CommandContext(ctx,
 		"journalctl",
 		// Match the systemd unit rather than the syslog identifier:
@@ -112,7 +133,7 @@ func tailSSHJournal(ctx context.Context, d Deps) error {
 		if err := json.Unmarshal(sc.Bytes(), &entry); err != nil {
 			continue
 		}
-		processSSHJournalEntry(ctx, d, entry)
+		processSSHJournalEntry(ctx, d, gr, entry)
 	}
 	// Wait so we collect the exit error if the scanner ended on a
 	// process death rather than ctx cancellation.
@@ -140,7 +161,7 @@ type journalEntry struct {
 // worker (`_COMM=sshd-session`) rather than the listener; older Debians
 // still use `sshd`. Accept both, plus any sshd-* prefix to cover the
 // privsep variants without listing every name explicitly.
-func processSSHJournalEntry(ctx context.Context, d Deps, entry journalEntry) {
+func processSSHJournalEntry(ctx context.Context, d Deps, gr *sshLoginGrouper, entry journalEntry) {
 	if entry.Comm != "sshd" && !strings.HasPrefix(entry.Comm, "sshd-") {
 		return
 	}
@@ -151,26 +172,13 @@ func processSSHJournalEntry(ctx context.Context, d Deps, entry journalEntry) {
 	if user == "" {
 		return
 	}
-	tag := fmt.Sprintf("ssh:%s@%s", user, ip)
-	// 30 second cooldown — repeat logins from the same user+IP collapse
-	// (rsync/scp loops, CI bots) but distinct sessions still fire.
-	if !shouldFire(ctx, d, "ssh.login", tag, 30*time.Second) {
-		return
-	}
-	body := fmt.Sprintf("User %s logged in over SSH from %s", user, ip)
-	if method != "" {
-		body += fmt.Sprintf(" via %s", method)
-	}
-	body += fmt.Sprintf(". (%s)", tag)
-	_, err := d.Queue.Publish(ctx, notifications.Envelope{
-		EventKind: "ssh.login",
-		Severity:  models.NotificationSeverityInfo,
-		Title:     fmt.Sprintf("SSH login: %s from %s", user, ip),
-		Body:      body,
-		Deeplink:  "/jabali-admin/security",
-	})
-	if err != nil {
-		d.Log.Warn("eventsources: publish ssh.login failed", "err", err)
+	// Smart grouping: a new (user, IP, method) fires immediately; repeats within
+	// the window are suppressed and counted, surfaced as periodic summaries by
+	// observe/flush. See ssh_login_group.go.
+	for _, env := range gr.observe(user, ip, method) {
+		if _, err := d.Queue.Publish(ctx, env); err != nil {
+			d.Log.Warn("eventsources: publish ssh.login failed", "err", err)
+		}
 	}
 }
 
@@ -195,7 +203,6 @@ func parseAcceptedLine(msg string) (user, ip, method string) {
 	}
 	return fields[3], fields[5], fields[1]
 }
-
 
 // isShutdownChildExit returns true when err looks like the journalctl
 // child got killed (SIGTERM/SIGKILL). At panel-api shutdown the parent

--- a/panel-api/internal/eventsources/ssh_login_group.go
+++ b/panel-api/internal/eventsources/ssh_login_group.go
@@ -1,0 +1,154 @@
+package eventsources
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+// Smart grouping for ssh.login (GH #1238-adjacent, "drfeed spam"): a noisy
+// account (a per-minute rsync/backup/feed loop over publickey) otherwise fires
+// one notification per login and floods the admin inbox. Instead we group by
+// user + source IP + auth method (the server is implicit — one box per panel):
+//
+//   - first login in a new group      → notify immediately (the security signal)
+//   - repeats within the group window → suppressed, only a counter increments
+//   - group quiet for the window      → emit a summary "N logins in ~M minutes"
+//   - continuously active past a window→ emit a rolling summary + start a new
+//     window, so a never-quiet feed still surfaces a bounded, counted digest
+//   - a new IP or auth method          → a distinct group → fresh immediate notify
+//
+// This lives entirely in the eventsource (no schema/dispatcher change). True
+// single-notification live-update and the per-event policy modes (every / smart
+// / threshold / digest / disabled) are the follow-up.
+const (
+	// sshGroupWindow is both the quiet gap that closes a group and the rolling
+	// digest cadence for a continuously-active one.
+	sshGroupWindow = 10 * time.Minute
+	// sshFlushInterval paces the ticker that emits quiet-close + rolling digest
+	// summaries. Finer than the window so a summary lands within ~a minute of a
+	// group going quiet.
+	sshFlushInterval = 1 * time.Minute
+)
+
+type sshGroup struct {
+	user, ip, method string
+	firstAt, lastAt  time.Time // firstAt resets each rolling window
+	count            int       // logins in the current window
+}
+
+// sshLoginGrouper aggregates ssh.login events. Safe for concurrent use: the
+// journal-tail goroutine calls observe, the flush ticker calls flush.
+type sshLoginGrouper struct {
+	now    Clock
+	mu     sync.Mutex
+	groups map[string]*sshGroup
+}
+
+func newSSHLoginGrouper(now Clock) *sshLoginGrouper {
+	if now == nil {
+		now = time.Now
+	}
+	return &sshLoginGrouper{now: now, groups: map[string]*sshGroup{}}
+}
+
+func sshGroupKey(user, ip, method string) string {
+	return user + "\x00" + ip + "\x00" + method
+}
+
+// observe records a login and returns the envelopes to publish now: an immediate
+// notification when the login opens a new group (optionally preceded by the
+// summary of a just-expired group for the same key), or nothing when it is a
+// suppressed repeat.
+func (g *sshLoginGrouper) observe(user, ip, method string) []notifications.Envelope {
+	now := g.now()
+	key := sshGroupKey(user, ip, method)
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	cur, ok := g.groups[key]
+	if ok && now.Sub(cur.lastAt) <= sshGroupWindow {
+		// Open group — suppress, just count.
+		cur.count++
+		cur.lastAt = now
+		return nil
+	}
+
+	var out []notifications.Envelope
+	// A stale group for this key expired without the ticker flushing it yet;
+	// emit its summary before the new group replaces it.
+	if ok && cur.count > 1 {
+		out = append(out, sshSummaryEnvelope(cur, now))
+	}
+	out = append(out, sshImmediateEnvelope(user, ip, method))
+	g.groups[key] = &sshGroup{user: user, ip: ip, method: method, firstAt: now, lastAt: now, count: 1}
+	return out
+}
+
+// flush closes quiet groups (emitting a summary for any with repeats) and emits
+// a rolling summary for groups that have stayed active across a full window,
+// resetting their window so the next digest counts fresh. Call on a ticker.
+func (g *sshLoginGrouper) flush() []notifications.Envelope {
+	now := g.now()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	var out []notifications.Envelope
+	for key, grp := range g.groups {
+		if now.Sub(grp.lastAt) > sshGroupWindow {
+			// Quiet → close.
+			if grp.count > 1 {
+				out = append(out, sshSummaryEnvelope(grp, now))
+			}
+			delete(g.groups, key)
+			continue
+		}
+		if now.Sub(grp.firstAt) >= sshGroupWindow && grp.count > 1 {
+			// Continuously active across a full window → rolling digest, then
+			// start a new window (keep the group open).
+			out = append(out, sshSummaryEnvelope(grp, now))
+			grp.firstAt = now
+			grp.count = 0
+		}
+	}
+	return out
+}
+
+func sshImmediateEnvelope(user, ip, method string) notifications.Envelope {
+	body := fmt.Sprintf("User %s logged in over SSH from %s", user, ip)
+	if method != "" {
+		body += fmt.Sprintf(" via %s", method)
+	}
+	body += fmt.Sprintf(". (ssh:%s@%s)", user, ip)
+	return notifications.Envelope{
+		EventKind: "ssh.login",
+		Severity:  models.NotificationSeverityInfo,
+		Title:     fmt.Sprintf("SSH login: %s from %s", user, ip),
+		Body:      body,
+		Deeplink:  "/jabali-admin/security",
+	}
+}
+
+func sshSummaryEnvelope(grp *sshGroup, now time.Time) notifications.Envelope {
+	mins := int((now.Sub(grp.firstAt) + 30*time.Second) / time.Minute)
+	if mins < 1 {
+		mins = 1
+	}
+	via := ""
+	if grp.method != "" {
+		via = fmt.Sprintf(" via %s", grp.method)
+	}
+	body := fmt.Sprintf("%s logged in over SSH %d times from %s%s in the last %d minute(s). (ssh:%s@%s)",
+		grp.user, grp.count, grp.ip, via, mins, grp.user, grp.ip)
+	return notifications.Envelope{
+		EventKind: "ssh.login",
+		Severity:  models.NotificationSeverityInfo,
+		Title:     fmt.Sprintf("SSH login: %s — %d logins from %s", grp.user, grp.count, grp.ip),
+		Body:      body,
+		Deeplink:  "/jabali-admin/security",
+	}
+}

--- a/panel-api/internal/eventsources/ssh_login_group_test.go
+++ b/panel-api/internal/eventsources/ssh_login_group_test.go
@@ -1,0 +1,102 @@
+package eventsources
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeClock is a mutable clock for driving the grouper deterministically.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time      { return c.t }
+func (c *fakeClock) add(d time.Duration) { c.t = c.t.Add(d) }
+
+func newGrouperAt(base time.Time) (*sshLoginGrouper, *fakeClock) {
+	c := &fakeClock{t: base}
+	return newSSHLoginGrouper(c.now), c
+}
+
+func base() time.Time { return time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC) }
+
+func TestSSHGroup_FirstLoginNotifiesImmediately(t *testing.T) {
+	g, _ := newGrouperAt(base())
+	out := g.observe("alice", "1.2.3.4", "publickey")
+	if len(out) != 1 {
+		t.Fatalf("first login should emit exactly one envelope, got %d", len(out))
+	}
+	if !strings.Contains(out[0].Title, "SSH login: alice from 1.2.3.4") {
+		t.Errorf("unexpected title: %q", out[0].Title)
+	}
+}
+
+func TestSSHGroup_RepeatsWithinWindowSuppressed(t *testing.T) {
+	g, c := newGrouperAt(base())
+	g.observe("drfeed", "1.2.3.4", "publickey") // first → immediate
+	total := 0
+	for i := 0; i < 20; i++ {
+		c.add(time.Minute) // every minute, within the 10-min sliding window
+		total += len(g.observe("drfeed", "1.2.3.4", "publickey"))
+	}
+	if total != 0 {
+		t.Fatalf("repeat logins within the window must be suppressed, but %d envelopes were emitted", total)
+	}
+}
+
+func TestSSHGroup_NewIPBypassesAggregation(t *testing.T) {
+	g, _ := newGrouperAt(base())
+	g.observe("alice", "1.2.3.4", "publickey")
+	out := g.observe("alice", "9.9.9.9", "publickey") // different IP
+	if len(out) != 1 || !strings.Contains(out[0].Title, "from 9.9.9.9") {
+		t.Fatalf("a new source IP must fire immediately; got %+v", out)
+	}
+}
+
+func TestSSHGroup_NewMethodBypassesAggregation(t *testing.T) {
+	g, _ := newGrouperAt(base())
+	g.observe("alice", "1.2.3.4", "publickey")
+	out := g.observe("alice", "1.2.3.4", "password") // different method
+	if len(out) != 1 || !strings.Contains(out[0].Body, "via password") {
+		t.Fatalf("a new auth method must fire immediately; got %+v", out)
+	}
+}
+
+func TestSSHGroup_QuietCloseEmitsCountedSummary(t *testing.T) {
+	g, c := newGrouperAt(base())
+	g.observe("drfeed", "1.2.3.4", "publickey") // 1
+	c.add(time.Minute)
+	g.observe("drfeed", "1.2.3.4", "publickey") // 2
+	c.add(time.Minute)
+	g.observe("drfeed", "1.2.3.4", "publickey") // 3
+
+	// Go quiet past the window, then flush.
+	c.add(11 * time.Minute)
+	out := g.flush()
+	if len(out) != 1 {
+		t.Fatalf("a closed group with repeats should emit one summary, got %d", len(out))
+	}
+	if !strings.Contains(out[0].Body, "3 times") {
+		t.Errorf("summary should carry the count of 3; body=%q", out[0].Body)
+	}
+	// A single-login group emits no summary on close.
+	g.observe("bob", "5.6.7.8", "publickey")
+	c.add(11 * time.Minute)
+	if s := g.flush(); len(s) != 0 {
+		t.Errorf("a single-login group must not emit a close summary, got %d", len(s))
+	}
+}
+
+func TestSSHGroup_ContinuouslyActiveRollsUpPerWindow(t *testing.T) {
+	g, c := newGrouperAt(base())
+	g.observe("drfeed", "1.2.3.4", "publickey") // first → immediate
+	// Keep it active every minute for > one window, never quiet.
+	summaries := 0
+	for i := 0; i < 12; i++ {
+		c.add(time.Minute)
+		g.observe("drfeed", "1.2.3.4", "publickey")
+		summaries += len(g.flush())
+	}
+	if summaries == 0 {
+		t.Fatal("a continuously-active group must emit at least one rolling digest across a window")
+	}
+}


### PR DESCRIPTION
## Problem

A per-minute publickey account (`drfeed` — an rsync/backup/feed loop) fired **one `ssh.login` notification per login** and buried the admin inbox at 99+. The existing 30-second per-(user,IP) cooldown was far too short to collapse a per-minute cadence, so every login still fired.

## Fix — smart grouping (in the eventsource, no schema/dispatcher change)

Group `ssh.login` by **user + source IP + auth method** (the server is implicit — one box per panel):

- **first** login in a new group → notify immediately (the security signal)
- **repeats within the 10-min window** → suppressed, a counter increments
- **quiet for a window** → a summary: *"drfeed logged in over SSH 37 times from 1.2.3.4 in the last 12 minute(s)."*
- **continuously active past a window** → a rolling counted digest, then a fresh window (so a never-quiet feed still surfaces a bounded, counted summary instead of nothing)
- **new source IP or auth method** → a distinct group → fresh immediate notify

Failed logins are unchanged (already ignored here — CrowdSec drives bans on those).

This is the **Smart grouping** default from the design discussion. True single-notification live-update (one item whose count grows in place) and the per-event **policy modes** (Every / Smart / Threshold / Digest / Disabled) are the follow-up — they need a `group_key`/count column + dispatcher upsert (a migration), out of scope for stopping the spam now.

## Tests
Grouper unit tests with a fake clock: first-immediate, suppress-repeats, new-IP bypass, new-method bypass, quiet-close counted summary, rolling per-window digest. No migrations.

GH — reported as "drfeed spam" in the admin Notifications inbox.
