### PR TITLE
refactor(mail): explicit system-relay + restore mailboxops entry points (JAB-291 criterion 5)

### DIFF
--- a/panel-api/internal/mailboxops/mailboxops.go
+++ b/panel-api/internal/mailboxops/mailboxops.go
@@ -153,6 +153,109 @@ func Create(ctx context.Context, d Deps, in CreateInput, notify NotifyFunc) (*mo
 	return mb, generated, nil
 }
 
+// SystemCreateInput mints an INFRASTRUCTURE principal — the GH #1056 sendmail
+// relay the reconciler ensures per email-enabled domain. This is the one place
+// System=true is expressible, and it is deliberately separate from CreateInput
+// so a tenant-facing create can never reach it.
+type SystemCreateInput struct {
+	Domain      *models.Domain // pre-loaded by the reconciler
+	LocalPart   string         // already canonical (the reconciler controls it)
+	DisplayName string
+	QuotaBytes  uint64 // 0 → DefaultQuotaBytes
+}
+
+// CreateSystem mints the sendmail relay principal (System=true, SendOnly=true):
+// generate → hash → seal → persist, and return the plaintext once so the caller
+// can write it into the cred file. Unlike Create it applies NO EmailEnabled gate
+// and NO duplicate check — the reconciler owns idempotency (it calls this only
+// when the relay is absent). The SSO key is REQUIRED: the relay's webmail SSO
+// depends on the sealed envelope, so a nil key is a hard error rather than a
+// silently unsealed row.
+func CreateSystem(ctx context.Context, d Deps, in SystemCreateInput, notify NotifyFunc) (*models.Mailbox, string, error) {
+	if d.Mailboxes == nil || in.Domain == nil {
+		return nil, "", fmt.Errorf("%w: mailboxes repo + domain required", ErrDeps)
+	}
+	if d.SSOKey == nil {
+		return nil, "", fmt.Errorf("%w: SSO key required to seal the system relay", ErrDeps)
+	}
+	password := ids.NewSecret()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: hash: %v", ErrInternal, err)
+	}
+	enc, err := d.SSOKey.Seal([]byte(password))
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: seal: %v", ErrInternal, err)
+	}
+	quota := in.QuotaBytes
+	if quota == 0 {
+		quota = DefaultQuotaBytes
+	}
+	now := time.Now().UTC()
+	mb := &models.Mailbox{
+		ID:           ids.NewULID(),
+		DomainID:     in.Domain.ID,
+		LocalPart:    in.LocalPart,
+		DisplayName:  in.DisplayName,
+		System:       true, // GH #1056: hide the JAB-230 relay from the mailbox lists
+		PasswordHash: string(hash),
+		PasswordEnc:  enc,
+		QuotaBytes:   quota,
+		SendOnly:     true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := d.Mailboxes.Create(ctx, mb); err != nil {
+		return nil, "", fmt.Errorf("%w: insert: %v", ErrInternal, err)
+	}
+	email := in.LocalPart + "@" + in.Domain.Name
+	if notify != nil {
+		notify(ctx, "mailbox.create", map[string]any{"id": mb.ID, "email": email})
+	}
+	mb.EmailCached = email
+	return mb, password, nil
+}
+
+// RestoreCreateInput persists a migrated mailbox from an ALREADY-computed bcrypt
+// hash (the tag-stripped source hash, or a fresh temp hash the caller generated
+// when the source could not be preserved). There is no plaintext, so nothing is
+// sealed and password_enc stays NULL until the tenant rotates.
+type RestoreCreateInput struct {
+	DomainID     string
+	LocalPart    string // already canonical
+	PasswordHash string // pre-computed; NEVER sealed
+	QuotaBytes   uint64 // 0 → DefaultQuotaBytes
+}
+
+// CreateForRestore persists a migrated mailbox row. It exists so the migration
+// stops hand-assembling the row: it applies NO EmailEnabled gate (the migration
+// provisions the domain it imports into), NO duplicate check (the caller already
+// resolved existence), and fires NO agent notify (the migration batches Stalwart
+// registration separately). password_enc is left NULL by construction.
+func CreateForRestore(ctx context.Context, d Deps, in RestoreCreateInput) (*models.Mailbox, error) {
+	if d.Mailboxes == nil {
+		return nil, fmt.Errorf("%w: mailboxes repo required", ErrDeps)
+	}
+	quota := in.QuotaBytes
+	if quota == 0 {
+		quota = DefaultQuotaBytes
+	}
+	now := time.Now().UTC()
+	mb := &models.Mailbox{
+		ID:           ids.NewULID(),
+		DomainID:     in.DomainID,
+		LocalPart:    in.LocalPart,
+		PasswordHash: in.PasswordHash,
+		QuotaBytes:   quota,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := d.Mailboxes.Create(ctx, mb); err != nil {
+		return nil, fmt.Errorf("%w: insert: %v", ErrInternal, err)
+	}
+	return mb, nil
+}
+
 // RotatePassword rotates a mailbox's password. Empty newPassword → generate one
 // and return it once. The hash and the sealed envelope are updated ATOMICALLY:
 // with a live SSO key the envelope is re-sealed to the new password; WITHOUT a

--- a/panel-api/internal/mailboxops/mailboxops_test.go
+++ b/panel-api/internal/mailboxops/mailboxops_test.go
@@ -120,6 +120,63 @@ func TestRotate_WithKey_Seals(t *testing.T) {
 	}
 }
 
