### PR TITLE
fix(ui): admin File Manager step-up bounces to dashboard instead of opening (GH #1184)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -21,12 +21,12 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { App as AntdApp, ConfigProvider, Empty, Spin } from "antd";
-import type { ReactNode } from "react";
 import { lazy, Suspense, useEffect } from "react";
 import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 import { FeedbackBridge } from "./lib/feedback";
 
 import { AuthProvider, useAuth } from "./auth/AuthContext";
+import { PublicOnly } from "./auth/PublicOnly";
 import { RequireAdmin } from "./auth/RequireAdmin";
 import { RequireUser } from "./auth/RequireUser";
 import useMuiTheme from "./muiTheme";
@@ -130,29 +130,6 @@ function KratosSettingsRedirect() {
   return <Navigate to={`${target}${search}`} replace />;
 }
 
-function PublicOnly({ children }: { children: ReactNode }) {
-  const { user, isLoading } = useAuth();
-  if (isLoading) {
-    return (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          minHeight: "100vh",
-        }}
-      >
-        <Spin size="large" />
-      </div>
-    );
-  }
-  if (user) {
-    return (
-      <Navigate to={user.isAdmin ? "/jabali-admin" : "/jabali-panel"} replace />
-    );
-  }
-  return <>{children}</>;
-}
 
 const BrandingTitleApplier = () => {
   useApplyBrandingToTitle();

--- a/panel-ui/src/auth/PublicOnly.test.tsx
+++ b/panel-ui/src/auth/PublicOnly.test.tsx
@@ -1,0 +1,67 @@
+// PublicOnly guard tests (GH #1184).
+//
+// PublicOnly wraps the public /login route. An authenticated visitor is
+// normally bounced to their shell home — EXCEPT when Kratos redirected them
+// back to /login with a `?flow=<id>` to complete a re-auth flow (a JAB-380
+// recent-auth step-up for the admin File Manager / Root Terminal, or an aal2
+// escalation). Bouncing then would strand the step-up on the dashboard, which
+// was the #1184 "File Manager sends me back to the main menu" regression.
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PublicOnly } from "./PublicOnly";
+
+// Mock the auth hook so we can drive the authenticated/loading state.
+const mockAuth = vi.fn();
+vi.mock("./AuthContext", () => ({
+  useAuth: () => mockAuth(),
+}));
+
+function renderAt(path: string) {
+  window.history.pushState({}, "", path);
+  return render(
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="/login"
+          element={
+            <PublicOnly>
+              <div>LOGIN_FORM</div>
+            </PublicOnly>
+          }
+        />
+        <Route path="/jabali-admin" element={<div>ADMIN_HOME</div>} />
+        <Route path="/jabali-panel" element={<div>USER_HOME</div>} />
+      </Routes>
+    </BrowserRouter>,
+  );
+}
+
+describe("PublicOnly", () => {
+  afterEach(() => {
+    mockAuth.mockReset();
+  });
+
+  it("bounces an authenticated admin from bare /login to their shell home", () => {
+    mockAuth.mockReturnValue({ user: { id: "u1" }, isAdmin: true, isLoading: false });
+    renderAt("/login");
+    expect(screen.getByText("ADMIN_HOME")).toBeInTheDocument();
+    expect(screen.queryByText("LOGIN_FORM")).not.toBeInTheDocument();
+  });
+
+  it("lets an authenticated user complete a step-up flow at /login?flow=<id>", () => {
+    // GH #1184: base session valid but Kratos needs a re-auth to satisfy the
+    // step-up — render the flow instead of bouncing home.
+    mockAuth.mockReturnValue({ user: { id: "u1" }, isAdmin: true, isLoading: false });
+    renderAt("/login?flow=abc123");
+    expect(screen.getByText("LOGIN_FORM")).toBeInTheDocument();
+    expect(screen.queryByText("ADMIN_HOME")).not.toBeInTheDocument();
+  });
+
+  it("renders the login form for an unauthenticated visitor", () => {
+    mockAuth.mockReturnValue({ user: null, isAdmin: false, isLoading: false });
+    renderAt("/login");
+    expect(screen.getByText("LOGIN_FORM")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/auth/PublicOnly.tsx
+++ b/panel-ui/src/auth/PublicOnly.tsx
@@ -1,0 +1,42 @@
+// PublicOnly — wraps the public /login route.
+//
+// An already-authenticated visitor to /login is normally bounced to their
+// shell home instead of seeing the form. The one exception is a `?flow=<id>`
+// in the URL: Kratos redirected the user back to /login to COMPLETE a re-auth
+// flow it created — a JAB-380 recent-auth step-up (admin File Manager / Root
+// Terminal) or an aal2 escalation. The base session is still valid, so bouncing
+// home would abandon that flow (authenticated_at is never re-stamped and the
+// step-up never satisfies), stranding the user on the dashboard — the GH #1184
+// "File Manager sends me back to the main menu" regression. When a flow is
+// present we render the LoginPage so the user can finish it; Login.tsx then
+// honours `post_login_return_to` back to the originating page.
+import type { ReactNode } from "react";
+import { Navigate } from "react-router";
+import { Spin } from "antd";
+
+import { useAuth } from "./AuthContext";
+
+export function PublicOnly({ children }: { children: ReactNode }) {
+  const { user, isAdmin, isLoading } = useAuth();
+  if (isLoading) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+        }}
+      >
+        <Spin size="large" />
+      </div>
+    );
+  }
+  if (user) {
+    const hasFlow = new URLSearchParams(window.location.search).has("flow");
+    if (!hasFlow) {
+      return <Navigate to={isAdmin ? "/jabali-admin" : "/jabali-panel"} replace />;
+    }
+  }
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Bug

After #1244 (JAB-380 recent-auth step-up for the admin File Manager / Root Terminal), clicking **File Manager** with a session older than the 10-minute step-up window bounces the admin to the dashboard (the reporter's "redirects me back to the main menu, and the page returns 403"). It worked before #1244 because nothing ever kicked a refresh-login for the File Manager.

## Root cause (reproduced live on a test box)

The step-up sequence:

1. `GET /admin/files` → `403 {"error":"stepup_required"}` (correct — the gate works).
2. The apiClient interceptor kicks a Kratos `?refresh=true` login and stashes `post_login_return_to`.
3. Kratos redirects the browser to `/login?flow=<id>` to complete the re-auth.
4. **`PublicOnly` (the `/login` route guard) sees the still-valid base session and immediately `<Navigate>`s the user to their shell home** — abandoning the refresh flow. `authenticated_at` is never re-stamped, and `post_login_return_to` (read only in Login.tsx's submit-success path) is never consulted.

Net effect: `403 → refresh → /login?flow → bounce to /jabali-admin/dashboard`, File Manager never opens. `MyProfile`'s refresh flow avoids this because it renders the Kratos flow inline and never hits `/login`.

## Fix

`PublicOnly` now lets `/login` render when a `?flow=<id>` is present (a Kratos-created re-auth flow the user must finish), so the step-up completes and `Login.tsx` returns them to the originating page via `post_login_return_to`. An authenticated visitor to bare `/login` (no flow) is still bounced home as before. Also fixes the Root Terminal step-up (same `/login?flow` route).

`PublicOnly` was extracted to `src/auth/PublicOnly.tsx` with unit tests for all three branches (authenticated+flow renders; authenticated+no-flow bounces; unauthenticated renders).

## Verification

- `tsc -b`, `vite build`, and the new `PublicOnly` tests (3/3) + `Login.test` (7/7) all green.
- **Reproduced the bug live** on a test box against the currently-shipped SPA: confirmed `/admin/files` 403 `stepup_required`, the `?refresh=true` redirect, the `/login?flow=<id>` hop, and the bounce to `/jabali-admin/dashboard`; traced to `PublicOnly` in code.
- The fix is deployed to the test box (binary + on-disk SPA both carry it). A full click-through of the fixed SPA was blocked by a stale app-caching Service Worker left in the test browser profile by an old build — a known, already-mitigated class (the current `sw-push.js` is push-only and purges legacy caches on activate), unrelated to this fix.

Note: a separate, environment-specific `503` on `/.ory/self-service/login/browser` was observed on the test box, caused by the panel's login-IP allowlist agent call timing out on a momentarily-slow agent. Not this bug; flagged for a follow-up (the allowlist add should be best-effort so it can't 503 the login flow).

GH #1184