### PR TITLE
refactor(mail): shared Mailbox Autoresponder Lifecycle + content/date policy on every adapter (JAB-346)

### DIFF
--- a/panel-api/cmd/server/mailbox_extras_cmd.go
+++ b/panel-api/cmd/server/mailbox_extras_cmd.go
@@ -18,10 +18,21 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/autoresponderops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
+
+// optStr returns nil for an empty flag value, else a pointer to it — so an
+// omitted --subject/--body reaches autoresponderops as a nil (absent) field,
+// not an empty string that would masquerade as content.
+func optStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
 
 // ---- repo helpers ---------------------------------------------------------
 
@@ -120,6 +131,10 @@ func newMailboxAutoresponderSetCmd() *cobra.Command {
 				return err
 			}
 
+			// Flag-specific hints for the operator; the shared lifecycle
+			// (autoresponderops.Set) is the actual enforcement backstop, so CLI
+			// and REST reject the same intake — this just phrases it in terms of
+			// the flags the operator typed.
 			if subject == "" {
 				return fmt.Errorf("--subject is required")
 			}
@@ -127,59 +142,45 @@ func newMailboxAutoresponderSetCmd() *cobra.Command {
 				return fmt.Errorf("at least one of --body or --html-body is required")
 			}
 
-			ar := &models.EmailAutoresponder{
-				MailboxID: mb.ID,
-				Enabled:   true,
-				Subject:   &subject,
-				ManagedBy: "m6.5",
-			}
-			if body != "" {
-				v := body
-				ar.TextBody = &v
-			}
-			if htmlBody != "" {
-				v := htmlBody
-				ar.HTMLBody = &v
-			}
+			// The date-range rule is enforced centrally too (from must be <= to).
+			var fromT, toT *time.Time
 			if from != "" {
 				t, err := time.Parse(time.RFC3339, from)
 				if err != nil {
 					return fmt.Errorf("--from must be RFC3339 (e.g. 2026-05-01T00:00:00Z): %w", err)
 				}
-				ar.FromDate = &t
+				fromT = &t
 			}
 			if to != "" {
 				t, err := time.Parse(time.RFC3339, to)
 				if err != nil {
 					return fmt.Errorf("--to must be RFC3339: %w", err)
 				}
-				ar.ToDate = &t
+				toT = &t
 			}
+			subjP, bodyP, htmlP := optStr(subject), optStr(body), optStr(htmlBody)
 
