### PR TITLE
feat(ssh): admin UI toggle + durable opt-in for SSH TCP forwarding (GH #1229)

### DIFF
--- a/panel-api/cmd/server/kratos_rebuild_cmd_test.go
+++ b/panel-api/cmd/server/kratos_rebuild_cmd_test.go
@@ -65,7 +65,10 @@ func (*fakeRebuildUserRepo) FindAdminsByEmail(context.Context) ([]*models.User, 
 	return nil, nil
 }
 func (*fakeRebuildUserRepo) SetSuspended(context.Context, string, bool, string) error { return nil }
-func (*fakeRebuildUserRepo) Delete(context.Context, string) error                     { return nil }
+func (*fakeRebuildUserRepo) SetSSHForwardingEnabled(context.Context, string, bool) error {
+	return nil
+}
+func (*fakeRebuildUserRepo) Delete(context.Context, string) error { return nil }
 
 // fakeKratos routes POST /admin/identities → returns a new UUID; POST
 // /admin/recovery/code → returns a recovery link. Both paths are optional

--- a/panel-api/cmd/server/user_ssh_forwarding_cmd.go
+++ b/panel-api/cmd/server/user_ssh_forwarding_cmd.go
@@ -53,6 +53,19 @@ Takes effect on the user's next SSH connection.`,
 				return fmt.Errorf("second argument must be on|off, got %q", args[1])
 			}
 
+			// Persist the durable flag FIRST — the SSH reconciler is the source
+			// of truth and converges jabali-ssh-forward membership from
+			// users.ssh_forwarding_enabled (GH #1229). Without this write the
+			// reconciler would strip a CLI-only opt-in within one re-dispatch
+			// interval (the flag defaults OFF), silently regressing forwarding.
+			if err := userRepo().SetSSHForwardingEnabled(ctx, target.ID, enable); err != nil {
+				cliAuditErr(ctx, "ssh.forwarding", "user", target.ID, &target.ID)
+				return fmt.Errorf("persist ssh_forwarding_enabled: %w", err)
+			}
+
+			// Apply now so it takes effect on the user's next connection without
+			// waiting for the reconcile tick. Best-effort: the reconciler
+			// self-heals group membership from the flag regardless.
 			verb := "ssh.user.leave_forward_group"
 			if enable {
 				verb = "ssh.user.join_forward_group"

--- a/panel-api/internal/api/automation_write_routes_test.go
+++ b/panel-api/internal/api/automation_write_routes_test.go
@@ -45,6 +45,7 @@ func (r *awUsers) SetSuspended(_ context.Context, _ string, s bool, _ string) er
 	r.suspended = &s
 	return nil
 }
+func (r *awUsers) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error { return nil }
 
 type awDomains struct {
 	repository.DomainRepository

--- a/panel-api/internal/api/cron_admin_list_test.go
+++ b/panel-api/internal/api/cron_admin_list_test.go
@@ -181,6 +181,9 @@ func (u *userRepoAdapterForCronAdminTest) FindAdminsByEmail(context.Context) ([]
 func (u *userRepoAdapterForCronAdminTest) SetSuspended(context.Context, string, bool, string) error {
 	return nil
 }
+func (u *userRepoAdapterForCronAdminTest) SetSSHForwardingEnabled(context.Context, string, bool) error {
+	return nil
+}
 func (u *userRepoAdapterForCronAdminTest) Delete(context.Context, string) error { return nil }
 
 func (r *userRepoAdapterForCronAdminTest) UpdateUsername(context.Context, string, string) error {

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -211,6 +211,9 @@ func (m *mockUserRepo) FindAdminsByEmail(ctx context.Context) ([]*models.User, e
 }
 
 func (m *mockUserRepo) SetSuspended(_ context.Context, _ string, _ bool, _ string) error { return nil }
+func (m *mockUserRepo) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error {
+	return nil
+}
 
 func (m *mockUserRepo) Delete(ctx context.Context, id string) error {
 	return nil

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5536,6 +5536,32 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /admin/users/{id}/ssh-forwarding:
+    get:
+      tags: [Users]
+      summary: Get a user's SSH TCP forwarding opt-in status (admin, GH #1229)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { type: object, properties: { ssh_forwarding_enabled: { type: boolean }, ssh_enabled: { type: boolean } } } } } }
+    post:
+      tags: [Users]
+      summary: Enable/disable a user's SSH TCP forwarding for VS Code Remote-SSH (admin, GH #1229)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { enabled: { type: boolean } }, required: [enabled] } } } }
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { type: object, properties: { ssh_forwarding_enabled: { type: boolean }, ssh_enabled: { type: boolean } } } } } }
+        "422": { description: Not a hosting user, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
+  /me/ssh-forwarding:
+    get:
+      tags: [Users]
+      summary: The caller's own SSH TCP forwarding status (read-only, GH #1229)
+      security: [ { KratosSession: [] } ]
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { type: object, properties: { ssh_forwarding_enabled: { type: boolean }, ssh_enabled: { type: boolean } } } } } }
+
   /users:
     get:
       tags: [Users]

--- a/panel-api/internal/api/sso_phpmyadmin_validate_test.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate_test.go
@@ -325,6 +325,10 @@ func (m *mockUserRepoValidate) SetSuspended(_ context.Context, _ string, _ bool,
 	return nil
 }
 
