### PR TITLE
feat(databases): upload-progress modal + robust large restore-from-file (GH #1044)

### DIFF
--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -557,8 +557,33 @@ func (h *databaseHandler) resolveMaxRestoreBytes(ctx context.Context) int64 {
 	return int64(s.UploadMaxSizeMB) * 1024 * 1024
 }
 
+// restoreAgentTimeout bounds the synchronous per-database restore-from-file
+// (GH #1044). A large PostgreSQL dump loaded through the privilege-scoped shadow
+// role (GH #1205) can run for several minutes; the previous 5-minute cap could
+// trip on 500 MB+ databases. Agent calls dial a fresh connection each and the
+// agent serves them concurrently (one goroutine per connection), so a long
+// restore stalls only this request, never other agent operations — a generous
+// cap is safe. Mirrors the 60-minute ceiling the async backup-restore uses.
+const restoreAgentTimeout = 60 * time.Minute
+
 func (h *databaseHandler) restore(c *gin.Context) {
 	ctx := c.Request.Context()
+
+	// GH #1044: the panel's http.Server sets a 30s Read/WriteTimeout (serve.go),
+	// which would guillotine both a large dump upload (read) and a long restore
+	// (write) — the "messenger dies while the restore keeps running" symptom the
+	// async backup-restore path already fixed (#1068). This per-database path
+	// stays synchronous, so clear the per-request deadlines for the whole
+	// upload+restore cycle. nginx allows 3600s upstream (proxy_read_timeout on
+	// `location /`), so the request survives end to end. ErrNotSupported comes
+	// from test ResponseRecorders (no real conn) — log at debug and continue.
+	rc := http.NewResponseController(c.Writer)
+	if err := rc.SetReadDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		slog.DebugContext(ctx, "databases.restore: clear read deadline failed", "err", err)
+	}
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		slog.DebugContext(ctx, "databases.restore: clear write deadline failed", "err", err)
+	}
 
 	// Load the database first
 	d, err := h.cfg.Databases.FindByID(ctx, c.Param("id"))
@@ -643,7 +668,13 @@ func (h *databaseHandler) restore(c *gin.Context) {
 		return
 	}
 
-	agentCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	// GH #1044: detach from the request context so a client disconnect (closed
+	// tab, network blip) mid-restore does NOT cancel the agent call — at up to
+	// restoreAgentTimeout the disconnect window is real, and aborting MariaDB's
+	// pipe-into-mysql mid-load would leave the database half-restored (Postgres'
+	// load-then-swap #1205 is safe either way). The restore outlives the
+	// messenger, exactly as the async backup-restore path does.
+	agentCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreAgentTimeout)
 	defer cancel()
 
 	// Dispatch by engine. Postgres loads the dump through a privilege-scoped

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -253,19 +253,49 @@ export async function downloadDatabaseBackup(
 }
 
 /**
+ * Progress snapshot for a database restore-from-file upload (GH #1044).
+ * `frac` is 0..1 of the upload; `rate`/`estimated` come from axios's
+ * AxiosProgressEvent (bytes/sec and seconds-remaining) when available.
+ * Progress covers only the upload leg — once the body is sent the server
+ * runs the restore synchronously and reports no further events, so the
+ * caller shows an indeterminate "Restoring…" state after frac reaches 1.
+ */
+export interface RestoreUploadProgress {
+  frac: number;
+  loaded: number;
+  total: number;
+  rate?: number;
+  estimated?: number;
+}
+
+/**
  * Restore a single database from an uploaded .sql dump (GH #1045).
- * Multipart field name is "file" (server contract, max 500 MB). The
- * restore runs synchronously server-side (agent pipes the dump into the
- * mysql client), so big dumps need the unbounded timeout too.
+ * Multipart field name is "file" (server contract; the app cap is the
+ * admin `upload_max_size_mb`). The restore runs synchronously server-side
+ * (the agent loads the dump), so the request uses no client timeout; the
+ * server clears its own read/write deadlines for this route (GH #1044).
+ * `onProgress` fires during the upload leg for the progress modal.
  */
 export async function restoreDatabaseUpload(
   databaseId: string,
   file: File,
+  onProgress?: (p: RestoreUploadProgress) => void,
 ): Promise<void> {
   const form = new FormData();
   form.append("file", file);
   await apiClient.post(`/databases/${databaseId}/restore`, form, {
     timeout: 0,
+    onUploadProgress: (e) => {
+      if (!onProgress) return;
+      const total = e.total ?? file.size;
+      onProgress({
+        frac: total > 0 ? Math.min(1, e.loaded / total) : 0,
+        loaded: e.loaded,
+        total,
+        rate: e.rate,
+        estimated: e.estimated,
+      });
+    },
   });
 }
 