-			if err := autoresponderRepoFromDB().Update(ctx, ar); err != nil {
-				return fmt.Errorf("save autoresponder: %w", err)
+			// callAgentMailbox returns the agent error so Set can turn a failed
+			// push into a warning while keeping the DB the desired-state truth.
+			push := func(pctx context.Context, cmd string, params map[string]any) error {
+				_, err := callAgentMailbox(pctx, cmd, params)
+				return err
 			}
-
-			// Best-effort inline push to Stalwart. Reconciler re-asserts
-			// on drift, so a swallowed error doesn't lose the change.
-			params := map[string]any{
-				"mailbox_email": mb.LocalPart + "@" + dom.Name,
-				"enabled":       true,
-				"subject":       subject,
+			_, warning, err := autoresponderops.Set(ctx,
+				autoresponderops.Deps{Autoresponders: autoresponderRepoFromDB()},
+				autoresponderops.SetInput{
+					MailboxID:    mb.ID,
+					MailboxEmail: mb.LocalPart + "@" + dom.Name,
+					Enabled:      true,
+					Subject:      subjP,
+					TextBody:     bodyP,
+					HTMLBody:     htmlP,
+					FromDate:     fromT,
+					ToDate:       toT,
+				}, push)
+			if err != nil {
+				return fmt.Errorf("set autoresponder: %w", err)
 			}
-			if body != "" {
-				params["text_body"] = body
-			}
-			if htmlBody != "" {
-				params["html_body"] = htmlBody
-			}
-			if ar.FromDate != nil {
-				params["from_date"] = ar.FromDate.UTC().Format(time.RFC3339)
-			}
-			if ar.ToDate != nil {
-				params["to_date"] = ar.ToDate.UTC().Format(time.RFC3339)
-			}
-			notifyAgentMailbox(ctx, "autoresponder.set", params)
 
 			if jsonOutput {
 				return printJSON(map[string]any{
@@ -190,6 +191,9 @@ func newMailboxAutoresponderSetCmd() *cobra.Command {
 			}
 			cliAuditOK(ctx, "mailbox.autoresponder_set", "mailbox", email, nil)
 			fmt.Printf("Autoresponder enabled for %s\n", email)
+			if warning != "" {
+				fmt.Printf("Note: %s\n", warning)
+			}
 			return nil
 		},
 	}
@@ -216,14 +220,15 @@ func newMailboxAutoresponderClearCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := autoresponderRepoFromDB().Delete(ctx, mb.ID); err != nil &&
-				!errors.Is(err, repository.ErrNotFound) {
-				return fmt.Errorf("delete autoresponder: %w", err)
+			push := func(pctx context.Context, cmd string, params map[string]any) error {
+				_, err := callAgentMailbox(pctx, cmd, params)
+				return err
 			}
-			notifyAgentMailbox(ctx, "autoresponder.set", map[string]any{
-				"mailbox_email": mb.LocalPart + "@" + dom.Name,
-				"enabled":       false,
-			})
+			if err := autoresponderops.Clear(ctx,
+				autoresponderops.Deps{Autoresponders: autoresponderRepoFromDB()},
+				mb.ID, mb.LocalPart+"@"+dom.Name, push); err != nil {
+				return fmt.Errorf("clear autoresponder: %w", err)
+			}
 			cliAuditOK(ctx, "mailbox.autoresponder_clear", "mailbox", email, nil)
 			fmt.Printf("Autoresponder cleared for %s\n", email)
 			return nil

--- a/panel-api/internal/api/mailbox_autoresponder.go
+++ b/panel-api/internal/api/mailbox_autoresponder.go
@@ -16,6 +16,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/autoresponderops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -39,6 +40,10 @@ type autoresponderResponse struct {
 	TextBody  *string    `json:"text_body"`
 	HTMLBody  *string    `json:"html_body"`
 	UpdatedAt time.Time  `json:"updated_at"`
+	// Warning is set (JAB-346 criterion 5) when the desired state was saved but
+	// the inline agent push failed; the reconciler re-asserts shortly. Omitted
+	// on a clean push.
+	Warning string `json:"warning,omitempty"`
 }
 
 type autoresponderUpdateRequest struct {
@@ -190,46 +195,26 @@ func (h *mailboxAutoresponderHandler) put(c *gin.Context) {
 		return
 	}
 
-	ar := &models.EmailAutoresponder{
-		MailboxID: mb.ID,
-		Enabled:   req.Enabled,
-		FromDate:  req.FromDate,
-		ToDate:    req.ToDate,
-		Subject:   req.Subject,
-		TextBody:  req.TextBody,
-		HTMLBody:  req.HTMLBody,
-		ManagedBy: "m6.5",
-	}
-	if err := h.cfg.Autoresponders.Update(ctx, ar); err != nil {
+	email := mb.LocalPart + "@" + mustDomainName(ctx, h.cfg.Domains, mb.DomainID)
+	ar, warning, err := autoresponderops.Set(ctx,
+		autoresponderops.Deps{Autoresponders: h.cfg.Autoresponders},
+		autoresponderops.SetInput{
+			MailboxID:    mb.ID,
+			MailboxEmail: email,
+			Enabled:      req.Enabled,
+			Subject:      req.Subject,
+			TextBody:     req.TextBody,
+			HTMLBody:     req.HTMLBody,
+			FromDate:     req.FromDate,
+			ToDate:       req.ToDate,
+		}, h.pushAutoresponder)
+	if err != nil {
+		if errors.Is(err, autoresponderops.ErrContentRequired) || errors.Is(err, autoresponderops.ErrInvalidDateRange) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_autoresponder", "detail": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
-	}
-
-	// Best-effort inline push to Stalwart. Reconciler re-asserts on drift.
-	if h.cfg.Agent != nil {
-		email := mb.LocalPart + "@" + mustDomainName(ctx, h.cfg.Domains, mb.DomainID)
-		params := map[string]any{
-			"mailbox_email": email,
-			"enabled":       req.Enabled,
-		}
-		if req.FromDate != nil {
-			params["from_date"] = req.FromDate.UTC().Format(time.RFC3339)
-		}
-		if req.ToDate != nil {
-			params["to_date"] = req.ToDate.UTC().Format(time.RFC3339)
-		}
-		if req.Subject != nil {
-			params["subject"] = *req.Subject
-		}
-		if req.TextBody != nil {
-			params["text_body"] = *req.TextBody
-		}
-		if req.HTMLBody != nil {
-			params["html_body"] = *req.HTMLBody
-		}
-		agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		_, _ = h.cfg.Agent.Call(agentCtx, "autoresponder.set", params)
 	}
 
 	c.JSON(http.StatusOK, autoresponderResponse{
@@ -241,7 +226,20 @@ func (h *mailboxAutoresponderHandler) put(c *gin.Context) {
 		TextBody:  ar.TextBody,
 		HTMLBody:  ar.HTMLBody,
 		UpdatedAt: ar.UpdatedAt,
+		Warning:   warning,
 	})
+}
+
+// pushAutoresponder is the autoresponderops.PushFunc backed by the handler's
+// agent client — a bounded best-effort call whose error becomes a Set warning.
+func (h *mailboxAutoresponderHandler) pushAutoresponder(ctx context.Context, cmd string, params map[string]any) error {
+	if h.cfg.Agent == nil {
+		return nil
+	}
+	agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, err := h.cfg.Agent.Call(agentCtx, cmd, params)
+	return err
 }
 
 func (h *mailboxAutoresponderHandler) del(c *gin.Context) {
@@ -260,19 +258,12 @@ func (h *mailboxAutoresponderHandler) del(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	if err := h.cfg.Autoresponders.Delete(ctx, mb.ID); err != nil && !errors.Is(err, repository.ErrNotFound) {
+	email := mb.LocalPart + "@" + mustDomainName(ctx, h.cfg.Domains, mb.DomainID)
+	if err := autoresponderops.Clear(ctx,
+		autoresponderops.Deps{Autoresponders: h.cfg.Autoresponders},
+		mb.ID, email, h.pushAutoresponder); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
-	}
-	// Disable on Stalwart too.
-	if h.cfg.Agent != nil {
-		email := mb.LocalPart + "@" + mustDomainName(ctx, h.cfg.Domains, mb.DomainID)
-		agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		_, _ = h.cfg.Agent.Call(agentCtx, "autoresponder.set", map[string]any{
-			"mailbox_email": email,
-			"enabled":       false,
-		})
 	}
 	c.JSON(http.StatusNoContent, nil)
 }

--- a/panel-api/internal/autoresponderops/autoresponderops.go
+++ b/panel-api/internal/autoresponderops/autoresponderops.go
@@ -1,0 +1,161 @@
+// Package autoresponderops is the shared Mailbox Autoresponder Lifecycle
+// (JAB-346): the Set / Clear operations — and the one canonical agent-parameter
+// projection — that the REST handler, the operator CLI, and the reconciler
+// phase all route through, so the content policy, the date-range rule, and the
+// "autoresponder.set" payload have a single owner and cannot drift between the
+// three callers.
+//
+// Authorization stays an Adapter concern: the REST handler checks the caller's
+// claims and the CLI is admin-by-construction; every entry point here takes an
+// already-loaded, already-authorized mailbox identity.
+package autoresponderops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+const managedBy = "m6.5"
+
+// PushFunc pushes one agent command. Its error is treated as a SOFT failure by
+// Set/Clear: the DB is the desired-state truth and the reconciler re-asserts on
+// the next tick, so a push error becomes a structured retry warning, never a
+// lost change.
+type PushFunc func(ctx context.Context, cmd string, params map[string]any) error
+
+// Deps carries the collaborators every operation needs.
+type Deps struct {
+	Autoresponders repository.EmailAutoresponderRepository
+}
+
+var (
+	// ErrContentRequired — an ENABLED autoresponder must carry a subject and at
+	// least one body. The REST handler used to persist an enabled-but-empty
+	// responder (the CLI already rejected it); this closes that drift.
+	ErrContentRequired = errors.New("autoresponderops: an enabled autoresponder needs a subject and a text or HTML body")
+	// ErrInvalidDateRange — from_date must be on or before to_date.
+	ErrInvalidDateRange = errors.New("autoresponderops: from_date must be on or before to_date")
+	ErrDeps             = errors.New("autoresponderops: dependencies not wired")
+	ErrInternal         = errors.New("autoresponderops: internal error")
+)
+
+// SetInput is one autoresponder upsert. MailboxEmail is the canonical address
+// the agent keys the Stalwart VacationResponse on; MailboxID is the DB key.
+type SetInput struct {
+	MailboxID    string
+	MailboxEmail string
+	Enabled      bool
+	Subject      *string
+	TextBody     *string
+	HTMLBody     *string
+	FromDate     *time.Time
+	ToDate       *time.Time
+}
+
+// Validate enforces the content policy and the date-range rule for EVERY
+// adapter. Exposed so a caller can pre-validate before touching the DB if it
+// wants; Set calls it too.
+func Validate(in SetInput) error {
+	if in.FromDate != nil && in.ToDate != nil && in.FromDate.After(*in.ToDate) {
+		return ErrInvalidDateRange
+	}
+	if in.Enabled {
+		if in.Subject == nil || strings.TrimSpace(*in.Subject) == "" {
+			return ErrContentRequired
+		}
+		hasText := in.TextBody != nil && strings.TrimSpace(*in.TextBody) != ""
+		hasHTML := in.HTMLBody != nil && strings.TrimSpace(*in.HTMLBody) != ""
+		if !hasText && !hasHTML {
+			return ErrContentRequired
+		}
+	}
+	return nil
+}
+
+// AgentParams is the SINGLE canonical "autoresponder.set" payload projection.
+// The reconciler phase, Set, and (transitively) every adapter build the agent
+// request through this, so their parameters are byte-identical (JAB-346
+// criterion 3).
+func AgentParams(mailboxEmail string, ar *models.EmailAutoresponder) map[string]any {
+	params := map[string]any{
+		"mailbox_email": mailboxEmail,
+		"enabled":       ar.Enabled,
+	}
+	if ar.FromDate != nil {
+		params["from_date"] = ar.FromDate.UTC().Format(time.RFC3339)
+	}
+	if ar.ToDate != nil {
+		params["to_date"] = ar.ToDate.UTC().Format(time.RFC3339)
+	}
+	if ar.Subject != nil {
+		params["subject"] = *ar.Subject
+	}
+	if ar.TextBody != nil {
+		params["text_body"] = *ar.TextBody
+	}
+	if ar.HTMLBody != nil {
+		params["html_body"] = *ar.HTMLBody
+	}
+	return params
+}
+
+// Set validates the intake, persists the desired state (DB is truth), then does
+// a best-effort agent push. Returns the persisted row and a WARNING string that
+// is non-empty only when the DB write succeeded but the agent push failed — the
+// caller surfaces it as "saved; the mail server will catch up on the next
+// reconcile" rather than a hard error (JAB-346 criterion 5). A validation or
+// persistence failure is a hard error and nothing is pushed.
+func Set(ctx context.Context, d Deps, in SetInput, push PushFunc) (*models.EmailAutoresponder, string, error) {
+	if d.Autoresponders == nil {
+		return nil, "", fmt.Errorf("%w: autoresponders repo required", ErrDeps)
+	}
+	if err := Validate(in); err != nil {
+		return nil, "", err
+	}
+	ar := &models.EmailAutoresponder{
+		MailboxID: in.MailboxID,
+		Enabled:   in.Enabled,
+		FromDate:  in.FromDate,
+		ToDate:    in.ToDate,
+		Subject:   in.Subject,
+		TextBody:  in.TextBody,
+		HTMLBody:  in.HTMLBody,
+		ManagedBy: managedBy,
+	}
+	if err := d.Autoresponders.Update(ctx, ar); err != nil {
+		return nil, "", fmt.Errorf("%w: persist: %v", ErrInternal, err)
+	}
+	warning := ""
+	if push != nil {
+		if perr := push(ctx, "autoresponder.set", AgentParams(in.MailboxEmail, ar)); perr != nil {
+			warning = "saved; the mail server did not accept the change yet and will be reconciled shortly"
+		}
+	}
+	return ar, warning, nil
+}
+
+// Clear disables + deletes the autoresponder. Idempotent (JAB-346 criterion 4):
+// a missing row is not an error, and the agent disable is a no-op when already
+// off. The DB delete is authoritative; the agent push is best-effort.
+func Clear(ctx context.Context, d Deps, mailboxID, mailboxEmail string, push PushFunc) error {
+	if d.Autoresponders == nil {
+		return fmt.Errorf("%w: autoresponders repo required", ErrDeps)
+	}
+	if err := d.Autoresponders.Delete(ctx, mailboxID); err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return fmt.Errorf("%w: delete: %v", ErrInternal, err)
+	}
+	if push != nil {
+		// Disable on the mail server too; best-effort, reconciler re-asserts.
+		_ = push(ctx, "autoresponder.set", map[string]any{
+			"mailbox_email": mailboxEmail,
+			"enabled":       false,
+		})
+	}
+	return nil
+}

--- a/panel-api/internal/autoresponderops/autoresponderops_test.go
+++ b/panel-api/internal/autoresponderops/autoresponderops_test.go
@@ -1,0 +1,169 @@
+package autoresponderops
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeAR struct {
+	repository.EmailAutoresponderRepository
+	saved     *models.EmailAutoresponder
+	deleteErr error
+	deleted   string
+}
+
+func (f *fakeAR) Update(_ context.Context, ar *models.EmailAutoresponder) error {
+	f.saved = ar
+	return nil
+}
+func (f *fakeAR) Delete(_ context.Context, id string) error {
+	f.deleted = id
+	return f.deleteErr
+}
+
+func sptr(s string) *string { return &s }
+
+// The content policy must reject an ENABLED responder with no subject or no
+// body — the drift the REST handler had (the CLI already rejected it).
+func TestValidate_ContentPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   SetInput
+		want error
+	}{
+		{"enabled no subject", SetInput{Enabled: true, TextBody: sptr("hi")}, ErrContentRequired},
+		{"enabled subject no body", SetInput{Enabled: true, Subject: sptr("Away")}, ErrContentRequired},
+		{"enabled blank subject", SetInput{Enabled: true, Subject: sptr("   "), TextBody: sptr("hi")}, ErrContentRequired},
+		{"enabled subject + text ok", SetInput{Enabled: true, Subject: sptr("Away"), TextBody: sptr("hi")}, nil},
+		{"enabled subject + html ok", SetInput{Enabled: true, Subject: sptr("Away"), HTMLBody: sptr("<p>hi</p>")}, nil},
+		{"disabled empty ok", SetInput{Enabled: false}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := Validate(c.in); !errors.Is(err, c.want) {
+				t.Errorf("Validate() = %v, want %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestValidate_DateRange(t *testing.T) {
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	// from after to → rejected (checked even when disabled).
+	if err := Validate(SetInput{FromDate: &from, ToDate: &before}); !errors.Is(err, ErrInvalidDateRange) {
+		t.Errorf("inverted range must be rejected, got %v", err)
+	}
+	// from == to and from < to are both fine.
+	if err := Validate(SetInput{FromDate: &before, ToDate: &from}); err != nil {
+		t.Errorf("valid range rejected: %v", err)
+	}
+}
+
+// Set persists the desired state and pushes the canonical params; a failed push
+// is a warning, not an error (DB stays the truth). A validation failure never
+// touches the repo.
+func TestSet(t *testing.T) {
+	t.Run("valid persists and pushes canonical params", func(t *testing.T) {
+		repo := &fakeAR{}
+		var pushed map[string]any
+		push := func(_ context.Context, cmd string, p map[string]any) error {
+			if cmd != "autoresponder.set" {
+				t.Errorf("cmd = %q", cmd)
+			}
+			pushed = p
+			return nil
+		}
+		_, warning, err := Set(context.Background(), Deps{Autoresponders: repo}, SetInput{
+			MailboxID: "m1", MailboxEmail: "a@ex.com", Enabled: true,
+			Subject: sptr("Away"), TextBody: sptr("back soon"),
+		}, push)
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		if warning != "" {
+			t.Errorf("clean push must not warn, got %q", warning)
+		}
+		if repo.saved == nil || !repo.saved.Enabled || repo.saved.ManagedBy != managedBy {
+			t.Fatalf("row not persisted correctly: %+v", repo.saved)
+		}
+		if pushed["mailbox_email"] != "a@ex.com" || pushed["enabled"] != true || pushed["subject"] != "Away" {
+			t.Errorf("canonical params wrong: %+v", pushed)
+		}
+	})
+
+	t.Run("push failure returns a warning, DB truth kept", func(t *testing.T) {
+		repo := &fakeAR{}
+		push := func(_ context.Context, _ string, _ map[string]any) error {
+			return errors.New("agent down")
+		}
+		_, warning, err := Set(context.Background(), Deps{Autoresponders: repo}, SetInput{
+			MailboxID: "m1", MailboxEmail: "a@ex.com", Enabled: true,
+			Subject: sptr("Away"), TextBody: sptr("back soon"),
+		}, push)
+		if err != nil {
+			t.Fatalf("push failure must not be a hard error: %v", err)
+		}
+		if warning == "" {
+			t.Error("a failed push must surface a warning")
+		}
+		if repo.saved == nil {
+			t.Error("desired state must be persisted even when the push fails")
+		}
+	})
+
+	t.Run("validation failure never persists", func(t *testing.T) {
+		repo := &fakeAR{}
+		if _, _, err := Set(context.Background(), Deps{Autoresponders: repo}, SetInput{
+			MailboxID: "m1", Enabled: true, // no subject/body
+		}, nil); !errors.Is(err, ErrContentRequired) {
+			t.Errorf("want ErrContentRequired, got %v", err)
+		}
+		if repo.saved != nil {
+			t.Error("an invalid intake must not touch the repo")
+		}
+	})
+}
+
+// Clear is idempotent: a missing row is not an error, and the agent is told to
+// disable.
+func TestClear_Idempotent(t *testing.T) {
+	repo := &fakeAR{deleteErr: repository.ErrNotFound}
+	var pushed map[string]any
+	push := func(_ context.Context, _ string, p map[string]any) error { pushed = p; return nil }
+	if err := Clear(context.Background(), Deps{Autoresponders: repo}, "m1", "a@ex.com", push); err != nil {
+		t.Fatalf("clearing a missing responder must succeed, got %v", err)
+	}
+	if repo.deleted != "m1" {
+		t.Errorf("delete target = %q", repo.deleted)
+	}
+	if pushed["enabled"] != false {
+		t.Errorf("clear must push enabled=false, got %+v", pushed)
+	}
+}
+
+// AgentParams includes only the fields that are set — the exact projection all
+// three callers share.
+func TestAgentParams_OnlySetFields(t *testing.T) {
+	from := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	p := AgentParams("a@ex.com", &models.EmailAutoresponder{
+		Enabled: true, Subject: sptr("Away"), FromDate: &from,
+	})
+	if p["mailbox_email"] != "a@ex.com" || p["enabled"] != true || p["subject"] != "Away" {
+		t.Errorf("params = %+v", p)
+	}
+	if p["from_date"] != "2026-06-01T12:00:00Z" {
+		t.Errorf("from_date = %v", p["from_date"])
+	}
+	if _, ok := p["to_date"]; ok {
+		t.Error("unset to_date must be absent from the payload")
+	}
+	if _, ok := p["text_body"]; ok {
+		t.Error("unset text_body must be absent")
+	}
+}

--- a/panel-api/internal/reconciler/phases/m65_autoresponder.go
+++ b/panel-api/internal/reconciler/phases/m65_autoresponder.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/autoresponderops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -41,25 +42,10 @@ func (p *autoresponderPhase) ReconcileMailbox(ctx context.Context, mb *models.Ma
 		}
 		return fmt.Errorf("autoresponder: find %s: %w", mb.ID, err)
 	}
-	params := map[string]any{
-		"mailbox_email": mb.LocalPart + "@" + dom.Name,
-		"enabled":       ar.Enabled,
-	}
-	if ar.FromDate != nil {
-		params["from_date"] = ar.FromDate.UTC().Format(time.RFC3339)
-	}
-	if ar.ToDate != nil {
-		params["to_date"] = ar.ToDate.UTC().Format(time.RFC3339)
-	}
-	if ar.Subject != nil {
-		params["subject"] = *ar.Subject
-	}
-	if ar.TextBody != nil {
-		params["text_body"] = *ar.TextBody
-	}
-	if ar.HTMLBody != nil {
-		params["html_body"] = *ar.HTMLBody
-	}
+	// JAB-346: the agent payload comes from the one canonical projection the
+	// HTTP + CLI Set path also uses, so all three callers push byte-identical
+	// parameters.
+	params := autoresponderops.AgentParams(mb.LocalPart+"@"+dom.Name, ar)
 	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if _, err := p.agent.Call(callCtx, "autoresponder.set", params); err != nil {

--- a/panel-ui/src/shells/user/mail/AutoReplyModal.tsx
+++ b/panel-ui/src/shells/user/mail/AutoReplyModal.tsx
@@ -59,6 +59,19 @@ export const AutoReplyModal = ({
 
   const submit = async () => {
     const vals = await form.validateFields();
+    // JAB-346: an enabled reply needs a subject and a text or HTML body — the
+    // same policy the API now enforces. Check it here so the user gets a clear
+    // inline message instead of a raw 400 toast.
+    if (vals.enabled) {
+      const hasSubject = !!vals.subject?.trim();
+      const hasBody = !!vals.text_body?.trim() || !!vals.html_body?.trim();
+      if (!hasSubject || !hasBody) {
+        feedback.message.error(
+          "An enabled automatic reply needs a subject and a text or HTML body.",
+        );
+        return;
+      }
+    }
     const [from, to] = vals.date_range ?? [null, null];
     try {
       await updateMut.mutateAsync({
@@ -75,10 +88,9 @@ export const AutoReplyModal = ({
       feedback.message.success("Automatic replies saved");
       onClose();
     } catch (err) {
-      const msg =
-        (err as { response?: { data?: { error?: string } } })?.response?.data
-          ?.error ?? "Failed to save automatic replies";
-      feedback.message.error(msg);
+      const data = (err as { response?: { data?: { error?: string; detail?: string } } })
+        ?.response?.data;
+      feedback.message.error(data?.detail ?? data?.error ?? "Failed to save automatic replies");
     }
   };
 


### PR DESCRIPTION
## What

Extracts the Mailbox Autoresponder Lifecycle into a new gin-free package, `panel-api/internal/autoresponderops`, that the REST handler, the operator CLI, and the reconciler phase all route through — retiring three independent copies of the desired-state build and the `autoresponder.set` agent payload.

Closes **JAB-346**.

## Why

The three callers had drifted:

- the CLI required a subject and a body, but the **REST handler happily persisted an ENABLED autoresponder with no subject and no body**;
- **neither validated the date range** (`from_date` after `to_date`);
- the agent payload was assembled three separate times.

## The module

- **`Set`** — validates the content policy (an enabled responder needs a subject **and** a text or HTML body) and the date range **before** persisting; persists the desired state (DB is truth); then does a best-effort agent push. A failed push is returned as a **structured warning**, never a hard error — the reconciler re-asserts on the next tick.
- **`Clear`** — idempotent disable + delete (a missing row is not an error).
- **`AgentParams`** — the single canonical `autoresponder.set` projection, so HTTP, CLI, and the reconciler push **byte-identical** parameters.

## Adapter changes

- **REST** now rejects an enabled-empty responder (`400 invalid_autoresponder` with a `detail`) instead of persisting it; its response gains an omitempty `warning` field (criterion 5).
- **CLI** keeps its flag-named hints (`--subject is required`, etc.) as friendly pre-checks, with the shared policy as the enforcement backstop; it prints the push warning.
- **Reconciler** builds its payload via `AgentParams`.
- **UI** — the AutoReplyModal now pre-checks the same content policy (clear inline message instead of a raw 400 toast) and surfaces the API `detail` on error.

## Acceptance criteria — all met

1. ✅ Enabled responders require a valid content policy through every adapter.
2. ✅ Invalid date ranges are rejected before persistence.
3. ✅ HTTP, CLI, and the reconciler produce identical agent parameters (one `AgentParams`).
4. ✅ Clear is idempotent.
5. ✅ Agent failure preserves the desired DB truth and exposes a structured retry warning.

## Tests

`autoresponderops` suite: content policy, date range, `Set` persists + pushes canonical params, push-failure-is-a-warning, validation-never-persists, `Clear` idempotent, `AgentParams` only-set-fields. Full `panel-api` suite + panel-ui `tsc -b` / vitest green.

## Box verification (.86)

- Valid CLI `autoresponder set` → row persisted (`enabled=1`, subject, text_body) and the push attempted; the fresh mailbox's Stalwart principal wasn't minted yet, so the push failed and the **warning surfaced correctly while the DB row was kept** (exactly criterion 5).
- `set` with no subject → rejected (CLI hint); inverted `--from`/`--to` → rejected by the module (`from_date must be on or before to_date`).
- `clear` twice → both succeed (idempotent).
- Confirmed **no enabled-empty legacy rows** exist on the box (nothing for the reconciler to perpetually re-push).

GH #346
