### PR TITLE
fix(php): self-heal active PHP pools with a vanished FPM socket; align pool default ordering (JAB-388)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1187,6 +1187,27 @@ func (r *Reconciler) ReconcileAllForce(ctx context.Context) error {
 
 // createDomainOnAgent calls the agent to provision a domain.
 // Logs errors but doesn't return them so reconciliation can continue.
+// activePoolSocketMissing reports whether an ACTIVE pool's FPM socket is gone
+// (JAB-388 self-heal trigger). The reconcilers otherwise only (re-)apply pools
+// in pending/error status, so a pool that is active in the DB but whose on-disk
+// artifacts were wiped out-of-band — e.g. an update regenerating the FPM tree
+// and dropping the versioned master, or a manual reset — is NEVER re-rendered,
+// and a full panel restart doesn't help (reconcile trusts the active status and
+// skips it). The only recovery was `jabali php pool reapply-all`. Probing the
+// socket here lets the ordinary tick self-heal instead.
+//
+// A non-active pool returns false — it is already handled by the pending/error
+// apply path. Admin / usernameless users return false (they own no pool). The
+// probe is a single non-blocking os.Stat (timeout 0 → one check) via the same
+// mockable socketReady the apply path uses, so tests drive it deterministically.
+func (r *Reconciler) activePoolSocketMissing(ctx context.Context, user *models.User, pool *models.PHPPool, isDefault bool) bool {
+	if pool == nil || pool.Status != "active" || user.Username == nil || *user.Username == "" || user.IsAdmin {
+		return false
+	}
+	socket := models.PoolSocketPath(*user.Username, pool.PHPVersion, isDefault)
+	return !r.socketReady(ctx, socket, 0, 0)
+}
+
 // reconcilePHPPools ensures every panel user has a default PHP pool
 // and converges pending/error pools to active status via agent apply.
 // Uses injectable socket-ready check for test mocking.
@@ -1212,8 +1233,10 @@ func (r *Reconciler) ReconcilePHPPools(ctx context.Context) {
 			continue
 		}
 
-		// User needs a pool if no pool exists OR pool is pending/error
-		if pool == nil || pool.Status == "pending" || pool.Status == "error" {
+		// User needs a pool if no pool exists OR pool is pending/error OR the
+		// pool is active but its socket vanished (JAB-388 self-heal).
+		if pool == nil || pool.Status == "pending" || pool.Status == "error" ||
+			r.activePoolSocketMissing(ctx, user, pool, true) {
 			usersNeedingPools = append(usersNeedingPools, user)
 		}
 
@@ -1287,8 +1310,9 @@ func (r *Reconciler) ReconcilePHPPools(ctx context.Context) {
 			r.log.Info("created default PHP pool for user", "user_id", user.ID, "pool_id", pool.ID)
 		}
 
-		// If pool is already active, skip agent call
-		if pool.Status == "active" {
+		// Skip a healthy active pool; but self-heal one whose socket vanished
+		// (JAB-388) by falling through to re-apply.
+		if pool.Status == "active" && !r.activePoolSocketMissing(ctx, user, pool, true) {
 			continue
 		}
 
@@ -1366,8 +1390,11 @@ func (r *Reconciler) reconcileVersionedPHPPools(ctx context.Context) {
 				continue
 			}
 
-			// Apply pending/error versioned pools (active ones are converged).
-			if pool.Status == "pending" || pool.Status == "error" {
+			// Apply pending/error versioned pools; also self-heal an active one
+			// whose socket vanished (JAB-388) — otherwise a wiped-but-active pool
+			// is skipped forever and only manual reapply-all recovers it.
+			if pool.Status == "pending" || pool.Status == "error" ||
+				r.activePoolSocketMissing(ctx, user, pool, false) {
 				r.applyPHPPool(ctx, user, pool, false)
 				processed++
 			}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -1569,11 +1569,53 @@ func TestReconcilePHPPools_SkipActivePool(t *testing.T) {
 
 	r := New(domainRepo, userRepo, agent, log, Config{Interval: 1 * time.Second}).
 		WithPHPPools(phpPoolRepo)
+	// The pool is active AND its socket is present — the healthy steady state,
+	// which must be skipped. (JAB-388 only re-applies an active pool whose socket
+	// has vanished; that path is covered by the self-heal test below.)
+	r.socketReady = func(context.Context, string, time.Duration, time.Duration) bool { return true }
 
 	r.ReconcilePHPPools(ctx)
 
 	// Verify that no agent calls were made (pool already active)
 	require.Len(t, agent.calls, 0, "should not call agent for active pool")
+}
+
+// JAB-388: an active pool whose FPM socket vanished (e.g. an update regenerated
+// the FPM tree and dropped the master) must self-heal on the ordinary tick — the
+// reconciler used to only re-apply pending/error pools, so a wiped-but-active
+// pool stayed broken until a manual `php pool reapply-all`.
+func TestReconcilePHPPools_SelfHealsActivePoolWithMissingSocket(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	agent := &fakeAgent{}
+	domainRepo := &fakeDomainRepo{domains: make(map[string]*models.Domain)}
+	userRepo := &fakeUserRepo{users: make(map[string]*models.User)}
+	phpPoolRepo := &fakePHPPoolRepo{pools: make(map[string]*models.PHPPool)}
+
+	username := "healme"
+	user := &models.User{ID: "user-1", Email: "healme@example.com", Username: &username}
+	userRepo.users[user.ID] = user
+
+	activePool := &models.PHPPool{ID: "pool-1", UserID: user.ID, PHPVersion: "8.3", PmMode: "ondemand", Status: "active"}
+	phpPoolRepo.pools[activePool.ID] = activePool
+
+	r := New(domainRepo, userRepo, agent, log, Config{Interval: 1 * time.Second}).
+		WithPHPPools(phpPoolRepo)
+	// Socket is GONE — the self-heal trigger.
+	r.socketReady = func(context.Context, string, time.Duration, time.Duration) bool { return false }
+
+	r.ReconcilePHPPools(ctx)
+
+	// The pool must be re-applied despite being "active" — the agent gets a
+	// php.pool.apply for it.
+	found := false
+	for _, c := range agent.calls {
+		if c.method == "php.pool.apply" {
+			found = true
+		}
+	}
+	require.True(t, found, "an active pool with a missing socket must be re-applied (JAB-388)")
 }
 
 func TestReconcilePHPPools_RetryPendingPool(t *testing.T) {
@@ -2327,6 +2369,62 @@ func TestReconcileVersionedPHPPools(t *testing.T) {
 		t.Errorf("fresh versioned pool must be spared by the reap grace: %v", err)
 	}
 	require.Equal(t, "phpuser-php8.0", rp["slug"], "only the OLD orphan should be reaped, not the fresh one")
+}
+
+// JAB-388: a versioned pool that is ACTIVE and has a bound domain, but whose FPM
+// socket has vanished, must be re-applied by the ordinary versioned pass — the
+// same self-heal the default pool gets. Without it the pool stays broken until a
+// manual `php pool reapply-all` (the reported symptom on a migrated site whose
+// PHP version never actually switched after the 04:30 update wiped the master).
+func TestReconcileVersionedPHPPools_SelfHealsWipedActivePool(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	agent := &fakeAgent{}
+	domainRepo := &fakeDomainRepo{domains: make(map[string]*models.Domain)}
+	userRepo := &fakeUserRepo{users: make(map[string]*models.User)}
+	phpPoolRepo := &fakePHPPoolRepo{pools: make(map[string]*models.PHPPool)}
+
+	username := "phpuser"
+	user := &models.User{ID: "user-1", Email: "u@e.com", Username: &username}
+	userRepo.users[user.ID] = user
+
+	base := time.Now().UTC().Add(-1 * time.Hour)
+	phpPoolRepo.pools["pool-default"] = &models.PHPPool{
+		ID: "pool-default", UserID: user.ID, PHPVersion: "8.4",
+		PmMode: "ondemand", PmMaxChildren: 20, ProcessIdleTimeoutSeconds: 60,
+		Status: "active", CreatedAt: base,
+	}
+	// Versioned pool, ACTIVE, with a bound domain — but its socket is gone.
+	phpPoolRepo.pools["pool-82"] = &models.PHPPool{
+		ID: "pool-82", UserID: user.ID, PHPVersion: "8.2",
+		PmMode: "ondemand", PmMaxChildren: 20, ProcessIdleTimeoutSeconds: 60,
+		Status: "active", CreatedAt: base.Add(time.Minute),
+	}
+	pool82 := "pool-82"
+	domainRepo.domains["d1"] = &models.Domain{
+		ID: "d1", UserID: user.ID, Name: "a.com", IsEnabled: true, PHPPoolID: &pool82,
+	}
+
+	r := New(domainRepo, userRepo, agent, log, Config{Interval: time.Second}).
+		WithPHPPools(phpPoolRepo)
+	// The 8.2 pool's socket is MISSING (the self-heal trigger). applyPHPPool's own
+	// post-apply readiness probe uses the same mock; returning false just leaves
+	// the pool "error" after the re-apply — the point here is that the agent was
+	// asked to re-render it at all.
+	r.socketReady = func(context.Context, string, time.Duration, time.Duration) bool { return false }
+
+	r.reconcileVersionedPHPPools(ctx)
+
+	var applied *fakeCall
+	for i := range agent.calls {
+		if agent.calls[i].method == "php.pool.apply" {
+			applied = &agent.calls[i]
+		}
+	}
+	require.NotNil(t, applied, "an active versioned pool with a missing socket must be re-applied (JAB-388)")
+	require.Equal(t, "phpuser-php8.2", applied.params.(map[string]any)["slug"],
+		"self-heal must re-apply the VERSIONED pool with its own slug, not the default")
 }
 
 func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, string) (int64, error) {

--- a/panel-api/internal/repository/php_pool_repository.go
+++ b/panel-api/internal/repository/php_pool_repository.go
@@ -56,11 +56,15 @@ func (r *phpPoolRepo) FindByID(ctx context.Context, id string) (*models.PHPPool,
 
 func (r *phpPoolRepo) FindByUserID(ctx context.Context, userID string) (*models.PHPPool, error) {
 	var pool models.PHPPool
-	// The DEFAULT pool is the earliest-created row (slug == username) — the
-	// same "pools[0]" convention domain_php_pool.go uses. Order by id ASC (ULIDs
-	// are time-ordered) so the default is deterministic and a later duplicate
-	// row can never win this lookup (JAB-174).
-	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("id ASC").First(&pool).Error; err != nil {
+	// The DEFAULT pool is the earliest-created row (slug == username) — the same
+	// "pools[0]" convention domain_php_pool.go / reconcileVersionedPHPPools use.
+	// JAB-388: order by created_at ASC to MATCH ListByUserID exactly (they used
+	// to disagree — id ASC here vs created_at ASC there — so with two rows the
+	// default-pool machinery and the versioned machinery could pick DIFFERENT
+	// rows as the default and fight over the master include / user-phpver). The
+	// id ASC tiebreak keeps it deterministic on a created_at tie, preserving the
+	// JAB-174 guarantee that a later duplicate row can never win this lookup.
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at ASC, id ASC").First(&pool).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -84,7 +88,9 @@ func (r *phpPoolRepo) ListByUserID(ctx context.Context, userID string) ([]models
 	var pools []models.PHPPool
 	if err := r.db.WithContext(ctx).
 		Where("user_id = ?", userID).
-		Order("created_at ASC").
+		// JAB-388: created_at ASC, id ASC — deterministic even on a created_at
+		// tie, and identical to FindByUserID so both agree on pools[0]=default.
+		Order("created_at ASC, id ASC").
 		Find(&pools).Error; err != nil {
 		return nil, err
 	}

--- a/panel-api/internal/repository/php_pool_repository_test.go
+++ b/panel-api/internal/repository/php_pool_repository_test.go
@@ -106,9 +106,11 @@ func TestPHPPoolRepository_FindByUserID_Found(t *testing.T) {
 
 	repo := NewPHPPoolRepository(db)
 
-	// JAB-174: the default pool is the earliest row — the lookup must ORDER BY
-	// id ASC so a later duplicate can't win.
-	mock.ExpectQuery("SELECT .* FROM `php_pools` WHERE user_id = \\?.*ORDER BY .*id.* ASC.*LIMIT").
+	// JAB-388: the default pool is the earliest row — the lookup must ORDER BY
+	// created_at ASC, id ASC, identical to ListByUserID, so both paths agree on
+	// pools[0]=default (the id ASC tiebreak keeps the JAB-174 anti-duplicate
+	// determinism on a created_at tie).
+	mock.ExpectQuery("SELECT .* FROM `php_pools` WHERE user_id = \\?.*ORDER BY created_at ASC, id ASC.*LIMIT").
 		WithArgs("user1", 1).
 		WillReturnRows(sqlmock.NewRows(
 			[]string{"id", "user_id", "php_version", "pm_mode", "pm_max_children", "process_idle_timeout_seconds", "status", "last_error", "created_at", "updated_at"},


### PR DESCRIPTION
## Summary

Fixes JAB-388: changing a domain's PHP version via `jabali domain php-version set` could leave the site stuck on the old version, unrecoverable by a panel restart and only fixed by the manual escape hatch `jabali php pool reapply-all`.

Two related pool-convergence defects, both confirmed on the box:

### 1. No self-heal for an `active` pool whose FPM artifacts vanished (the reported symptom)

`ReconcilePHPPools` and `reconcileVersionedPHPPools` only ever (re-)apply pools in `pending`/`error` status — an `active` pool is assumed converged and skipped. So if a pool is `active` in the DB but its on-disk artifacts are gone (the report's site: the 04:30 `jabali update` regenerated the FPM tree and dropped the versioned master; the confs' mtime was the update's), nothing ever re-renders it. A full `systemctl restart jabali-panel` doesn't help — the forced reconcile still trusts the `active` status and skips. The only recovery was `jabali php pool reapply-all` (flip active→pending so the reconciler re-applies).

**Fix:** a new `activePoolSocketMissing` probe — a single non-blocking `os.Stat` on the pool's FPM socket, via the same mockable `socketReady` the apply path already uses. Both reconcilers now re-apply an `active` pool whose socket is gone, so the ordinary ~60s tick self-heals instead of needing a manual command. Bounded by the existing per-tick apply caps; a healthy active pool (socket present) is still skipped with zero extra agent work.

### 2. `FindByUserID` and `ListByUserID` disagreed on which pool is the default

`FindByUserID` ordered by `id ASC` (used by `ReconcilePHPPools` to converge "the default pool", and by `domain php-version show` / `php pool get`), while `ListByUserID` ordered by `created_at ASC` (used by the `set` command, `reconcileVersionedPHPPools`, and `createDomainOnAgent`'s socket resolution). With two rows those can pick **different** rows as `pools[0]=default` — nondeterministic on a `created_at` tie — so the default-pool machinery and the versioned machinery can fight over the master include / `user-phpver`. Aligned both to `created_at ASC, id ASC`: created_at is the semantic key ("earliest-created = default"), the `id ASC` (ULID) tiebreak keeps it deterministic and preserves the JAB-174 guarantee that a later duplicate row can never win the lookup.

### Not changed (deliberately)

- **Two `active` rows per user is correct**, not a bug: a user whose domains span PHP versions legitimately has one active default pool + one active versioned pool each. The ticket's suggested "enforce a single active pool" contradicts the multi-version design (GH #329), so it is not implemented.
- Migration defaulting to 8.4 instead of carrying the source cPanel version is a separate slice (create_www-gap class) and out of scope here.

## Tests

- `TestReconcilePHPPools_SelfHealsActivePoolWithMissingSocket` — active default pool, socket gone → re-applied.
- `TestReconcileVersionedPHPPools_SelfHealsWipedActivePool` — active versioned pool with a bound domain, socket gone → re-applied with its own slug (not the default).
- `TestReconcilePHPPools_SkipActivePool` updated to assert the healthy steady state (active + socket present → skipped).
- `TestPHPPoolRepository_FindByUserID_Found` asserts the aligned `created_at ASC, id ASC` ordering.
- Full `panel-api` suite green.

## Box verification (.86)

Reproduced the exact stuck state on current `main`: `set 123123.com --version 8.4` converged the 8.4 pool fresh, then simulating the update-wipe (stop master + `rm` pool file + socket, leave DB `active`) left it **stuck for 6+ ticks** — pool_file MISSING, master inactive, db_status active — with no self-heal, matching the report. Deploying this build self-healed it within ~2 ticks (t≈66s): pool file recreated, master active, socket present. Original binary restored afterward; `/login` = 200.

GH #388
