### PR TITLE
feat(ssh): opt-in TCP forwarding for VS Code Remote-SSH, firewall-guarded (GH #1229)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -5454,6 +5454,14 @@ jabali user reprovision <email|username|user-id> [flags]
 - `--password` — new password (min 10 chars; omit to auto-generate)
 - `--password-stdin` — read password from stdin (no prompt, no echo)
 
+#### `jabali user ssh-forwarding`
+
+Opt a hosting user into/out of SSH TCP forwarding for VS Code Remote-SSH (GH #1229)
+
+```
+jabali user ssh-forwarding <email|username|user-id> <on|off>
+```
+
 #### `jabali user suspend`
 
 Suspend a user (same cascade as the admin GUI/API)

--- a/install.sh
+++ b/install.sh
@@ -8562,6 +8562,15 @@ install_ssh_sandbox() {
     _ok "jabali-ssh-sandbox system group created"
   fi
 
+  # GH #1229: members of jabali-ssh-forward are EXCLUDED from the JAB-352
+  # forwarding lockdown (opt-in, default empty) so VS Code Remote-SSH can forward
+  # to its own loopback VS Code Server. The sensitive loopback services stay
+  # firewall-blocked per-uid, so this never re-opens the tunneling vector.
+  if ! getent group jabali-ssh-forward >/dev/null; then
+    groupadd --system jabali-ssh-forward 2>/dev/null || true
+    _ok "jabali-ssh-forward system group created"
+  fi
+
   # Directories required by the wrapper / agent + reconciler.
   install -d -m 0755 -o root -g root /etc/jabali
   install -d -m 0755 -o root -g root /etc/jabali/users

--- a/install/crowdsec/jabali-diag-loopback-isolation.nft
+++ b/install/crowdsec/jabali-diag-loopback-isolation.nft
@@ -22,8 +22,21 @@
 # A future metrics scraper (Zabbix) runs as a system user (<1000) / in
 # system.slice → unaffected. Separate `add`/`flush` table idiom so a re-apply on
 # `jabali update` replaces the rules rather than appending duplicates.
+# GH #1229: this ruleset now also underpins opt-in SSH TCP forwarding for VS Code
+# Remote-SSH (jabali-ssh-forward group). A per-uid nft drop cannot tell a tenant
+# app connection from an SSH-forwarded one (both run as the tenant uid), so it can
+# only block ports a tenant app never needs. The set below is exactly that:
+# sensitive control/admin/diagnostic loopback services that no tenant workload
+# uses — CrowdSec (6060 pprof/metrics, 7422, 8081 LAPI), Stalwart admin/internal
+# (8446, 18181), the pdns authoritative backend (5300), the panel itself (8443),
+# the mailhook (8462), and CUPS (631). The tenant-facing data services a hosted
+# app legitimately reaches over loopback — MariaDB 3306, PostgreSQL 5432, the DNS
+# recursor 53, Redis — are DELIBERATELY absent, so their DSNs keep working. With
+# these dropped for tenant uids, enabling forwarding for the opt-in group can never
+# tunnel into a sensitive service.
+define jabali_blocked_loopback_ports = { 631, 5300, 6060, 7422, 8081, 8443, 8446, 8462, 18181 }
 add table inet jabali_diag_isolation
 flush table inet jabali_diag_isolation
 add chain inet jabali_diag_isolation output { type filter hook output priority filter; policy accept; }
-add rule inet jabali_diag_isolation output meta skuid >= 1000 ip daddr 127.0.0.1 tcp dport 6060 drop
-add rule inet jabali_diag_isolation output meta skuid >= 1000 ip6 daddr ::1 tcp dport 6060 drop
+add rule inet jabali_diag_isolation output meta skuid >= 1000 ip daddr 127.0.0.1 tcp dport $jabali_blocked_loopback_ports drop
+add rule inet jabali_diag_isolation output meta skuid >= 1000 ip6 daddr ::1 tcp dport $jabali_blocked_loopback_ports drop

--- a/install/ssh/jabali-ssh-sandbox.conf
+++ b/install/ssh/jabali-ssh-sandbox.conf
@@ -15,7 +15,15 @@
 # SFTP-only path is handled separately by jabali-sftp.conf, which already
 # disables forwarding for the jabali-sftp group.
 
-Match Group jabali-ssh-sandbox
+# GH #1229: opt-in exception. A hosting user placed in jabali-ssh-forward (an
+# operator action, default OFF) is EXCLUDED from this lockdown block and gets the
+# relaxed block below instead — so VS Code Remote-SSH can forward to its own
+# loopback VS Code Server. sshd uses the FIRST obtained value per keyword, so the
+# exclusion must live on the Match line here; a later override would not win. The
+# sensitive loopback services stay unreachable for the opt-in user via the per-uid
+# nftables drop (install/crowdsec/jabali-diag-loopback-isolation.nft) — the forward
+# relaxation never opens a tunnel into them.
+Match Group jabali-ssh-sandbox,!jabali-ssh-forward
     # No TCP forwarding: blocks local (-L), remote (-R) and dynamic/SOCKS (-D).
     AllowTcpForwarding no
     # No Unix-domain-socket forwarding: -L/-R to a socket path (e.g. the panel
@@ -32,3 +40,21 @@ Match Group jabali-ssh-sandbox
     # Belt-and-suspenders: even if a future edit re-enabled a forwarding knob,
     # permit no destinations at all.
     PermitOpen none
+
+# Opt-in SSH TCP forwarding for VS Code Remote-SSH (GH #1229). Only local (-L) and
+# dynamic/SOCKS (-D) forwarding to LOOPBACK is allowed — enough for the VS Code
+# client to reach its own VS Code Server on 127.0.0.1:<random high port>. Remote
+# (-R) forwarding, socket/agent/X11/tunnel forwarding, and non-loopback binds stay
+# OFF. The sensitive loopback services (CrowdSec/Stalwart admin, panel, pdns
+# backend, …) remain unreachable via the per-uid nftables drop, so this never
+# re-opens the JAB-352 tunneling vector.
+Match Group jabali-ssh-forward
+    AllowTcpForwarding local
+    AllowStreamLocalForwarding no
+    GatewayPorts no
+    AllowAgentForwarding no
+    X11Forwarding no
+    PermitTunnel no
+    # Loopback destinations only. VS Code's forward target is 127.0.0.1:<port>;
+    # the firewall drop above keeps the sensitive ports off-limits.
+    PermitOpen 127.0.0.1:* [::1]:*

--- a/install/tests/test_crowdsec_diag_isolation.sh
+++ b/install/tests/test_crowdsec_diag_isolation.sh
@@ -29,11 +29,21 @@ unit=install/systemd/jabali-diag-loopback-isolation-load.service
 if [[ ! -f "$nft" ]]; then
   echo "FAIL: missing nft ruleset $nft"; exit 1
 fi
-if ! grep -qE 'meta skuid >= 1000 ip daddr 127\.0\.0\.1 tcp dport 6060 drop' "$nft"; then
-  echo "FAIL: $nft must drop skuid>=1000 → 127.0.0.1 tcp/6060 (JAB-368)"; fail=1
+# GH #1229: the drop is now a port SET (still includes 6060) so opt-in SSH
+# forwarding can never tunnel into any sensitive loopback service.
+if ! grep -qE 'meta skuid >= 1000 ip daddr 127\.0\.0\.1 tcp dport \$jabali_blocked_loopback_ports drop' "$nft"; then
+  echo "FAIL: $nft must drop skuid>=1000 → 127.0.0.1 to the sensitive loopback port set (JAB-368/GH #1229)"; fail=1
 fi
-if ! grep -qE 'meta skuid >= 1000 ip6 daddr ::1 tcp dport 6060 drop' "$nft"; then
-  echo "FAIL: $nft must also drop the IPv6 ::1 :6060 path (JAB-368)"; fail=1
+if ! grep -qE 'meta skuid >= 1000 ip6 daddr ::1 tcp dport \$jabali_blocked_loopback_ports drop' "$nft"; then
+  echo "FAIL: $nft must also drop the IPv6 ::1 sensitive port set (JAB-368/GH #1229)"; fail=1
+fi
+# 6060 (the JAB-368 baseline) must stay in the blocked set.
+if ! grep -qE '^define jabali_blocked_loopback_ports = \{[^}]*(^|[ ,{])6060([ ,}])' "$nft"; then
+  echo "FAIL: $nft blocked-port set must include 6060 (JAB-368)"; fail=1
+fi
+# GH #1229: app-facing data services must NOT be blocked, or tenant DSNs break.
+if grep -E '^define jabali_blocked_loopback_ports' "$nft" | grep -qE '[ ,{](3306|5432|53)[ ,}]'; then
+  echo "FAIL: $nft blocked set must NOT include app-facing ports 3306/5432/53 (GH #1229)"; fail=1
 fi
 # Idempotent re-apply: the add/flush idiom must be present (a bare `table {...}`
 # re-declaration would append duplicate rules on every `jabali update`).

--- a/install/tests/test_ssh_forwarding_lockdown.sh
+++ b/install/tests/test_ssh_forwarding_lockdown.sh
@@ -37,8 +37,11 @@ if [[ ! -f "$conf" ]]; then
   echo "FAIL: $conf missing"
   exit 1
 fi
-if ! grep -qE '^Match Group jabali-ssh-sandbox$' "$conf"; then
-  echo "FAIL: $conf does not Match the jabali-ssh-sandbox group"
+# GH #1229: the lockdown block now EXCLUDES the opt-in jabali-ssh-forward group so
+# VS Code Remote-SSH users can be relaxed. sshd first-value-wins → the exclusion
+# must be on the Match line here.
+if ! grep -qE '^Match Group jabali-ssh-sandbox,!jabali-ssh-forward$' "$conf"; then
+  echo "FAIL: $conf lockdown block must Match jabali-ssh-sandbox and exclude jabali-ssh-forward (GH #1229)"
   fail=1
 fi
 for d in 'AllowTcpForwarding no' 'AllowStreamLocalForwarding no' 'GatewayPorts no' \
@@ -53,6 +56,29 @@ if grep -qE '^[[:space:]]*ForceCommand' "$conf"; then
   echo "FAIL: $conf must NOT ForceCommand — the restricted login shell must still work"
   fail=1
 fi
+
+# GH #1229: the opt-in forward block must exist and be narrow — local forwarding
+# to loopback only; remote/socket/agent/X11/tunnel must stay off.
+if ! grep -qE '^Match Group jabali-ssh-forward$' "$conf"; then
+  echo "FAIL: $conf missing the Match Group jabali-ssh-forward opt-in block (GH #1229)"
+  fail=1
+fi
+if ! grep -qE '^[[:space:]]*AllowTcpForwarding local$' "$conf"; then
+  echo "FAIL: $conf forward block must allow only 'local' forwarding, not 'yes'/'all' (GH #1229)"
+  fail=1
+fi
+if ! grep -qE '^[[:space:]]*PermitOpen 127\.0\.0\.1:\* \[::1\]:\*$' "$conf"; then
+  echo "FAIL: $conf forward block must scope PermitOpen to loopback (GH #1229)"
+  fail=1
+fi
+for d in 'AllowStreamLocalForwarding no' 'AllowAgentForwarding no' 'X11Forwarding no' 'PermitTunnel no'; do
+  # These must appear at least twice — once per block — so the forward block does
+  # not silently re-enable a channel. (grep -c counts matching lines.)
+  if [[ "$(grep -cE "^[[:space:]]*${d}$" "$conf")" -lt 2 ]]; then
+    echo "FAIL: $conf forward block must also keep '$d' (GH #1229)"
+    fail=1
+  fi
+done
 
 # --- 2. The converger behaves, exercised for real against temp files. ---
 fn_src=$(awk '/^ensure_ssh_forwarding_lockdown\(\) \{$/,/^\}$/' install.sh)

--- a/panel-agent/internal/commands/ssh_user_forward_group.go
+++ b/panel-agent/internal/commands/ssh_user_forward_group.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// ssh.user.join_forward_group / ssh.user.leave_forward_group — manage membership
+// in jabali-ssh-forward (GH #1229).
+//
+// A hosting user in jabali-ssh-forward is EXCLUDED from the JAB-352 forwarding
+// lockdown (Match Group jabali-ssh-sandbox,!jabali-ssh-forward) and instead gets
+// local/dynamic loopback TCP forwarding, enough for VS Code Remote-SSH to reach
+// its own VS Code Server. The sensitive loopback services stay firewall-blocked
+// per-uid, so this never re-opens the tunneling vector. Opt-in, operator-driven.
+//
+// No sshd reload is needed: sshd evaluates Match Group against the user's current
+// group membership at connection time, so the next SSH connection picks it up.
+
+const forwardGroupName = "jabali-ssh-forward"
+
+type sshUserForwardGroupParams struct {
+	Username string `json:"username"`
+}
+
+type sshUserForwardGroupResponse struct {
+	Username      string `json:"username"`
+	Joined        bool   `json:"joined,omitempty"`
+	Left          bool   `json:"left,omitempty"`
+	AlreadyMember bool   `json:"already_member,omitempty"`
+	NotMember     bool   `json:"not_member,omitempty"`
+}
+
+func sshUserJoinForwardGroupHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p sshUserForwardGroupParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	isMember, gErr := isUserInGroup(ctx, p.Username, forwardGroupName)
+	if gErr != nil {
+		return nil, gErr
+	}
+	if isMember {
+		return &sshUserForwardGroupResponse{Username: p.Username, AlreadyMember: true}, nil
+	}
+	cmd := execCommandContext(ctx, "usermod", "-aG", forwardGroupName, p.Username)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod -aG %s %s: %v (stderr: %s)", forwardGroupName, p.Username, err, stderr.String())}
+	}
+	return &sshUserForwardGroupResponse{Username: p.Username, Joined: true}, nil
+}
+
+func sshUserLeaveForwardGroupHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p sshUserForwardGroupParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	isMember, gErr := isUserInGroup(ctx, p.Username, forwardGroupName)
+	if gErr != nil {
+		return nil, gErr
+	}
+	if !isMember {
+		return &sshUserForwardGroupResponse{Username: p.Username, NotMember: true}, nil
+	}
+	cmd := execCommandContext(ctx, "gpasswd", "-d", p.Username, forwardGroupName)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("gpasswd -d %s %s: %v (stderr: %s)", p.Username, forwardGroupName, err, stderr.String())}
+	}
+	return &sshUserForwardGroupResponse{Username: p.Username, Left: true}, nil
+}
+
+func init() {
+	Default.Register("ssh.user.join_forward_group", sshUserJoinForwardGroupHandler)
+	Default.Register("ssh.user.leave_forward_group", sshUserLeaveForwardGroupHandler)
+}

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1080,6 +1080,10 @@ fi
 					// M13 SSH sandbox: refresh wrapper + nspawn-enter +
 					// sudoers + mode files on every update. Idempotent.
 					"getent group jabali-ssh-sandbox >/dev/null || groupadd --system jabali-ssh-sandbox; "+
