### PR TITLE
refactor(mail-ui): shared Mailbox Inventory module + Safe Webmail Launcher (JAB-333, JAB-354)

### DIFF
--- a/panel-ui/src/components/mail/mailboxInventory.test.tsx
+++ b/panel-ui/src/components/mail/mailboxInventory.test.tsx
@@ -1,0 +1,138 @@
+// mailboxInventory.test.tsx — the Mailbox Inventory module's invariants
+// (JAB-333 / JAB-354). All three mailbox inventories (admin, tenant,
+// per-domain) route their webmail launch through useMailboxWebmail, so the
+// opener-severing security invariant lives in exactly one tested place.
+
+import {
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { post: vi.fn() },
+}));
+vi.mock("../../lib/feedback", () => ({
+  feedback: { message: { warning: vi.fn(), error: vi.fn(), success: vi.fn() } },
+}));
+
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback";
+import { formatMailboxBytes, useMailboxWebmail } from "./mailboxInventory";
+
+const post = apiClient.post as unknown as ReturnType<typeof vi.fn>;
+const warn = feedback.message.warning as unknown as ReturnType<typeof vi.fn>;
+const err = feedback.message.error as unknown as ReturnType<typeof vi.fn>;
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+// A fake popup whose opener starts non-null so we can prove it gets severed.
+function fakePopup() {
+  return { opener: {} as unknown, location: { href: "" }, close: vi.fn() };
+}
+
+beforeEach(() => {
+  post.mockReset();
+  warn.mockReset();
+  err.mockReset();
+});
+
+describe("useMailboxWebmail", () => {
+  it("severs popup.opener SYNCHRONOUSLY, before the async mint resolves", async () => {
+    const popup = fakePopup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    // Mint that never settles during the synchronous window we assert on.
+    post.mockReturnValue(new Promise(() => {}));
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxWebmail(), { wrapper });
+
+    act(() => result.current.launch("mb-1"));
+
+    // The opener MUST already be null right after launch returns — i.e. before
+    // any mint response could navigate the tab (reverse-tabnab guard, JAB-330).
+    expect(popup.opener).toBeNull();
+    openSpy.mockRestore();
+  });
+
+  it("navigates the popup to the minted URL on success", async () => {
+    const popup = fakePopup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    post.mockResolvedValue({ data: { url: "https://webmail.example/sso?t=abc" } });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxWebmail(), { wrapper });
+    act(() => result.current.launch("mb-1"));
+
+    await waitFor(() =>
+      expect(popup.location.href).toBe("https://webmail.example/sso?t=abc"),
+    );
+    expect(post).toHaveBeenCalledWith("/mailboxes/mb-1/sso");
+    openSpy.mockRestore();
+  });
+
+  it("does NOT mint when the popup is blocked (would burn a one-shot URL)", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxWebmail(), { wrapper });
+    act(() => result.current.launch("mb-1"));
+
+    expect(post).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    openSpy.mockRestore();
+  });
+
+  it("surfaces the typed rotate-password hint and closes the popup on mint failure", async () => {
+    const popup = fakePopup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    post.mockRejectedValue({
+      response: {
+        data: {
+          error: "sso_unavailable_rotate_password",
+          detail: "Rotate the password to enable SSO.",
+        },
+      },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxWebmail(), { wrapper });
+    act(() => result.current.launch("mb-1"));
+
+    await waitFor(() => expect(popup.close).toHaveBeenCalled());
+    expect(warn).toHaveBeenCalledWith("Rotate the password to enable SSO.");
+    expect(err).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("surfaces detail on a generic mint failure", async () => {
+    const popup = fakePopup();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    post.mockRejectedValue({ response: { data: { detail: "boom" } } });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxWebmail(), { wrapper });
+    act(() => result.current.launch("mb-1"));
+
+    await waitFor(() => expect(err).toHaveBeenCalledWith("boom"));
+    openSpy.mockRestore();
+  });
+});
+
+describe("formatMailboxBytes", () => {
+  it("uses KiB/MiB and drops the decimal for values >= 10 (the unified format)", () => {
+    expect(formatMailboxBytes(0)).toBe("0 B");
+    expect(formatMailboxBytes(null)).toBe("0 B");
+    expect(formatMailboxBytes(512)).toBe("512 B");
+    expect(formatMailboxBytes(500 * 1024 * 1024)).toBe("500 MiB");
+    expect(formatMailboxBytes(1.5 * 1024 * 1024 * 1024)).toBe("1.5 GiB");
+  });
+});

