### PR TITLE
refactor(mail): shared Domain Mail Policy lifecycle — catch-all + disclaimer (JAB-338)

### DIFF
--- a/panel-api/cmd/server/domain_extras_cmd.go
+++ b/panel-api/cmd/server/domain_extras_cmd.go
@@ -14,7 +14,18 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailpolicy"
 )
+
+// mailPolicyPush is the domainmailpolicy.PushFunc backed by the CLI's agent
+// client. It returns the agent error so Set/Clear can turn a failed push into a
+// warning while keeping the DB the desired-state truth (the reconciler
+// re-asserts).
+func mailPolicyPush(ctx context.Context, cmd string, params map[string]any) error {
+	_, err := callAgentMailbox(ctx, cmd, params)
+	return err
+}
 
 // domainExtraSubcommands returns the cobra commands wired into newDomainCmd.
 func domainExtraSubcommands() []*cobra.Command {
@@ -56,18 +67,15 @@ func newDomainCatchallSetCmd() *cobra.Command {
 			if strings.TrimSpace(target) == "" {
 				return fmt.Errorf("--target is required (use 'catchall clear' to remove)")
 			}
-			if _, err := callAgentMailbox(ctx, "domain.catchall_set", map[string]any{
-				"domain_id":   dom.ID,
-				"domain_name": dom.Name,
-				"target":      target,
-			}); err != nil {
-				return fmt.Errorf("agent domain.catchall_set: %w", err)
+			canon, warning, err := domainmailpolicy.SetCatchall(ctx,
+				domainmailpolicy.Deps{Domains: domainRepoFromDB()}, dom, target, mailPolicyPush)
+			if err != nil {
+				return fmt.Errorf("set catch-all: %w", err)
 			}
-			t := target
-			if err := domainRepoFromDB().UpdateCatchallTarget(ctx, dom.ID, &t); err != nil {
-				return fmt.Errorf("save catchall: %w", err)
+			fmt.Printf("Catch-all for %s -> %s\n", dom.Name, canon)
+			if warning != "" {
+				fmt.Printf("Note: %s\n", warning)
 			}
-			fmt.Printf("Catch-all for %s -> %s\n", dom.Name, target)
 			return nil
 		},
 	}
@@ -89,16 +97,15 @@ func newDomainCatchallClearCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := callAgentMailbox(ctx, "domain.catchall_clear", map[string]any{
-				"domain_id":   dom.ID,
-				"domain_name": dom.Name,
-			}); err != nil {
-				return fmt.Errorf("agent domain.catchall_clear: %w", err)
-			}
-			if err := domainRepoFromDB().UpdateCatchallTarget(ctx, dom.ID, nil); err != nil {
-				return fmt.Errorf("clear catchall: %w", err)
+			warning, err := domainmailpolicy.ClearCatchall(ctx,
+				domainmailpolicy.Deps{Domains: domainRepoFromDB()}, dom, mailPolicyPush)
+			if err != nil {
+				return fmt.Errorf("clear catch-all: %w", err)
 			}
 			fmt.Printf("Catch-all cleared for %s\n", dom.Name)
+			if warning != "" {
+				fmt.Printf("Note: %s\n", warning)
+			}
 			return nil
 		},
 	}
@@ -181,18 +188,15 @@ func newDomainDisclaimerSetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if !dom.EmailEnabled {
-				return fmt.Errorf("email is not enabled on %s — run 'jabali domain email-enable %s' first", dom.Name, dom.Name)
+			norm, warning, err := domainmailpolicy.SetDisclaimer(ctx,
+				domainmailpolicy.Deps{Domains: domainRepoFromDB()}, dom, true, text, mailPolicyPush)
+			if err != nil {
+				return fmt.Errorf("set disclaimer: %w", err)
 			}
-			if err := domainRepoFromDB().UpdateDisclaimer(ctx, dom.ID, true, &text); err != nil {
-				return fmt.Errorf("save disclaimer: %w", err)
+			fmt.Printf("Disclaimer enabled for %s (%d bytes)\n", dom.Name, len(norm))
+			if warning != "" {
+				fmt.Printf("Note: %s\n", warning)
 			}
-			notifyAgentMailbox(ctx, "domain.disclaimer_apply", map[string]any{
-				"domain_name": dom.Name,
-				"enabled":     true,
-				"text":        text,
-			})
-			fmt.Printf("Disclaimer enabled for %s (%d bytes)\n", dom.Name, len(text))
 			return nil
 		},
 	}
@@ -214,16 +218,15 @@ func newDomainDisclaimerClearCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			empty := ""
-			if err := domainRepoFromDB().UpdateDisclaimer(ctx, dom.ID, false, &empty); err != nil {
+			warning, err := domainmailpolicy.ClearDisclaimer(ctx,
+				domainmailpolicy.Deps{Domains: domainRepoFromDB()}, dom, mailPolicyPush)
+			if err != nil {
 				return fmt.Errorf("clear disclaimer: %w", err)
 			}
-			notifyAgentMailbox(ctx, "domain.disclaimer_apply", map[string]any{
-				"domain_name": dom.Name,
-				"enabled":     false,
-				"text":        "",
-			})
 			fmt.Printf("Disclaimer cleared for %s\n", dom.Name)
+			if warning != "" {
+				fmt.Printf("Note: %s\n", warning)
+			}
 			return nil
 		},
 	}