+					// GH #1229: opt-in SSH-forwarding group (excluded from the JAB-352
+					// lockdown). Ensure it exists on every update so the sshd drop-in's
+					// Match negation resolves on existing fleet hosts.
+					"getent group jabali-ssh-forward >/dev/null || groupadd --system jabali-ssh-forward; "+
 					"install -d -m 0755 -o root -g root /etc/jabali /etc/jabali/users /var/lib/jabali-nspawn /var/lib/jabali-nspawn/images; "+
 					"install -m 0755 -o root -g root "+repoDir+"/install/ssh/jabali-nspawn-enter /usr/local/bin/jabali-nspawn-enter; "+
 					"visudo -cf "+repoDir+"/install/ssh/jabali-nspawn-sudoers >/dev/null && install -m 0440 -o root -g root "+repoDir+"/install/ssh/jabali-nspawn-sudoers /etc/sudoers.d/jabali-nspawn; "+

--- a/panel-api/cmd/server/user.go
+++ b/panel-api/cmd/server/user.go
@@ -35,6 +35,7 @@ func newUserCmd() *cobra.Command {
 		newUser2FAResetCmd(),
 		newUserSuspendCmd(),
 		newUserUnsuspendCmd(),
+		newUserSSHForwardingCmd(),
 	)
 	return cmd
 }