--- a/panel-ui/src/shells/user/databases/RestoreProgressModal.tsx
+++ b/panel-ui/src/shells/user/databases/RestoreProgressModal.tsx
@@ -1,0 +1,151 @@
+// RestoreProgressModal — upload + restore feedback for "Restore from file"
+// (GH #1044). The reporter asked for a File-Manager-style upload experience on
+// the per-database restore: progress, uploaded/total, speed, ETA, and a clear
+// success/failure state, instead of clicking Restore and waiting blind.
+//
+// Two phases the modal makes visible:
+//   1. uploading  — the browser streams the dump to the panel. Progress, bytes,
+//                   speed and ETA come from axios's upload events (real numbers).
+//   2. restoring  — the body is up; the server loads the dump synchronously and
+//                   emits no further progress, so this leg is intentionally
+//                   indeterminate ("Restoring…"). Large PostgreSQL dumps can sit
+//                   here for minutes — that is expected, not a hang.
+// Then a terminal success / error state the user dismisses.
+//
+// Presentational + controlled: the parent (UserDatabaseList) owns the progress
+// object and drives phase transitions from the upload callback and the request
+// outcome. Close is offered only in a terminal phase — the restore keeps running
+// server-side regardless of this dialog (the request is detached from the tab),
+// so there is nothing safe to cancel mid-flight.
+import { Button, Modal, Progress, Space, Typography } from "antd";
+import { CheckCircleOutlined, CloseCircleOutlined, LoadingOutlined } from "@icons";
+
+export type RestorePhase = "uploading" | "restoring" | "success" | "error";
+
+export interface RestoreProgress {
+  dbName: string;
+  fileName: string;
+  fileSize: number;
+  phase: RestorePhase;
+  /** Bytes uploaded so far (upload leg only). */
+  loaded: number;
+  /** Upload speed in bytes/sec, when the transport reports it. */
+  rate?: number;
+  /** Estimated seconds remaining for the upload, when reported. */
+  estimated?: number;
+  errorMessage?: string;
+}
+
+interface RestoreProgressModalProps {
+  progress: RestoreProgress | null;
+  onClose: () => void;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function formatRate(bytesPerSec?: number): string | null {
+  if (!bytesPerSec || bytesPerSec <= 0) return null;
+  return `${formatBytes(bytesPerSec)}/s`;
+}
+
+function formatDuration(seconds?: number): string | null {
+  if (seconds === undefined || !isFinite(seconds) || seconds < 0) return null;
+  const s = Math.round(seconds);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return `${m}m ${rem}s`;
+}
+
+export function RestoreProgressModal({ progress, onClose }: RestoreProgressModalProps) {
+  const p = progress;
+  const active = p?.phase === "uploading" || p?.phase === "restoring";
+
+  const percent =
+    p && p.fileSize > 0 ? Math.min(100, Math.round((p.loaded / p.fileSize) * 100)) : 0;
+
+  const rate = formatRate(p?.rate);
+  const eta = formatDuration(p?.estimated);
+
+  return (
+    <Modal
+      open={p !== null}
+      title={p ? `Restore ${p.dbName}` : "Restore"}
+      maskClosable={!active}
+      closable={!active}
+      keyboard={!active}
+      onCancel={active ? undefined : onClose}
+      footer={
+        active ? null : (
+          <Button type="primary" onClick={onClose}>
+            Close
+          </Button>
+        )
+      }
+    >
+      {p && (
+        <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+          <Space style={{ width: "100%", justifyContent: "space-between" }}>
+            <Typography.Text strong ellipsis style={{ maxWidth: 340 }}>
+              {p.fileName}
+            </Typography.Text>
+            <Typography.Text type="secondary">{formatBytes(p.fileSize)}</Typography.Text>
+          </Space>
+
+          {p.phase === "uploading" && (
+            <>
+              <Progress percent={percent} status="active" />
+              <Space
+                style={{ width: "100%", justifyContent: "space-between" }}
+                size="large"
+                wrap
+              >
+                <Typography.Text type="secondary">
+                  Uploading — {formatBytes(p.loaded)} / {formatBytes(p.fileSize)}
+                </Typography.Text>
+                <Typography.Text type="secondary">
+                  {[rate, eta ? `~${eta} left` : null].filter(Boolean).join(" · ") || " "}
+                </Typography.Text>
+              </Space>
+            </>
+          )}
+
+          {p.phase === "restoring" && (
+            <>
+              <Progress percent={100} status="success" showInfo={false} />
+              <Space>
+                <LoadingOutlined />
+                <Typography.Text>
+                  Upload complete — restoring database…
+                </Typography.Text>
+              </Space>
+              <Typography.Text type="secondary">
+                A large dump can take several minutes. You can leave this open;
+                the restore continues on the server even if you close it.
+              </Typography.Text>
+            </>
+          )}
+
+          {p.phase === "success" && (
+            <Typography.Text type="success">
+              <CheckCircleOutlined /> Database “{p.dbName}” restored from{" "}
+              {p.fileName}.
+            </Typography.Text>
+          )}
+
+          {p.phase === "error" && (
+            <Typography.Text type="danger">
+              <CloseCircleOutlined /> Restore failed
+              {p.errorMessage ? `: ${p.errorMessage}` : "."}
+            </Typography.Text>
+          )}
+        </Space>
+      )}
+    </Modal>
+  );
+}

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -161,11 +161,21 @@ describe("UserDatabaseList backup/restore (GH #1045)", () => {
     });
     fireEvent.change(input, { target: { files: [file] } });
 
+    // GH #1044: the call now carries a third arg — the upload-progress
+    // callback that drives the restore progress modal.
     await waitFor(() => {
-      expect(mockedRestore).toHaveBeenCalledWith("db1", file);
+      expect(mockedRestore).toHaveBeenCalledWith(
+        "db1",
+        file,
+        expect.any(Function),
+      );
     });
+    // The progress modal reaches its success state after the upload resolves.
+    expect(
+      await screen.findByText(/restored from/i, undefined, { timeout: 5000 }),
+    ).toBeInTheDocument();
     // Same teardown-race guard as the download test: flush the restore
-    // continuation (toast + query invalidation), then unmount.
+    // continuation (modal state + query invalidation), then unmount.
     await act(async () => {});
     unmount();
   });

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -37,6 +37,10 @@ import { useDeleteMutation } from "../../../hooks/useQueries";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { QuickSetupModal } from "./QuickSetupModal";
 import { UserDatabaseDrawer } from "./UserDatabaseDrawer";
