### PR TITLE
fix(db): CLI process-kill audits the failure outcome too (JAB-305 slice)

### DIFF
--- a/panel-api/cmd/server/db_ops_cmd.go
+++ b/panel-api/cmd/server/db_ops_cmd.go
@@ -150,11 +150,16 @@ func newDBKillCmd() *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 			defer cancel()
-			err := csCall(ctx, verb, map[string]any{"id": args[0]})
-			if err == nil {
-				cliAuditOK(ctx, "database.process_kill", "database_process", args[0], nil)
+			// JAB-305: audit exactly one true outcome. This recorded only the
+			// success case, so a failed privileged kill left no audit trail;
+			// mirror the maintenance + root-password commands (Err on failure,
+			// OK on success).
+			if err := csCall(ctx, verb, map[string]any{"id": args[0]}); err != nil {
+				cliAuditErr(ctx, "database.process_kill", "database_process", args[0], nil)
+				return err
 			}
-			return err
+			cliAuditOK(ctx, "database.process_kill", "database_process", args[0], nil)
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&engine, "engine", "mariadb", "mariadb|postgres")


### PR DESCRIPTION
## What

`jabali db kill` (a privileged DB process termination) recorded `cliAuditOK` only on success and left a **failed** kill with no audit entry at all — so a failed privileged action produced no audit trail.

## Fix

Mirror the sibling privileged commands — `maintenance` (fixed in #1289) and `root-password` — which record `cliAuditErr` on an Agent failure and `cliAuditOK` on success. Every action now audits exactly one true outcome (criterion 1).

## Scope

Concrete slice of the Privileged DB Admin Action module (JAB-305). Criterion 2 (no success audit after an Agent failure) shipped for `maintenance` in #1289; `root-password` already audits both outcomes and reveals once. Still on the parent:
- criterion 3: required announcements/notifications fire from the CLI adapter (HTTP centralizes them; the CLI omits them);
- criterion 5 + the full typed rotate-root/kill/maintenance/tuning module extraction with HTTP/CLI parity tests.

## Verification

Full `panel-api` suite green. No unit test: the CLI db ops have no audit-sink test seam, and the change mirrors the two proven sibling commands verbatim (inspection-verified).

GH #305