### PR TITLE
fix(nightly): submit failure email via mx1.reeva.me (cert-valid host)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -139,7 +139,7 @@ jobs:
           printf 'user = "%s:%s"\n' "$from" "$SMTP_PASSWORD" > curlrc
           trap 'rm -f curlrc' EXIT
           curl --fail --show-error --silent --ssl-reqd \
-            --url "smtps://mx.jabali-panel.com:465" \
+            --url "smtps://mx1.reeva.me:465" \
             --config curlrc \
             --mail-from "$from" \
             --mail-rcpt "$to" \


### PR DESCRIPTION
#1335 pointed the notify job at `mx.jabali-panel.com:465`, which wildcards to the panel box and serves a `mail.jabali.site` cert → TLS hostname mismatch (`curl (60)`). jabali-panel.com mail is on **reeva** (MX `mx1/mx2.reeva.me`); `mx1.reeva.me:465` offers submission with a `*.reeva.me` cert. **Test-fired** via `workflow_dispatch` with a forced-fail — the alert delivered to `webmaster@jabali-panel.com` (verified in reeva webmail).

One-line host change; the rest of the notify job is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)