--- a/panel-api/cmd/server/user_ssh_forwarding_cmd.go
+++ b/panel-api/cmd/server/user_ssh_forwarding_cmd.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newUserSSHForwardingCmd opts a hosting user into (or out of) SSH TCP forwarding
+// for VS Code Remote-SSH (GH #1229), by managing jabali-ssh-forward membership.
+//
+// Default OFF: an SSH-enabled user is in the JAB-352 forwarding lockdown. Opting
+// in EXCLUDES them from the lockdown and allows local/dynamic loopback forwarding
+// only; the sensitive loopback services stay firewall-blocked per-uid, so this
+// never re-opens the tunneling vector. Takes effect on the user's next SSH
+// connection (sshd re-evaluates Match Group per connection).
+func newUserSSHForwardingCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ssh-forwarding <email|username|user-id> <on|off>",
+		Short: "Opt a hosting user into/out of SSH TCP forwarding for VS Code Remote-SSH (GH #1229)",
+		Long: `Opt a hosting user into or out of SSH TCP forwarding.
+
+Default is OFF — SSH-enabled users cannot forward (JAB-352 lockdown), which blocks
+VS Code Remote-SSH. Turning it ON adds the user to the jabali-ssh-forward group:
+they get local/dynamic loopback forwarding (enough for VS Code Remote-SSH to reach
+its own VS Code Server), while remote/socket/agent/X11/tunnel forwarding stays off
+and the sensitive loopback services remain firewall-blocked per-uid.
+
+Takes effect on the user's next SSH connection.`,
+		Args:    cobra.ExactArgs(2),
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+			defer cancel()
+
+			target, err := resolveUser(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			if target.Username == nil || *target.Username == "" {
+				return fmt.Errorf("%q has no Linux username — SSH forwarding applies only to hosting users", args[0])
+			}
+			var enable bool
+			switch strings.ToLower(args[1]) {
+			case "on", "enable", "true", "yes":
+				enable = true
+			case "off", "disable", "false", "no":
+				enable = false
+			default:
+				return fmt.Errorf("second argument must be on|off, got %q", args[1])
+			}
+
+			verb := "ssh.user.leave_forward_group"
+			if enable {
+				verb = "ssh.user.join_forward_group"
+			}
+			if _, err := sharedAgent.Call(ctx, verb, map[string]any{"username": *target.Username}); err != nil {
+				cliAuditErr(ctx, "ssh.forwarding", "user", target.ID, &target.ID)
+				return fmt.Errorf("%s: %w", verb, err)
+			}
+			cliAuditOK(ctx, "ssh.forwarding", "user", target.ID, &target.ID)
+
+			if enable {
+				fmt.Printf("SSH TCP forwarding ENABLED for %q — VS Code Remote-SSH will work on their next connection.\n"+
+					"Only loopback forwarding is allowed; sensitive services stay firewall-blocked.\n", *target.Username)
+			} else {
+				fmt.Printf("SSH TCP forwarding DISABLED for %q — back in the JAB-352 lockdown on their next connection.\n", *target.Username)
+			}
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Problem (GH #1229)

JAB-352's forwarding lockdown (`jabali-ssh-sandbox`: `AllowTcpForwarding no`, `PermitOpen none`) breaks VS Code Remote-SSH, which must forward to its **own** VS Code Server on `127.0.0.1:<random high port>`. The reporter asked for a safe exception that preserves the JAB-352 security.

## Approach — opt-in, defense at the resource (chosen by the operator)

Default OFF → **JAB-352 is unchanged for everyone**. An operator opts a user in; the sensitive loopback services stay unreachable via a per-uid firewall drop, so the relaxation can never tunnel into them.

- **Firewall guard** (`jabali-diag-loopback-isolation.nft`): extend the JAB-368 `skuid>=1000` drop from `:6060` alone to the full sensitive loopback set `{631,5300,6060,7422,8081,8443,8446,8462,18181}` (CrowdSec/Stalwart admin, the panel, pdns backend, mailhook, CUPS). A per-uid drop can't distinguish an app connection from a forwarded one, so it blocks **only** ports a tenant app never needs — the app-facing data services (`:3306`/`:5432`/`:53`/Redis) are deliberately left reachable. Applied to **all** tenant uids: a security improvement in its own right.
- **sshd** (`jabali-ssh-sandbox.conf`): the lockdown block now excludes the opt-in group (`Match Group jabali-ssh-sandbox,!jabali-ssh-forward` — sshd's first-value-wins requires the exclusion on the Match line), and a new `Match Group jabali-ssh-forward` allows `AllowTcpForwarding local` (covers VS Code's dynamic `-D`) with loopback-only `PermitOpen`; remote/socket/agent/X11/tunnel stay off.
- **Opt-in**: `jabali-ssh-forward` group (groupadd on install + every update), agent verbs `ssh.user.join/leave_forward_group`, and `jabali user ssh-forwarding <user> on|off`. Membership drives the sshd Match (per-connection, no reload).

## Security drill on .86 — verified by behavior
- Tenant uid → `:6060` / `:8446` **blocked**; → `:3306` / `:5432` **allowed** (app DSNs work); root unaffected.
- Opt-in flips a user's effective `sshd -T` `allowtcpforwarding no`→`local` + loopback `PermitOpen`; toggle-off returns to `no`.
- `sshd -t` validates the drop-in (an invalid directive would make the converger remove the whole lockdown — verified valid first).

## Scope / follow-ups
- Group-membership opt-in (no DB flag/reconciler yet — **fails safe** on reprovision; durability across reprovision + a UI toggle are the follow-up).
- Design + audit in `plans/gh1229-vscode-remote-ssh-optin-forwarding.md`. No DB migration.

GH #1229