+import {
+  RestoreProgressModal,
+  type RestoreProgress,
+} from "./RestoreProgressModal";
 
 export type Database = {
   id: string;
@@ -84,6 +88,10 @@ export const UserDatabaseList = () => {
   );
   const [loadingBackupId, setLoadingBackupId] = useState<string | null>(null);
   const [restoringId, setRestoringId] = useState<string | null>(null);
+  // GH #1044: drives the upload+restore progress modal for "Restore from file".
+  const [restoreProgress, setRestoreProgress] = useState<RestoreProgress | null>(
+    null,
+  );
   const [quickSetupOpen, setQuickSetupOpen] = useState(false);
   const [createDrawerOpen, setCreateDrawerOpen] = useState(false);
   // Hidden file input for "Restore from file" — the row action only
@@ -217,18 +225,43 @@ export const UserDatabaseList = () => {
       );
       return;
     }
+    // GH #1044: show a File-Manager-style progress modal instead of a blind
+    // wait. The upload leg reports real progress/speed/ETA; the restore leg is
+    // indeterminate (the server emits no further events once the body is up).
+    setRestoringId(row.id);
+    setRestoreProgress({
+      dbName: row.name,
+      fileName: file.name,
+      fileSize: file.size,
+      phase: "uploading",
+      loaded: 0,
+    });
     try {
-      setRestoringId(row.id);
-      await restoreDatabaseUpload(row.id, file);
-      feedback.message.success(
-        `Database "${row.name}" restored from ${file.name}`,
+      await restoreDatabaseUpload(row.id, file, (pr) => {
+        setRestoreProgress((prev) =>
+          prev
+            ? {
+                ...prev,
+                // Once the body is fully sent, flip to the restoring leg.
+                phase: pr.frac >= 1 ? "restoring" : "uploading",
+                loaded: pr.loaded,
+                rate: pr.rate,
+                estimated: pr.estimated,
+              }
+            : prev,
+        );
+      });
+      setRestoreProgress((prev) =>
+        prev ? { ...prev, phase: "success" } : prev,
       );
       // Size changed — refresh the listing.
       qc.invalidateQueries({ queryKey: ["list", "databases"] });
     } catch (error) {
       const errorMsg =
         error instanceof Error ? error.message : "Restore failed";
-      feedback.message.error(`Restore failed: ${errorMsg}`);
+      setRestoreProgress((prev) =>
+        prev ? { ...prev, phase: "error", errorMessage: errorMsg } : prev,
+      );
     } finally {
       setRestoringId(null);
     }
@@ -285,6 +318,11 @@ export const UserDatabaseList = () => {
       <UserDatabaseDrawer
         open={createDrawerOpen}
         onClose={() => setCreateDrawerOpen(false)}
+      />
+
+      <RestoreProgressModal
+        progress={restoreProgress}
+        onClose={() => setRestoreProgress(null)}
       />
 
       <Card>


### PR DESCRIPTION
## What

Per-database **Restore from file** (GH #1045) uploaded the dump and ran the restore in one **synchronous** request, with no upload feedback and stacked timeouts that could kill a large PostgreSQL restore. This addresses the reporter's remaining asks on GH #1044:

- **Upload-progress modal** (the reporter's live request): reuse the File-Manager upload experience for the DB restore upload.
- **PG restore robustness**: a large restore could exceed the panel's 30s write timeout and return an error while the restore kept running server-side (the same "messenger dies while the work continues" class the async backup-restore flow fixed in #1068).

The other items in the issue (restore mislabeled "Account Backup"; "Restore Home Directory" on a database-only backup) were already shipped on the backup-restore path (#1068/#1070) and are not touched here.

## Backend (`panel-api/internal/api/databases.go`)

- Clear the per-request read/write deadlines on the restore route via `http.ResponseController` (nginx already allows 3600s upstream on `location /`), so a large upload and a multi-minute restore aren't guillotined at 30s. `ErrNotSupported` (test ResponseRecorders) is logged at debug and ignored.
- Detach the agent call from the request context (`context.WithoutCancel`) so a client disconnect can't abort MariaDB's pipe-into-mysql mid-load (Postgres' load-then-swap #1205 is safe either way), and raise the cap 5m → 60m to match the async restore ceiling. Agent calls dial a fresh connection each and the agent serves them concurrently, so a long restore never blocks other agent operations.

## Frontend

- `restoreDatabaseUpload` now reports upload progress (bytes, rate, ETA) via axios `onUploadProgress`.
- New `RestoreProgressModal`: upload progress / speed / ETA → indeterminate "Restoring…" → success / failure. The restore continues server-side even if the modal is closed.
- Wired into `UserDatabaseList`; unit test updated for the new 3-arg call + success render.

## Verification

- `go build ./... ` + `go vet`, `tsc -b`, `vite build`, 3/3 UI unit tests — all green.
- **Live before/after on a test box** (35s restore via `SELECT SLEEP(35)`, through the real nginx → unix socket → gin → agent stack):
  - pre-fix binary: **HTTP 502** at 35.9s (response torn; restore continued server-side — the reporter's symptom).
  - fixed binary: **HTTP 204** at 35.6s (clean).

GH #1044