--- a/panel-api/internal/api/domain_catchall.go
+++ b/panel-api/internal/api/domain_catchall.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailpolicy"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -18,6 +21,20 @@ type domainCatchallResponse struct {
 	DomainName string    `json:"domain_name"`
 	Target     *string   `json:"target"` // null if no catch-all set
 	UpdatedAt  time.Time `json:"updated_at"`
+	// Warning is set (JAB-338) when the DB write succeeded but the inline agent
+	// push failed; the reconciler re-asserts. Omitted on a clean push.
+	Warning string `json:"warning,omitempty"`
+}
+
+// catchallPush is the domainmailpolicy.PushFunc backed by the handler's agent.
+func (h *domainCatchallHandler) catchallPush(ctx context.Context, cmd string, params map[string]any) error {
+	if h.cfg.Agent == nil {
+		return nil
+	}
+	agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, err := h.cfg.Agent.Call(agentCtx, cmd, params)
+	return err
 }
 
 // RegisterDomainCatchallRoutes registers catch-all endpoints.
@@ -102,37 +119,37 @@ func (h *domainCatchallHandler) update(c *gin.Context) {
 		return
 	}
 
-	// Call agent to update catch-all on Stalwart
-	if h.cfg.Agent != nil {
-		agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		_, err := h.cfg.Agent.Call(agentCtx, "domain.catchall_set", map[string]any{
-			"domain_id":   domID,
-			"domain_name": dom.Name,
-			"target":      req.Target,
-		})
+	deps := domainmailpolicy.Deps{Domains: h.cfg.Domains}
+	// An empty target clears the catch-all; a non-empty one sets it (JAB-338:
+	// email-enabled gate + canonical target, DB-first then best-effort push).
+	if strings.TrimSpace(req.Target) == "" {
+		warning, err := domainmailpolicy.ClearCatchall(ctx, deps, dom, h.catchallPush)
 		if err != nil {
-			respondAgentErr(c, "agent_error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 			return
 		}
-	}
-
-	// Update database
-	now := time.Now().UTC()
-	var target *string
-	if req.Target != "" {
-		target = &req.Target
-	}
-	if err := h.cfg.Domains.UpdateCatchallTarget(ctx, domID, target); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "update_failed", "details": err.Error()})
+		c.JSON(http.StatusOK, domainCatchallResponse{
+			DomainID: domID, DomainName: dom.Name, Target: nil,
+			UpdatedAt: time.Now().UTC(), Warning: warning,
+		})
 		return
 	}
-
+	canon, warning, err := domainmailpolicy.SetCatchall(ctx, deps, dom, req.Target, h.catchallPush)
+	if err != nil {
+		switch {
+		case errors.Is(err, domainmailpolicy.ErrEmailNotEnabled):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "email_not_enabled"})
+		case errors.Is(err, domainmailpolicy.ErrInvalidTarget):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_target", "details": err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
+		return
+	}
+	ct := canon
 	c.JSON(http.StatusOK, domainCatchallResponse{
-		DomainID:   domID,
-		DomainName: dom.Name,
-		Target:     target,
-		UpdatedAt:  now,
+		DomainID: domID, DomainName: dom.Name, Target: &ct,
+		UpdatedAt: time.Now().UTC(), Warning: warning,
 	})
 }
 
@@ -160,25 +177,10 @@ func (h *domainCatchallHandler) delete(c *gin.Context) {
 		return
 	}
 
