### PR TITLE
fix(dns): CLI hands off managed non-SOA/NS records on edit/delete (JAB-323 slice)

### DIFF
--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -127,9 +127,16 @@ func dnsLoadRecordInZone(ctx context.Context, zones repository.DNSZoneRepository
 	if rec.ZoneID != zone.ID {
 		return nil, fmt.Errorf("record %s does not belong to zone %s", recordID, zone.Name)
 	}
-	if rec.Managed {
-		return nil, fmt.Errorf("record %s is managed by the panel (%s); edit the owning feature instead of the raw record",
-			rec.ID, managedByLabel(rec.ManagedBy))
+	// JAB-323 / ADR-0107: only SOA/NS managed rows are zone infrastructure and
+	// stay panel-owned (the SOA serial is auto-generated; the apex NS set must
+	// point at jabali's nameservers). Every other managed row (MX/SRV/A/…) is
+	// operator-editable/deletable — matching the HTTP handler. The CLI used to
+	// refuse ALL managed rows, so an admin could not, e.g., hand-edit a
+	// managed MX the way the web UI allows. The update path demotes it to
+	// operator-owned after the edit (see dnsRecordUpdate).
+	if rec.Managed && (rec.Type == "SOA" || rec.Type == "NS") {
+		return nil, fmt.Errorf("record %s is zone infrastructure (%s) managed by jabali's nameserver — the SOA serial is auto-generated and the apex NS set must point at the jabali nameservers, so it is not directly editable",
+			rec.ID, rec.Type)
 	}
 	return rec, nil
 }
@@ -159,6 +166,14 @@ func dnsRecordUpdate(ctx context.Context, zones repository.DNSZoneRepository, re
 	if set["content"] {
 		api.NormaliseSRVRecord(rec, srvPriorityPtr(spec.Priority, set["priority"]))
 	}
+	// JAB-323 / ADR-0107: an operator edit is authoritative. Demote a managed
+	// row to operator-owned (Managed=false, ManagedBy=NULL) so every reconciler
+	// hand-off path (which all gate on Managed=true + a matching ManagedBy)
+	// steps aside and the edited value becomes the desired state pushed into
+	// PowerDNS — identical to the HTTP handler. A no-op for already-unmanaged
+	// rows. SOA/NS were already refused in dnsLoadRecordInZone.
+	rec.Managed = false
+	rec.ManagedBy = nil
 	if err := api.ValidateDNSRecord(rec); err != nil {
 		return nil, err
 	}
@@ -181,13 +196,6 @@ func dnsRecordDelete(ctx context.Context, zones repository.DNSZoneRepository, re
 		return nil, fmt.Errorf("delete record: %w", err)
 	}
 	return rec, nil
-}
-
-func managedByLabel(m *string) string {
-	if m == nil {
-		return "unknown"
-	}
-	return *m
 }
 
 // ---------- cobra wiring ----------

--- a/panel-api/cmd/server/dns_cmd_test.go
+++ b/panel-api/cmd/server/dns_cmd_test.go
@@ -198,19 +198,62 @@ func TestDNSRecordDelete_ForceRemovesNonManaged(t *testing.T) {
 	}
 }
 
