### PR TITLE
refactor(mail): shared Mailbox Lifecycle ops + stale password_enc fix (JAB-291)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3136,10 +3136,12 @@ jabali mailbox create [flags]
 
 **Flags:**
 
+- `--display-name` — Human-readable display name (GH #197)
 - `--domain` — Domain name or ID (required)
 - `--local` — Local part, e.g. "alice" (required)
 - `--password` — Explicit password (omit to auto-generate)
 - `--quota-mb` — Disk quota in MiB (default 1024) (default `0`)
+- `--send-only` — SMTP-submission only — authenticates to send but never receives (GH #371)
 
 #### `jabali mailbox delete`
 

--- a/panel-api/cmd/server/mailbox_cmd.go
+++ b/panel-api/cmd/server/mailbox_cmd.go
@@ -100,10 +100,12 @@ func newMailboxListCmd() *cobra.Command {
 
 func newMailboxCreateCmd() *cobra.Command {
 	var (
-		domainSpec string
-		localPart  string
-		password   string
-		quotaMB    uint64
+		domainSpec  string
+		localPart   string
+		password    string
+		quotaMB     uint64
+		displayName string
+		sendOnly    bool
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -121,7 +123,7 @@ and cannot be recovered.`,
 				return err
 			}
 			quotaBytes := quotaMB * 1024 * 1024
-			mb, generatedPassword, err := createMailboxDirect(ctx, mailboxRepoFromDB(), notifyAgentMailbox, ssoKeyForCLI(), dom, localPart, password, quotaBytes)
+			mb, generatedPassword, err := createMailboxDirect(ctx, mailboxRepoFromDB(), notifyAgentMailbox, ssoKeyForCLI(), dom, localPart, password, quotaBytes, displayName, sendOnly)
 			if err != nil {
 				return err
 			}
@@ -147,6 +149,8 @@ and cannot be recovered.`,
 	cmd.Flags().StringVar(&localPart, "local", "", "Local part, e.g. \"alice\" (required)")
 	cmd.Flags().StringVar(&password, "password", "", "Explicit password (omit to auto-generate)")
 	cmd.Flags().Uint64Var(&quotaMB, "quota-mb", 0, "Disk quota in MiB (default 1024)")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "Human-readable display name (GH #197)")
+	cmd.Flags().BoolVar(&sendOnly, "send-only", false, "SMTP-submission only — authenticates to send but never receives (GH #371)")
 	_ = cmd.MarkFlagRequired("domain")
 	_ = cmd.MarkFlagRequired("local")
 	return cmd

--- a/panel-api/cmd/server/mailbox_cmd_test.go
+++ b/panel-api/cmd/server/mailbox_cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailboxops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -284,7 +285,7 @@ func TestCreateMailbox_HappyPath(t *testing.T) {
 
 	mb, generated, err := createMailboxDirect(
 		context.Background(), repo, notify, nil,
-		dom, "Alice", "", 0,
+		dom, "Alice", "", 0, "", false,
 	)
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -301,8 +302,8 @@ func TestCreateMailbox_HappyPath(t *testing.T) {
 	if bcrypt.CompareHashAndPassword([]byte(mb.PasswordHash), []byte(generated)) != nil {
 		t.Error("stored bcrypt hash must verify against generated password")
 	}
-	if mb.QuotaBytes != cliMailboxDefaultQuotaBytes {
-		t.Errorf("default quota should be %d, got %d", cliMailboxDefaultQuotaBytes, mb.QuotaBytes)
+	if mb.QuotaBytes != mailboxops.DefaultQuotaBytes {
+		t.Errorf("default quota should be %d, got %d", mailboxops.DefaultQuotaBytes, mb.QuotaBytes)
 	}
 	if notifyCmd != "mailbox.create" {
 		t.Errorf("agent notify should fire mailbox.create, got %q", notifyCmd)
@@ -322,7 +323,7 @@ func TestCreateMailbox_RefusesOnDisabledEmail(t *testing.T) {
 
 	_, _, err := createMailboxDirect(
 		context.Background(), repo, nil, nil,
-		dom, "alice", "", 0,
+		dom, "alice", "", 0, "", false,
 	)
 	if err == nil {
 		t.Fatal("expected error when email is not enabled on the domain")
@@ -346,7 +347,7 @@ func TestCreateMailbox_UniquenessConflict(t *testing.T) {
 	// First create succeeds.
 	_, _, err := createMailboxDirect(
 		context.Background(), repo, nil, nil,
-		dom, "alice", "", 0,
+		dom, "alice", "", 0, "", false,
 	)
 	if err != nil {
 		t.Fatalf("first create: %v", err)
@@ -354,7 +355,7 @@ func TestCreateMailbox_UniquenessConflict(t *testing.T) {
 	// Second create with the same local_part must fail.
 	_, _, err = createMailboxDirect(
 		context.Background(), repo, nil, nil,
-		dom, "alice", "", 0,
+		dom, "alice", "", 0, "", false,
 	)
 	if err == nil {
 		t.Fatal("duplicate create should have failed")
@@ -374,7 +375,7 @@ func TestCreateMailbox_ExplicitPassword(t *testing.T) {
 
 	mb, generated, err := createMailboxDirect(
 		context.Background(), repo, nil, nil,
-		dom, "alice", "super-secret-12345", 0,
+		dom, "alice", "super-secret-12345", 0, "", false,
 	)
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -395,9 +396,9 @@ func TestCreateMailbox_QuotaFloor(t *testing.T) {
 
 	_, _, err := createMailboxDirect(
 		context.Background(), repo, nil, nil,
-		dom, "alice", "pw12345678", 1*1024*1024, // 1 MiB — below floor
+		dom, "alice", "pw12345678", 1*1024*1024, "", false, // 1 MiB — below floor
 	)
-	if err == nil || !strings.Contains(err.Error(), "at least 16") {
+	if err == nil || !strings.Contains(err.Error(), "16 MiB") {
 		t.Fatalf("expected quota-floor error, got %v", err)
 	}
 }
@@ -493,7 +494,7 @@ func TestSetMailboxQuota_Floor(t *testing.T) {
 		context.Background(), repo, nil,
 		"alice@example.com", 1*1024*1024,
 	)
-	if err == nil || !strings.Contains(err.Error(), "at least 16") {
+	if err == nil || !strings.Contains(err.Error(), "16 MiB") {
 		t.Fatalf("expected quota-floor error, got %v", err)
 	}
 }

--- a/panel-api/cmd/server/mailbox_ops.go
+++ b/panel-api/cmd/server/mailbox_ops.go
@@ -7,10 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
-
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/mailaddr"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailboxops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
@@ -22,16 +19,11 @@ import (
 // there's no per-user claims resolution — ownership checks collapse to
 // "admin", which is fine for operator-only tooling.
 //
-// Constants must stay in sync with panel-api/internal/api/mailboxes.go
-// (defaultMailboxQuotaBytes, minMailboxQuotaBytes, mailboxBcryptCost,
-// mailboxAgentTimeout). We duplicate them here rather than export from
-// the api package because the CLI doesn't link against gin.
-const (
-	cliMailboxDefaultQuotaBytes uint64 = 1 << 30
-	cliMailboxMinQuotaBytes     uint64 = 16 * 1024 * 1024
-	cliMailboxBcryptCost               = bcrypt.DefaultCost
-	cliMailboxAgentTimeout             = 30 * time.Second
-)
+// The create/rotate/quota/delete logic + the quota/bcrypt constants now live in
+// the shared mailboxops package (JAB-291); these helpers are thin CLI wrappers
+// over it, so the CLI and the REST handlers can no longer drift. Only the
+// CLI-local agent timeout stays here.
+const cliMailboxAgentTimeout = 30 * time.Second
 
 // agentNotifier is the minimal surface the CLI needs from the agent
 // client. Small interface so tests can pass a recording stub without
@@ -112,78 +104,15 @@ func listMailboxesDirect(ctx context.Context, repo repository.MailboxRepository,
 // Returns the row plus the generated password, which is empty when the
 // caller supplied one — the CLI layer owns the reveal-once printing
 // contract.
-func createMailboxDirect(ctx context.Context, repo repository.MailboxRepository, notify agentNotifier, ssoKey *ssokey.Key, dom *models.Domain, localPart, password string, quotaBytes uint64) (*models.Mailbox, string, error) {
-	if !dom.EmailEnabled {
-		return nil, "", fmt.Errorf("email is not enabled on domain %s — run `jabali domain email-enable %s` first", dom.Name, dom.Name)
-	}
-	canonLocal, _, err := mailaddr.Canonicalise(localPart + "@" + dom.Name)
-	if err != nil {
-		return nil, "", fmt.Errorf("invalid local_part: %w", err)
-	}
-
-	exists, err := repo.ExistsByDomainAndLocalPart(ctx, dom.ID, canonLocal)
-	if err != nil {
-		return nil, "", fmt.Errorf("uniqueness check: %w", err)
-	}
-	if exists {
-		return nil, "", fmt.Errorf("mailbox %s@%s already exists", canonLocal, dom.Name)
-	}
-
-	generated := ""
-	if password == "" {
-		password = ids.NewSecret()
-		generated = password
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), cliMailboxBcryptCost)
-	if err != nil {
-		return nil, "", fmt.Errorf("hash password: %w", err)
-	}
-
-	if quotaBytes == 0 {
-		quotaBytes = cliMailboxDefaultQuotaBytes
-	}
-	if quotaBytes < cliMailboxMinQuotaBytes {
-		return nil, "", fmt.Errorf("quota-mb must be at least 16 (MiB)")
-	}
-
-	var enc []byte
-	if ssoKey != nil {
-		sealed, err := ssoKey.Seal([]byte(password))
-		if err != nil {
-			return nil, "", fmt.Errorf("seal password: %w", err)
-		}
-		enc = sealed
-	}
-
-	now := time.Now().UTC()
-	mb := &models.Mailbox{
-		ID:           ids.NewULID(),
-		DomainID:     dom.ID,
-		LocalPart:    canonLocal,
-		PasswordHash: string(hash),
-		PasswordEnc:  enc,
-		QuotaBytes:   quotaBytes,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if err := repo.Create(ctx, mb); err != nil {
-		return nil, "", fmt.Errorf("insert mailbox row: %w", err)
-	}
-
-	// Best-effort agent notify, same as the HTTP handler. Errors are
-	// swallowed inside `notify`; the reconciler re-asserts if Stalwart
-	// ever diverges.
-	if notify != nil {
-		notify(ctx, "mailbox.create", map[string]any{
-			"id":    mb.ID,
-			"email": canonLocal + "@" + dom.Name,
-		})
-	}
-	// Fill EmailCached locally — the BEFORE INSERT trigger already wrote
-	// it in the DB, but our `mb` struct doesn't reflect that without a
-	// re-read. Set it so the caller's printout is correct.
-	mb.EmailCached = canonLocal + "@" + dom.Name
-	return mb, generated, nil
+func createMailboxDirect(ctx context.Context, repo repository.MailboxRepository, notify agentNotifier, ssoKey *ssokey.Key, dom *models.Domain, localPart, password string, quotaBytes uint64, displayName string, sendOnly bool) (*models.Mailbox, string, error) {
+	return mailboxops.Create(ctx, mailboxops.Deps{Mailboxes: repo, SSOKey: ssoKey}, mailboxops.CreateInput{
+		Domain:      dom,
+		LocalPart:   localPart,
+		Password:    password,
+		QuotaBytes:  quotaBytes,
+		DisplayName: displayName,
+		SendOnly:    sendOnly,
+	}, mailboxops.NotifyFunc(notify))
 }
 
 // deleteMailboxDirect mirrors DELETE /mailboxes/:mbid: agent call first
@@ -202,54 +131,13 @@ func createMailboxDirect(ctx context.Context, repo repository.MailboxRepository,
 type agentCaller func(ctx context.Context, cmd string, params any) (json.RawMessage, error)
 
 func deleteMailboxDirect(ctx context.Context, repo repository.MailboxRepository, call agentCaller, email string) error {
-	mb, err := repo.FindByEmail(ctx, email)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return fmt.Errorf("mailbox %s not found", email)
-		}
-		return fmt.Errorf("lookup mailbox: %w", err)
-	}
-	if call == nil {
-		return fmt.Errorf("agent not configured")
-	}
-	if _, err := call(ctx, "mailbox.delete", map[string]any{
-		"id":    mb.ID,
-		"email": email,
-	}); err != nil {
-		return fmt.Errorf("agent mailbox.delete: %w", err)
-	}
-	if err := repo.Delete(ctx, mb.ID); err != nil {
-		return fmt.Errorf("delete mailbox row: %w", err)
-	}
-	return nil
+	return mailboxops.Delete(ctx, repo, mailboxops.CallFunc(call), email)
 }
 
 // setMailboxQuotaDirect mirrors PATCH /mailboxes/:mbid. Quota floor
 // check matches the HTTP handler (16 MiB).
 func setMailboxQuotaDirect(ctx context.Context, repo repository.MailboxRepository, notify agentNotifier, email string, quotaBytes uint64) (*models.Mailbox, error) {
-	if quotaBytes < cliMailboxMinQuotaBytes {
-		return nil, fmt.Errorf("quota-mb must be at least 16 (MiB)")
-	}
-	mb, err := repo.FindByEmail(ctx, email)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil, fmt.Errorf("mailbox %s not found", email)
-		}
-		return nil, fmt.Errorf("lookup mailbox: %w", err)
-	}
-	if err := repo.UpdateQuota(ctx, mb.ID, quotaBytes); err != nil {
-		return nil, fmt.Errorf("update quota: %w", err)
-	}
-	if notify != nil {
-		notify(ctx, "mailbox.set_quota", map[string]any{
-			"id":          mb.ID,
-			"email":       email,
-			"quota_bytes": quotaBytes,
-		})
-	}
-	mb.QuotaBytes = quotaBytes
-	mb.UpdatedAt = time.Now().UTC()
-	return mb, nil
+	return mailboxops.SetQuota(ctx, mailboxops.Deps{Mailboxes: repo}, email, quotaBytes, mailboxops.NotifyFunc(notify))
 }
 
 // rotateMailboxPasswordDirect mirrors POST /mailboxes/:mbid/rotate-password.
@@ -257,41 +145,7 @@ func setMailboxQuotaDirect(ctx context.Context, repo repository.MailboxRepositor
 // AES-256-GCM envelope too when ssoKey is non-nil so the webmail SSO
 // flow stays in sync with the bcrypt hash.
 func rotateMailboxPasswordDirect(ctx context.Context, repo repository.MailboxRepository, notify agentNotifier, ssoKey *ssokey.Key, email, newPassword string) (string, error) {
-	mb, err := repo.FindByEmail(ctx, email)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return "", fmt.Errorf("mailbox %s not found", email)
-		}
-		return "", fmt.Errorf("lookup mailbox: %w", err)
-	}
-
-	generated := ""
-	if newPassword == "" {
-		newPassword = ids.NewSecret()
-		generated = newPassword
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), cliMailboxBcryptCost)
-	if err != nil {
-		return "", fmt.Errorf("hash password: %w", err)
-	}
-	if ssoKey != nil {
-		sealed, err := ssoKey.Seal([]byte(newPassword))
-		if err != nil {
-			return "", fmt.Errorf("seal password: %w", err)
-		}
-		if err := repo.UpdatePasswordHashAndEnc(ctx, mb.ID, string(hash), sealed); err != nil {
-			return "", fmt.Errorf("update password: %w", err)
-		}
-	} else if err := repo.UpdatePasswordHash(ctx, mb.ID, string(hash)); err != nil {
-		return "", fmt.Errorf("update password: %w", err)
-	}
-	if notify != nil {
-		notify(ctx, "mailbox.set_password", map[string]any{
-			"id":    mb.ID,
-			"email": email,
-		})
-	}
-	return generated, nil
+	return mailboxops.RotatePassword(ctx, mailboxops.Deps{Mailboxes: repo, SSOKey: ssoKey}, email, newPassword, mailboxops.NotifyFunc(notify))
 }
 
 // notifyAgentMailbox is the production agentNotifier wired off the

--- a/panel-api/internal/api/mailboxes.go
+++ b/panel-api/internal/api/mailboxes.go
@@ -6,18 +6,18 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/crypto/bcrypt"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/mailaddr"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailboxops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -45,20 +45,12 @@ const (
 	defaultMailboxesPageSize = 20
 	maxMailboxesPageSize     = 200
 
-	// Default mailbox quota — 1 GiB. Mirrors the column DEFAULT in
-	// migration 000054; kept here as a fallback if a caller somehow
-	// sends a zero QuotaBytes.
-	defaultMailboxQuotaBytes uint64 = 1 << 30
-
-	// Floor for user-supplied quotas. Anything below 16 MiB would make
-	// even a test mailbox unusable (a single MIME attachment would
-	// push past quota). The panel-UI will carry its own slider min,
-	// but defence in depth here.
-	minMailboxQuotaBytes uint64 = 16 * 1024 * 1024
-
-	// Bcrypt cost — matches what Stalwart's SqlDirectory expects.
-	// DefaultCost (10) is fine; higher would slow logins noticeably.
-	mailboxBcryptCost = bcrypt.DefaultCost
+	// Mailbox quota floor/default + bcrypt cost are owned by the shared Mailbox
+	// Lifecycle package (JAB-291) and aliased here so these handlers and the CLI
+	// reference one source and can't drift.
+	defaultMailboxQuotaBytes = mailboxops.DefaultQuotaBytes
+	minMailboxQuotaBytes     = mailboxops.MinQuotaBytes
+	mailboxBcryptCost        = mailboxops.BcryptCost
 
 	// Agent call budget. Matches other handlers that SSH or shell out.
 	mailboxAgentTimeout = 30 * time.Second
@@ -243,13 +235,6 @@ func (h *mailboxHandler) create(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
-	if !dom.EmailEnabled {
-		c.JSON(http.StatusConflict, gin.H{
-			"error":  "email_not_enabled",
-			"detail": "enable email on the domain before creating mailboxes",
-		})
-		return
-	}
 
 	var req createMailboxRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -257,105 +242,41 @@ func (h *mailboxHandler) create(c *gin.Context) {
 		return
 	}
 
-	// Canonicalise the full address (local@domain.name) so rejection
-	// rules (shell meta, empty, too long, non-ASCII) match what the
-	// agent's domain.email_enable validator enforces.
-	canonLocal, _, err := mailaddr.Canonicalise(req.LocalPart + "@" + dom.Name)
+	// Shared Mailbox Lifecycle create (JAB-291): the EmailEnabled gate, address
+	// canonicalization, quota default/floor, password gen/hash/seal, duplicate
+	// rule, and display_name/send_only all live in the op. Authorization stayed
+	// here (the ownership check above).
+	mb, generatedPassword, err := mailboxops.Create(ctx, mailboxops.Deps{
+		Mailboxes: h.cfg.Mailboxes,
+		SSOKey:    h.cfg.SSOKey,
+	}, mailboxops.CreateInput{
+		Domain:      dom,
+		LocalPart:   req.LocalPart,
+		Password:    req.Password,
+		QuotaBytes:  req.QuotaBytes,
+		DisplayName: req.DisplayName,
+		SendOnly:    req.SendOnly,
+	}, h.notifyAgent)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_local_part", "detail": err.Error()})
-		return
-	}
-
-	// Uniqueness is enforced by the UNIQUE index on email_cached — we
-	// check up-front for a friendlier error code than the driver's
-	// "duplicate entry" string.
-	exists, err := h.cfg.Mailboxes.ExistsByDomainAndLocalPart(ctx, dom.ID, canonLocal)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-	if exists {
-		c.JSON(http.StatusConflict, gin.H{"error": "mailbox_exists"})
-		return
-	}
-
-	password := req.Password
-	generatedPassword := ""
-	if password == "" {
-		// ULID as password — 26 chars of Crockford base32 is ~130 bits
-		// of entropy. Adequate for "reveal once, user copies to a
-		// client". No hidden dependency, no extra import.
-		password = ids.NewSecret()
-		generatedPassword = password
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), mailboxBcryptCost)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-
-	quota := req.QuotaBytes
-	if quota == 0 {
-		quota = defaultMailboxQuotaBytes
-	}
-	if quota < minMailboxQuotaBytes {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "quota_too_small",
-			"detail": "quota_bytes must be at least 16 MiB",
-		})
-		return
-	}
-
-	// Cipher the plaintext for the webmail SSO flow. Best-effort — when
-	// the SSOKey isn't configured (panel running without sso.key) we
-	// store the mailbox without an encrypted blob; the SSO mint endpoint
-	// will then 503 until the next rotate repopulates it.
-	var enc []byte
-	if h.cfg.SSOKey != nil {
-		sealed, err := h.cfg.SSOKey.Seal([]byte(password))
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-			return
-		}
-		enc = sealed
-	}
-
-	now := time.Now().UTC()
-	mb := &models.Mailbox{
-		ID:           ids.NewULID(),
-		DomainID:     dom.ID,
-		LocalPart:    canonLocal,
-		DisplayName:  strings.TrimSpace(req.DisplayName),
-		PasswordHash: string(hash),
-		PasswordEnc:  enc,
-		QuotaBytes:   quota,
-		SendOnly:     req.SendOnly,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if err := h.cfg.Mailboxes.Create(ctx, mb); err != nil {
-		if isConflict(err) {
+		switch {
+		case errors.Is(err, mailboxops.ErrEmailNotEnabled):
+			c.JSON(http.StatusConflict, gin.H{"error": "email_not_enabled", "detail": "enable email on the domain before creating mailboxes"})
+		case errors.Is(err, mailboxops.ErrInvalidLocalPart):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_local_part", "detail": err.Error()})
+		case errors.Is(err, mailboxops.ErrMailboxExists):
 			c.JSON(http.StatusConflict, gin.H{"error": "mailbox_exists"})
-			return
+		case errors.Is(err, mailboxops.ErrQuotaTooSmall):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "quota_too_small", "detail": "quota_bytes must be at least 16 MiB"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-
-	// Inline best-effort agent notify (ADR-0013). Stalwart's
-	// SqlDirectory syncs on every auth so this is a typed
-	// acknowledgement rather than a cache-invalidate — but we still
-	// surface agent errors so operators can see them.
-	h.notifyAgent(ctx, "mailbox.create", map[string]any{
-		"id":           mb.ID,
-		"email":        canonLocal + "@" + dom.Name,
-		"display_name": mb.DisplayName,
-	})
 
 	c.JSON(http.StatusCreated, createMailboxResponse{
 		ID:          mb.ID,
-		Email:       canonLocal + "@" + dom.Name,
-		QuotaBytes:  quota,
+		Email:       mb.EmailCached,
+		QuotaBytes:  mb.QuotaBytes,
 		DisplayName: mb.DisplayName,
 		SendOnly:    mb.SendOnly,
 		Password:    generatedPassword,
@@ -488,39 +409,22 @@ func (h *mailboxHandler) rotatePassword(c *gin.Context) {
 		return
 	}
 
-	password := req.NewPassword
-	generated := ""
-	if password == "" {
-		password = ids.NewSecret()
-		generated = password
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), mailboxBcryptCost)
+	// Shared Mailbox Lifecycle rotate (JAB-291): hash + sealed envelope are
+	// updated atomically — with a live SSO key the envelope is re-sealed, without
+	// one it is cleared (never left stale, which previously made the SSO mint
+	// decrypt to the old password Stalwart no longer accepts).
+	generated, err := mailboxops.RotatePassword(ctx, mailboxops.Deps{
+		Mailboxes: h.cfg.Mailboxes,
+		SSOKey:    h.cfg.SSOKey,
+	}, mb.LocalPart+"@"+dom.Name, req.NewPassword, h.notifyAgent)
 	if err != nil {
+		if errors.Is(err, mailboxops.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "mailbox_not_found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-
-	// Re-cipher the plaintext so password_enc stays in sync with
-	// password_hash. Same best-effort fallback as create.
-	if h.cfg.SSOKey != nil {
-		sealed, err := h.cfg.SSOKey.Seal([]byte(password))
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-			return
-		}
-		if err := h.cfg.Mailboxes.UpdatePasswordHashAndEnc(ctx, mb.ID, string(hash), sealed); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-			return
-		}
-	} else if err := h.cfg.Mailboxes.UpdatePasswordHash(ctx, mb.ID, string(hash)); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-
-	h.notifyAgent(ctx, "mailbox.set_password", map[string]any{
-		"id":    mb.ID,
-		"email": mb.LocalPart + "@" + dom.Name,
-	})
 
 	c.JSON(http.StatusOK, rotateMailboxPasswordResponse{Password: generated})
 }
@@ -540,23 +444,18 @@ func (h *mailboxHandler) delete(c *gin.Context) {
 		return
 	}
 
-	// Delete agent-side first: it's the step that actually removes mail
-	// content from RocksDB (via x:Account/set destroy — see
-	// mailbox_delete.go in panel-agent). If that fails, abort before
-	// the DB delete so the rows stays consistent with Stalwart's state.
-	agentCtx, cancel := context.WithTimeout(ctx, mailboxAgentTimeout)
-	defer cancel()
-	_, err = h.cfg.Agent.Call(agentCtx, "mailbox.delete", map[string]any{
-		"id":    mb.ID,
-		"email": mb.LocalPart + "@" + dom.Name,
-	})
-	if err != nil {
-		respondAgentErr(c, "agent_failed", err)
-		return
-	}
-
-	if err := h.cfg.Mailboxes.Delete(ctx, mb.ID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+	// Shared Mailbox Lifecycle delete (JAB-291): destroy the Stalwart account
+	// first (hard dependency), then the row — a failed destroy aborts before the
+	// row delete so the DB never tombstones a mailbox whose Stalwart side is live.
+	if err := mailboxops.Delete(ctx, h.cfg.Mailboxes, h.cfg.Agent.Call, mb.LocalPart+"@"+dom.Name); err != nil {
+		switch {
+		case errors.Is(err, mailboxops.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "mailbox_not_found"})
+		case errors.Is(err, mailboxops.ErrAgentUnavailable):
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		default:
+			respondAgentErr(c, "agent_failed", err)
+		}
 		return
 	}
 

--- a/panel-api/internal/mailboxops/mailboxops.go
+++ b/panel-api/internal/mailboxops/mailboxops.go
@@ -1,0 +1,254 @@
+// Package mailboxops is the shared Mailbox Lifecycle (JAB-291): the create,
+// password-rotation, quota, and delete operations the REST handlers and the
+// operator CLI both route through, so address canonicalization, the quota
+// default/floor, password generation/hash/sealing, the duplicate rule, and the
+// display_name/send_only fields have one owner and cannot drift between the two.
+//
+// Authorization stays an Adapter concern: every entry point takes an already-
+// loaded, already-authorized domain/mailbox (the REST handler checks the
+// caller's claims; the operator CLI is admin-by-construction). System mailboxes
+// (the GH #1056 noreply relay) are created only by the reconciler and are NOT
+// expressible here; the migration restore path keeps its own semantics too.
+package mailboxops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/mailaddr"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// The single source for these constants — the CLI used to duplicate them with a
+// "keep in sync" comment.
+const (
+	DefaultQuotaBytes uint64 = 1 << 30          // 1 GiB
+	MinQuotaBytes     uint64 = 16 * 1024 * 1024 // 16 MiB floor
+	BcryptCost               = bcrypt.DefaultCost
+)
+
+// NotifyFunc is the best-effort agent notify (ADR-0013): its errors are
+// swallowed by the caller's implementation and never fail the operation.
+type NotifyFunc func(ctx context.Context, cmd string, params any)
+
+// CallFunc is the hard agent call used by Delete — its error aborts before the
+// row is removed so Stalwart and the DB never diverge.
+type CallFunc func(ctx context.Context, cmd string, params any) (json.RawMessage, error)
+
+// Deps carries the collaborators every operation needs.
+type Deps struct {
+	Mailboxes repository.MailboxRepository
+	// SSOKey seals the plaintext into password_enc for the webmail SSO flow.
+	// Nil → the row is stored/rotated with NO envelope (SSO unavailable until a
+	// rotate with a live key), never a stale one.
+	SSOKey *ssokey.Key
+}
+
+var (
+	ErrEmailNotEnabled  = errors.New("mailboxops: email is not enabled on the domain")
+	ErrInvalidLocalPart = errors.New("mailboxops: invalid local part")
+	ErrMailboxExists    = errors.New("mailboxops: mailbox already exists")
+	ErrQuotaTooSmall    = errors.New("mailboxops: quota below the 16 MiB floor")
+	ErrNotFound         = errors.New("mailboxops: mailbox not found")
+	ErrAgentUnavailable = errors.New("mailboxops: agent not configured")
+	ErrDeps             = errors.New("mailboxops: dependencies not wired")
+	ErrInternal         = errors.New("mailboxops: internal error")
+)
+
+// CreateInput is one interactive mailbox creation. Note the ABSENCE of a System
+// field — user-facing creates must never mint an infrastructure principal.
+type CreateInput struct {
+	Domain      *models.Domain // pre-loaded + authorized by the Adapter
+	LocalPart   string
+	Password    string // "" → generate a reveal-once secret
+	QuotaBytes  uint64 // 0 → DefaultQuotaBytes
+	DisplayName string
+	SendOnly    bool
+}
+
+// Create canonicalizes the address, enforces the EmailEnabled gate + the
+// duplicate rule + the quota default/floor, generates/hashes/seals the password,
+// persists the row (with display_name + send_only), and fires the best-effort
+// agent notify. Returns the row and the generated password ("" when the caller
+// supplied one — the reveal-once contract).
+func Create(ctx context.Context, d Deps, in CreateInput, notify NotifyFunc) (*models.Mailbox, string, error) {
+	if d.Mailboxes == nil || in.Domain == nil {
+		return nil, "", fmt.Errorf("%w: mailboxes repo + domain required", ErrDeps)
+	}
+	if !in.Domain.EmailEnabled {
+		return nil, "", ErrEmailNotEnabled
+	}
+	canonLocal, _, err := mailaddr.Canonicalise(in.LocalPart + "@" + in.Domain.Name)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %v", ErrInvalidLocalPart, err)
+	}
+	exists, err := d.Mailboxes.ExistsByDomainAndLocalPart(ctx, in.Domain.ID, canonLocal)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: uniqueness check: %v", ErrInternal, err)
+	}
+	if exists {
+		return nil, "", ErrMailboxExists
+	}
+
+	password := in.Password
+	generated := ""
+	if password == "" {
+		password = ids.NewSecret()
+		generated = password
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: hash: %v", ErrInternal, err)
+	}
+
+	quota := in.QuotaBytes
+	if quota == 0 {
+		quota = DefaultQuotaBytes
+	}
+	if quota < MinQuotaBytes {
+		return nil, "", ErrQuotaTooSmall
+	}
+
+	enc, err := sealIfKey(d.SSOKey, password)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: seal: %v", ErrInternal, err)
+	}
+
+	now := time.Now().UTC()
+	mb := &models.Mailbox{
+		ID:           ids.NewULID(),
+		DomainID:     in.Domain.ID,
+		LocalPart:    canonLocal,
+		DisplayName:  strings.TrimSpace(in.DisplayName),
+		PasswordHash: string(hash),
+		PasswordEnc:  enc,
+		QuotaBytes:   quota,
+		SendOnly:     in.SendOnly,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := d.Mailboxes.Create(ctx, mb); err != nil {
+		if errors.Is(err, repository.ErrConflict) {
+			return nil, "", ErrMailboxExists
+		}
+		return nil, "", fmt.Errorf("%w: insert: %v", ErrInternal, err)
+	}
+
+	email := canonLocal + "@" + in.Domain.Name
+	if notify != nil {
+		notify(ctx, "mailbox.create", map[string]any{"id": mb.ID, "email": email, "display_name": mb.DisplayName})
+	}
+	// The BEFORE INSERT trigger already wrote email_cached in the DB; reflect it
+	// on the returned struct so the caller's response is correct without a re-read.
+	mb.EmailCached = email
+	return mb, generated, nil
+}
+
+// RotatePassword rotates a mailbox's password. Empty newPassword → generate one
+// and return it once. The hash and the sealed envelope are updated ATOMICALLY:
+// with a live SSO key the envelope is re-sealed to the new password; WITHOUT a
+// key it is CLEARED (password_enc = NULL), never left stale — a stale envelope
+// makes the webmail SSO mint decrypt to the OLD password Stalwart no longer
+// accepts (this closes a live bug where both adapters called the hash-only
+// UpdatePasswordHash, leaving the old envelope behind).
+func RotatePassword(ctx context.Context, d Deps, email, newPassword string, notify NotifyFunc) (string, error) {
+	if d.Mailboxes == nil {
+		return "", fmt.Errorf("%w: mailboxes repo required", ErrDeps)
+	}
+	mb, err := d.Mailboxes.FindByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("%w: lookup: %v", ErrInternal, err)
+	}
+	generated := ""
+	if newPassword == "" {
+		newPassword = ids.NewSecret()
+		generated = newPassword
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), BcryptCost)
+	if err != nil {
+		return "", fmt.Errorf("%w: hash: %v", ErrInternal, err)
+	}
+	enc, err := sealIfKey(d.SSOKey, newPassword)
+	if err != nil {
+		return "", fmt.Errorf("%w: seal: %v", ErrInternal, err)
+	}
+	// enc is nil when no key → password_enc is set to NULL (never left stale).
+	if err := d.Mailboxes.UpdatePasswordHashAndEnc(ctx, mb.ID, string(hash), enc); err != nil {
+		return "", fmt.Errorf("%w: persist: %v", ErrInternal, err)
+	}
+	if notify != nil {
+		notify(ctx, "mailbox.set_password", map[string]any{"id": mb.ID, "email": email})
+	}
+	return generated, nil
+}
+
+// SetQuota updates a mailbox's quota (floor: MinQuotaBytes).
+func SetQuota(ctx context.Context, d Deps, email string, quotaBytes uint64, notify NotifyFunc) (*models.Mailbox, error) {
+	if d.Mailboxes == nil {
+		return nil, fmt.Errorf("%w: mailboxes repo required", ErrDeps)
+	}
+	if quotaBytes < MinQuotaBytes {
+		return nil, ErrQuotaTooSmall
+	}
+	mb, err := d.Mailboxes.FindByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("%w: lookup: %v", ErrInternal, err)
+	}
+	if err := d.Mailboxes.UpdateQuota(ctx, mb.ID, quotaBytes); err != nil {
+		return nil, fmt.Errorf("%w: update quota: %v", ErrInternal, err)
+	}
+	if notify != nil {
+		notify(ctx, "mailbox.set_quota", map[string]any{"id": mb.ID, "email": email, "quota_bytes": quotaBytes})
+	}
+	mb.QuotaBytes = quotaBytes
+	mb.UpdatedAt = time.Now().UTC()
+	return mb, nil
+}
+
+// Delete destroys the Stalwart account FIRST (a hard dependency) then removes
+// the row — a failed destroy aborts before the row delete so the DB never
+// tombstones a mailbox whose Stalwart side is still live.
+func Delete(ctx context.Context, mailboxes repository.MailboxRepository, call CallFunc, email string) error {
+	if mailboxes == nil {
+		return fmt.Errorf("%w: mailboxes repo required", ErrDeps)
+	}
+	mb, err := mailboxes.FindByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("%w: lookup: %v", ErrInternal, err)
+	}
+	if call == nil {
+		return ErrAgentUnavailable
+	}
+	if _, err := call(ctx, "mailbox.delete", map[string]any{"id": mb.ID, "email": email}); err != nil {
+		return fmt.Errorf("%w: agent mailbox.delete: %v", ErrInternal, err)
+	}
+	if err := mailboxes.Delete(ctx, mb.ID); err != nil {
+		return fmt.Errorf("%w: delete row: %v", ErrInternal, err)
+	}
+	return nil
+}
+
+func sealIfKey(key *ssokey.Key, password string) ([]byte, error) {
+	if key == nil {
+		return nil, nil
+	}
+	return key.Seal([]byte(password))
+}

--- a/panel-api/internal/mailboxops/mailboxops_test.go
+++ b/panel-api/internal/mailboxops/mailboxops_test.go
@@ -1,0 +1,136 @@
+package mailboxops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+type fakeMBRepo struct {
+	repository.MailboxRepository
+	existing  map[string]*models.Mailbox
+	exists    bool
+	created   *models.Mailbox
+	lastEnc   []byte
+	encCalled bool
+	quotaSet  uint64
+	deleted   string
+	createErr error
+}
+
+func (f *fakeMBRepo) ExistsByDomainAndLocalPart(_ context.Context, _, _ string) (bool, error) {
+	return f.exists, nil
+}
+func (f *fakeMBRepo) Create(_ context.Context, mb *models.Mailbox) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created = mb
+	return nil
+}
+func (f *fakeMBRepo) FindByEmail(_ context.Context, email string) (*models.Mailbox, error) {
+	if mb, ok := f.existing[email]; ok {
+		return mb, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (f *fakeMBRepo) UpdatePasswordHashAndEnc(_ context.Context, _ string, _ string, enc []byte) error {
+	f.lastEnc = enc
+	f.encCalled = true
+	return nil
+}
+func (f *fakeMBRepo) UpdateQuota(_ context.Context, _ string, q uint64) error { f.quotaSet = q; return nil }
+func (f *fakeMBRepo) Delete(_ context.Context, id string) error              { f.deleted = id; return nil }
+
+func enabledDomain() *models.Domain {
+	return &models.Domain{ID: "d1", Name: "example.com", EmailEnabled: true}
+}
+
+func TestCreate_FieldParityAndDefaults(t *testing.T) {
+	repo := &fakeMBRepo{}
+	key := ssokey.Key{}
+	mb, gen, err := Create(context.Background(), Deps{Mailboxes: repo, SSOKey: &key},
+		CreateInput{Domain: enabledDomain(), LocalPart: "alice", DisplayName: "  Alice A  ", SendOnly: true}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if gen == "" {
+		t.Fatal("a generated password must be revealed once")
+	}
+	if repo.created == nil || repo.created.DisplayName != "Alice A" || !repo.created.SendOnly {
+		t.Fatalf("display_name/send_only not persisted (field parity): %+v", repo.created)
+	}
+	if repo.created.QuotaBytes != DefaultQuotaBytes {
+		t.Errorf("quota default not applied: %d", repo.created.QuotaBytes)
+	}
+	if len(repo.created.PasswordEnc) == 0 {
+		t.Errorf("password_enc must be sealed when an SSO key is present")
+	}
+	if mb.EmailCached != "alice@example.com" {
+		t.Errorf("email_cached not reflected: %q", mb.EmailCached)
+	}
+}
+
+func TestCreate_Gates(t *testing.T) {
+	key := ssokey.Key{}
+	base := func(repo *fakeMBRepo, dom *models.Domain, q uint64) (*models.Mailbox, string, error) {
+		return Create(context.Background(), Deps{Mailboxes: repo, SSOKey: &key},
+			CreateInput{Domain: dom, LocalPart: "a", QuotaBytes: q}, nil)
+	}
+	if _, _, err := base(&fakeMBRepo{}, &models.Domain{Name: "x.com"}, 0); !errors.Is(err, ErrEmailNotEnabled) {
+		t.Errorf("email-disabled domain must be rejected, got %v", err)
+	}
+	if _, _, err := base(&fakeMBRepo{exists: true}, enabledDomain(), 0); !errors.Is(err, ErrMailboxExists) {
+		t.Errorf("duplicate must be rejected, got %v", err)
+	}
+	if _, _, err := base(&fakeMBRepo{}, enabledDomain(), 1); !errors.Is(err, ErrQuotaTooSmall) {
+		t.Errorf("below-floor quota must be rejected, got %v", err)
+	}
+}
+
+// The #5 fix: rotating WITHOUT an SSO key must CLEAR the envelope (enc = nil),
+// never leave the old sealed password behind. Both adapters previously called
+// the hash-only UpdatePasswordHash, leaving a stale envelope.
+func TestRotate_NilKey_ClearsEnvelope(t *testing.T) {
+	repo := &fakeMBRepo{existing: map[string]*models.Mailbox{"a@example.com": {ID: "m1"}}}
+	if _, err := RotatePassword(context.Background(), Deps{Mailboxes: repo, SSOKey: nil}, "a@example.com", "", nil); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if !repo.encCalled {
+		t.Fatal("rotate must persist hash + envelope atomically via UpdatePasswordHashAndEnc")
+	}
+	if repo.lastEnc != nil {
+		t.Fatalf("nil SSO key must CLEAR the envelope (enc=nil), got %d bytes", len(repo.lastEnc))
+	}
+}
+
+func TestRotate_WithKey_Seals(t *testing.T) {
+	repo := &fakeMBRepo{existing: map[string]*models.Mailbox{"a@example.com": {ID: "m1"}}}
+	key := ssokey.Key{}
+	if _, err := RotatePassword(context.Background(), Deps{Mailboxes: repo, SSOKey: &key}, "a@example.com", "newpassw0rd", nil); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if len(repo.lastEnc) == 0 {
+		t.Fatal("a live SSO key must re-seal the envelope to the new password")
+	}
+}
+
+// Delete destroys the Stalwart side first: an agent failure aborts BEFORE the
+// row is removed.
+func TestDelete_HostFailureKeepsRow(t *testing.T) {
+	repo := &fakeMBRepo{existing: map[string]*models.Mailbox{"a@example.com": {ID: "m1"}}}
+	failCall := func(context.Context, string, any) (json.RawMessage, error) {
+		return nil, errors.New("stalwart down")
+	}
+	if err := Delete(context.Background(), repo, failCall, "a@example.com"); err == nil {
+		t.Fatal("a failed Stalwart destroy must abort the delete")
+	}
+	if repo.deleted != "" {
+		t.Fatalf("the row must NOT be deleted when the host destroy failed, got %q", repo.deleted)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -359,7 +359,11 @@ func insertOneMailboxRow(
 		if cur.PasswordHash == srcHash {
 			return []string{fmt.Sprintf("mailbox_rows: %s@%s already exists with the SOURCE password", localPart, domainName)}
 		}
-		if uErr := mbRepo.UpdatePasswordHash(ctx, cur.ID, srcHash); uErr != nil {
+		// JAB-291 (#5): retrofitting the SOURCE hash changes the password, so any
+		// password_enc sealed by the earlier fresh-random create is now stale — it
+		// would decrypt to a password the new hash rejects, breaking webmail SSO.
+		// Clear it (enc=nil); a later rotate with a live SSO key re-seals it.
+		if uErr := mbRepo.UpdatePasswordHashAndEnc(ctx, cur.ID, srcHash, nil); uErr != nil {
 			return []string{fmt.Sprintf("mailbox_rows: %s@%s exists; SOURCE-password retrofit failed: %v", localPart, domainName, uErr)}
 		}
 		return []string{fmt.Sprintf(

--- a/panel-api/internal/migrate/cpanel/restore_mail_preserve_retrofit_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_preserve_retrofit_test.go
@@ -19,6 +19,8 @@ type fakeExistingMailboxRepo struct {
 	updatedTo   string
 	updateCalls int
 	createCalls int
+	lastEnc     []byte
+	encCleared  bool
 }
 
 func (f *fakeExistingMailboxRepo) ExistsByDomainAndLocalPart(_ context.Context, _, _ string) (bool, error) {
@@ -27,9 +29,11 @@ func (f *fakeExistingMailboxRepo) ExistsByDomainAndLocalPart(_ context.Context, 
 func (f *fakeExistingMailboxRepo) FindByEmail(_ context.Context, _ string) (*models.Mailbox, error) {
 	return f.mb, nil
 }
-func (f *fakeExistingMailboxRepo) UpdatePasswordHash(_ context.Context, id, hash string) error {
+func (f *fakeExistingMailboxRepo) UpdatePasswordHashAndEnc(_ context.Context, id, hash string, enc []byte) error {
 	f.updateCalls++
 	f.updatedTo = hash
+	f.lastEnc = enc
+	f.encCleared = enc == nil
 	if f.mb != nil && f.mb.ID == id {
 		f.mb.PasswordHash = hash
 	}
@@ -66,6 +70,12 @@ func TestImportMailboxes_RetrofitsExistingRowOnPreserve(t *testing.T) {
 	}
 	if mb.updatedTo != testSrcBcrypt {
 		t.Errorf("retrofit hash = %q, want tag-stripped source %q", mb.updatedTo, testSrcBcrypt)
+	}
+	// JAB-291 (#5): changing the hash must CLEAR any password_enc sealed by the
+	// earlier fresh-random create — a stale envelope would decrypt to a password
+	// the new hash rejects, breaking webmail SSO.
+	if !mb.encCleared {
+		t.Errorf("retrofit must clear password_enc (enc=nil), got %d bytes", len(mb.lastEnc))
 	}
 	if !containsSubstr(res.Skipped, "SOURCE password RE-APPLIED") {
 		t.Errorf("expected a 'SOURCE password RE-APPLIED' notice, got %v", res.Skipped)


### PR DESCRIPTION
## What

Extracts the shared **Mailbox Lifecycle** into a new gin-free package, `panel-api/internal/mailboxops`, that both adapters — the REST handlers (`internal/api/mailboxes.go`) and the operator CLI (`cmd/server/mailbox_ops.go`) — import. This is the same consolidation pattern already used for `userops` and `limits`, and it retires a real drift between two hand-maintained copies.

Along the way it fixes a **live stale-envelope bug** in password rotation and closes the last field-parity gap in the CLI create command.

## Why

Create / rotate-password / set-quota / delete for mailboxes each had two copies of the same logic (address canonicalization, quota default + 16 MiB floor, password generation/hash/seal, the duplicate rule). The copies had already drifted:

- the CLI `mailbox.create` notify omitted `display_name`;
- the quota/bcrypt constants lived only in the CLI with a "keep in sync" comment;
- the CLI create command had **no** `--display-name` / `--send-only`, so operator-created mailboxes couldn't set the fields the REST API already supported (GH #197 / GH #371).

## The #5 fix — stale `password_enc` envelope

`password_enc` is the AES-256-GCM envelope the webmail SSO mint decrypts to hand Stalwart the plaintext. A rotation that wrote **only** the bcrypt hash (`UpdatePasswordHash`) left `password_enc` pointing at the **old** password — which Stalwart no longer accepts — so SSO silently logged the tenant into a password that fails.

`mailboxops.RotatePassword` now updates hash **and** envelope atomically:

- **live SSO key** → re-seal the envelope to the new password;
- **no key** → **clear** `password_enc` (NULL), never leave it stale — SSO is unavailable for that row until the next rotate with a live key, which is correct.

The concrete API used, `MailboxRepository.UpdatePasswordHashAndEnc`, writes via a map-based GORM `Updates`, so `enc = nil` actually persists `NULL` (a struct update would skip the zero value).

The cPanel migration retrofit path (`restore_mail.go`) gets the same fix: when `--preserve-source-state` overwrites the hash on an **existing** row, the envelope the earlier fresh-random create sealed is now stale, so it is cleared.

## Design boundary

Authorization stays an **adapter** concern — every entry point takes an already-loaded, already-authorized domain/mailbox (REST checks the caller's claims; the CLI is admin-by-construction). `CreateInput` deliberately has **no** `System` field: user-facing creates must never mint an infrastructure principal. System mailboxes (the GH #1056 noreply relay) remain reconciler-only, and the migration restore path keeps its own semantics.

## Tests

- **New `mailboxops` suite**: field parity + defaults, the three gates (email-disabled / duplicate / below-floor), the #5 `nil-key-clears-envelope` and `with-key-re-seals` cases, and delete-aborts-before-row-delete on a host-destroy failure.
- **Migration retrofit test** now asserts the envelope is cleared on hash retrofit.
- **CLI reference golden** regenerated for `--display-name` / `--send-only`.
- Full `panel-api` suite green.

## Box verification (.86, throwaway `jab291probe@jabali.site`)

- `jabali mailbox create --display-name "JAB291 Probe" --send-only` → row has `display_name`, `send_only=1`, default 1 GiB quota, sealed `password_enc` (60 bytes).
- `jabali mailbox passwd …` → `password_enc` **changed** (re-sealed, non-null), `password_hash` rotated, `display_name` + `send_only` preserved.
- `jabali mailbox delete … --force` → row gone (0 rows).
- Original binary restored; panel active, `/login` = 200.

GH #291
