### PR TITLE
feat(limits): shared Effective Resource Limits Apply/Clear plan (JAB-309)

### DIFF
--- a/internal/limits/plan.go
+++ b/internal/limits/plan.go
@@ -1,0 +1,87 @@
+package limits
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// AgentCaller is the minimal agent surface LimitsPlan.Execute needs — satisfied
+// structurally by the panel's agent client, so the limits package stays free of
+// any dependency on it.
+type AgentCaller interface {
+	Call(ctx context.Context, method string, params any) (json.RawMessage, error)
+}
+
+// PlanKind is Apply (converge the effective limits) or Clear (the user must be
+// unlimited — remove any drop-in + POSIX quota a previously-assigned package
+// left behind).
+type PlanKind int
+
+const (
+	PlanApply PlanKind = iota
+	PlanClear
+)
+
+// LimitsPlan is the typed Apply/Clear decision for one user's effective resource
+// limits, shared by the Reconciler and the operator CLI so both emit identical
+// plans for identical stored state (JAB-309). The REST layer computes the same
+// effective limits for its read view via Resolve but does not dispatch.
+type LimitsPlan struct {
+	Kind      PlanKind
+	Effective EffectiveLimits // meaningful only for PlanApply
+	// QuotaMount is the setquota mount path passed to the agent. For Apply it is
+	// gated by the disk-quota feature toggle ("" when disabled, so the agent's
+	// setquota step short-circuits while cgroup limits still apply). For Clear it
+	// is ALWAYS the raw mount: removing a POSIX quota needs the mount even when
+	// the feature is currently disabled, or a stale quota from a prior package
+	// survives on disk — the exact "old quota wall" a clear exists to remove.
+	QuotaMount string
+}
+
+// PlanFor computes the plan from stored state. No package AND no override → the
+// user must be unlimited, so Clear (skipping instead would leave stale quota +
+// cgroup drop-ins on the host). Otherwise Apply the resolved effective limits.
+func PlanFor(pkg *PackageLimits, override *OverrideLimits, quotaEnabled bool, quotaMount string) LimitsPlan {
+	if pkg == nil && override == nil {
+		return LimitsPlan{Kind: PlanClear, QuotaMount: quotaMount}
+	}
+	applyMount := quotaMount
+	if !quotaEnabled {
+		applyMount = ""
+	}
+	return LimitsPlan{Kind: PlanApply, Effective: Resolve(pkg, override), QuotaMount: applyMount}
+}
+
+// Execute dispatches the plan to the agent: user.limits.apply with the effective
+// values, or user.limits.clear. Both handlers are idempotent.
+func (p LimitsPlan) Execute(ctx context.Context, ag AgentCaller, username string) error {
+	if p.Kind == PlanClear {
+		_, err := ag.Call(ctx, "user.limits.clear", map[string]any{
+			"username":    username,
+			"quota_mount": p.QuotaMount,
+		})
+		return err
+	}
+	_, err := ag.Call(ctx, "user.limits.apply", map[string]any{
+		"username":          username,
+		"disk_quota_mb":     p.Effective.DiskQuotaMB,
+		"cpu_quota_percent": p.Effective.CPUQuotaPercent,
+		"memory_limit_mb":   p.Effective.MemoryLimitMB,
+		"io_read_mbps":      p.Effective.IOReadMbps,
+		"io_write_mbps":     p.Effective.IOWriteMbps,
+		"max_tasks":         p.Effective.MaxTasks,
+		"quota_mount":       p.QuotaMount,
+	})
+	return err
+}
+
+// Describe renders the plan for a dry-run, without dispatching.
+func (p LimitsPlan) Describe(username string) string {
+	if p.Kind == PlanClear {
+		return fmt.Sprintf("clear  %s (no package or override — remove limits)", username)
+	}
+	return fmt.Sprintf("apply  %s (disk=%dMB cpu=%d%% mem=%dMB io_r=%d io_w=%d tasks=%d quota_mount=%q)",
+		username, p.Effective.DiskQuotaMB, p.Effective.CPUQuotaPercent, p.Effective.MemoryLimitMB,
+		p.Effective.IOReadMbps, p.Effective.IOWriteMbps, p.Effective.MaxTasks, p.QuotaMount)
+}