-	// Call agent to clear catch-all on Stalwart
-	if h.cfg.Agent != nil {
-		agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		_, err := h.cfg.Agent.Call(agentCtx, "domain.catchall_clear", map[string]any{
-			"domain_id":   domID,
-			"domain_name": dom.Name,
-		})
-		if err != nil {
-			respondAgentErr(c, "agent_error", err)
-			return
-		}
-	}
-
-	// Clear database
-	if err := h.cfg.Domains.UpdateCatchallTarget(ctx, domID, nil); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete_failed", "details": err.Error()})
+	if _, err := domainmailpolicy.ClearCatchall(ctx,
+		domainmailpolicy.Deps{Domains: h.cfg.Domains}, dom, h.catchallPush); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-
 	c.JSON(http.StatusNoContent, nil)
 }

--- a/panel-api/internal/api/domain_catchall_test.go
+++ b/panel-api/internal/api/domain_catchall_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"github.com/gin-gonic/gin"
+)
+
+// The catch-all HTTP path is thin over domainmailpolicy and cannot be
+// box-verified (the socket needs a Kratos session), so these handler tests
+// cover the JAB-338 error mapping + the empty-target-clears branch. Agent is
+// nil, so the inline push is a clean no-op (no warning).
+func buildCatchallRouter(dom *models.Domain) (*gin.Engine, *mockDomainRepo) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: dom.UserID, IsAdmin: true}); c.Next() })
+	repo := newMockDomainRepo()
+	repo.domains[dom.ID] = dom
+	RegisterDomainCatchallRoutes(v1, DomainCatchallHandlerConfig{Domains: repo})
+	return r, repo
+}
+
+func putCatchall(r *gin.Engine, target string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/domains/d1/catchall", bytes.NewBufferString(`{"target":"`+target+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestCatchallPut(t *testing.T) {
+	t.Run("valid external target is accepted + persisted (domain lowercased, +tag kept)", func(t *testing.T) {
+		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com", EmailEnabled: true}
+		r, repo := buildCatchallRouter(dom)
+		if code := putCatchall(r, "Me+tag@Gmail.COM").Code; code != http.StatusOK {
+			t.Fatalf("status %d", code)
+		}
+		if got := repo.domains["d1"].CatchallTarget; got == nil || *got != "Me+tag@gmail.com" {
+			t.Errorf("persisted target = %v", got)
+		}
+	})
+
+	t.Run("garbage target is rejected 400", func(t *testing.T) {
+		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com", EmailEnabled: true}
+		r, repo := buildCatchallRouter(dom)
+		if code := putCatchall(r, "not-an-email").Code; code != http.StatusBadRequest {
+			t.Fatalf("garbage target should be 400, got %d", code)
+		}
+		if repo.domains["d1"].CatchallTarget != nil {
+			t.Error("garbage target must not persist")
+		}
+	})
+
+	t.Run("non-email domain is rejected 400", func(t *testing.T) {
+		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com", EmailEnabled: false}
+		r, _ := buildCatchallRouter(dom)
+		if code := putCatchall(r, "a@b.com").Code; code != http.StatusBadRequest {
+			t.Fatalf("catch-all on a non-email domain should be 400, got %d", code)
+		}
+	})
+
+	t.Run("empty target clears", func(t *testing.T) {
+		tgt := "old@b.com"
+		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com", EmailEnabled: true, CatchallTarget: &tgt}
+		r, repo := buildCatchallRouter(dom)
+		if code := putCatchall(r, "").Code; code != http.StatusOK {
+			t.Fatalf("status %d", code)
+		}
+		if repo.domains["d1"].CatchallTarget != nil {
+			t.Errorf("empty target must clear, got %v", *repo.domains["d1"].CatchallTarget)
+		}
+	})
+}

--- a/panel-api/internal/api/domain_disclaimer.go
+++ b/panel-api/internal/api/domain_disclaimer.go
@@ -10,13 +10,14 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailpolicy"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -31,6 +32,20 @@ type disclaimerResponse struct {
 	Enabled    bool   `json:"enabled"`
 	Text       string `json:"text"`
 	UpdatedAt  string `json:"updated_at"`
+	// Warning (JAB-338) is set when the DB write succeeded but the inline agent
+	// push failed; the reconciler re-asserts. Omitted on a clean push.
+	Warning string `json:"warning,omitempty"`
+}
+
+// disclaimerPush is the domainmailpolicy.PushFunc backed by the handler's agent.
+func (h *domainDisclaimerHandler) disclaimerPush(ctx context.Context, cmd string, params map[string]any) error {
+	if h.cfg.Agent == nil {
+		return nil
+	}
+	agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, err := h.cfg.Agent.Call(agentCtx, cmd, params)
+	return err
 }
 
 type disclaimerUpdateRequest struct {
@@ -52,7 +67,7 @@ func RegisterDomainDisclaimerRoutes(g *gin.RouterGroup, cfg DomainDisclaimerHand
 	g.DELETE("/domains/:id/disclaimer", h.del)
 }
 
-func (h *domainDisclaimerHandler) loadDomain(c *gin.Context) (string, string, bool) {
+func (h *domainDisclaimerHandler) loadDomain(c *gin.Context) (*models.Domain, bool) {
 	ctx := c.Request.Context()
 	claims := ginctx.Claims(c)
 	dom, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
@@ -62,22 +77,17 @@ func (h *domainDisclaimerHandler) loadDomain(c *gin.Context) (string, string, bo
 		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		}
-		return "", "", false
+		return nil, false
 	}
 	if !claims.IsAdmin && dom.UserID != claims.UserID {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-		return "", "", false
+		return nil, false
 	}
 	if !dom.EmailEnabled {
 		c.JSON(http.StatusForbidden, gin.H{"error": "email_not_enabled"})
-		return "", "", false
+		return nil, false
 	}
-	text := ""
-	if dom.DisclaimerText != nil {
-		text = *dom.DisclaimerText
-	}
-	_ = text
-	return dom.ID, dom.Name, true
+	return dom, true
 }
 
 func (h *domainDisclaimerHandler) get(c *gin.Context) {
@@ -107,7 +117,7 @@ func (h *domainDisclaimerHandler) get(c *gin.Context) {
 
 func (h *domainDisclaimerHandler) put(c *gin.Context) {
 	ctx := c.Request.Context()
-	id, domainName, ok := h.loadDomain(c)
+	dom, ok := h.loadDomain(c)
 	if !ok {
 		return
 	}
@@ -116,52 +126,39 @@ func (h *domainDisclaimerHandler) put(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
 		return
 	}
-	if req.Enabled && strings.TrimSpace(req.Text) == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "text_required_when_enabled"})
+	norm, warning, err := domainmailpolicy.SetDisclaimer(ctx,
+		domainmailpolicy.Deps{Domains: h.cfg.Domains}, dom, req.Enabled, req.Text, h.disclaimerPush)
+	if err != nil {
+		switch {
+		case errors.Is(err, domainmailpolicy.ErrDisclaimerTextRequired):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "text_required_when_enabled"})
+		case errors.Is(err, domainmailpolicy.ErrEmailNotEnabled):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "email_not_enabled"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
 		return
-	}
-	text := strings.TrimSpace(req.Text)
-	if err := h.cfg.Domains.UpdateDisclaimer(ctx, id, req.Enabled, &text); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-	if h.cfg.Agent != nil {
-		agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		_, _ = h.cfg.Agent.Call(agentCtx, "domain.disclaimer_apply", map[string]any{
-			"domain_name": domainName,
-			"enabled":     req.Enabled,
-			"text":        text,
-		})
 	}
 	c.JSON(http.StatusOK, disclaimerResponse{
-		DomainID:   id,
-		DomainName: domainName,
+		DomainID:   dom.ID,
+		DomainName: dom.Name,
 		Enabled:    req.Enabled,
-		Text:       text,
+		Text:       norm,
 		UpdatedAt:  time.Now().UTC().Format("2006-01-02T15:04:05Z07:00"),
+		Warning:    warning,
 	})
 }
 
 func (h *domainDisclaimerHandler) del(c *gin.Context) {
 	ctx := c.Request.Context()
-	id, domainName, ok := h.loadDomain(c)
+	dom, ok := h.loadDomain(c)
 	if !ok {
 		return
 	}
-	empty := ""
-	if err := h.cfg.Domains.UpdateDisclaimer(ctx, id, false, &empty); err != nil {
+	if _, err := domainmailpolicy.ClearDisclaimer(ctx,
+		domainmailpolicy.Deps{Domains: h.cfg.Domains}, dom, h.disclaimerPush); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
-	}
-	if h.cfg.Agent != nil {
-		agentCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		_, _ = h.cfg.Agent.Call(agentCtx, "domain.disclaimer_apply", map[string]any{
-			"domain_name": domainName,
-			"enabled":     false,
-			"text":        "",
-		})
 	}
 	c.JSON(http.StatusNoContent, nil)
 }

--- a/panel-api/internal/domainmailpolicy/domainmailpolicy.go
+++ b/panel-api/internal/domainmailpolicy/domainmailpolicy.go
@@ -1,0 +1,175 @@
+// Package domainmailpolicy is the shared Domain Mail Policy lifecycle (JAB-338):
+// the catch-all and outbound-disclaimer Set/Clear operations the REST handlers
+// and the operator CLI both route through, so the email-enabled gate, the
+// canonical target / disclaimer-text validation, the DB→agent call sequence,
+// and the best-effort-with-warning semantics have one owner and cannot drift
+// between the four previous implementations.
+//
+// Both features are re-asserted every reconciler tick (phases/m65_catchall.go,
+// phases/m65_disclaimer.go read the domains-table columns as truth), so these
+// operations persist the DB first and treat the inline agent push as
+// best-effort: a failed push is a structured warning, not a hard error — the
+// reconciler converges Stalwart on the next tick.
+//
+// Authorization and response shaping stay in the Adapters (the REST handler
+// checks claims; the CLI is admin-by-construction). Every entry point takes an
+// already-loaded, already-authorized domain.
+package domainmailpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// PushFunc runs one agent command. Its error becomes a warning (never a hard
+// failure): the DB is the desired-state truth and the reconciler re-asserts.
+type PushFunc func(ctx context.Context, cmd string, params map[string]any) error
+
+// Deps carries the collaborators every operation needs.
+type Deps struct {
+	Domains repository.DomainRepository
+}
+
+var (
+	// ErrEmailNotEnabled — mail policy can only be set on a mail-enabled domain.
+	// The disclaimer CLI already gated on this; catch-all (HTTP + CLI) did not.
+	ErrEmailNotEnabled = errors.New("domainmailpolicy: email is not enabled on the domain")
+	// ErrInvalidTarget — the catch-all destination must be a valid email address.
+	// Neither adapter validated this before (criterion 2).
+	ErrInvalidTarget = errors.New("domainmailpolicy: catch-all target must be a valid email address")
+	// ErrDisclaimerTextRequired — an enabled disclaimer needs non-empty text.
+	ErrDisclaimerTextRequired = errors.New("domainmailpolicy: an enabled disclaimer needs non-empty text")
+	ErrDeps                   = errors.New("domainmailpolicy: dependencies not wired")
+	ErrInternal               = errors.New("domainmailpolicy: internal error")
+)
+
+// pushWarning message surfaced when the DB write succeeded but the inline agent
+// push failed. The reconciler re-asserts within a tick.
+const pushWarning = "saved; the mail server did not accept the change yet and will be reconciled shortly"
+
+// canonicalTarget validates a catch-all destination as a syntactically valid
+// email and lowercases the DOMAIN half only. Unlike mailaddr.Canonicalise
+// (which is for provisioning hosted mailboxes), it must NOT strip +tag
+// sub-addressing or restrict the local-part charset: catch-all targets are
+// frequently EXTERNAL addresses (e.g. me+catchall@gmail.com), whose local part
+// is opaque to us and case- / plus-significant at the receiving provider.
+func canonicalTarget(raw string) (string, error) {
+	addr, err := mail.ParseAddress(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidTarget, err)
+	}
+	at := strings.LastIndexByte(addr.Address, '@')
+	if at < 0 {
+		return "", ErrInvalidTarget
+	}
+	// Preserve the local part verbatim; lowercase only the (case-insensitive)
+	// domain half.
+	return addr.Address[:at] + "@" + strings.ToLower(addr.Address[at+1:]), nil
+}
+
+// runPush executes the best-effort agent push and returns a warning string when
+// it fails (empty on success or when no push func is wired).
+func runPush(ctx context.Context, push PushFunc, cmd string, params map[string]any) string {
+	if push == nil {
+		return ""
+	}
+	if err := push(ctx, cmd, params); err != nil {
+		return pushWarning
+	}
+	return ""
+}
+
+// SetCatchall gates on email-enabled, canonicalizes the target, persists it
+// (DB is truth), then pushes best-effort. Returns the canonical target and a
+// warning (non-empty only when the push failed).
+func SetCatchall(ctx context.Context, d Deps, dom *models.Domain, target string, push PushFunc) (string, string, error) {
+	if d.Domains == nil || dom == nil {
+		return "", "", fmt.Errorf("%w: domains repo + domain required", ErrDeps)
+	}
+	if !dom.EmailEnabled {
+		return "", "", ErrEmailNotEnabled
+	}
+	canon, err := canonicalTarget(target)
+	if err != nil {
+		return "", "", err
+	}
+	if err := d.Domains.UpdateCatchallTarget(ctx, dom.ID, &canon); err != nil {
+		return "", "", fmt.Errorf("%w: persist catch-all: %v", ErrInternal, err)
+	}
+	warning := runPush(ctx, push, "domain.catchall_set", map[string]any{
+		"domain_id":   dom.ID,
+		"domain_name": dom.Name,
+		"target":      canon,
+	})
+	return canon, warning, nil
+}
+
+// ClearCatchall removes the catch-all. Idempotent: clearing an unset domain is
+// a success (the column is set to NULL either way).
+func ClearCatchall(ctx context.Context, d Deps, dom *models.Domain, push PushFunc) (string, error) {
+	if d.Domains == nil || dom == nil {
+		return "", fmt.Errorf("%w: domains repo + domain required", ErrDeps)
+	}
+	if err := d.Domains.UpdateCatchallTarget(ctx, dom.ID, nil); err != nil {
+		return "", fmt.Errorf("%w: clear catch-all: %v", ErrInternal, err)
+	}
+	warning := runPush(ctx, push, "domain.catchall_clear", map[string]any{
+		"domain_id":   dom.ID,
+		"domain_name": dom.Name,
+	})
+	return warning, nil
+}
+
+// SetDisclaimer persists the disclaimer's enabled flag + text, then pushes
+// best-effort. When enabling it gates on email-enabled and requires non-empty
+// normalized text (the REST handler previously skipped the email gate the CLI
+// had); when disabling it keeps whatever text was passed (so the UI can toggle
+// off without losing the draft) and applies no gate or text requirement. To
+// disable AND remove the text, use ClearDisclaimer. Returns the normalized text
+// and a warning.
+func SetDisclaimer(ctx context.Context, d Deps, dom *models.Domain, enabled bool, text string, push PushFunc) (string, string, error) {
+	if d.Domains == nil || dom == nil {
+		return "", "", fmt.Errorf("%w: domains repo + domain required", ErrDeps)
+	}
+	norm := strings.TrimSpace(text)
+	if enabled {
+		if !dom.EmailEnabled {
+			return "", "", ErrEmailNotEnabled
+		}
+		if norm == "" {
+			return "", "", ErrDisclaimerTextRequired
+		}
+	}
+	if err := d.Domains.UpdateDisclaimer(ctx, dom.ID, enabled, &norm); err != nil {
+		return "", "", fmt.Errorf("%w: persist disclaimer: %v", ErrInternal, err)
+	}
+	warning := runPush(ctx, push, "domain.disclaimer_apply", map[string]any{
+		"domain_name": dom.Name,
+		"enabled":     enabled,
+		"text":        norm,
+	})
+	return norm, warning, nil
+}
+
+// ClearDisclaimer disables + empties the disclaimer. Idempotent.
+func ClearDisclaimer(ctx context.Context, d Deps, dom *models.Domain, push PushFunc) (string, error) {
+	if d.Domains == nil || dom == nil {
+		return "", fmt.Errorf("%w: domains repo + domain required", ErrDeps)
+	}
+	empty := ""
+	if err := d.Domains.UpdateDisclaimer(ctx, dom.ID, false, &empty); err != nil {
+		return "", fmt.Errorf("%w: clear disclaimer: %v", ErrInternal, err)
+	}
+	warning := runPush(ctx, push, "domain.disclaimer_apply", map[string]any{
+		"domain_name": dom.Name,
+		"enabled":     false,
+		"text":        "",
+	})
+	return warning, nil
+}

--- a/panel-api/internal/domainmailpolicy/domainmailpolicy_test.go
+++ b/panel-api/internal/domainmailpolicy/domainmailpolicy_test.go
@@ -1,0 +1,176 @@
+package domainmailpolicy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeDomRepo struct {
+	repository.DomainRepository
+	catchall    *string
+	catchallSet bool
+	discEnabled bool
+	discText    *string
+	discSet     bool
+}
+
+func (f *fakeDomRepo) UpdateCatchallTarget(_ context.Context, _ string, target *string) error {
+	f.catchall = target
+	f.catchallSet = true
+	return nil
+}
+func (f *fakeDomRepo) UpdateDisclaimer(_ context.Context, _ string, enabled bool, text *string) error {
+	f.discEnabled = enabled
+	f.discText = text
+	f.discSet = true
+	return nil
+}
+
+func mailDomain(enabled bool) *models.Domain {
+	return &models.Domain{ID: "d1", Name: "example.com", EmailEnabled: enabled}
+}
+
+func okPush(captured *map[string]any) PushFunc {
+	return func(_ context.Context, _ string, p map[string]any) error {
+		if captured != nil {
+			*captured = p
+		}
+		return nil
+	}
+}
+
+func TestSetCatchall(t *testing.T) {
+	t.Run("gates on email-enabled", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		if _, _, err := SetCatchall(context.Background(), Deps{Domains: repo}, mailDomain(false), "a@b.com", nil); !errors.Is(err, ErrEmailNotEnabled) {
+			t.Errorf("want ErrEmailNotEnabled, got %v", err)
+		}
+		if repo.catchallSet {
+			t.Error("must not persist when the gate rejects")
+		}
+	})
+
+	t.Run("rejects a non-canonical target", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		if _, _, err := SetCatchall(context.Background(), Deps{Domains: repo}, mailDomain(true), "not-an-email", nil); !errors.Is(err, ErrInvalidTarget) {
+			t.Errorf("want ErrInvalidTarget, got %v", err)
+		}
+		if repo.catchallSet {
+			t.Error("must not persist a garbage target")
+		}
+	})
+
+	t.Run("validates + lowercases the domain half, preserving +tag and local case", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		var pushed map[string]any
+		// External target with plus-addressing + mixed case — the local part
+		// and its +tag must survive; only the domain half is lowercased.
+		canon, warning, err := SetCatchall(context.Background(), Deps{Domains: repo}, mailDomain(true), "  Me+catchall@Gmail.COM ", okPush(&pushed))
+		if err != nil {
+			t.Fatalf("SetCatchall: %v", err)
+		}
+		if canon != "Me+catchall@gmail.com" {
+			t.Errorf("target normalization wrong: %q (must keep +tag and local case, lowercase domain)", canon)
+		}
+		if repo.catchall == nil || *repo.catchall != "Me+catchall@gmail.com" {
+			t.Errorf("persisted target = %v", repo.catchall)
+		}
+		if warning != "" {
+			t.Errorf("clean push should not warn, got %q", warning)
+		}
+		if pushed["target"] != "Me+catchall@gmail.com" || pushed["domain_name"] != "example.com" {
+			t.Errorf("push params wrong: %+v", pushed)
+		}
+	})
+
+	t.Run("push failure is a warning, DB truth kept", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		failPush := func(_ context.Context, _ string, _ map[string]any) error { return errors.New("down") }
+		_, warning, err := SetCatchall(context.Background(), Deps{Domains: repo}, mailDomain(true), "a@b.com", failPush)
+		if err != nil {
+			t.Fatalf("push failure must not be a hard error: %v", err)
+		}
+		if warning == "" {
+			t.Error("failed push must surface a warning")
+		}
+		if !repo.catchallSet {
+			t.Error("target must be persisted even when the push fails")
+		}
+	})
+}
+
+func TestClearCatchall_Idempotent(t *testing.T) {
+	repo := &fakeDomRepo{}
+	var pushed map[string]any
+	if _, err := ClearCatchall(context.Background(), Deps{Domains: repo}, mailDomain(false), okPush(&pushed)); err != nil {
+		t.Fatalf("clear (even on a non-email domain) must succeed: %v", err)
+	}
+	if !repo.catchallSet || repo.catchall != nil {
+		t.Errorf("clear must NULL the target, got %v", repo.catchall)
+	}
+}
+
+func TestSetDisclaimer(t *testing.T) {
+	t.Run("enabled requires text", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		if _, _, err := SetDisclaimer(context.Background(), Deps{Domains: repo}, mailDomain(true), true, "   ", nil); !errors.Is(err, ErrDisclaimerTextRequired) {
+			t.Errorf("want ErrDisclaimerTextRequired, got %v", err)
+		}
+	})
+
+	t.Run("enabled gates on email", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		if _, _, err := SetDisclaimer(context.Background(), Deps{Domains: repo}, mailDomain(false), true, "hi", nil); !errors.Is(err, ErrEmailNotEnabled) {
+			t.Errorf("want ErrEmailNotEnabled, got %v", err)
+		}
+	})
+
+	t.Run("disabling keeps text without gate/requirement", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		// A disabled disclaimer on a non-email domain, with text, must persist
+		// {false, text} — the UI toggle-off-but-keep-draft flow.
+		norm, _, err := SetDisclaimer(context.Background(), Deps{Domains: repo}, mailDomain(false), false, "  draft  ", nil)
+		if err != nil {
+			t.Fatalf("disabling must not gate or require text: %v", err)
+		}
+		if repo.discEnabled {
+			t.Error("must persist enabled=false")
+		}
+		if norm != "draft" || repo.discText == nil || *repo.discText != "draft" {
+			t.Errorf("disabled disclaimer must keep the trimmed text, got %v", repo.discText)
+		}
+	})
+
+	t.Run("enabled persists + pushes", func(t *testing.T) {
+		repo := &fakeDomRepo{}
+		var pushed map[string]any
+		norm, _, err := SetDisclaimer(context.Background(), Deps{Domains: repo}, mailDomain(true), true, "  Out of office  ", okPush(&pushed))
+		if err != nil {
+			t.Fatalf("SetDisclaimer: %v", err)
+		}
+		if norm != "Out of office" || !repo.discEnabled {
+			t.Errorf("persisted wrong: enabled=%v text=%v", repo.discEnabled, repo.discText)
+		}
+		if pushed["enabled"] != true || pushed["text"] != "Out of office" {
+			t.Errorf("push params wrong: %+v", pushed)
+		}
+	})
+}
+
+func TestClearDisclaimer_WipesAndDisables(t *testing.T) {
+	repo := &fakeDomRepo{}
+	var pushed map[string]any
+	if _, err := ClearDisclaimer(context.Background(), Deps{Domains: repo}, mailDomain(true), okPush(&pushed)); err != nil {
+		t.Fatalf("ClearDisclaimer: %v", err)
+	}
+	if repo.discEnabled || repo.discText == nil || *repo.discText != "" {
+		t.Errorf("clear must persist {false, \"\"}, got enabled=%v text=%v", repo.discEnabled, repo.discText)
+	}
+	if pushed["enabled"] != false {
+		t.Errorf("clear must push enabled=false, got %+v", pushed)
+	}
+}


### PR DESCRIPTION
## What

Extracts catch-all and outbound-disclaimer lifecycle into a new gin-free package, `panel-api/internal/domainmailpolicy` (`SetCatchall` / `ClearCatchall` / `SetDisclaimer` / `ClearDisclaimer`), that both REST handlers and both CLI commands route through — retiring four independent implementations with drifted validation and Agent/DB ordering.

Closes **JAB-338**.

## The drifts fixed

- **Ordering**: catch-all pushed the agent **first** then wrote the DB (hard-failing on agent error); disclaimer wrote the DB first. Both features are re-asserted every reconciler tick (`m65_catchall`, `m65_disclaimer` read the columns as truth), so the module now persists **DB-first** and treats the push as best-effort — a failed push is a structured `warning`, the reconciler converges next tick. Consistent + compensating (criterion 4).
- **Catch-all target validation** (criterion 2): the target was never validated. Now checked with `net/mail.ParseAddress`, lowercasing **only the domain half** — deliberately **not** `mailaddr.Canonicalise` (built for hosted mailboxes; it strips `+tag` and restricts the charset), because catch-all targets are frequently **external** (`me+catchall@gmail.com`).
- **Email-enabled gate** (criterion 1): the disclaimer already gated; catch-all now does too, on `Set`.
- **Idempotent clears** (criterion 5).

`SetDisclaimer(enabled, text)` preserves the UI's toggle-off-but-keep-draft flow: when disabling it keeps the passed text without gate/requirement; only enabling requires non-empty text + the email gate.

## Deliberate behavior changes (named, not discovered)

- HTTP catch-all on agent-push failure: was `500` nothing-saved → now `200` with `warning` (DB saved, reconciler converges). A garbage target is now `400 invalid_target` and a non-email domain `400 email_not_enabled`, rejected **before** any agent call.
- `DELETE` discards the push warning (204 has no body).
- The cpanel migration importer (`restore_extras.go`) still writes `catchall_target` directly — an intentional exception (migration semantics), same pattern as the JAB-291 restore path.

## Verification

- `domainmailpolicy` unit suite (gate / external-target validation with +tag preserved / persist+push / push-warning; disclaimer enabled-requires-text, enabled-gates-email, disabling-keeps-text, clear-wipes; idempotent clears).
- A thin **catch-all HTTP handler test** (external target accepted, garbage 400, non-email 400, empty clears) — the HTTP path can't be box-verified (socket needs a Kratos session), so it's covered by handler + module tests + compilation.
- Full `panel-api` suite green.
- **Box-verified on .86**: CLI `catchall set --target "Me+ca@Gmail.COM"` → stored `Me+ca@gmail.com` (+tag kept, domain lowercased, local case preserved); garbage target → `invalid_target`; `clear` ×2 idempotent (DB → NULL); disclaimer `set`/`clear` clean (agent pushes succeeded). No legacy non-canonical catch-all targets exist on the box.

GH #338