--- a/panel-ui/src/components/mail/mailboxInventory.tsx
+++ b/panel-ui/src/components/mail/mailboxInventory.tsx
@@ -1,0 +1,141 @@
+// Mailbox Inventory module (JAB-333) — the one owner for the presentation and
+// webmail-launch behavior the three mailbox inventories used to each copy:
+//
+//   - admin/mail/AdminMailPage.tsx          (server-wide)
+//   - user/mail/tabs/MailboxesTab.tsx       (tenant, cross-domain)
+//   - admin/domains/DomainMailboxesSection.tsx (per-domain)
+//
+// Adapters still own their data source and their role-specific columns/actions
+// (admin owner filter, tenant groups + autoresponders, domain enable-email +
+// create wizard). This module owns only what MUST stay identical: the quota /
+// status presentation and the safe webmail launcher (JAB-354).
+
+import { Progress, Tag, Tooltip } from "antd";
+
+import { useMintMailboxSSO } from "../../hooks/useMailboxes";
+import { feedback } from "../../lib/feedback";
+
+// ---- byte formatting ----------------------------------------------------
+
+// The three inventories each rolled their own formatBytes; AdminMailPage always
+// printed a decimal ("500.0 MiB") while the others dropped it for values >= 10
+// ("500 MiB"). This is the single owner — KiB/MiB (binary, matching the byte
+// columns the API returns). (utils/bytes.ts `humanBytes` uses SI labels KB/MB
+// on binary math; unifying the ~10 formatBytes copies across the app is a
+// separate cleanup and intentionally out of scope here.)
+export function formatMailboxBytes(n: number | null | undefined): string {
+  if (!n || n <= 0) return "0 B";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  const i = Math.floor(Math.log(n) / Math.log(1024));
+  const v = n / Math.pow(1024, i);
+  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+// ---- column renderers ---------------------------------------------------
+
+// Structural row shapes — AdminMailbox / MailboxRow / Mailbox all satisfy these
+// without a forced canonical row type (TS structural typing keeps the adapters'
+// own row types intact).
+export interface MailboxQuotaRow {
+  quota_bytes: number;
+  last_usage_bytes?: number | null;
+}
+
+// renderMailboxQuota — the quota progress bar + "used / quota" tooltip, shared
+// verbatim so the >=90%-is-exception threshold and the byte formatting can't
+// drift between screens.
+export function renderMailboxQuota(row: MailboxQuotaRow) {
+  const quota = row.quota_bytes ?? 0;
+  const used = row.last_usage_bytes ?? 0;
+  const pct = quota > 0 ? Math.min(100, Math.round((used / quota) * 100)) : 0;
+  return (
+    <Tooltip title={`${formatMailboxBytes(used)} of ${formatMailboxBytes(quota)}`}>
+      <Progress
+        percent={pct}
+        size="small"
+        status={pct >= 90 ? "exception" : "normal"}
+        format={() => `${formatMailboxBytes(used)} / ${formatMailboxBytes(quota)}`}
+      />
+    </Tooltip>
+  );
+}
+
+// renderMailboxStatus — the active/disabled tag.
+export function renderMailboxStatus(isDisabled: boolean | undefined | null) {
+  return isDisabled ? (
+    <Tag color="red">disabled</Tag>
+  ) : (
+    <Tag color="green">active</Tag>
+  );
+}
+
+// ---- safe webmail launcher (JAB-354) ------------------------------------
+
+// useMailboxWebmail is the single owner of the open-blank-popup ->
+// sever-opener -> mint -> navigate flow. Keeping it in one place is the point:
+// JAB-330 shipped the opener-severing fix by hand into each of the three
+// copies, and a fourth copy is exactly how the security fix was originally
+// forgotten. It also unifies the two behaviors that had drifted between the
+// copies:
+//
+//   - Blocked popup: warn and DO NOT mint. Admin/tenant used to call the mint
+//     even when window.open returned null, silently burning a one-shot SSO URL
+//     the user could never see.
+//   - Mint failure: surface the typed `detail` (e.g. the rotate-password hint)
+//     consistently, via the themed feedback bridge.
+export function useMailboxWebmail() {
+  const sso = useMintMailboxSSO();
+
+  const launch = (id: string) => {
+    // window.open MUST run synchronously with the click or popup blockers
+    // intercept it; pop a blank tab now, navigate it once the mint responds.
+    const popup = window.open("about:blank", "_blank");
+    if (!popup) {
+      feedback.message.warning(
+        "Browser blocked the webmail popup — allow popups for this site or click again.",
+      );
+      return; // never mint an SSO URL the user can't reach
+    }
+    // JAB-330: sever the opener link BEFORE the async mint so the webmail tab
+    // can never reach back into the panel window (reverse tabnabbing). Must run
+    // synchronously here. (noopener can't be passed to window.open — it returns
+    // null and breaks the synchronous-popup-then-set-href trick.)
+    try {
+      popup.opener = null;
+    } catch {
+      // older Safari — best effort
+    }
+    sso.mutate(
+      { id },
+      {
+        onSuccess: (data) => {
+          if (data?.url) popup.location.href = data.url;
+          else popup.close();
+        },
+        onError: (err: unknown) => {
+          popup.close();
+          const resp = (
+            err as { response?: { data?: { error?: string; detail?: string } } }
+          )?.response?.data;
+          // Typed hint for pre-Step-8 mailboxes (password_enc NULL): tell the
+          // user to rotate the password so SSO material gets populated.
+          if (resp?.error === "sso_unavailable_rotate_password") {
+            feedback.message.warning(
+              resp.detail ?? "Rotate the mailbox password to enable webmail SSO.",
+            );
+            return;
+          }
+          feedback.message.error(
+            resp?.detail ?? resp?.error ?? "Failed to open webmail",
+          );
+        },
+      },
+    );
+  };
+
+  return {
+    launch,
+    // Per-row pending flag for the action's spinner.
+    isLaunching: (id: string) => sso.isPending && sso.variables?.id === id,
+  };
+}

--- a/panel-ui/src/hooks/useMailboxes.test.tsx
+++ b/panel-ui/src/hooks/useMailboxes.test.tsx
@@ -211,6 +211,16 @@ describe("useDeleteMailbox", () => {
     expect(mocked.delete).toHaveBeenCalledWith("/mailboxes/mb1");
     const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidatedKeys).toContainEqual(["list", "mailboxes", "dom1"]);
+    expect(invalidatedKeys).toContainEqual(["admin", "mailboxes"]);
+    // JAB-333: a deleted mailbox also leaves the tenant screen's group-membership
+    // and autoresponder panels — those shared keys must be invalidated too, or
+    // they render a ghost row for the deleted mailbox until the next refetch.
+    expect(invalidatedKeys).toContainEqual([
+      "list",
+      "mailbox-group-memberships",
+      "dom1",
+    ]);
+    expect(invalidatedKeys).toContainEqual(["autoresponders", "by-domain", "dom1"]);
   });
 });
 

