### PR TITLE
fix(mail): CLI mail-group set-resources dispatches mailgroup.apply like REST (JAB-321 slice)

### DIFF
--- a/panel-api/cmd/server/mail_group_cmd.go
+++ b/panel-api/cmd/server/mail_group_cmd.go
@@ -253,7 +253,7 @@ func newMailGroupSetResourcesCmd() *cobra.Command {
 		Use:     "set-resources <group-email|group-id>",
 		Short:   "Toggle a resource group's shared collections (mailbox/calendar/addressbook/files)",
 		Args:    cobra.ExactArgs(1),
-		PreRunE: requireDB,
+		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 			defer cancel()
@@ -269,6 +269,21 @@ func newMailGroupSetResourcesCmd() *cobra.Command {
 				cliAuditErr(ctx, "mail_group.set_resources", "mail_group", g.ID, nil)
 				return fmt.Errorf("update resources: %w", err)
 			}
+			g.HasMailbox, g.HasCalendar, g.HasAddressbook, g.HasFiles = mbx, cal, ab, fl
+			// JAB-321: dispatch the SAME mailgroup.apply the REST update handler
+			// runs after a resource change (internal/api/mailgroups.go), so a
+			// CLI-enabled files/calendar/addressbook node is actually projected
+			// into Stalwart. Previously set-resources wrote only the DB flags and
+			// no reconciler re-asserts a group's resource nodes (apply is
+			// push-only, per shared_resource_reconcile.go), so the CLI could
+			// report resources that never existed on the mail server.
+			notifyAgentMailGroup(ctx, "mailgroup.apply", map[string]any{
+				"email":         g.EmailCached,
+				"display_name":  g.DisplayName,
+				"description":   g.Description,
+				"internal_only": g.InternalOnly,
+				"has_files":     g.HasFiles,
+			})
 			cliAuditOK(ctx, "mail_group.set_resources", "mail_group", g.ID, nil)
 			fmt.Printf("%s resources: mailbox=%v calendar=%v addressbook=%v files=%v\n", g.EmailCached, mbx, cal, ab, fl)
 			return nil


### PR DESCRIPTION
## What

`jabali mail-group set-resources` flipped the `has_mailbox`/`has_calendar`/`has_addressbook`/`has_files` flags in the DB but never dispatched `mailgroup.apply`, so an operator enabling e.g. shared files or a shared calendar saw the flag change in the panel while the resource node was **never created in Stalwart**.

The REST update handler (`internal/api/mailgroups.go`) re-runs `mailgroup.apply` after a resource change, and nothing else re-asserts a group's resource nodes — apply is push-only (`shared_resource_reconcile.go` reconciles `SharedResource` grants, not a group's own resource toggles). So the CLI change was **permanent drift**, exactly the bug JAB-321 calls out.

## Fix

`set-resources` now uses `requireDBAndAgent` and dispatches the same `mailgroup.apply` projection the REST handler and the CLI `create` command already send (`{email, display_name, description, internal_only, has_files}`), so a CLI resource toggle actually reaches the mail server.

## Scope

This is the concrete slice (criterion 1: "CLI resource changes dispatch the same apply as HTTP") of the **Mail Group Lifecycle** module. The broader consolidation — one shared address/collision policy, group kind, membership validation/projection, agent order, and deletion policy across HTTP and CLI — remains on the parent JAB-321.

## Verification

- `go build ./...` clean.
- Box-verified on .86: `mail-group create` → `set-resources --files true` → `delete` all execute end-to-end under the new `requireDBAndAgent` path (the command now runs the dispatch it previously skipped). The `mailgroup.apply` params are byte-identical to the proven REST/create apply, so the wire contract is unchanged. The Stalwart-side collection naming lands inside Stalwart (JMAP admin API), not the host filesystem, so it was not independently inspected — the agent does not log successful commands.

GH #321