+func (m *mockUserRepoValidate) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+
 func (m *mockUserRepoValidate) Delete(ctx context.Context, id string) error {
 	return nil
 }

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -50,6 +50,9 @@ type UserHandlerConfig struct {
 	DomainTeardowns repository.DomainTeardownRepository
 	Reconciler      *reconciler.Reconciler
 	Log             *slog.Logger
+	// AuditEvents records the admin SSH-forwarding toggle (GH #1229), a
+	// hardening-relaxation control. Optional; nil skips the audit write.
+	AuditEvents repository.AuditEventRepository
 	// Redis is the shared client used to revoke a tenant's wp_<osuser> cache
 	// ACL user on the delete cascade (GH #408). Optional; nil skips revoke.
 	Redis *redis.Client
@@ -118,6 +121,12 @@ func RegisterUserRoutes(g *gin.RouterGroup, cfg UserHandlerConfig) {
 	// bulk-disable owned domains. See users_suspend.go.
 	g.POST("/admin/users/:id/suspend", middleware.RequireAdmin(), h.suspend)
 	g.POST("/admin/users/:id/unsuspend", middleware.RequireAdmin(), h.unsuspend)
+
+	// GH #1229: admin opt-in for a user's SSH TCP forwarding (VS Code
+	// Remote-SSH). Admin-only to flip; the tenant can read their own status.
+	g.GET("/admin/users/:id/ssh-forwarding", middleware.RequireAdmin(), h.getSSHForwarding)
+	g.POST("/admin/users/:id/ssh-forwarding", middleware.RequireAdmin(), h.setSSHForwarding)
+	g.GET("/me/ssh-forwarding", h.mySSHForwarding)
 }
 
 type userHandler struct{ cfg UserHandlerConfig }

--- a/panel-api/internal/api/users_ssh_forwarding.go
+++ b/panel-api/internal/api/users_ssh_forwarding.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// users_ssh_forwarding.go — admin opt-in for a hosting user's SSH TCP
+// forwarding, GH #1229. VS Code Remote-SSH needs to forward to its own VS Code
+// Server on 127.0.0.1, which the JAB-352 sandbox lockdown blocks. The opt-in is
+// a durable per-user flag (users.ssh_forwarding_enabled); the SSH reconciler
+// converges jabali-ssh-forward group membership from it (join → excluded from
+// the lockdown Match block, into the loopback-only one). Default OFF keeps
+// JAB-352 unchanged for everyone.
+//
+// Admin-only to flip: relaxing a hardening control is an operator decision. A
+// tenant can only READ their own status (GET /me/ssh-forwarding) so the SSH
+// page shows it and points them at their admin. Either way the sensitive
+// loopback services stay firewall-blocked per-uid, so an opted-in user can
+// still only forward to their own apps + the VS Code Server.
+
+type sshForwardingRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// sshForwardingStatus is returned by both the admin setter and the tenant
+// read. ssh_enabled lets the UI show the relevant note (the toggle is moot for
+// a user whose package has no SSH shell).
+type sshForwardingStatus struct {
+	SSHForwardingEnabled bool `json:"ssh_forwarding_enabled"`
+	SSHEnabled           bool `json:"ssh_enabled"`
+}
+
+// setSSHForwarding handles POST /admin/users/:id/ssh-forwarding {enabled}.
+func (h *userHandler) setSSHForwarding(c *gin.Context) {
+	userID := c.Param("id")
+	if userID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user id required"})
+		return
+	}
+	var req sshForwardingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	user, err := h.cfg.Repo.FindByID(ctx, userID)
+	if err != nil || user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	// Forwarding applies only to a hosting user with a Linux account.
+	if user.Username == nil || *user.Username == "" || user.IsAdmin {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error":  "not_a_hosting_user",
+			"detail": "SSH forwarding applies only to hosting users with a Linux account.",
+		})
+		return
+	}
+
+	if err := h.cfg.Repo.SetSSHForwardingEnabled(ctx, userID, req.Enabled); err != nil {
+		h.auditSSHForwarding(c, userID, req.Enabled, models.AuditResultError)
+		h.log().ErrorContext(ctx, "ssh-forwarding: set flag failed",
+			"user_id", userID, "enabled", req.Enabled, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db_write_failed"})
+		return
+	}
+	h.auditSSHForwarding(c, userID, req.Enabled, models.AuditResultOK)
+
+	// Converge the OS group now so the change takes effect on the user's next
+	// SSH connection without waiting for the ~60s reconcile tick. Best-effort:
+	// the reconciler self-heals from the flag anyway.
+	if h.cfg.Reconciler != nil {
+		go func() {
+			rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := h.cfg.Reconciler.ReconcileSSHKeysForUser(rctx, userID); err != nil {
+				h.log().WarnContext(rctx, "ssh-forwarding: reconcile after toggle failed",
+					"user_id", userID, "error", err)
+			}
+		}()
+	}
+
+	c.JSON(http.StatusOK, sshForwardingStatus{
+		SSHForwardingEnabled: req.Enabled,
+		SSHEnabled:           h.userSSHEnabled(ctx, user),
+	})
+}
+
+// getSSHForwarding handles GET /admin/users/:id/ssh-forwarding — admin read
+// of a user's opt-in state + whether their package grants SSH at all.
+func (h *userHandler) getSSHForwarding(c *gin.Context) {
+	userID := c.Param("id")
+	if userID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user id required"})
+		return
+	}
+	ctx := c.Request.Context()
+	user, err := h.cfg.Repo.FindByID(ctx, userID)
+	if err != nil || user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	c.JSON(http.StatusOK, sshForwardingStatus{
+		SSHForwardingEnabled: user.SSHForwardingEnabled,
+		SSHEnabled:           h.userSSHEnabled(ctx, user),
+	})
+}
+
+// mySSHForwarding handles GET /me/ssh-forwarding — the caller's own status.
+// Read-only: a tenant cannot flip the opt-in.
+func (h *userHandler) mySSHForwarding(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	ctx := c.Request.Context()
+	user, err := h.cfg.Repo.FindByID(ctx, claims.UserID)
+	if err != nil || user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	c.JSON(http.StatusOK, sshForwardingStatus{
+		SSHForwardingEnabled: user.SSHForwardingEnabled,
+		SSHEnabled:           h.userSSHEnabled(ctx, user),
+	})
+}
+
+// userSSHEnabled reports whether the user's package grants SSH shell access.
+// A missing/unfetchable package is the safe default (no SSH).
+func (h *userHandler) userSSHEnabled(ctx context.Context, user *models.User) bool {
+	if h.cfg.Packages == nil || user.PackageID == nil || *user.PackageID == "" {
+		return false
+	}
+	pkg, err := h.cfg.Packages.FindByID(ctx, *user.PackageID)
+	if err != nil || pkg == nil {
+		return false
+	}
+	return pkg.SSHEnabled
+}
+
+// auditSSHForwarding records the admin toggle of this security control. No-op
+// when the audit repo isn't wired (dev binaries).
+func (h *userHandler) auditSSHForwarding(c *gin.Context, userID string, enabled bool, result string) {
+	if h.cfg.AuditEvents == nil {
+		return
+	}
+	meta, _ := json.Marshal(map[string]bool{"enabled": enabled})
+	subject := userID
+	ev := &models.AuditEvent{
+		ID:            ids.NewULID(),
+		TS:            time.Now().UTC(),
+		ActorKind:     models.AuditActorAdmin,
+		SubjectUserID: &subject,
+		Action:        "admin.user.ssh_forwarding",
+		TargetType:    "user",
+		TargetID:      userID,
+		Result:        result,
+		Meta:          meta,
+	}
+	if claims := ginctx.Claims(c); claims != nil && claims.UserID != "" {
+		actor := claims.UserID
+		ev.ActorUserID = &actor
+	}
+	if ip := c.ClientIP(); ip != "" {
+		ev.SourceIP = &ip
+	}
+	if reqID := ginctx.RequestID(c); reqID != "" {
+		ev.RequestID = &reqID
+	}
+	_ = h.cfg.AuditEvents.Create(c.Request.Context(), ev)
+}
+
+// log returns a non-nil logger for this handler.
+func (h *userHandler) log() *slog.Logger {
+	if h.cfg.Log != nil {
+		return h.cfg.Log
+	}
+	return slog.Default()
+}