-func TestDNSRecordDelete_RefusesManaged(t *testing.T) {
+// JAB-323 / ADR-0107: only managed SOA/NS (zone infrastructure) are undeletable;
+// a managed MX/SRV/etc. is operator-deletable, matching the HTTP handler.
+func TestDNSRecordDelete_RefusesManagedSOAandNS_AllowsOthers(t *testing.T) {
 	ctx := context.Background()
 	z := testDNSZone()
-	zones := newMemDNSZoneRepo(z)
 	mb := "m6"
-	rec := &models.DNSRecord{ID: "01MANAGEDREC00000000000000", ZoneID: z.ID, Name: "_autodiscover._tcp", Type: "SRV", Content: "0 0 443 mail.example.com", TTL: 300, Managed: true, ManagedBy: &mb, IsEnabled: true}
-	recs := newMemDNSRecordRepo(rec)
-	_, err := dnsRecordDelete(ctx, zones, recs, "example.com", rec.ID)
-	if err == nil || !strings.Contains(err.Error(), "managed") {
-		t.Fatalf("want managed-record refusal, got %v", err)
+
+	// Managed NS → refused (SOA/NS stay panel-owned).
+	nsRec := &models.DNSRecord{ID: "01MANAGEDNS000000000000000", ZoneID: z.ID, Name: "@", Type: "NS", Content: "ns1.jabali.example", TTL: 300, Managed: true, ManagedBy: &mb, IsEnabled: true}
+	recs := newMemDNSRecordRepo(nsRec)
+	if _, err := dnsRecordDelete(ctx, newMemDNSZoneRepo(z), recs, "example.com", nsRec.ID); err == nil || !strings.Contains(err.Error(), "infrastructure") {
+		t.Fatalf("managed NS must be refused, got %v", err)
 	}
-	if _, ok := recs.byID[rec.ID]; !ok {
-		t.Errorf("managed record was deleted despite refusal")
+	if _, ok := recs.byID[nsRec.ID]; !ok {
+		t.Errorf("managed NS was deleted despite refusal")
+	}
+
+	// Managed SRV (a feature row like _autodiscover) → operator may delete it.
+	srvRec := &models.DNSRecord{ID: "01MANAGEDSRV00000000000000", ZoneID: z.ID, Name: "_autodiscover._tcp", Type: "SRV", Content: "0 0 443 mail.example.com", TTL: 300, Managed: true, ManagedBy: &mb, IsEnabled: true}
+	recs2 := newMemDNSRecordRepo(srvRec)
+	if _, err := dnsRecordDelete(ctx, newMemDNSZoneRepo(z), recs2, "example.com", srvRec.ID); err != nil {
+		t.Fatalf("managed non-infra record must be deletable, got %v", err)
+	}
+	if _, ok := recs2.byID[srvRec.ID]; ok {
+		t.Errorf("managed SRV should have been deleted")
+	}
+}
+
+// JAB-323 / ADR-0107: an admin edit of a managed non-SOA/NS record hands it off
+// to operator-owned state (Managed=false, ManagedBy=nil) so the edit persists,
+// exactly like the HTTP handler. A managed SOA/NS edit is still refused.
+func TestDNSRecordUpdate_ManagedHandoff(t *testing.T) {
+	ctx := context.Background()
+	z := testDNSZone()
+	mb := "m6"
+
+	mxRec := &models.DNSRecord{ID: "01MANAGEDMX00000000000000A", ZoneID: z.ID, Name: "@", Type: "MX", Content: "mail.example.com", Priority: 10, TTL: 300, Managed: true, ManagedBy: &mb, IsEnabled: true}
+	recs := newMemDNSRecordRepo(mxRec)
+	out, err := dnsRecordUpdate(ctx, newMemDNSZoneRepo(z), recs, "example.com", mxRec.ID,
+		dnsRecordSpec{Content: "newmail.example.com"}, map[string]bool{"content": true})
+	if err != nil {
+		t.Fatalf("admin edit of a managed MX must succeed (handoff): %v", err)
+	}
+	if out.Managed || out.ManagedBy != nil {
+		t.Errorf("edited row must be demoted to operator-owned, got Managed=%v ManagedBy=%v", out.Managed, out.ManagedBy)
+	}
+	if got := recs.byID[mxRec.ID]; got.Content != "newmail.example.com" || got.Managed {
+		t.Errorf("handoff not persisted: %+v", got)
+	}
+
+	// A managed NS edit is still refused.
+	nsRec := &models.DNSRecord{ID: "01MANAGEDNS0000000000000AA", ZoneID: z.ID, Name: "@", Type: "NS", Content: "ns1.jabali.example", TTL: 300, Managed: true, ManagedBy: &mb, IsEnabled: true}
+	recs2 := newMemDNSRecordRepo(nsRec)
+	if _, err := dnsRecordUpdate(ctx, newMemDNSZoneRepo(z), recs2, "example.com", nsRec.ID,
+		dnsRecordSpec{Content: "ns2.jabali.example"}, map[string]bool{"content": true}); err == nil || !strings.Contains(err.Error(), "infrastructure") {
+		t.Fatalf("managed NS edit must be refused, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

The CLI DNS record commands refused **every** panel-managed row, so an operator couldn't hand-edit or delete a managed `MX`/`SRV`/`A`/etc. the way the web UI and REST API allow. HTTP (ADR-0107) blocks only managed `SOA`/`NS` — zone infrastructure (auto-generated SOA serial; apex NS must point at jabali's nameservers) — and for every other managed row applies the edit then **demotes** it to operator-owned (`Managed=false`, `ManagedBy=NULL`) so the reconciler hand-off paths step aside and the edit becomes the desired state pushed into PowerDNS.

## Fix — CLI parity

- `dnsLoadRecordInZone` (shared by update + delete) now refuses only managed `SOA`/`NS`.
- `dnsRecordUpdate` demotes the row to operator-owned after applying the edit, identical to the HTTP handler (a no-op for already-unmanaged rows).
- Removes the now-unused `managedByLabel` helper.

## Scope

Concrete slice of the DNS Record Lifecycle module (JAB-323): **criterion 1** (admin edit of a managed MX hands off to operator-owned state) + **criterion 2** (SOA/NS protected). Criterion 3 (four-field SRV normalization) already shipped in #1280. Still on the parent:
- criterion 4: settings-derived default TTL (the CLI hardcodes `300` vs the HTTP settings rule);
- criterion 5: immediate convergence scheduling — the CLI is out-of-process from the in-process reconciler (the JAB-292 limit), so a CLI edit converges on the next tick rather than being nudged;
- plus the full `Create`/`Update`/`Delete` module extraction.

## Verification

- New tests: managed MX edit succeeds + is demoted + persisted; managed NS edit refused; managed SRV deletable; managed NS delete refused. (The old `TestDNSRecordDelete_RefusesManaged`, which asserted the wrong "refuse all managed" behavior on a managed SRV, is updated to the correct SOA/NS-only rule.)
- Full `panel-api` suite green.
- No box-verify: a deterministic DB-side ownership flip with no agent/reconciler surface (the reconciler picks up the demoted row on its next tick); fully unit-covered.

GH #323
