### PR TITLE
fix(updates): reflect a scheduled OS auto-apply in the Updates Center immediately (GH #1224)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -5362,6 +5362,14 @@ jabali update [flags]
 - `--force` — Run the full rebuild/restart cycle even when git pull found no new commits
 - `--from-source` — Build binaries on this host instead of downloading the release tarball from Gitea Releases. Default is to download the tarball (90s update vs 5-10min source build). Use --from-source when offline, on a private fork, or to test uncommitted changes.
 
+#### `jabali update apt-refresh`
+
+Refresh the Updates Center OS-patch state now (used after an auto-apply) (GH #1224)
+
+```
+jabali update apt-refresh
+```
+
 ### `jabali user`
 
 Manage panel users

--- a/panel-agent/internal/commands/system_autoupdate.go
+++ b/panel-agent/internal/commands/system_autoupdate.go
@@ -44,9 +44,14 @@ const (
 	aptUpgradeOverrideDir  = "/etc/systemd/system/apt-daily-upgrade.timer.d"
 	aptUpgradeOverrideFile = "/etc/systemd/system/apt-daily-upgrade.timer.d/jabali-schedule.conf"
 	aptUpgradeTimer        = "apt-daily-upgrade.timer"
-	jabaliAutoSvcFile      = "/etc/systemd/system/jabali-autoupdate.service"
-	jabaliAutoTimerFile    = "/etc/systemd/system/jabali-autoupdate.timer"
-	jabaliAutoTimer        = "jabali-autoupdate.timer"
+	// GH #1224: report the apply to the Updates Center immediately. The background
+	// poll only runs every 6h, so without this the page shows a stale "Last
+	// Applied" for hours after the scheduled run — which reads as "never ran".
+	aptUpgradeSvcDropinDir  = "/etc/systemd/system/apt-daily-upgrade.service.d"
+	aptUpgradeSvcDropinFile = "/etc/systemd/system/apt-daily-upgrade.service.d/jabali-report.conf"
+	jabaliAutoSvcFile       = "/etc/systemd/system/jabali-autoupdate.service"
+	jabaliAutoTimerFile     = "/etc/systemd/system/jabali-autoupdate.timer"
+	jabaliAutoTimer         = "jabali-autoupdate.timer"
 )
 
 var autoupdateHHMM = regexp.MustCompile(`^([01]\d|2[0-3]):[0-5]\d$`)
@@ -85,6 +90,20 @@ func systemAutoupdateApplyHandler(ctx context.Context, raw json.RawMessage) (any
 	// Reset OnCalendar (blank line clears the stock value) then pin ours.
 	aptOverride := fmt.Sprintf("[Timer]\nOnCalendar=\nOnCalendar=*-*-* %s:00\nRandomizedDelaySec=0\nPersistent=true\n", p.AptTime)
 	if wrote, err := writeIfChanged(aptUpgradeOverrideFile, aptOverride); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	} else if wrote {
+		changed = true
+	}
+
+	// --- apt-daily-upgrade.service ExecStartPost: push state to the panel now ---
+	// (GH #1224) So the Updates Center reflects a scheduled apply within seconds
+	// instead of waiting up to 6h for the background poll. Best-effort ('-'): a
+	// refresh failure must never fail the apt upgrade itself.
+	if err := os.MkdirAll(aptUpgradeSvcDropinDir, 0o755); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir service dropin dir: %v", err)}
+	}
+	aptReport := "[Service]\nExecStartPost=-/usr/local/bin/jabali update apt-refresh\n"
+	if wrote, err := writeIfChanged(aptUpgradeSvcDropinFile, aptReport); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	} else if wrote {
 		changed = true

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -76,6 +76,11 @@ func newUpdateCmd() *cobra.Command {
 		"Run the full rebuild/restart cycle even when git pull found no new commits")
 	cmd.Flags().Bool("from-source", false,
 		"Build binaries on this host instead of downloading the release tarball from Gitea Releases. Default is to download the tarball (90s update vs 5-10min source build). Use --from-source when offline, on a private fork, or to test uncommitted changes.")
+	// GH #1224: `jabali update apt-refresh` pushes the Updates Center state now
+	// (called by the apt-daily-upgrade ExecStartPost). A real subcommand routes
+	// here; the parent's NoArgs still rejects a mistyped positional, so this never
+	// accidentally triggers the self-updater.
+	cmd.AddCommand(newUpdateAptRefreshCmd())
 	return cmd
 }
 