--- a/internal/limits/plan_test.go
+++ b/internal/limits/plan_test.go
@@ -1,0 +1,98 @@
+package limits
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type recPlanAgent struct {
+	method string
+	params map[string]any
+	err    error
+}
+
+func (a *recPlanAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.method = method
+	a.params, _ = params.(map[string]any)
+	return json.RawMessage(`{}`), a.err
+}
+
+func pkgLimits() *PackageLimits {
+	return &PackageLimits{DiskQuotaMB: 100, CPUQuotaPercent: 50, MemoryLimitMB: 512, IOReadMbps: 20, IOWriteMbps: 20, MaxTasks: 200}
+}
+
+// The four "cases agree" scenarios the ticket names, plus the mount gate.
+func TestPlanFor(t *testing.T) {
+	const mount = "/home"
+
+	// package-only → apply the package values with the (enabled) mount.
+	p := PlanFor(pkgLimits(), nil, true, mount)
+	if p.Kind != PlanApply || p.Effective.CPUQuotaPercent != 50 || p.QuotaMount != mount {
+		t.Fatalf("package-only: %+v", p)
+	}
+
+	// override-only → apply the override values.
+	ov := &OverrideLimits{CPUQuotaPercent: u32(75)}
+	p = PlanFor(nil, ov, true, mount)
+	if p.Kind != PlanApply || p.Effective.CPUQuotaPercent != 75 {
+		t.Fatalf("override-only: %+v", p)
+	}
+
+	// package + override → override field wins, package fills the rest.
+	p = PlanFor(pkgLimits(), &OverrideLimits{CPUQuotaPercent: u32(90)}, true, mount)
+	if p.Effective.CPUQuotaPercent != 90 || p.Effective.MemoryLimitMB != 512 {
+		t.Fatalf("merge: %+v", p.Effective)
+	}
+
+	// explicit-zero override + package → the explicit 0 WINS over the package
+	// value (pick returns the non-nil override pointer, even when it is 0).
+	p = PlanFor(pkgLimits(), &OverrideLimits{CPUQuotaPercent: u32(0)}, true, mount)
+	if p.Effective.CPUQuotaPercent != 0 {
+		t.Fatalf("explicit-zero override must win, got cpu=%d", p.Effective.CPUQuotaPercent)
+	}
+
+	// no package + no override → CLEAR (user must be unlimited).
+	p = PlanFor(nil, nil, true, mount)
+	if p.Kind != PlanClear {
+		t.Fatalf("no-policy must clear, got %+v", p)
+	}
+}
+
+// Apply gates the mount when the disk-quota feature is disabled; Clear NEVER
+// does — removing a stale quota needs the mount regardless of the toggle.
+func TestPlanFor_MountGate(t *testing.T) {
+	const mount = "/home"
+
+	// Apply with quota disabled → mount blanked (setquota short-circuits).
+	if got := PlanFor(pkgLimits(), nil, false, mount); got.Kind != PlanApply || got.QuotaMount != "" {
+		t.Fatalf("apply with quota disabled must blank the mount, got %q", got.QuotaMount)
+	}
+	// Apply with quota enabled → mount carried.
+	if got := PlanFor(pkgLimits(), nil, true, mount); got.QuotaMount != mount {
+		t.Fatalf("apply with quota enabled must carry the mount, got %q", got.QuotaMount)
+	}
+	// Clear with quota DISABLED → still carries the raw mount.
+	if got := PlanFor(nil, nil, false, mount); got.Kind != PlanClear || got.QuotaMount != mount {
+		t.Fatalf("clear must always carry the raw mount even when quota disabled, got %q", got.QuotaMount)
+	}
+}
+
+func TestLimitsPlan_Execute(t *testing.T) {
+	ag := &recPlanAgent{}
+	if err := PlanFor(pkgLimits(), nil, true, "/home").Execute(context.Background(), ag, "alice"); err != nil {
+		t.Fatalf("apply execute: %v", err)
+	}
+	if ag.method != "user.limits.apply" || ag.params["username"] != "alice" ||
+		ag.params["cpu_quota_percent"] != uint32(50) || ag.params["quota_mount"] != "/home" {
+		t.Fatalf("apply wire wrong: method=%s params=%v", ag.method, ag.params)
+	}
+
+	ag = &recPlanAgent{}
+	if err := PlanFor(nil, nil, false, "/home").Execute(context.Background(), ag, "bob"); err != nil {
+		t.Fatalf("clear execute: %v", err)
+	}
+	if ag.method != "user.limits.clear" || ag.params["username"] != "bob" || ag.params["quota_mount"] != "/home" {
+		t.Fatalf("clear wire wrong: method=%s params=%v", ag.method, ag.params)
+	}
+}