--- a/panel-ui/src/hooks/useMailboxes.ts
+++ b/panel-ui/src/hooks/useMailboxes.ts
@@ -248,6 +248,11 @@ export function useDeleteMailbox(): UseMutationResult<
     onSuccess: (_data, { domainId }) => {
       qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
       qc.invalidateQueries({ queryKey: ["admin", "mailboxes"] });
+      // JAB-333: a deleted mailbox also disappears from the tenant screen's
+      // group-membership and autoresponder panels — invalidate those shared
+      // keys so they don't render a ghost row until the next refetch.
+      qc.invalidateQueries({ queryKey: ["list", "mailbox-group-memberships", domainId] });
+      qc.invalidateQueries({ queryKey: ["autoresponders", "by-domain", domainId] });
     },
   });
 }

--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -8,7 +8,7 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
-import { Alert, Button, Card, Form, Input, Checkbox, InputNumber, Modal, Progress, Select, Skeleton, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { Alert, Button, Card, Form, Input, Checkbox, InputNumber, Modal, Select, Skeleton, Space, Table, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   DeleteOutlined,
@@ -20,12 +20,16 @@ import {
 import { DatabaseUserPasswordModal } from "../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../components/PasswordInput";
 import {
+  renderMailboxQuota,
+  renderMailboxStatus,
+  useMailboxWebmail,
+} from "../../../components/mail/mailboxInventory";
+import {
   useCreateMailbox,
   useDeleteMailbox,
   useDomainEmail,
   useEnableDomainEmail,
   useMailboxes,
-  useMintMailboxSSO,
   useRotateMailboxPassword,
   type Mailbox,
 } from "../../../hooks/useMailboxes";
@@ -49,14 +53,6 @@ type Props = {
 // the 16 MiB floor is panel-api's minMailboxQuotaBytes.
 const QUOTA_DEFAULT_BYTES = 1 * 1024 * 1024 * 1024;
 const QUOTA_MIN_BYTES = 16 * 1024 * 1024;
-
-function formatBytes(n: number): string {
-  if (n === 0) return "0 B";
-  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
-  const i = Math.floor(Math.log(n) / Math.log(1024));
-  const v = n / Math.pow(1024, i);
-  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
-}
 
 function parseQuotaInput(v: number | string | null | undefined): number | undefined {
   if (v === null || v === undefined || v === "") return undefined;
@@ -85,7 +81,7 @@ export const DomainMailboxesSection = ({
   const createMutation = useCreateMailbox();
   const deleteMutation = useDeleteMailbox();
   const rotateMutation = useRotateMailboxPassword();
-  const ssoMutation = useMintMailboxSSO();
+  const webmail = useMailboxWebmail();
   // enableMutation is only used when the section lands in the
   // disabled state (auto-enable failed at domain.create time, or an
   // operator explicitly turned email off). In the happy path — email
@@ -181,51 +177,6 @@ export const DomainMailboxesSection = ({
     }
   };
 
-  // openWebmail mints a one-shot SSO URL and opens it in a new tab.
-  // IMPORTANT: window.open MUST be called synchronously with the click
-  // event or popup blockers intercept it. We pop a blank tab first,
-  // then navigate it once the mint responds — same trick the
-  // phpMyAdmin-SSO flow uses.
-  const openWebmail = (row: Mailbox) => {
-    const popup = window.open("about:blank", "_blank");
-    if (!popup) {
-      feedback.message.warning(
-        "Browser blocked the webmail popup — allow popups for this site or click again.",
-      );
-      return;
-    }
-    // JAB-330: sever the opener link BEFORE the async SSO mint so the webmail
-    // tab can never reach back into the panel window (reverse tabnabbing). Must
-    // run synchronously here — the same fix the sibling mailbox flows already
-    // apply. (noopener can't be passed to window.open: it returns null and
-    // breaks the synchronous-popup-then-set-href trick that dodges blockers.)
-    popup.opener = null;
-    ssoMutation.mutate(
-      { id: row.id },
-      {
-        onSuccess: (data) => {
-          popup.location.href = data.url;
-        },
-        onError: (err: unknown) => {
-          popup.close();
-          const resp = (err as { response?: { data?: { error?: string; detail?: string } } })
-            ?.response?.data;
-          // sso_unavailable_rotate_password is the typed hint for
-          // pre-Step-8 mailboxes (password_enc is NULL) — surface the
-          // remediation so the user knows what to do.
-          if (resp?.error === "sso_unavailable_rotate_password") {
-            feedback.message.warning(
-              resp.detail ??
-                "Rotate the mailbox password to enable webmail SSO.",
-            );
-            return;
-          }
-          feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to open webmail");
-        },
-      },
-    );
-  };
-
   const onCreate = async () => {
     const values = await form.validateFields();
     // Fall back to the section's bound domain when the picker wasn't
@@ -315,20 +266,7 @@ export const DomainMailboxesSection = ({
               title: "Quota",
               dataIndex: "quota_bytes",
               width: 220,
-              render: (quota: number, row: Mailbox) => {
-                const used = row.last_usage_bytes ?? 0;
-                const pct = quota > 0 ? Math.min(100, Math.round((used / quota) * 100)) : 0;
-                return (
-                  <Tooltip title={`${formatBytes(used)} of ${formatBytes(quota)}`}>
-                    <Progress
-                      percent={pct}
-                      size="small"
-                      status={pct >= 90 ? "exception" : "normal"}
-                      format={() => `${formatBytes(used)} / ${formatBytes(quota)}`}
-                    />
-                  </Tooltip>
-                );
-              },
+              render: (_quota: number, row: Mailbox) => renderMailboxQuota(row),
             },
             {
               title: "Last usage",
@@ -344,8 +282,10 @@ export const DomainMailboxesSection = ({
               dataIndex: "is_disabled",
               width: 100,
               render: (disabled: boolean, row: Mailbox) => (
+                // Domain adapter composes the shared active/disabled tag with its
+                // own send-only marker (GH #371) — kept explicit per JAB-333.
                 <Space size={4} wrap>
-                  {disabled ? <Tag color="red">disabled</Tag> : <Tag color="green">active</Tag>}
+                  {renderMailboxStatus(disabled)}
                   {row.send_only && <Tag color="blue">send-only</Tag>}
                 </Space>
               ),
@@ -356,7 +296,7 @@ export const DomainMailboxesSection = ({
               render: (_, row) => (
                 <RowActions
                   actions={[
-                    { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: ssoMutation.isPending && ssoMutation.variables?.id === row.id, onClick: () => openWebmail(row) },
+                    { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: webmail.isLaunching(row.id), onClick: () => webmail.launch(row.id) },
                     { key: "rotate", label: "Rotate password", icon: <KeyOutlined />, loading: rotatingId === row.id, onClick: () => rotate(row) },
                     {
                       key: "delete",

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -12,12 +12,10 @@ import {
   Input,
   Modal,
   Card,
-  Progress,
   Skeleton,
   Space,
   Table,
   Tag,
-  Tooltip,
   Typography,
 } from "antd";
 import { DeleteOutlined, EditOutlined, KeyOutlined, MailOutlined, PlusOutlined } from "@icons";
@@ -25,7 +23,6 @@ import { DeleteOutlined, EditOutlined, KeyOutlined, MailOutlined, PlusOutlined }
 import {
   useAdminMailboxes,
   useDeleteMailbox,
-  useMintMailboxSSO,
   useRotateMailboxPassword,
   type AdminMailbox,
 } from "../../../hooks/useMailboxes";
@@ -35,19 +32,17 @@ import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, ownerLabel, adminLinks } from "../../../components/admin/entityLinks";
 import type { Domain } from "../../user/domains/UserDomainList";
 import { EditMailboxModal } from "../../../components/mail/EditMailboxModal";
+import {
+  renderMailboxQuota,
+  renderMailboxStatus,
+  useMailboxWebmail,
+} from "../../../components/mail/mailboxInventory";
 import { AdminGroupsTab } from "./AdminGroupsTab";
 import { MailStatsTab } from "./MailStatsTab";
 import { CreateMailboxWizardModal } from "../../user/mail/CreateMailboxWizardModal";
 import { DatabaseUserPasswordModal } from "../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../components/PasswordInput";
 import { RowActions } from "../../../components/RowActions";
-
-function formatBytes(n: number): string {
-  if (!n) return "0 B";
-  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
-  const i = Math.floor(Math.log(n) / Math.log(1024));
-  return `${(n / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
-}
 
 export function AdminMailPage() {
   const { t } = useTranslation();
@@ -76,41 +71,7 @@ export function AdminMailPage() {
 
   const deleteMutation = useDeleteMailbox();
   const rotate = useRotateMailboxPassword();
-  const ssoMutation = useMintMailboxSSO();
-
-  const openWebmail = (row: AdminMailbox) => {
-    // Sever the opener link so the webmail tab can't reverse-tabnab the panel.
-    // (noopener can't be passed to window.open here — it returns null and
-    // breaks the synchronous-popup-then-set-href pattern that dodges blockers.)
-    const popup = window.open("about:blank", "_blank");
-    if (popup) {
-      try {
-        popup.opener = null;
-      } catch {
-        // older Safari — best effort
-      }
-    }
-    ssoMutation.mutate(
-      { id: row.id },
-      {
-        onSuccess: (data) => {
-          if (popup && data?.url) popup.location.href = data.url;
-        },
-        onError: (err) => {
-          const code = (err as { response?: { data?: { error?: string } } })?.response
-            ?.data?.error;
-          popup?.close();
-          if (code === "sso_unavailable_rotate_password") {
-            message.error(
-              "Rotate the mailbox password first — SSO material is populated on rotation.",
-            );
-          } else {
-            message.error("Failed to open webmail");
-          }
-        },
-      },
-    );
-  };
+  const webmail = useMailboxWebmail();
 
   const [tab, setTab] = useTabParam<string>("mailboxes");
   const [createOpen, setCreateOpen] = useState(false);
@@ -264,28 +225,14 @@ export function AdminMailPage() {
               dataIndex: "quota_bytes",
               width: 200,
               sorter: (a, b) => (a.quota_bytes ?? 0) - (b.quota_bytes ?? 0),
-              render: (quota: number, row) => {
-                const used = row.last_usage_bytes ?? 0;
-                const pct = quota > 0 ? Math.min(100, Math.round((used / quota) * 100)) : 0;
-                return (
-                  <Tooltip title={`${formatBytes(used)} of ${formatBytes(quota)}`}>
-                    <Progress
-                      percent={pct}
-                      size="small"
-                      status={pct >= 90 ? "exception" : "normal"}
-                      format={() => `${formatBytes(used)} / ${formatBytes(quota)}`}
-                    />
-                  </Tooltip>
-                );
-              },
+              render: (_quota: number, row) => renderMailboxQuota(row),
             },
             {
               title: "Status",
               dataIndex: "is_disabled",
               width: 100,
               sorter: (a, b) => Number(a.is_disabled) - Number(b.is_disabled),
-              render: (disabled: boolean) =>
-                disabled ? <Tag color="red">disabled</Tag> : <Tag color="green">active</Tag>,
+              render: (disabled: boolean) => renderMailboxStatus(disabled),
             },
             {
               title: "Actions",
@@ -293,7 +240,7 @@ export function AdminMailPage() {
               render: (_, row) => (
                 <RowActions
                   actions={[
-                    { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: ssoMutation.isPending && ssoMutation.variables?.id === row.id, onClick: () => openWebmail(row) },
+                    { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: webmail.isLaunching(row.id), onClick: () => webmail.launch(row.id) },
                     { key: "edit", label: "Edit mailbox", icon: <EditOutlined />, onClick: () => setEditTarget(row) },
                     { key: "reset", label: "Reset password", icon: <KeyOutlined />, onClick: () => { resetForm.resetFields(); setResetTarget(row); } },
                     {

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -5,7 +5,7 @@
 // client-side and provides password rotation, SSO mint, and delete actions.
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import { Button, Empty, Form, Modal, Progress, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
+import { Button, Empty, Form, Modal, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../../components/RowActions";
 import { SearchableTableStringQ } from "../../../../components/SearchableTable";
@@ -26,10 +26,14 @@ import { useForwarders } from "../../../../hooks/useForwarders";
 import { apiClient } from "../../../../apiClient";
 import {
   useDeleteMailbox,
-  useMintMailboxSSO,
   useRotateMailboxPassword,
   type Mailbox,
 } from "../../../../hooks/useMailboxes";
+import {
+  renderMailboxQuota,
+  renderMailboxStatus,
+  useMailboxWebmail,
+} from "../../../../components/mail/mailboxInventory";
 import { useListQuery } from "../../../../hooks/useQueries";
 import type { Domain } from "../../domains/UserDomainList";
 import { DatabaseUserPasswordModal } from "../../../../components/DatabaseUserPasswordModal";
@@ -43,14 +47,6 @@ type GroupMembership = {
   group_name: string;
   group_email: string;
 };
-
-function formatBytes(n: number): string {
-  if (n === 0) return "0 B";
-  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
-  const i = Math.floor(Math.log(n) / Math.log(1024));
-  const v = n / Math.pow(1024, i);
-  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
-}
 
 export const MailboxesTab = () => {
   const { t } = useTranslation();
@@ -172,7 +168,7 @@ export const MailboxesTab = () => {
 
   const deleteMutation = useDeleteMailbox();
   const rotateMutation = useRotateMailboxPassword();
-  const ssoMutation = useMintMailboxSSO();
+  const webmail = useMailboxWebmail();
 
   const openReset = (row: MailboxRow) => {
     resetForm.resetFields();
@@ -208,40 +204,6 @@ export const MailboxesTab = () => {
     } finally {
       setRotatingId(null);
     }
-  };
-
-  const openWebmail = (row: MailboxRow) => {
-    // Sever the opener link so the webmail tab can't reverse-tabnab the panel.
-    // (noopener can't be passed to window.open here — it returns null and
-    // breaks the synchronous-popup-then-set-href pattern that dodges blockers.)
-    const popup = window.open("about:blank", "_blank");
-    if (popup) {
-      try {
-        popup.opener = null;
-      } catch {
-        // older Safari — best effort
-      }
-    }
-    ssoMutation.mutate(
-      { id: row.id },
-      {
-        onSuccess: (data) => {
-          if (popup && data?.url) popup.location.href = data.url;
-        },
-        onError: (err) => {
-          const code = (err as { response?: { data?: { error?: string } } })?.response
-            ?.data?.error;
-          popup?.close();
-          if (code === "sso_unavailable_rotate_password") {
-            feedback.message.error(
-              "Rotate the mailbox password first — SSO material is populated on rotation.",
-            );
-          } else {
-            feedback.message.error("Failed to open webmail");
-          }
-        },
-      },
-    );
   };
 
   const loading = loadingDomains || mailboxResults.some((r) => r.isLoading);
@@ -386,26 +348,7 @@ export const MailboxesTab = () => {
             dataIndex: "quota_bytes",
             sorter: (a, b) => (a.quota_bytes ?? 0) - (b.quota_bytes ?? 0),
             width: 220,
-            render: (quota: number, row) => {
-              const used = row.last_usage_bytes ?? 0;
-              const pct =
-                quota > 0 ? Math.min(100, Math.round((used / quota) * 100)) : 0;
-              return (
-                <Tooltip title={`${formatBytes(used)} of ${formatBytes(quota)}`}>
-                  <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                    <Typography.Text style={{ fontSize: 12 }}>
-                      {`${formatBytes(used)} / ${formatBytes(quota)}`}
-                    </Typography.Text>
-                    <Progress
-                      percent={pct}
-                      size="small"
-                      showInfo={false}
-                      status={pct >= 90 ? "exception" : "normal"}
-                    />
-                  </div>
-                </Tooltip>
-              );
-            },
+            render: (_quota: number, row) => renderMailboxQuota(row),
           },
           {
             title: "Last usage",
@@ -424,12 +367,7 @@ export const MailboxesTab = () => {
             dataIndex: "is_disabled",
             sorter: (a, b) => Number(a.is_disabled) - Number(b.is_disabled),
             width: 100,
-            render: (disabled: boolean) =>
-              disabled ? (
-                <Tag color="red">disabled</Tag>
-              ) : (
-                <Tag color="green">active</Tag>
-              ),
+            render: (disabled: boolean) => renderMailboxStatus(disabled),
           },
           {
             title: "Actions",
@@ -442,8 +380,8 @@ export const MailboxesTab = () => {
                     label: "Webmail",
                     icon: <MailOutlined />,
                     tooltip: "Open webmail for this mailbox",
-                    loading: ssoMutation.isPending && ssoMutation.variables?.id === row.id,
-                    onClick: () => openWebmail(row),
+                    loading: webmail.isLaunching(row.id),
+                    onClick: () => webmail.launch(row.id),
                   },
                   { key: "edit", label: "Edit", icon: <EditOutlined />, onClick: () => setEditTarget(row) },
                   // Send-only mailboxes (GH #371 relays like noreply@) have no


### PR DESCRIPTION
## What

Introduces `panel-ui/src/components/mail/mailboxInventory.tsx` as the single owner of the behavior the three mailbox inventories used to each copy, and rewires all three screens to it:

- `shells/admin/mail/AdminMailPage.tsx` (server-wide)
- `shells/user/mail/tabs/MailboxesTab.tsx` (tenant, cross-domain)
- `shells/admin/domains/DomainMailboxesSection.tsx` (per-domain)

Closes **JAB-354** (Safe Webmail Launcher) fully, and delivers the security/presentation/invalidation core of **JAB-333** (Mailbox Inventory Module).

## The module

- **`useMailboxWebmail()`** — the one Safe Webmail Launcher. Owns popup creation, synchronous opener isolation (reverse-tabnab guard), async navigation, blocked-popup handling, and cleanup. `window.open` now appears in **exactly one file** across the mail surfaces (verifiable: `grep -rl window.open shells/…/mail components/mail` → only `mailboxInventory.tsx`), so the opener-severing invariant can't drift into a fourth copy — which is exactly how JAB-330's fix was originally forgotten.
- **`renderMailboxQuota` / `renderMailboxStatus` / `formatMailboxBytes`** — shared presentation.

## Behavioral fixes (not just de-dup)

1. **Blocked popup no longer burns a one-shot SSO URL.** Admin/tenant used to call the SSO mint even when `window.open` returned null — silently spending a single-use URL the user could never see. The launcher now warns and does not mint.
2. **`formatBytes` drift.** AdminMailPage always printed a decimal (`500.0 MiB`) where the other two dropped it (`500 MiB`). Unified on the latter.
3. **Delete cache-staleness (JAB-333 criterion 3).** `useDeleteMailbox` now also invalidates `["list","mailbox-group-memberships",domainId]` and `["autoresponders","by-domain",domainId]` — deleting a mailbox that was in a group or had an autoresponder used to leave those tenant panels showing a ghost row until the next refetch.
4. **Consistent mint-failure reporting** — the typed `detail` (e.g. the rotate-password hint) is surfaced consistently via the themed feedback bridge.

## Visible change to call out

The **tenant** (`MailboxesTab`) quota cell's DOM changed: it previously stacked a `Typography.Text` label above a `showInfo={false}` bar; it now uses the same inline-`format` Progress bar as the admin/domain screens (the unified `renderMailboxQuota`). Same data, unified presentation.

## Kept adapter-explicit (JAB-333 criterion 4)

Admin owner filter, tenant groups + autoresponder columns/actions, and the domain enable-email affordance + create wizard + send-only tag are unchanged. `DomainMailboxesSection` composes `renderMailboxStatus` with its own send-only tag.

## Not extracted — why JAB-333 stays In Progress

The ticket asks the module to also own the **password action** and **deletion** UIs. Those genuinely differ per adapter and were left explicit: admin uses an explicit-password **form** modal, the per-domain screen is **one-click** reveal-once, and the delete confirms differ (tenant `feedback.modal.confirm` vs the others' inline confirm). Forcing one UI would be a UX regression, so I left them adapter-specific and flag the shared password/delete extraction as the remaining slice on the ticket. **JAB-354** (launcher only) meets all four of its criteria and is complete.

## Verification

- `tsc -b` clean; full panel-ui **vitest: 300 tests pass**; production `vite build` clean.
- New `mailboxInventory.test.tsx`: opener severed **synchronously before** the mint, blocked-popup mints nothing, rotate-hint + generic `detail` surfaced, `formatMailboxBytes` output.
- `useMailboxes.test.tsx` extended to assert the two new delete-invalidation keys.
- The existing JAB-330 opener test now exercises the shared hook through the real `DomainMailboxesSection`.
- `tests/e2e/m6-email.spec.ts` exercises the per-domain webmail launch (through the new hook) + delete end-to-end — the CI Playwright gate for this change.
- **Live authed visual check not performed**: it requires signing into the panel (credential entry I don't do), and no already-authenticated browser session was available. Recommend a human spot-check of the three screens' quota/status rendering + one webmail launch.

GH #333, GH #354