--- a/panel-api/cmd/server/update_apt_refresh_cmd.go
+++ b/panel-api/cmd/server/update_apt_refresh_cmd.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// newUpdateAptRefreshCmd refreshes the Updates Center's OS-patch state right now
+// (GH #1224). The background poll runs only every 6h, so after unattended-upgrades
+// applies at the scheduled time the page shows a stale "Last Checked"/"Last
+// Applied" for up to 6 hours — which reads as "auto-updates never ran". An
+// ExecStartPost drop-in on apt-daily-upgrade.service calls this immediately after
+// an apply so the panel reflects it within seconds.
+//
+// It does exactly what the update-poll reconciler does (agent system.apt_check ->
+// UpsertApt + UpsertAptStatus), on demand. Best-effort by design: the drop-in
+// prefixes it with '-' so a transient failure never fails the apt run.
+func newUpdateAptRefreshCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "apt-refresh",
+		Short: "Refresh the Updates Center OS-patch state now (used after an auto-apply) (GH #1224)",
+		Args:  cobra.NoArgs,
+		// requireDBAndAgent, not requireDB: it calls the agent for system.apt_check.
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Minute)
+			defer cancel()
+
+			raw, err := sharedAgent.Call(ctx, "system.apt_check", nil)
+			if err != nil {
+				return fmt.Errorf("system.apt_check: %w", err)
+			}
+			var av struct {
+				Total          int        `json:"total"`
+				SecurityTotal  int        `json:"security_total"`
+				RebootRequired bool       `json:"reboot_required"`
+				LastAppliedAt  *time.Time `json:"last_applied_at"`
+			}
+			if err := json.Unmarshal(raw, &av); err != nil {
+				return fmt.Errorf("parse system.apt_check: %w", err)
+			}
+
+			state := repository.NewUpdateStateRepository(sharedDB)
+			now := time.Now()
+			if err := state.UpsertApt(ctx, av.Total, av.SecurityTotal, now); err != nil {
+				return fmt.Errorf("persist apt totals: %w", err)
+			}
+			if err := state.UpsertAptStatus(ctx, av.LastAppliedAt, av.RebootRequired); err != nil {
+				return fmt.Errorf("persist apt status: %w", err)
+			}
+
+			applied := "never"
+			if av.LastAppliedAt != nil {
+				applied = av.LastAppliedAt.Local().Format(time.RFC3339)
+			}
+			fmt.Printf("Updates Center refreshed: %d upgradable (%d security), last applied %s, reboot_required=%v\n",
+				av.Total, av.SecurityTotal, applied, av.RebootRequired)
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Problem (GH #1224)

Reported as "auto-updates are not running": a user set the OS auto-update time and saw the Updates Center's **Last Checked** stuck (e.g. `01:24`) with no sign the configured `01:30` run happened.

## Diagnosis

The timer is fine. On a live box the `apt-daily-upgrade.timer` override pins `OnCalendar=<configured time>` with `RandomizedDelaySec=0` and **fires at the configured time** (verified: `list-timers` shows the apply ran, and `apt_last_applied_at` matches the unattended-upgrades stamp).

The real gap is the **reporting cadence**: the panel refreshes `update_state` only via a background poll that runs **every 6 hours** (`updatePollInterval`), and there's no immediate report after an apply. So `Last Checked`/`Last Applied` can lag a scheduled run by up to 6h — which looks exactly like "it never ran". (Also, `Last Checked` is that background scan, not the apply time — a separate source of confusion.)

## Fix — report the apply the moment it happens

- **`jabali update apt-refresh`** — runs `system.apt_check` and writes `update_state` (`UpsertApt` + `UpsertAptStatus`) on demand: the same DB write the 6h reconciler does. It's a real subcommand of `update`, so a mistyped positional still hits the parent's `NoArgs` and can never trigger the self-updater.
- **`system.autoupdate_apply`** now also writes an `ExecStartPost` drop-in on `apt-daily-upgrade.service` (`…/apt-daily-upgrade.service.d/jabali-report.conf` = `-/usr/local/bin/jabali update apt-refresh`). Best-effort (`-`): a refresh failure never fails the apt upgrade. Converged next to the existing timer override, idempotent.

## Drill on .86
- `jabali update apt-refresh` bumps `apt_checked_at` to now and reads last-applied from the stamp.
- The drop-in is picked up by systemd (`systemctl cat apt-daily-upgrade.service` shows the `ExecStartPost`).
- cli-reference golden regenerated. No migration.

GH #1224