--- a/panel-api/cmd/server/limits_cmd.go
+++ b/panel-api/cmd/server/limits_cmd.go
@@ -167,7 +167,7 @@ func newLimitsApplyCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 			defer cancel()
-			return applyForUsername(ctx, args[0])
+			return applyForUsername(ctx, args[0], diskQuotaEnabled(ctx))
 		},
 	}
 }
@@ -276,6 +276,9 @@ func newLimitsPackageCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("list users: %w", err)
 			}
+			// Read the disk-quota toggle once for the whole fan-out (mirrors the
+			// reconciler's once-per-pass read).
+			quotaEnabled := diskQuotaEnabled(ctx)
 			matched := 0
 			for i := range all {
 				u := &all[i]
@@ -291,7 +294,7 @@ func newLimitsPackageCmd() *cobra.Command {
 					fmt.Printf("would apply: %s\n", *u.Username)
 					continue
 				}
-				if err := applyForUsername(ctx, *u.Username); err != nil {
+				if err := applyForUsername(ctx, *u.Username, quotaEnabled); err != nil {
 					fmt.Printf("FAIL %s: %v\n", *u.Username, err)
 				} else {
 					fmt.Printf("ok   %s\n", *u.Username)
@@ -315,7 +318,7 @@ func newLimitsPackageCmd() *cobra.Command {
 //
 // `username` is misnamed for back-compat: any of email / username /
 // user-id is accepted (delegated to resolveUser).
-func applyForUsername(ctx context.Context, username string) error {
+func applyForUsername(ctx context.Context, username string, quotaEnabled bool) error {
 	pkgs := packageRepoFromDB()
 	// Direct new constructor — no helper yet because this is the only
 	// CLI consumer; if we grow more we'll factor it into root.go.
@@ -347,7 +350,7 @@ func applyForUsername(ctx context.Context, username string) error {
 		}
 	}
 	var ovL *limits.OverrideLimits
-	if ov, err := ovRepo.FindByUserID(ctx, user.ID); err == nil {
+	if ov, err := ovRepo.FindByUserID(ctx, user.ID); err == nil && ov != nil {
 		ovL = &limits.OverrideLimits{
 			DiskQuotaMB:     ov.DiskQuotaMB,
 			CPUQuotaPercent: ov.CPUQuotaPercent,
@@ -357,22 +360,26 @@ func applyForUsername(ctx context.Context, username string) error {
 			MaxTasks:        ov.MaxTasks,
 		}
 	}
-	effective := limits.Resolve(pkgL, ovL)
 
-	_, err = sharedAgent.Call(ctx, "user.limits.apply", map[string]any{
-		"username":          posixUsername,
-		"disk_quota_mb":     effective.DiskQuotaMB,
-		"cpu_quota_percent": effective.CPUQuotaPercent,
-		"memory_limit_mb":   effective.MemoryLimitMB,
-		"io_read_mbps":      effective.IOReadMbps,
-		"io_write_mbps":     effective.IOWriteMbps,
-		"max_tasks":         effective.MaxTasks,
-		"quota_mount":       quotaMountOrEmpty(),
-	})
-	if err != nil {
+	// JAB-309: dispatch the shared Apply/Clear plan the reconciler uses. A user
+	// with no package and no override is CLEARED (the CLI previously always
+	// applied — leaving a zeros drop-in instead of removing it), and the
+	// disk-quota feature gate is honoured (the CLI previously ignored it).
+	plan := limits.PlanFor(pkgL, ovL, quotaEnabled, quotaMountOrEmpty())
+	if err := plan.Execute(ctx, sharedAgent, posixUsername); err != nil {
 		return fmt.Errorf("agent: %w", err)
 	}
 	return nil
+}
+
+// diskQuotaEnabled reads the global disk-quota feature toggle
+// (server_settings.disk_quota_enabled). Defaults to enabled on a read failure,
+// matching the reconciler.
+func diskQuotaEnabled(ctx context.Context) bool {
+	if s, err := repository.NewServerSettingsRepository(sharedDB).Get(ctx); err == nil && s != nil {
+		return s.DiskQuotaEnabled
+	}
+	return true
 }
 
 // humanBytes renders a byte count using SI scaling so disk + memory

--- a/panel-api/internal/reconciler/user_limits_reconcile.go
+++ b/panel-api/internal/reconciler/user_limits_reconcile.go
@@ -71,15 +71,15 @@ func (r *Reconciler) ReconcileUserLimits(ctx context.Context) {
 		return
 	}
 
-	// Read the global disk-quota toggle once per pass. When false we
-	// still apply cgroup limits (cpu/mem/io/tasks) but pass quota_mount=""
-	// to the agent so the setquota step short-circuits — matches the
-	// `QuotaMount empty skips setquota` convention used by user.limits.*.
-	// See server_settings.disk_quota_enabled (migration 000071).
-	quotaMount := r.quotaMount
+	// Read the global disk-quota toggle once per pass (server_settings.
+	// disk_quota_enabled, migration 000071). The shared PlanFor gates it into
+	// the wire mount: Apply blanks the mount when disabled (setquota
+	// short-circuits, cgroup limits still apply); Clear always carries the raw
+	// mount so a stale quota can still be removed.
+	quotaEnabled := true
 	if r.serverSettings != nil {
-		if s, sErr := r.serverSettings.Get(ctx); sErr == nil && s != nil && !s.DiskQuotaEnabled {
-			quotaMount = ""
+		if s, sErr := r.serverSettings.Get(ctx); sErr == nil && s != nil {
+			quotaEnabled = s.DiskQuotaEnabled
 		}
 	}
 
@@ -122,44 +122,18 @@ func (r *Reconciler) ReconcileUserLimits(ctx context.Context) {
 				}
 			}
 		}
-		effective := limits.Resolve(pkgL, overridesByUser[u.ID])
-
-		// No package + no override → user must be unlimited.
-		// Dispatch user.limits.clear instead of skipping: skipping
-		// leaves stale POSIX quotas + cgroup drop-ins from a
-		// previously-assigned package on the host, so the user
-		// keeps hitting the old quota wall. The clear handler is
-		// idempotent (setquota -d is a no-op when no quota set;
-		// the cgroup drop-in delete is conditional on existence).
-		if pkgL == nil && overridesByUser[u.ID] == nil {
-			ctxCall, cancel := context.WithTimeout(ctx, 10*time.Second)
-			if _, err := r.agent.Call(ctxCall, "user.limits.clear", map[string]any{
-				"username":    *u.Username,
-				"quota_mount": r.quotaMount,
-			}); err != nil {
-				r.log.WarnContext(ctx, "user.limits.clear failed",
-					"username", *u.Username, "err", err)
-			}
-			cancel()
-			continue
-		}
-
+		// Compute + dispatch the shared Apply/Clear plan (JAB-309). No package
+		// AND no override → Clear (the user must be unlimited); skipping would
+		// leave stale POSIX quotas + cgroup drop-ins from a previously-assigned
+		// package, so the user keeps hitting the old quota wall. Both agent
+		// handlers are idempotent.
+		plan := limits.PlanFor(pkgL, overridesByUser[u.ID], quotaEnabled, r.quotaMount)
 		ctxCall, cancel := context.WithTimeout(ctx, 10*time.Second)
-		_, err := r.agent.Call(ctxCall, "user.limits.apply", map[string]any{
-			"username":          *u.Username,
-			"disk_quota_mb":     effective.DiskQuotaMB,
-			"cpu_quota_percent": effective.CPUQuotaPercent,
-			"memory_limit_mb":   effective.MemoryLimitMB,
-			"io_read_mbps":      effective.IOReadMbps,
-			"io_write_mbps":     effective.IOWriteMbps,
-			"max_tasks":         effective.MaxTasks,
-			"quota_mount":       quotaMount,
-		})
-		cancel()
-		if err != nil {
-			r.log.Warn("reconcile user-limits: apply failed",
-				"username", *u.Username, "quota_mount", quotaMount, "err", err)
+		if err := plan.Execute(ctxCall, r.agent, *u.Username); err != nil {
+			r.log.Warn("reconcile user-limits: dispatch failed",
+				"username", *u.Username, "plan", plan.Describe(*u.Username), "err", err)
 		}
+		cancel()
 	}
 }
 


### PR DESCRIPTION
## What

The Reconciler and the operator CLI each independently chose apply-vs-clear and built the wire params for per-user resource limits, and diverged:

- the CLI **always** dispatched `user.limits.apply` — even for a user with no package and no override, where `Resolve()` yields all-zeros. That wrote a zeros drop-in instead of removing the limits, so a user whose package was **removed** kept a stale drop-in (and any prior POSIX quota) on the host.
- the CLI **ignored** the global disk-quota feature toggle (`server_settings.disk_quota_enabled`): it passed the real quota mount unconditionally, so on a quota-disabled box it told the agent to `setquota` anyway.

## The module

One owner: `limits.PlanFor(pkg, override, quotaEnabled, mount)` returns a typed `LimitsPlan` — **Apply** the resolved effective limits, or **Clear** when there is no package and no override — and `LimitsPlan.Execute` dispatches `user.limits.apply` / `.clear` through a structural `AgentCaller`. The Reconciler and the CLI both route through it, so they emit identical plans for identical stored state; the REST layer computes the same effective limits for its read view via `Resolve` but does not dispatch.

The mount gate is deliberately **asymmetric**: Apply blanks the mount when the feature is disabled (setquota short-circuits, cgroup limits still apply), but Clear **always** carries the raw mount — removing a stale quota needs the mount even when the feature is currently off, or the old quota survives on disk. The reconciler already did exactly this (clear=raw, apply=gated); the plan preserves it and the CLI now matches. The CLI reads the toggle **once per fan-out** (mirroring the reconciler's once-per-pass read).

## Tests

`PlanFor` table: package-only / override-only / merged / explicit-zero-wins / no-policy-clears; the mount gate (apply-disabled blanks, clear-disabled keeps the raw mount); `Execute`'s wire shape. Full `limits` + `reconciler` + `cmd/server` suites green.

**Box-verified** on the smoke host with a throwaway user:
- no-policy `jabali limits apply` leaves **no drop-in** (clear, not apply-zeros);
- assign a package then apply writes the drop-in (`CPUQuota=50` percent / `MemoryMax=512M`);
- remove the package then apply **removes** the drop-in (the policy-disappeared clear).

Baseline restored.

## Acceptance criteria

- Package-only / override / explicit-zero / no-policy cases agree (PlanFor table).
- Quota-disabled plans omit the mount on Apply (unit-asserted; Clear keeps it).
- Invalid overrides perform no write / agent call (shared validator, #1309).
- All callers emit identical plans for identical stored state (one `PlanFor`).

GH JAB-309