--- a/panel-api/internal/api/users_ssh_forwarding_test.go
+++ b/panel-api/internal/api/users_ssh_forwarding_test.go
@@ -1,0 +1,122 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1229 — admin opt-in + tenant read-only for SSH TCP forwarding.
+
+// hostingUserWithSSH seeds a non-admin user with a Linux username on an
+// SSH-enabled package, returning the user and package.
+func hostingUserWithSSH(t *testing.T, repo *memUserRepo, pkgRepo *memPackageRepo, sshEnabled bool) *models.User {
+	t.Helper()
+	pkg := &models.HostingPackage{ID: ids.NewULID(), Name: "Shell", SSHEnabled: sshEnabled}
+	pkgRepo.seed(pkg)
+	u := makeUser(t, "host@example.com", false, "password123")
+	uname := "hostuser"
+	u.Username = &uname
+	u.PackageID = &pkg.ID
+	repo.seed(u)
+	return u
+}
+
+func TestSSHForwarding_AdminEnableDisableRoundTrip(t *testing.T) {
+	t.Parallel()
+	repo := newMemUserRepo()
+	pkgRepo := newMemPackageRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	repo.seed(admin)
+	u := hostingUserWithSSH(t, repo, pkgRepo, true)
+
+	r := buildRouterWithPackages(repo, pkgRepo, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+
+	// Enable.
+	rec := doJSON(t, r, http.MethodPost, "/api/v1/admin/users/"+u.ID+"/ssh-forwarding", map[string]any{"enabled": true})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out struct {
+		SSHForwardingEnabled bool `json:"ssh_forwarding_enabled"`
+		SSHEnabled           bool `json:"ssh_enabled"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.True(t, out.SSHForwardingEnabled)
+	assert.True(t, out.SSHEnabled)
+
+	// Persisted on the row (durable flag, not just group membership).
+	got, err := repo.FindByID(t.Context(), u.ID)
+	require.NoError(t, err)
+	assert.True(t, got.SSHForwardingEnabled)
+
+	// Admin GET reflects it.
+	rec = doJSON(t, r, http.MethodGet, "/api/v1/admin/users/"+u.ID+"/ssh-forwarding", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.True(t, out.SSHForwardingEnabled)
+
+	// Disable.
+	rec = doJSON(t, r, http.MethodPost, "/api/v1/admin/users/"+u.ID+"/ssh-forwarding", map[string]any{"enabled": false})
+	require.Equal(t, http.StatusOK, rec.Code)
+	got, err = repo.FindByID(t.Context(), u.ID)
+	require.NoError(t, err)
+	assert.False(t, got.SSHForwardingEnabled)
+}
+
+func TestSSHForwarding_NonAdminForbidden(t *testing.T) {
+	t.Parallel()
+	repo := newMemUserRepo()
+	pkgRepo := newMemPackageRepo()
+	u := hostingUserWithSSH(t, repo, pkgRepo, true)
+
+	// The target user themselves must NOT be able to flip the control.
+	r := buildRouterWithPackages(repo, pkgRepo, &auth.AccessClaims{UserID: u.ID, Email: u.Email})
+	rec := doJSON(t, r, http.MethodPost, "/api/v1/admin/users/"+u.ID+"/ssh-forwarding", map[string]any{"enabled": true})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	got, err := repo.FindByID(t.Context(), u.ID)
+	require.NoError(t, err)
+	assert.False(t, got.SSHForwardingEnabled, "non-admin POST must not have changed the flag")
+}
+
+func TestSSHForwarding_NotAHostingUser422(t *testing.T) {
+	t.Parallel()
+	repo := newMemUserRepo()
+	pkgRepo := newMemPackageRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	repo.seed(admin)
+	// Another admin (no Linux username) is not a valid target.
+	target := makeUser(t, "admin2@example.com", true, "pw")
+	repo.seed(target)
+
+	r := buildRouterWithPackages(repo, pkgRepo, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	rec := doJSON(t, r, http.MethodPost, "/api/v1/admin/users/"+target.ID+"/ssh-forwarding", map[string]any{"enabled": true})
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not_a_hosting_user")
+}
+
+func TestSSHForwarding_MeReadOnlyStatus(t *testing.T) {
+	t.Parallel()
+	repo := newMemUserRepo()
+	pkgRepo := newMemPackageRepo()
+	u := hostingUserWithSSH(t, repo, pkgRepo, true)
+	// Pretend an admin already turned it on (seed copies, so set via the repo).
+	require.NoError(t, repo.SetSSHForwardingEnabled(t.Context(), u.ID, true))
+
+	r := buildRouterWithPackages(repo, pkgRepo, &auth.AccessClaims{UserID: u.ID, Email: u.Email})
+	rec := doJSON(t, r, http.MethodGet, "/api/v1/me/ssh-forwarding", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out struct {
+		SSHForwardingEnabled bool `json:"ssh_forwarding_enabled"`
+		SSHEnabled           bool `json:"ssh_enabled"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.True(t, out.SSHForwardingEnabled)
+	assert.True(t, out.SSHEnabled)
+}

--- a/panel-api/internal/api/users_test.go
+++ b/panel-api/internal/api/users_test.go
@@ -214,6 +214,18 @@ func (m *memUserRepo) FindAdminsByEmail(_ context.Context) ([]*models.User, erro
 
 func (m *memUserRepo) SetSuspended(_ context.Context, _ string, _ bool, _ string) error { return nil }
 
+func (m *memUserRepo) SetSSHForwardingEnabled(_ context.Context, id string, enabled bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	u, ok := m.byID[id]
+	if !ok {
+		return repository.ErrNotFound
+	}
+	u.SSHForwardingEnabled = enabled
+	u.UpdatedAt = time.Now()
+	return nil
+}
+
 func (m *memUserRepo) Delete(_ context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -640,6 +640,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Reconciler:      deps.Reconciler,
 				Log:             deps.Log,
 				Redis:           deps.Redis,
+				// GH #1229: audit the admin SSH-forwarding toggle.
+				AuditEvents: repository.NewAuditEventRepository(deps.DB),
 				// M20: atomic Kratos identity creation on POST /users.
 				KratosClient: deps.KratosClient,
 			})

--- a/panel-api/internal/auth/testhelpers_test.go
+++ b/panel-api/internal/auth/testhelpers_test.go
@@ -127,6 +127,10 @@ func (f *fakeUserRepo) FindAdminsByEmail(_ context.Context) ([]*models.User, err
 
 func (f *fakeUserRepo) SetSuspended(_ context.Context, _ string, _ bool, _ string) error { return nil }
 
+func (f *fakeUserRepo) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+
 func (f *fakeUserRepo) Delete(_ context.Context, id string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/panel-api/internal/db/migrations/000275_user_ssh_forwarding_optin.down.sql
+++ b/panel-api/internal/db/migrations/000275_user_ssh_forwarding_optin.down.sql
@@ -1,0 +1,3 @@
+-- Revert GH #1229 per-user SSH-forwarding opt-in flag.
+ALTER TABLE users
+    DROP COLUMN ssh_forwarding_enabled;

--- a/panel-api/internal/db/migrations/000275_user_ssh_forwarding_optin.up.sql
+++ b/panel-api/internal/db/migrations/000275_user_ssh_forwarding_optin.up.sql
@@ -1,0 +1,8 @@
+-- GH #1229: per-user opt-in for SSH TCP forwarding (VS Code Remote-SSH).
+-- Default 0 keeps the JAB-352 forwarding lockdown for everyone; an admin opts a
+-- user in, and the SSH reconciler converges jabali-ssh-forward group membership
+-- from this flag so it is durable across user reprovision (the v1 group-only
+-- opt-in reverted to OFF on reprovision). TINYINT on users — no row-ceiling
+-- concern (that ceiling is server_settings' VARCHAR width, not this table).
+ALTER TABLE users
+    ADD COLUMN ssh_forwarding_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/middleware/auth_kratos_test.go
+++ b/panel-api/internal/middleware/auth_kratos_test.go
@@ -73,6 +73,7 @@ func (f *fakeUsersRepo) FindAdminsByEmail(context.Context) ([]*models.User, erro
 	panic("FindAdminsByEmail not expected from middleware")
 }
 func (f *fakeUsersRepo) SetSuspended(context.Context, string, bool, string) error { return nil }
+func (f *fakeUsersRepo) SetSSHForwardingEnabled(context.Context, string, bool) error { return nil }
 func (f *fakeUsersRepo) Delete(context.Context, string) error {
 	panic("Delete not expected from middleware")
 }

--- a/panel-api/internal/models/user.go
+++ b/panel-api/internal/models/user.go
@@ -90,6 +90,17 @@ type User struct {
 	// 1 = ON (migration 000203). Mail delivery (IMAP/SMTP/JMAP) is unaffected.
 	WebmailEnabled bool `gorm:"column:webmail_enabled;type:tinyint(1);not null;default:1" json:"webmail_enabled"`
 
+	// SSHForwardingEnabled (GH #1229) opts an SSH-enabled user out of the
+	// JAB-352 forwarding lockdown into loopback-only TCP forwarding, which
+	// VS Code Remote-SSH needs to reach its own VS Code Server on 127.0.0.1.
+	// Default 0 = OFF: the lockdown is unchanged for everyone. Admin-only to
+	// flip. The SSH reconciler converges jabali-ssh-forward group membership
+	// from this flag, so the opt-in is durable across user reprovision (unlike
+	// the v1 group-only opt-in, which reverted to OFF). Sensitive loopback
+	// services stay firewall-blocked per-uid regardless, so an opted-in user
+	// can still only forward to their own apps + the VS Code Server.
+	SSHForwardingEnabled bool `gorm:"column:ssh_forwarding_enabled;type:tinyint(1);not null;default:0" json:"ssh_forwarding_enabled"`
+
 	// Disk-usage snapshot, written by the disk-usage sweeper
 	// (panel-api/internal/diskusagesweeper) from the same agent report the
 	// per-user /users/:id/usage endpoint calls.

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -578,6 +578,9 @@ func (f *fakeUserRepo) LinkKratosIdentity(ctx context.Context, userID, kratosID 
 }
 
 func (f *fakeUserRepo) SetSuspended(_ context.Context, _ string, _ bool, _ string) error { return nil }
+func (f *fakeUserRepo) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error {
+	return nil
+}
 
 func (f *fakeUserRepo) Delete(ctx context.Context, id string) error {
 	delete(f.users, id)

--- a/panel-api/internal/reconciler/ssh_keys_forward_group_test.go
+++ b/panel-api/internal/reconciler/ssh_keys_forward_group_test.go
@@ -1,0 +1,60 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1229: the SSH reconciler converges jabali-ssh-forward group membership
+// from the durable per-user opt-in flag (users.ssh_forwarding_enabled), so the
+// opt-in survives user reprovision — unlike the v1 group-only opt-in, which
+// reverted to OFF. Membership excludes the user from the JAB-352 forwarding
+// lockdown Match block and into the loopback-only one (VS Code Remote-SSH).
+
+func forwardGroupCalls(t *testing.T, sshEnabled, forwardingEnabled bool) map[string][]fakeCall {
+	t.Helper()
+	uname := "shop"
+	pkgID := "pkg1"
+	users := &ftpUsersRepo{byID: map[string]*models.User{
+		"u1": {ID: "u1", Username: &uname, PackageID: &pkgID, SSHForwardingEnabled: forwardingEnabled},
+	}}
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{}}
+	r := New(nil, users, agent, slog.Default(), Config{})
+	r.WithSSHKeys(homeModeSSHKeysRepo{})
+	r.WithPackages(&homeModePkgRepo{pkg: &models.HostingPackage{ID: pkgID, SSHEnabled: sshEnabled}})
+
+	if err := r.ReconcileSSHKeysForUser(context.Background(), "u1"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	return ftpCallsByMethod(agent)
+}
+
+func TestSSHForwardGroup_OptInJoins(t *testing.T) {
+	calls := forwardGroupCalls(t, true, true)
+	if len(calls["ssh.user.join_forward_group"]) != 1 || len(calls["ssh.user.leave_forward_group"]) != 0 {
+		t.Fatalf("opted-in SSH user must JOIN jabali-ssh-forward exactly once; got join=%d leave=%d",
+			len(calls["ssh.user.join_forward_group"]), len(calls["ssh.user.leave_forward_group"]))
+	}
+}
+
+func TestSSHForwardGroup_OptOutLeaves(t *testing.T) {
+	calls := forwardGroupCalls(t, true, false)
+	if len(calls["ssh.user.leave_forward_group"]) != 1 || len(calls["ssh.user.join_forward_group"]) != 0 {
+		t.Fatalf("SSH user without the opt-in must LEAVE jabali-ssh-forward; got join=%d leave=%d",
+			len(calls["ssh.user.join_forward_group"]), len(calls["ssh.user.leave_forward_group"]))
+	}
+}
+
+func TestSSHForwardGroup_NonSSHUserAlwaysLeaves(t *testing.T) {
+	// Even with the flag set, a user whose package grants no SSH shell is
+	// removed from the forward group (forwarding is meaningless without a shell).
+	calls := forwardGroupCalls(t, false, true)
+	if len(calls["ssh.user.leave_forward_group"]) != 1 || len(calls["ssh.user.join_forward_group"]) != 0 {
+		t.Fatalf("non-SSH user must LEAVE the forward group regardless of the flag; got join=%d leave=%d",
+			len(calls["ssh.user.join_forward_group"]), len(calls["ssh.user.leave_forward_group"]))
+	}
+}

--- a/panel-api/internal/reconciler/ssh_keys_reconcile.go
+++ b/panel-api/internal/reconciler/ssh_keys_reconcile.go
@@ -42,18 +42,23 @@ func desiredSSHKeysHash(keys []string) string {
 // desiredSSHFullHash combines every user-state input the reconcile pass
 // dispatches to the agent: keys + sshEnabled + nspawn pin + username.
 // When this hash matches the cached one AND we're within
-// sshKeysReDispatchInterval, we skip ALL six per-user agent calls (set_shell,
-// home_chown, join/leave sftp group, join/leave sandbox group, write_nspawn_pin,
-// authorized_keys write/delete) — not just the keys op the v1 cache covered.
+// sshKeysReDispatchInterval, we skip ALL seven per-user agent calls (set_shell,
+// home_chown, join/leave sftp group, join/leave sandbox group, join/leave
+// forward group, write_nspawn_pin, authorized_keys write/delete) — not just the
+// keys op the v1 cache covered.
 // This was the next per-tick chatter source after PR #61: even with the keys
 // op gated, 3 users x 5 unconditional IPCs/tick = 15 agent round-trips/min for
 // no diff. Self-heals on the next interval to catch drift (manual chsh, gpasswd).
-func desiredSSHFullHash(username string, sshEnabled bool, pin string, keys []string) string {
+func desiredSSHFullHash(username string, sshEnabled, forwardingEnabled bool, pin string, keys []string) string {
 	sorted := append([]string(nil), keys...)
 	sort.Strings(sorted)
 	parts := []string{
 		"u=" + username,
 		"ssh=" + strconv.FormatBool(sshEnabled),
+		// GH #1229: the forward-group converge below is one of the gated
+		// IPCs, so its input must be in the hash — otherwise flipping the
+		// opt-in leaves the hash unchanged and the reconcile is skipped.
+		"fwd=" + strconv.FormatBool(forwardingEnabled),
 		"pin=" + pin,
 		"n=" + strconv.Itoa(len(sorted)),
 		"k=" + strings.Join(sorted, "\n"),
@@ -122,7 +127,7 @@ func (r *Reconciler) ReconcileSSHKeysForUser(ctx context.Context, userID string)
 		pinPreview = ""
 	}
 
-	fullHash := desiredSSHFullHash(*user.Username, sshEnabled, pinPreview, desiredLines)
+	fullHash := desiredSSHFullHash(*user.Username, sshEnabled, user.SSHForwardingEnabled, pinPreview, desiredLines)
 
 	// Combined-hash gate. When everything matches AND we re-dispatched
 	// within sshKeysReDispatchInterval, skip ALL six agent IPCs below.
@@ -212,6 +217,25 @@ func (r *Reconciler) ReconcileSSHKeysForUser(ctx context.Context, userID string)
 		// can't sudo. Log and continue.
 		r.log.WarnContext(ctx, "reconcile ssh keys: sandbox group failed",
 			"user_id", userID, "username", *user.Username, "method", sandboxGroupMethod, "error", err)
+	}
+
+	// GH #1229 forward group: converge jabali-ssh-forward membership from the
+	// per-user opt-in. Membership EXCLUDES the user from the JAB-352 forwarding
+	// lockdown Match block and into the relaxed (loopback-only) one, so VS Code
+	// Remote-SSH can forward to its own VS Code Server. Only meaningful for an
+	// SSH-shell user; an SFTP-only user is always removed. Reconciling from the
+	// DB flag here is what makes the opt-in durable across reprovision.
+	forwardGroupMethod := "ssh.user.leave_forward_group"
+	if sshEnabled && user.SSHForwardingEnabled {
+		forwardGroupMethod = "ssh.user.join_forward_group"
+	}
+	if _, err := r.agent.Call(ctx, forwardGroupMethod, map[string]interface{}{
+		"username": *user.Username,
+	}); err != nil {
+		// Non-fatal, like the sandbox group: an older host without the
+		// forward group (jabali update pending) just stays in the lockdown.
+		r.log.WarnContext(ctx, "reconcile ssh keys: forward group failed",
+			"user_id", userID, "username", *user.Username, "method", forwardGroupMethod, "error", err)
 	}
 
 	// M13 nspawn pin (pre-computed as pinPreview above; reuse so the

--- a/panel-api/internal/repository/user_repository.go
+++ b/panel-api/internal/repository/user_repository.go
@@ -60,6 +60,10 @@ type UserRepository interface {
 	// suspend_reason. Kept separate from Update so the profile-edit
 	// path can't accidentally lift / apply a suspension.
 	SetSuspended(ctx context.Context, id string, suspended bool, reason string) error
+	// SetSSHForwardingEnabled flips users.ssh_forwarding_enabled (GH #1229).
+	// Dedicated method: the profile-edit path must not toggle a security
+	// control, and the Select-allowlist Update would silently drop the column.
+	SetSSHForwardingEnabled(ctx context.Context, id string, enabled bool) error
 	Delete(ctx context.Context, id string) error
 }
 
@@ -284,6 +288,23 @@ func (r *userRepo) SetSuspended(ctx context.Context, id string, suspended bool, 
 		Model(&models.User{}).
 		Where("id = ?", id).
 		Updates(patch)
+	if res.Error != nil {
+		return translate(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *userRepo) SetSSHForwardingEnabled(ctx context.Context, id string, enabled bool) error {
+	res := r.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"ssh_forwarding_enabled": enabled,
+			"updated_at":             time.Now().UTC(),
+		})
 	if res.Error != nil {
 		return translate(res.Error)
 	}

--- a/panel-api/internal/repository/user_repository_test.go
+++ b/panel-api/internal/repository/user_repository_test.go
@@ -51,6 +51,7 @@ func TestUserRepository_Create(t *testing.T) {
 			nil,              // suspended_at
 			"",               // suspend_reason
 			true,             // webmail_enabled (GORM default:1 promotes the zero-value bool)
+			false,            // ssh_forwarding_enabled (GH #1229; default OFF)
 			uint64(0),        // disk_used_kb (migration 000257; sweeper fills it in)
 			uint64(0),        // disk_limit_kb
 			nil,              // disk_checked_at — NULL until the first sweep, which is

--- a/panel-api/internal/sso/sso_test.go
+++ b/panel-api/internal/sso/sso_test.go
@@ -144,6 +144,9 @@ func (m *mockUsersForSSO) FindAdminsByEmail(ctx context.Context) ([]*models.User
 func (m *mockUsersForSSO) SetSuspended(_ context.Context, _ string, _ bool, _ string) error {
 	return nil
 }
+func (m *mockUsersForSSO) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error {
+	return nil
+}
 
 func (m *mockUsersForSSO) Delete(ctx context.Context, id string) error {
 	return nil

--- a/panel-api/internal/userops/userops_suspend_test.go
+++ b/panel-api/internal/userops/userops_suspend_test.go
@@ -23,6 +23,9 @@ func (f *fakeSuspendUsers) SetSuspended(_ context.Context, id string, v bool, re
 	f.lastSetID, f.lastSetVal, f.lastSetReason = id, v, reason
 	return nil
 }
+func (f *fakeSuspendUsers) SetSSHForwardingEnabled(_ context.Context, _ string, _ bool) error {
+	return nil
+}
 
 type fakeSuspendDomains struct {
 	repository.DomainRepository

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -459,6 +459,40 @@ export async function getSSHConnection(): Promise<SSHConnection> {
   return resp.data;
 }
 
+// === SSH TCP forwarding opt-in (GH #1229) ===
+// Off by default keeps the JAB-352 lockdown; opting a user in gives them
+// loopback-only forwarding (enough for VS Code Remote-SSH). Admin-only to flip;
+// a tenant can read their own status. ssh_enabled reflects the package grant —
+// the toggle is moot for a user with no SSH shell.
+export interface SSHForwardingStatus {
+  ssh_forwarding_enabled: boolean;
+  ssh_enabled: boolean;
+}
+
+/** The caller's own SSH-forwarding status (read-only for tenants). */
+export async function getMySSHForwarding(): Promise<SSHForwardingStatus> {
+  const resp = await apiClient.get<SSHForwardingStatus>("/me/ssh-forwarding");
+  return resp.data;
+}
+
+/** Admin: read a user's SSH-forwarding status. */
+export async function getUserSSHForwarding(userId: string): Promise<SSHForwardingStatus> {
+  const resp = await apiClient.get<SSHForwardingStatus>(`/admin/users/${userId}/ssh-forwarding`);
+  return resp.data;
+}
+
+/** Admin: enable/disable a user's SSH forwarding. Returns the new status. */
+export async function setUserSSHForwarding(
+  userId: string,
+  enabled: boolean,
+): Promise<SSHForwardingStatus> {
+  const resp = await apiClient.post<SSHForwardingStatus>(
+    `/admin/users/${userId}/ssh-forwarding`,
+    { enabled },
+  );
+  return resp.data;
+}
+
 // === Cron Jobs API ===
 
 export interface CronJob {

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1285,7 +1285,20 @@
     "update_carefully_especially_system_packages": "Update carefully — especially system packages"
   },
   "adminuseroverview": {
-    "user_not_found": "User not found"
+    "user_not_found": "User not found",
+    "ssh_fwd": {
+      "title": "SSH Forwarding",
+      "label": "Allow SSH TCP forwarding",
+      "note": "Enables the loopback-only forwarding VS Code Remote-SSH needs to reach its VS Code Server. Sensitive services (the panel, mail/DNS admin) stay firewall-blocked, so the user can only forward to their own apps. Takes effect on their next SSH connection.",
+      "no_ssh": "This user's package has no SSH shell access. Enable SSH on the package first — forwarding only applies to shell users.",
+      "confirm_on": "Allow SSH forwarding for this user? This relaxes the default SSH hardening to permit loopback-only forwarding.",
+      "confirm_ok": "Enable",
+      "confirm_cancel": "Cancel",
+      "enabled_toast": "SSH forwarding enabled — VS Code Remote-SSH will work on the user's next connection.",
+      "disabled_toast": "SSH forwarding disabled — the user is back in the default lockdown.",
+      "load_error": "Could not load SSH forwarding status.",
+      "save_error": "Could not update SSH forwarding."
+    }
   },
   "userreset2faaction": {
     "reset": "Reset",
@@ -1734,7 +1747,12 @@
     "save_your_private_key_now": "Save your private key now",
     "search_by_name_or_fingerprint": "Search by name or fingerprint",
     "this_is_the_only_time_the_private_key_will_b": "This is the only time the private key will be shown.",
-    "yes": "Yes"
+    "yes": "Yes",
+    "ssh_fwd": {
+      "title": "SSH Forwarding (VS Code Remote-SSH)",
+      "on": "Enabled. VS Code Remote-SSH can forward to its own server. Only loopback (127.0.0.1) forwarding is allowed; sensitive services stay blocked.",
+      "off": "Disabled. VS Code Remote-SSH needs SSH port forwarding, which is off by default for security — ask your administrator to enable SSH forwarding for your account."
+    }
   },
   "dnsrecordspage": {
     "no_dns_records_yet": "No DNS records yet",

--- a/panel-ui/src/shells/admin/users/AdminSSHForwardingCard.tsx
+++ b/panel-ui/src/shells/admin/users/AdminSSHForwardingCard.tsx
@@ -1,0 +1,102 @@
+// AdminSSHForwardingCard — admin control for a user's SSH TCP forwarding
+// opt-in (GH #1229). Off by default keeps the JAB-352 lockdown; turning it on
+// gives the user loopback-only forwarding, which VS Code Remote-SSH needs to
+// reach its own VS Code Server. Sensitive loopback services stay firewall-
+// blocked regardless, so an opted-in user can only forward to their own apps.
+//
+// Admin-only surface: relaxing a hardening control is an operator decision. The
+// matching read-only status shows on the tenant's own SSH Keys page.
+import { Alert, Card, Space, Spin, Switch, Typography } from "antd";
+import { useTranslation } from "react-i18next";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { ApiOutlined } from "@icons";
+import { feedback } from "../../../lib/feedback";
+import { getUserSSHForwarding, setUserSSHForwarding } from "../../../apiClient";
+
+export function AdminSSHForwardingCard({ userId }: { userId: string }) {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+
+  const statusQ = useQuery({
+    queryKey: ["admin-user-ssh-forwarding", userId],
+    queryFn: () => getUserSSHForwarding(userId),
+    enabled: userId !== "",
+  });
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) => setUserSSHForwarding(userId, enabled),
+    onSuccess: (data) => {
+      qc.setQueryData(["admin-user-ssh-forwarding", userId], data);
+      feedback.message.success(
+        data.ssh_forwarding_enabled
+          ? t("adminuseroverview.ssh_fwd.enabled_toast")
+          : t("adminuseroverview.ssh_fwd.disabled_toast"),
+      );
+    },
+    onError: () => feedback.message.error(t("adminuseroverview.ssh_fwd.save_error")),
+  });
+
+  const title = (
+    <span>
+      <ApiOutlined /> {t("adminuseroverview.ssh_fwd.title")}
+    </span>
+  );
+
+  if (statusQ.isLoading) {
+    return (
+      <Card size="small" title={title}>
+        <Spin />
+      </Card>
+    );
+  }
+  if (statusQ.isError || !statusQ.data) {
+    return (
+      <Card size="small" title={title}>
+        <Alert type="error" showIcon message={t("adminuseroverview.ssh_fwd.load_error")} />
+      </Card>
+    );
+  }
+
+  const { ssh_forwarding_enabled: enabled, ssh_enabled: sshEnabled } = statusQ.data;
+
+  // Package grants no SSH shell — the toggle is moot. Explain instead of
+  // offering a switch the admin can flip to no effect.
+  if (!sshEnabled) {
+    return (
+      <Card size="small" title={title}>
+        <Typography.Text type="secondary">
+          {t("adminuseroverview.ssh_fwd.no_ssh")}
+        </Typography.Text>
+      </Card>
+    );
+  }
+
+  // The Switch is controlled by server state (statusQ.data), so it only flips
+  // after a successful save. Turning it ON confirms first (it relaxes the
+  // hardening); turning it OFF tightens, so it applies immediately.
+  const onChange = (next: boolean) => {
+    if (next) {
+      feedback.modal.confirm({
+        title: t("adminuseroverview.ssh_fwd.confirm_on"),
+        okText: t("adminuseroverview.ssh_fwd.confirm_ok"),
+        cancelText: t("adminuseroverview.ssh_fwd.confirm_cancel"),
+        onOk: () => mutation.mutate(true),
+      });
+    } else {
+      mutation.mutate(false);
+    }
+  };
+
+  return (
+    <Card size="small" title={title}>
+      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+        <Space>
+          <Switch checked={enabled} loading={mutation.isPending} onChange={onChange} />
+          <Typography.Text strong>{t("adminuseroverview.ssh_fwd.label")}</Typography.Text>
+        </Space>
+        <Alert type="info" showIcon message={t("adminuseroverview.ssh_fwd.note")} />
+      </Space>
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
+++ b/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
@@ -43,6 +43,7 @@ import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { adminLinks, ownerCrumbs, ownerLabel } from "../../../components/admin/entityLinks";
 import { startImpersonation } from "../../../impersonation";
 import { UserLimitsCard } from "./UserLimitsCard";
+import { AdminSSHForwardingCard } from "./AdminSSHForwardingCard";
 
 type AdminUser = {
   id: string;
@@ -229,6 +230,12 @@ export function AdminUserOverview() {
       {!user.is_admin && (
         <div style={{ marginTop: 24 }}>
           <UserLimitsCard userId={id} />
+        </div>
+      )}
+
+      {!user.is_admin && (
+        <div style={{ marginTop: 24 }}>
+          <AdminSSHForwardingCard userId={id} />
         </div>
       )}
 

--- a/panel-ui/src/shells/user/ssh-keys/UserSSHKeysPage.tsx
+++ b/panel-ui/src/shells/user/ssh-keys/UserSSHKeysPage.tsx
@@ -34,6 +34,7 @@ import {
   createSSHKey,
   deleteSSHKey,
   getSSHConnection,
+  getMySSHForwarding,
   type SSHKey,
 } from "../../../apiClient";
 import { useQuery } from "@tanstack/react-query";
@@ -92,6 +93,15 @@ export const UserSSHKeysPage = () => {
   const { data: conn, isLoading: connLoading } = useQuery({
     queryKey: ["ssh-connection"],
     queryFn: getSSHConnection,
+    retry: false,
+  });
+
+  // Read-only SSH-forwarding status (GH #1229). VS Code Remote-SSH needs
+  // forwarding, which is off by default (JAB-352 lockdown) and only an admin
+  // can enable per user — so this is display + guidance, not a control.
+  const { data: fwd } = useQuery({
+    queryKey: ["me-ssh-forwarding"],
+    queryFn: getMySSHForwarding,
     retry: false,
   });
 
@@ -281,6 +291,20 @@ export const UserSSHKeysPage = () => {
       )}
       {connLoading && !conn && (
         <Card loading style={{ marginBottom: 16 }} />
+      )}
+
+      {fwd?.ssh_enabled && (
+        <Alert
+          type={fwd.ssh_forwarding_enabled ? "success" : "info"}
+          showIcon
+          style={{ marginBottom: 16 }}
+          title={<strong>{t("usersshkeyspage.ssh_fwd.title")}</strong>}
+          description={
+            fwd.ssh_forwarding_enabled
+              ? t("usersshkeyspage.ssh_fwd.on")
+              : t("usersshkeyspage.ssh_fwd.off")
+          }
+        />
       )}
 
       <Card>


### PR DESCRIPTION
## Summary

GH #1229 — VS Code Remote-SSH broke under the JAB-352 sandbox lockdown, which
disables all SSH forwarding for `jabali-ssh-sandbox` users. The v1 fix added a
CLI opt-in (`jabali user ssh-forwarding`) backed by `jabali-ssh-forward` group
membership, but that state was **not durable** (it reverted to OFF on user
reprovision) and had **no UI**. The reporter asked for a UI toggle.

This completes the design in `plans/gh1229`:

- **Durable per-user flag** `users.ssh_forwarding_enabled` (migration 000275,
  TINYINT, default OFF). The SSH reconciler converges `jabali-ssh-forward`
  membership from the flag, so the opt-in survives reprovision. The flag is
  folded into the reconcile idempotency hash so a toggle actually re-dispatches.
- **API**: admin `GET`/`POST /admin/users/:id/ssh-forwarding` (admin-only,
  audited) + tenant `GET /me/ssh-forwarding` (read-only status). Dedicated repo
  setter avoids the Select-allowlist drop.
- **UI**: admin "SSH Forwarding" toggle on the user overview (confirm-on-enable,
  security note, hidden when the package has no SSH shell); read-only status +
  guidance on the tenant SSH Keys page.
- **CLI fix**: the v1 CLI wrote only the OS group, never the flag — so once the
  reconciler converges from the flag it would strip a CLI-only opt-in within one
  re-dispatch interval. The CLI now writes the flag as the source of truth, then
  applies immediately.

Admin-only to flip — relaxing a hardening control is an operator decision. The
per-uid firewall drop on the sensitive loopback services is unchanged, so an
opted-in user can still only forward to their own apps + the VS Code Server.

## Test plan

- Unit/integration (all green): reconciler converge (join/leave by flag, non-SSH
  always leaves), API handler (admin round-trip, non-admin 403, non-hosting-user
  422, tenant read), openapi + cli-reference goldens, repository insert.
- `go vet ./panel-api/...`, full api/reconciler/repository/cmd-server/sso/
  middleware/userops suites; SPA `tsc -b` + `vite build`.
- **Live box drill (jabalitest):**
  - Migration 000275 applied clean (`tinyint(1) NO default 0`, not dirty).
  - CLI enable → flag `0→1`, joins group, `sshd allowtcpforwarding no→local`,
    `permitopen 127.0.0.1:* [::1]:*`.
  - Reprovision durability: drop from group (flag stays) → restart → reconciler
    rebuilds membership from the flag.
  - Firewall invariant: `skuid≥1000` still drops the sensitive set
    (`631,5300,6060,7422,8081,8443,8446,8462,18181`, v4+v6) for the opted-in
    user; `:3306` reachable.
  - CLI disable → flag `1→0`, leaves group, forwarding back to `no`.

## Upgrade note

Any user opted-in via the v1 CLI before this deploys resets to OFF on the first
reconcile (the flag defaults 0). Fail-closed and intended for a hardening
control — re-enable once via the toggle or the (now flag-writing) CLI after
updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
