### PR TITLE
fix(ftp): idempotent jail teardown skips umount2 when the mountpoint is absent (GH #1226)

### DIFF
--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -392,26 +392,47 @@ func ftpEnsureJailHandler(ctx context.Context, params json.RawMessage) (any, err
 // reason we abort WITHOUT removing — a stranded empty jail is recoverable by
 // the reconciler; a RemoveAll that recurses through a live bind mount would
 // delete the tenant's real files.
+// ftpJailUnmount is the umount2(2) seam for teardownIsolatedJail — a package var
+// so a test can drive the unprivileged-container errno (EPERM) without root.
+var ftpJailUnmount = syscall.Unmount
+
 func teardownIsolatedJail(ctx context.Context, jailPath string) *agentwire.AgentError {
 	if jailPath == "" {
 		return nil
 	}
 	mountpoint := filepath.Join(jailPath, ftpJailMountpoint)
-	// MNT_DETACH: lazy unmount removes the mount from the tree immediately
-	// (new lookups see the underlying empty dir) even if a session holds it,
-	// so the subsequent RemoveAll cannot descend into the source.
-	for {
-		err := syscall.Unmount(mountpoint, syscall.MNT_DETACH)
-		if err == nil {
-			continue // detached one layer; loop for any stacked binds
+	// Existence guard (GH #1226 / Nightly CI). A bind mount can only exist on a
+	// mountpoint that EXISTS, so an absent mountpoint means there is nothing to
+	// unmount — and we must not issue umount2() on it: an unprivileged caller
+	// (a CI container without CAP_SYS_ADMIN) gets EPERM, not ENOENT, because the
+	// kernel checks the capability before the path, turning this idempotent
+	// teardown into a hard failure. This is a pure EXISTENCE check on a fixed
+	// path — NOT the unreliable "is it mounted" stat-probe the blind loop below
+	// deliberately avoids: a mountpoint that EXISTS is still unmounted blind, so
+	// the same-device data-safety invariant is untouched.
+	switch _, statErr := os.Lstat(mountpoint); {
+	case statErr == nil:
+		// MNT_DETACH: lazy unmount removes the mount from the tree immediately
+		// (new lookups see the underlying empty dir) even if a session holds
+		// it, so the subsequent RemoveAll cannot descend into the source.
+		for {
+			err := ftpJailUnmount(mountpoint, syscall.MNT_DETACH)
+			if err == nil {
+				continue // detached one layer; loop for any stacked binds
+			}
+			// EINVAL = not a mountpoint (anymore); ENOENT = it vanished mid-
+			// teardown. Both mean "nothing mounted here" — safe to remove.
+			if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOENT) {
+				break
+			}
+			return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unmount jail %q: %v", mountpoint, err)}
 		}
-		// EINVAL = not a mountpoint (anymore); ENOENT = the mountpoint/jail
-		// doesn't exist at all (e.g. teardown of a legacy account, or a
-		// double teardown). Both mean "nothing mounted here" — safe to remove.
-		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOENT) {
-			break
-		}
-		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unmount jail %q: %v", mountpoint, err)}
+	case errors.Is(statErr, os.ErrNotExist):
+		// Mountpoint absent — nothing mounted. Fall through to RemoveAll, which
+		// is itself a no-op when jailPath is also absent (the common idempotent
+		// "delete an account that was never provisioned" path).
+	default:
+		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("stat jail mountpoint %q: %v", mountpoint, statErr)}
 	}
 	if err := os.RemoveAll(jailPath); err != nil {
 		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove jail %q: %v", jailPath, err)}

--- a/panel-agent/internal/commands/ftp_account_jail_test.go
+++ b/panel-agent/internal/commands/ftp_account_jail_test.go
@@ -187,3 +187,52 @@ func TestTeardownIsolatedJailPreservesSourceOnSameFs(t *testing.T) {
 		t.Fatalf("SOURCE DATA DELETED by teardown — marker gone: %v", err)
 	}
 }
+
+// TestTeardownIsolatedJail_AbsentMountpointSkipsUnmount is the GH #1226 / Nightly
+// regression: tearing down an account that was never provisioned (absent jail)
+// must be idempotent success WITHOUT issuing umount2(). On a real host that
+// syscall returns ENOENT and the old EINVAL/ENOENT branch swallowed it, but in an
+// unprivileged CI container (no CAP_SYS_ADMIN) the kernel checks the capability
+// before the path and returns EPERM, which fell through to a hard failure. The
+// existence guard skips the syscall entirely when the mountpoint is absent, so
+// this passes at any privilege level. Uses the seam to PROVE the syscall is never
+// issued (a privileged local run would otherwise mask the regression).
+func TestTeardownIsolatedJail_AbsentMountpointSkipsUnmount(t *testing.T) {
+	calls := 0
+	orig := ftpJailUnmount
+	t.Cleanup(func() { ftpJailUnmount = orig })
+	ftpJailUnmount = func(string, int) error { calls++; return syscall.EPERM }
+
+	// Jail (and therefore its "data" mountpoint) does not exist.
+	jail := filepath.Join(t.TempDir(), "bob", "nosuchacct")
+	if aerr := teardownIsolatedJail(context.Background(), jail); aerr != nil {
+		t.Fatalf("absent teardown must be idempotent success, got %v", aerr)
+	}
+	if calls != 0 {
+		t.Fatalf("umount2() must NOT be issued for an absent mountpoint; called %d times", calls)
+	}
+}
+
+// TestTeardownIsolatedJail_PresentPathSurfacesUnmountError proves the existence
+// guard did NOT weaken the data-safety invariant: when the mountpoint EXISTS and
+// the unmount fails for a reason other than EINVAL/ENOENT, teardown must surface
+// the error and must NOT RemoveAll (a RemoveAll through a still-live bind mount
+// would delete tenant data). Driven through the seam so it needs no privilege.
+func TestTeardownIsolatedJail_PresentPathSurfacesUnmountError(t *testing.T) {
+	orig := ftpJailUnmount
+	t.Cleanup(func() { ftpJailUnmount = orig })
+	ftpJailUnmount = func(string, int) error { return syscall.EPERM }
+
+	jail := filepath.Join(t.TempDir(), "jail")
+	mp := filepath.Join(jail, ftpJailMountpoint)
+	if err := os.MkdirAll(mp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aerr := teardownIsolatedJail(context.Background(), jail)
+	if aerr == nil {
+		t.Fatal("present mountpoint with a failing unmount must surface an error, got nil")
+	}
+	if _, err := os.Stat(jail); err != nil {
+		t.Fatalf("jail must be preserved when unmount fails (RemoveAll must not run): stat err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

GH #1226 (diagnosed via the Nightly failure, not the reporter's mail/file issue — see note). `teardownIsolatedJail` unmounts blind and tolerated only `EINVAL`/`ENOENT`, so tearing down an **absent** account relied on `umount2()` returning `ENOENT`. That holds on a privileged host, but in an **unprivileged CI container** (no `CAP_SYS_ADMIN`) the kernel checks the capability before the path and returns **`EPERM`**, which fell through to a hard `unmount jail %q` failure.

That is why the **Nightly** job's `TestFtpAccountDelete_AbsentIsIdempotent` has been red since **#1179** (`fix(security): fail-closed FTP disable`, JAB-259) promoted the previously-swallowed teardown error into a hard failure. **Production is unaffected** — the agent holds `CAP_SYS_ADMIN` and gets `ENOENT`.

## Fix

Add an **existence guard**: a bind mount can only exist on a mountpoint that exists, so an absent mountpoint means there is nothing to unmount → skip the privileged syscall entirely, then `RemoveAll` (a no-op for an absent jail). This is a pure existence check on a fixed path — **not** the unreliable "is it mounted" stat-probe the blind loop deliberately avoids (the same-device data-loss scar). A mountpoint that **exists** is still unmounted blind, so the data-safety invariant is untouched.

Introduces a `ftpJailUnmount` seam so the tests are privilege-independent.

## Test plan

- `TestTeardownIsolatedJail_AbsentMountpointSkipsUnmount` — absent path returns idempotent success and the unmount syscall is **never issued** (seam call count 0); would fail pre-fix in a capless container, passes at any privilege now.
- `TestTeardownIsolatedJail_PresentPathSurfacesUnmountError` — a present mountpoint whose unmount fails still surfaces the error and does **not** `RemoveAll` (the data-safety guard survives the refactor).
- `TestFtpAccountDelete_AbsentIsIdempotent` (the Nightly test) now passes.
- `TestTeardownIsolatedJailPreservesSourceOnSameFs` (root-gated bind-mount safety test) unchanged.
- Full `panel-agent/internal/commands` package green; `go vet` clean.

## Notes

- This closes the CI half of #1226. The reporter's two other parts are separate: Bulwark showing the migration date is **upstream** (bulwarkmail/webmail#891), and file **birthtime** ("creation date") isn't settable on Linux (mtime is already preserved by the migration's `rsync -aH`).
- **Nightly has no failure notification** — it ran red 9 nights silently. Wiring a failure step to the existing ntfy topic is a worthwhile follow-up (offered separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
