### PR TITLE
fix(migration): imported mail received-date from the Maildir filename, not file mtime (GH #1226)

### DIFF
--- a/panel-agent/internal/commands/maildir_flags_test.go
+++ b/panel-agent/internal/commands/maildir_flags_test.go
@@ -3,7 +3,42 @@ package commands
 import (
 	"reflect"
 	"testing"
+	"time"
 )
+
+// TestMaildirDeliveryTime — GH #1226: the received date must come from the
+// Maildir filename's leading delivery timestamp (canonical, survives an mtime
+// rewrite during migration), and must fall back (return false) when the head is
+// not a plausible unix time so the caller keeps the file mtime.
+func TestMaildirDeliveryTime(t *testing.T) {
+	const sec int64 = 1650000000 // 2022-04-15, comfortably in range
+	cases := []struct {
+		name string
+		want int64 // expected unix seconds; -1 = expect ok==false
+	}{
+		{"1650000000.M123456P789.mail.example:2,S", sec}, // Dovecot cur
+		{"1650000000.12345.host", sec},                   // qmail-style new
+		{"1650000000.abcXYZ", sec},                       // minimal
+		{"1650000000", sec},                              // bare numeric, no dot
+		{"Mabcdef.P1.host", -1},                          // non-numeric head
+		{"0.unique.host", -1},                            // below the 1990 floor
+		{"99999999999.unique.host", -1},                  // absurd future
+		{"", -1},                                         // empty
+	}
+	for _, c := range cases {
+		got, ok := maildirDeliveryTime(c.name)
+		if c.want == -1 {
+			if ok {
+				t.Errorf("maildirDeliveryTime(%q) = (%v, true), want ok=false", c.name, got)
+			}
+			continue
+		}
+		if !ok || !got.Equal(time.Unix(c.want, 0).UTC()) {
+			t.Errorf("maildirDeliveryTime(%q) = (%v, %v), want (%v, true)",
+				c.name, got, ok, time.Unix(c.want, 0).UTC())
+		}
+	}
+}
 
 // TestKeywordsToMaildirFlags — export side: JMAP keywords → sorted
 // Maildir info-flag letters (D,F,R,S order). Regression for the

--- a/panel-agent/internal/commands/migration_import_mailboxes.go
+++ b/panel-agent/internal/commands/migration_import_mailboxes.go
@@ -11,7 +11,8 @@
 //     a. POST raw bytes to /jmap/upload → blobId
 //     b. Email/import with blobId + mailboxIds:{<inbox>:true} +
 //     keywords:{$seen:true for cur/, none for new/} +
-//     receivedAt parsed from Maildir filename
+//     receivedAt from the Maildir filename's delivery timestamp (GH #1226),
+//     falling back to the file mtime when the filename has no usable time
 //  4. Record bytes + count in MailboxImportResult
 //
 // Idempotent on resume: pushMaildirSlots skips any message whose
@@ -37,6 +38,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -395,7 +397,15 @@ func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string,
 					keywords["$seen"] = true
 				}
 			}
-			n, err := importOneMessage(ctx, accountID, mailboxID, path, info.Size(), keywords, info.ModTime(), allowedRoots)
+			// GH #1226: prefer the Maildir filename's delivery timestamp (the
+			// canonical received time) over the file mtime, which a migration
+			// copy can rewrite to "now". Fall back to mtime when the filename
+			// carries no usable time.
+			receivedAt := info.ModTime()
+			if t, ok := maildirDeliveryTime(e.Name()); ok {
+				receivedAt = t
+			}
+			n, err := importOneMessage(ctx, accountID, mailboxID, path, info.Size(), keywords, receivedAt, allowedRoots)
 			if err != nil {
 				skipped = append(skipped, fmt.Sprintf("%s: %v", path, err))
 				continue
@@ -427,6 +437,35 @@ func maildirInfoFlags(name string) (string, bool) {
 		return "", false
 	}
 	return name[i+3:], true
+}
+
+// maildirDeliveryTimeFloor is 1990-01-01T00:00:00Z — a sanity floor so a
+// malformed filename whose leading segment isn't really a timestamp (a huge
+// unique-id, or 0) can't stamp an absurd received date.
+const maildirDeliveryTimeFloor = 631152000
+
+// maildirDeliveryTime extracts the delivery (received) time encoded at the head
+// of a Maildir filename. Every Maildir name begins with the unix delivery time
+// in whole seconds ("<sec>.<unique>.<host>", or Dovecot's "<sec>.M<usec>P<pid>…");
+// a "cur" file's trailing ":2,<flags>" does not affect the head. GH #1226: this
+// is the canonical received time — more authoritative than the file mtime (which
+// a copy/rsync/tool can rewrite, the exact way a migration loses it) and than the
+// sender-supplied "Date:" header (unauthenticated). Returns (t, true) only when
+// the leading segment parses to a plausible unix time; a non-numeric head or an
+// out-of-range value returns false so the caller falls back to the file mtime.
+func maildirDeliveryTime(name string) (time.Time, bool) {
+	head := name
+	if i := strings.IndexByte(head, '.'); i >= 0 {
+		head = head[:i]
+	}
+	sec, err := strconv.ParseInt(head, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if sec < maildirDeliveryTimeFloor || sec > time.Now().Add(24*time.Hour).Unix() {
+		return time.Time{}, false
+	}
+	return time.Unix(sec, 0).UTC(), true
 }
 
 // maildirFlagsToKeywords maps Maildir info-flag letters to JMAP keywords


### PR DESCRIPTION
## Summary

GH #1226 (mail side). The Maildir importer set Stalwart's `receivedAt` (INTERNALDATE) from the message **file's mtime** (`migration_import_mailboxes.go`). That's only correct as long as every migration copy step preserves mtime — and it's fragile: anything that rewrites it stamps the migration time, and it's the wrong source of truth for "received" anyway.

The Maildir filename already carries the **canonical delivery timestamp** as its leading unix-seconds segment (`<sec>.<unique>.<host>`, Dovecot `<sec>.M<usec>P<pid>…`, `:2,<flags>` on `cur`). The file's own header comment even claimed this is what we used. This change makes it true:

- Parse the leading timestamp and use it as `receivedAt`, **falling back to the file mtime** when the filename has no usable time.
- Bounded to a sane `1990-01-01 .. now+1d` window so a malformed name (a huge unique-id, a `0`, an absurd future value) can't stamp a nonsense date — out-of-range ⇒ fall back to mtime.

More authoritative than mtime (rewritable, the exact way a migration loses it) and than the sender-supplied `Date:` header (unauthenticated).

## Test plan

- `TestMaildirDeliveryTime` — table over Dovecot/qmail/minimal/bare-numeric names (parsed) and non-numeric / below-floor / absurd-future / empty (fall back). Passes.
- Full `panel-agent/internal/commands` package green; `go vet` + gofmt clean.

## Notes

- Hardens our side only. The reporter's **Bulwark webmail** showing the migration date is a separate **upstream** issue (bulwarkmail/webmail#891) — Thunderbird already showed correct dates because INTERNALDATE was right. This makes the received date robust even if a future migration path clobbers mtime.
- The non-mail file half of #1226 is a Linux limitation (birthtime isn't settable; mtime is already preserved by the migration's `rsync -aH`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
