### PR TITLE
fix(python-app): CLI create fails closed on env/proxy-rule write errors (JAB-343 slice)

### DIFF
--- a/panel-api/cmd/server/python_app_create_cmd.go
+++ b/panel-api/cmd/server/python_app_create_cmd.go
@@ -169,15 +169,28 @@ func newPythonAppCreateCmd() *cobra.Command {
 			if err := repo.Create(ctx, app); err != nil {
 				return fmt.Errorf("create app (domain+path may already be in use): %w", err)
 			}
+			// JAB-343: app, env, and domain rules must not partially succeed
+			// silently. A failure after the app row is inserted rolls the app
+			// back (Delete) and returns the error, so the operator sees the
+			// failure instead of a half-created pending app whose env is missing
+			// or that has no proxy rule (and is therefore unreachable). The env
+			// rows are removed with the app (the parse-error path above uses the
+			// same Delete compensation).
 			if len(envPairs) > 0 {
 				rows, perr := parsePythonEnvPairs(envPairs)
 				if perr != nil {
 					_ = repo.Delete(ctx, app.ID)
 					return perr
 				}
-				_ = repo.ReplaceEnv(ctx, app.ID, rows)
+				if err := repo.ReplaceEnv(ctx, app.ID, rows); err != nil {
+					_ = repo.Delete(ctx, app.ID)
+					return fmt.Errorf("persist app env: %w", err)
+				}
 			}
-			attachPythonProxyRuleCLI(ctx, dom, app, fwStaticURL, fwStaticRoot)
+			if err := attachPythonProxyRuleCLI(ctx, dom, app, fwStaticURL, fwStaticRoot); err != nil {
+				_ = repo.Delete(ctx, app.ID)
+				return fmt.Errorf("attach proxy/static rules: %w", err)
+			}
 
 			cliAuditOK(ctx, "python_app.create", "python_app", app.ID, &dom.UserID)
 			if jsonOutput {
@@ -216,7 +229,7 @@ func parsePythonEnvPairs(pairs []string) ([]models.PythonAppEnv, error) {
 // attachPythonProxyRuleCLI mirrors api.attachProxyRule: proxy_pass base_uri ->
 // loopback port, replacing any same-path rule, then persists the domain so the
 // reconciler renders the vhost.
-func attachPythonProxyRuleCLI(ctx context.Context, dom *models.Domain, app *models.PythonApp, staticURL, staticRoot string) {
+func attachPythonProxyRuleCLI(ctx context.Context, dom *models.Domain, app *models.PythonApp, staticURL, staticRoot string) error {
 	port := 0
 	if app.LoopbackPort != nil {
 		port = *app.LoopbackPort
@@ -247,7 +260,7 @@ func attachPythonProxyRuleCLI(ctx context.Context, dom *models.Domain, app *mode
 	}
 
 	dom.NginxRules = rules
-	_ = domainRepoFromDB().Update(ctx, dom)
+	return domainRepoFromDB().Update(ctx, dom)
 }
 
 // detachPythonRulesCLI removes the app's proxy_pass + framework static_alias


### PR DESCRIPTION
## What

`jabali python-app create` inserted the app row, then wrote the app's env (`repo.ReplaceEnv`) and the domain's proxy/static nginx rules (`attachPythonProxyRuleCLI` → `domainRepo.Update`) while **discarding both errors**. A failed env write left an app with no environment; a failed rule write left an app with no `proxy_pass` rule (unreachable) — both silently half-created pending rows the reconciler would then act on.

## Fix

Make the create **fail closed**: `attachPythonProxyRuleCLI` now returns the domain `Update` error, and the create path rolls the app back (`repo.Delete`, which also removes the env rows — the same compensation the existing env-parse-error path uses) and returns the error on either failure.

## Scope

Concrete slice of the Python Application Lifecycle module (JAB-343, **criterion 3**: "App, env, and domain rules cannot partially succeed silently"). Still on the parent:
- criterion 1: the CLI can't probe installed runtimes, so it can accept an uninstalled `--python-version` (needs an agent capability lookup like the HTTP path);
- criterion 2: tenant package/quota admission on CLI-owned creation;
- the full module extraction (validation, runtime lookup, canonical root/port allocation, transactional persistence, convergence).

## Verification

Full `panel-api` suite green. No unit test: the python create command has no test-harness/repo-mock seam, and the change mirrors the adjacent env-parse-error compensation verbatim (inspection-verified). No box-verify — the rollback path needs a forced DB write failure; the unchanged happy path has no new surface.

GH #343