+// CreateSystem mints the GH #1056 relay: System=true, SendOnly=true, a sealed
+// envelope, and the plaintext returned once. A nil SSO key is a hard error.
+func TestCreateSystem_MintsSealedRelayPrincipal(t *testing.T) {
+	repo := &fakeMBRepo{}
+	key := ssokey.Key{}
+	mb, pw, err := CreateSystem(context.Background(), Deps{Mailboxes: repo, SSOKey: &key},
+		SystemCreateInput{Domain: enabledDomain(), LocalPart: "sendmail", DisplayName: "example.com (system sender)", QuotaBytes: 16 * 1024 * 1024}, nil)
+	if err != nil {
+		t.Fatalf("CreateSystem: %v", err)
+	}
+	if pw == "" {
+		t.Error("the generated relay password must be returned once")
+	}
+	if repo.created == nil || !repo.created.System || !repo.created.SendOnly {
+		t.Fatalf("relay must be System+SendOnly: %+v", repo.created)
+	}
+	if len(repo.created.PasswordEnc) == 0 {
+		t.Error("relay envelope must be sealed (webmail SSO depends on it)")
+	}
+	if repo.created.QuotaBytes != 16*1024*1024 {
+		t.Errorf("relay quota = %d, want 16 MiB", repo.created.QuotaBytes)
+	}
+	if mb.EmailCached != "sendmail@example.com" {
+		t.Errorf("email_cached = %q", mb.EmailCached)
+	}
+}
+
+func TestCreateSystem_NilKeyRejected(t *testing.T) {
+	if _, _, err := CreateSystem(context.Background(), Deps{Mailboxes: &fakeMBRepo{}, SSOKey: nil},
+		SystemCreateInput{Domain: enabledDomain(), LocalPart: "sendmail"}, nil); !errors.Is(err, ErrDeps) {
+		t.Errorf("a nil SSO key must be rejected (relay must be sealed), got %v", err)
+	}
+}
+
+// CreateForRestore persists a pre-computed hash and leaves password_enc NULL —
+// there is no plaintext to seal.
+func TestCreateForRestore_NoSealNoGate(t *testing.T) {
+	repo := &fakeMBRepo{}
+	mb, err := CreateForRestore(context.Background(), Deps{Mailboxes: repo},
+		RestoreCreateInput{DomainID: "d1", LocalPart: "info", PasswordHash: "$2b$12$sourcehash", QuotaBytes: 0})
+	if err != nil {
+		t.Fatalf("CreateForRestore: %v", err)
+	}
+	if repo.created.PasswordHash != "$2b$12$sourcehash" {
+		t.Errorf("restore must persist the pre-computed hash verbatim, got %q", repo.created.PasswordHash)
+	}
+	if repo.created.PasswordEnc != nil {
+		t.Errorf("restore has no plaintext to seal — password_enc must be nil, got %d bytes", len(repo.created.PasswordEnc))
+	}
+	if repo.created.QuotaBytes != DefaultQuotaBytes {
+		t.Errorf("quota 0 must default, got %d", repo.created.QuotaBytes)
+	}
+	if mb.ID == "" {
+		t.Error("row must be assigned an id")
+	}
+}
+
 // Delete destroys the Stalwart side first: an agent failure aborts BEFORE the
 // row is removed.
 func TestDelete_HostFailureKeepsRow(t *testing.T) {

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -9,13 +9,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailboxops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -379,16 +378,16 @@ func insertOneMailboxRow(
 		}
 		passwordHash = string(hash)
 	}
-	mb := &models.Mailbox{
-		ID:           ids.NewULID(),
+	// JAB-291: assemble + persist the migrated row via the shared Mailbox
+	// Lifecycle's explicit restore entry point. It takes the already-computed
+	// bcrypt hash verbatim, leaves password_enc NULL (no plaintext to seal), and
+	// applies no EmailEnabled gate or agent notify — the migration's semantics.
+	if _, cErr := mailboxops.CreateForRestore(ctx, mailboxops.Deps{Mailboxes: mbRepo}, mailboxops.RestoreCreateInput{
 		DomainID:     domain.ID,
 		LocalPart:    localPart,
 		PasswordHash: passwordHash,
 		QuotaBytes:   1073741824,
-		CreatedAt:    time.Now().UTC(),
-		UpdatedAt:    time.Now().UTC(),
-	}
-	if cErr := mbRepo.Create(ctx, mb); cErr != nil {
+	}); cErr != nil {
 		return []string{fmt.Sprintf("mailbox_rows: create %s@%s: %v", localPart, domainName, cErr)}
 	}
 	// GH #327: the pre-scan already counted maildir-shaped dirs into

--- a/panel-api/internal/reconciler/sendmail_cred_reconcile.go
+++ b/panel-api/internal/reconciler/sendmail_cred_reconcile.go
@@ -12,6 +12,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailboxops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
@@ -212,37 +213,27 @@ func (r *Reconciler) ensureRelayMailbox(ctx context.Context, d *models.Domain) (
 }
 
 func (r *Reconciler) createRelayMailbox(ctx context.Context, d *models.Domain, localPart, email string) (string, error) {
-	password := ids.NewSecret()
-	hash, herr := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if herr != nil {
-		return "", fmt.Errorf("hash: %w", herr)
+	// JAB-291: the sendmail relay is an infrastructure principal — mint it via
+	// the shared Mailbox Lifecycle's explicit system entry point (System=true,
+	// SendOnly=true, sealed envelope) rather than hand-assembling the row here.
+	// Stalwart JMAP-registry registration stays best-effort (ADR-0045: DB is
+	// authoritative), passed as the notify hook.
+	notify := func(nctx context.Context, cmd string, params any) {
+		ncctx, ncancel := context.WithTimeout(nctx, 10*time.Second)
+		defer ncancel()
+		_, _ = r.agent.Call(ncctx, cmd, params)
 	}
-	enc, serr := r.sendmailSSOKey.Seal([]byte(password))
-	if serr != nil {
-		return "", fmt.Errorf("seal: %w", serr)
+	_, password, err := mailboxops.CreateSystem(ctx,
+		mailboxops.Deps{Mailboxes: r.mailboxes, SSOKey: r.sendmailSSOKey},
+		mailboxops.SystemCreateInput{
+			Domain:      d,
+			LocalPart:   localPart,
+			DisplayName: d.Name + " (system sender)",
+			QuotaBytes:  16 * 1024 * 1024,
+		}, notify)
+	if err != nil {
+		return "", fmt.Errorf("create %s: %w", email, err)
 	}
-	now := time.Now().UTC()
-	mb := &models.Mailbox{
-		ID:           ids.NewULID(),
-		DomainID:     d.ID,
-		LocalPart:    localPart,
-		DisplayName:  d.Name + " (system sender)",
-		System:       true, // GH #1056: hide the JAB-230 relay from the mailbox lists
-		PasswordHash: string(hash),
-		PasswordEnc:  enc,
-		QuotaBytes:   16 * 1024 * 1024,
-		SendOnly:     true,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if cerr := r.mailboxes.Create(ctx, mb); cerr != nil {
-		return "", fmt.Errorf("create %s: %w", email, cerr)
-	}
-	// Register the principal in Stalwart's JMAP registry (best-effort,
-	// same as the HTTP create path — DB is authoritative, ADR-0045).
-	nctx, ncancel := context.WithTimeout(ctx, 10*time.Second)
-	_, _ = r.agent.Call(nctx, "mailbox.create", map[string]any{"id": mb.ID, "email": email})
-	ncancel()
 	return password, nil
 }
 


### PR DESCRIPTION
## What

Completes the **Mailbox Lifecycle** consolidation (JAB-291, criterion 5). Follow-up to #1313, which extracted the tenant-facing create/rotate/quota/delete into `panel-api/internal/mailboxops` and fixed the stale `password_enc` bug. This PR routes the **two remaining callers** that still hand-assembled a `models.Mailbox` through explicit `mailboxops` entry points, so all four kinds of mailbox creation — tenant intake, the GH #1056 system relay, and migration restore — share one owner for row assembly, quota defaults, and password/seal semantics.

## Two explicit entry points

- **`mailboxops.CreateSystem`** — mints the sendmail relay principal (`System=true`, `SendOnly=true`). It is the **only** place `System=true` is expressible, kept deliberately separate from `CreateInput` (which has no `System` field) so a tenant-facing create can never reach it. Generates + hashes + seals the password and returns the plaintext once; the SSO key is **required** (the relay's webmail SSO depends on the sealed envelope, so a nil key is a hard error, not a silently unsealed row). No `EmailEnabled` gate or duplicate check — the reconciler owns idempotency. `internal/reconciler/sendmail_cred_reconcile.go` routes through it, keeping the best-effort Stalwart JMAP registration as the `notify` hook.

- **`mailboxops.CreateForRestore`** — persists a migrated row from an already-computed bcrypt hash (the tag-stripped source hash, or a fresh temp hash the caller generated). There is no plaintext, so `password_enc` stays **NULL**, and there is no `EmailEnabled` gate and no agent notify — the migration's own semantics. `internal/migrate/cpanel/restore_mail.go` routes through it.

## Behavior

Both are **pure behavior-preserving refactors** — the persisted row is byte-for-byte what the inline code built (same fields, same `repo.Create`), so there is no new DB interaction. #1313 already box-proved the live envelope/relay DB behavior on .86, which is unchanged here.

## Tests

- `mailboxops` gains `CreateSystem` cases (sealed relay principal: `System`+`SendOnly`+sealed envelope+returned password+16 MiB quota; nil-key rejected) and a `CreateForRestore` case (pre-computed hash persisted verbatim, `password_enc` nil, quota default).
- The reconciler and cPanel migration suites stay green (they exercise the rewired callers).
- Full `panel-api` suite green; `go vet` clean.

GH #291
