### PR TITLE
feat(db): chunked async Restore-from-file upload (beats Cloudflare 100MB/524) (GH #1323)

### DIFF
--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -63,6 +63,10 @@ func RegisterDatabaseRoutes(g *gin.RouterGroup, cfg DatabaseHandlerConfig) {
 	databases.DELETE("/:id", h.delete)
 	databases.GET("/:id/backup", h.backup)
 	databases.POST("/:id/restore", h.restore)
+	// GH #1323: chunked restore upload (beats the Cloudflare 100 MB request cap).
+	databases.POST("/:id/restore-chunk", h.restoreChunk)
+	databases.GET("/:id/restore-chunk-status", h.restoreChunkStatus)
+	databases.GET("/:id/restore-status", h.restoreStatus)
 }
 
 type databaseHandler struct{ cfg DatabaseHandlerConfig }
@@ -647,10 +651,10 @@ func (h *databaseHandler) restore(c *gin.Context) {
 
 	// Generate restore file path
 	ul := ids.NewULID()
-	restorePath := fmt.Sprintf("/var/lib/jabali/restore/%s.sql", ul)
+	restorePath := filepath.Join(restoreRoot, ul+".sql")
 
 	// Create restore directory if needed
-	if err := createDir("/var/lib/jabali/restore"); err != nil {
+	if err := createDir(restoreRoot); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
@@ -661,19 +665,21 @@ func (h *databaseHandler) restore(c *gin.Context) {
 		return
 	}
 
-	// Call agent to restore the database
-	if h.cfg.Agent == nil {
-		_ = deleteFile(restorePath)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
+	// GH #1323: the single-upload and chunked-restore finalize share the same
+	// detached agent-restore + cleanup + response.
+	h.runDatabaseRestore(c, ctx, d, restorePath)
+}
 
-	// GH #1044: detach from the request context so a client disconnect (closed
-	// tab, network blip) mid-restore does NOT cancel the agent call — at up to
-	// restoreAgentTimeout the disconnect window is real, and aborting MariaDB's
-	// pipe-into-mysql mid-load would leave the database half-restored (Postgres'
-	// load-then-swap #1205 is safe either way). The restore outlives the
-	// messenger, exactly as the async backup-restore path does.
+// doDatabaseRestore loads an already-staged dump at restorePath into d and
+// returns nil on success or the agent error. It detaches from the passed context
+// so a client disconnect (closed tab, network blip) mid-restore does NOT cancel
+// the agent call — at up to restoreAgentTimeout the disconnect window is real, and
+// aborting MariaDB's pipe-into-mysql mid-load would leave the database
+// half-restored (Postgres' load-then-swap #1205 is safe either way). Deletes
+// restorePath on failure (the agent also cleans up). Shared by the synchronous
+// single-upload path (runDatabaseRestore) and the asynchronous chunked-restore
+// finalize (GH #1323); the caller must have verified h.cfg.Agent != nil.
+func (h *databaseHandler) doDatabaseRestore(ctx context.Context, d *models.Database, restorePath string) error {
 	agentCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreAgentTimeout)
 	defer cancel()
 
@@ -688,14 +694,26 @@ func (h *databaseHandler) restore(c *gin.Context) {
 		restoreParams["owner_role"] = ownerRole
 		restoreParams["grant_roles"] = grantRoles
 	}
-	_, err = h.cfg.Agent.Call(agentCtx, restoreCmd, restoreParams)
-	if err != nil {
-		// Agent cleanup the file on failure, but delete it here too just in case
+	if _, err := h.cfg.Agent.Call(agentCtx, restoreCmd, restoreParams); err != nil {
 		_ = deleteFile(restorePath)
+		return err
+	}
+	return nil
+}
+
+// runDatabaseRestore is the SYNCHRONOUS single-upload wrapper: it runs the restore
+// and writes the final HTTP response (204 or an agent error). The chunked path
+// (GH #1323) calls doDatabaseRestore directly from a detached goroutine instead.
+func (h *databaseHandler) runDatabaseRestore(c *gin.Context, ctx context.Context, d *models.Database, restorePath string) {
+	if h.cfg.Agent == nil {
+		_ = deleteFile(restorePath)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if err := h.doDatabaseRestore(ctx, d, restorePath); err != nil {
 		respondAgentErr(c, "agent_failed", err)
 		return
 	}
-
 	c.Status(http.StatusNoContent)
 }
 

--- a/panel-api/internal/api/databases_restore_chunk.go
+++ b/panel-api/internal/api/databases_restore_chunk.go
@@ -1,0 +1,361 @@
+package api
+
+// GH #1323 — chunked "Restore from file" upload with async finalize.
+//
+// The single-request restore 413s at Cloudflare (Free plan caps request bodies at
+// 100 MB) before it reaches the panel. The File Manager already uploads >100 MB
+// files as sequential 10 MB chunks; this brings the same to database restore.
+//
+// Each chunk is a plain octet-stream POST appended at `offset` into a
+// PANEL-CONTROLLED staging file (never a tenant-influenced path). The staging path
+// is derived from the AUTHENTICATED user id + the client upload_id, so one tenant
+// can never target another's staging file even if they learn the id.
+//
+// FINALIZE IS ASYNC. A large dump can restore for minutes; holding the final
+// chunk's connection through the load would trip Cloudflare's ~100 s origin
+// timeout (524) even though every request is now chunk-sized. So `final=1`
+// assembles the dump, kicks the restore on a DETACHED goroutine, records the
+// outcome to a marker keyed by upload_id, and returns 202 immediately — the client
+// polls GET /restore-status until done/failed.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// restoreRoot is where restore dumps (and, under staging/, partial chunked
+// uploads + outcome markers) are written. A var, not a const, so tests can point
+// it at t.TempDir() — production always uses the fixed path. Shared with the
+// single-upload restore.
+var restoreRoot = "/var/lib/jabali/restore"
+
+// restoreStagingDir holds partial chunked-restore uploads + outcome markers until
+// they age out, under the restore root so it shares the service partition.
+func restoreStagingDir() string { return filepath.Join(restoreRoot, "staging") }
+
+const (
+	// maxInFlightRestoreUploads caps concurrent partial uploads per user so a
+	// tenant can't fill the service partition with never-finalized chunks.
+	maxInFlightRestoreUploads = 2
+	// restoreStagingTTL evicts abandoned partials + terminal outcome markers so
+	// two dead uploads can't permanently 429-lock a user out of chunked restore.
+	restoreStagingTTL = 24 * time.Hour
+)
+
+func restoreUserTag(userID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-user:" + userID))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// restoreChunkStagingPath derives the staging path from the AUTHENTICATED user +
+// the client upload_id (Gitea #426 pattern): the path depends on the server-side
+// userID, so a tenant can never write into or read another tenant's staging file.
+func restoreChunkStagingPath(userID, uploadID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore:" + userID + ":" + uploadID))
+	return filepath.Join(restoreStagingDir(), "ru-"+restoreUserTag(userID)+"-"+hex.EncodeToString(sum[:])+".part")
+}
+
+// restoreOutcomePath is the async-restore result marker for one upload.
+func restoreOutcomePath(userID, uploadID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-outcome:" + userID + ":" + uploadID))
+	return filepath.Join(restoreStagingDir(), "ro-"+restoreUserTag(userID)+"-"+hex.EncodeToString(sum[:])+".json")
+}
+
+func globUserRestoreStaging(userID string) []string {
+	m, _ := filepath.Glob(filepath.Join(restoreStagingDir(), "ru-"+restoreUserTag(userID)+"-*.part"))
+	return m
+}
+
+// evictStaleRestoreStaging removes this user's partials + outcome markers older
+// than restoreStagingTTL, so abandoned uploads can't permanently occupy an
+// in-flight slot or leak disk. Best-effort.
+func evictStaleRestoreStaging(userID string) {
+	patterns := []string{
+		filepath.Join(restoreStagingDir(), "ru-"+restoreUserTag(userID)+"-*.part"),
+		filepath.Join(restoreStagingDir(), "ro-"+restoreUserTag(userID)+"-*.json"),
+	}
+	cutoff := time.Now().Add(-restoreStagingTTL)
+	for _, p := range patterns {
+		matches, _ := filepath.Glob(p)
+		for _, m := range matches {
+			if fi, err := os.Stat(m); err == nil && fi.ModTime().Before(cutoff) {
+				_ = os.Remove(m)
+			}
+		}
+	}
+}
+
+type restoreOutcome struct {
+	Status string `json:"status"` // "restoring" | "done" | "failed"
+	TS     int64  `json:"ts"`
+}
+
+func writeRestoreOutcome(path, status string) {
+	b, _ := json.Marshal(restoreOutcome{Status: status, TS: time.Now().Unix()})
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err == nil {
+		_ = os.Rename(tmp, path) // atomic swap so a poll never sees a torn write
+	}
+}
+
+// loadRestoreDatabase loads the target DB and enforces the same authorization as
+// the single-upload restore (admin: any; user: own). On failure it writes the
+// response and returns ok=false.
+func (h *databaseHandler) loadRestoreDatabase(c *gin.Context) (*models.Database, bool) {
+	d, err := h.cfg.Databases.FindByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
+		return nil, false
+	}
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return nil, false
+	}
+	if !claims.IsAdmin && d.UserID != claims.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return nil, false
+	}
+	return d, true
+}
+
+// clearRequestDeadlines lifts the http.Server's 30 s Read/Write deadlines
+// (serve.go) for this request. Every chunk body read and the finalize response
+// must not be guillotined — a slow uplink can take >30 s to send a 10 MB chunk.
+func clearRequestDeadlines(c *gin.Context) {
+	rc := http.NewResponseController(c.Writer)
+	if err := rc.SetReadDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		slog.DebugContext(c.Request.Context(), "restoreChunk: clear read deadline failed", "err", err)
+	}
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		slog.DebugContext(c.Request.Context(), "restoreChunk: clear write deadline failed", "err", err)
+	}
+}
+
+// restoreChunkStatus handles GET /databases/:id/restore-chunk-status?upload_id=…
+// It returns how many bytes of the staging file have landed, so the client can
+// resume an interrupted upload from the right offset.
+func (h *databaseHandler) restoreChunkStatus(c *gin.Context) {
+	if _, ok := h.loadRestoreDatabase(c); !ok {
+		return
+	}
+	claims := ginctx.Claims(c)
+	uploadID := c.Query("upload_id")
+	if uploadID == "" || strings.ContainsAny(uploadID, "/\\.") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	var written int64
+	if fi, err := os.Stat(restoreChunkStagingPath(claims.UserID, uploadID)); err == nil && fi.Mode().IsRegular() {
+		written = fi.Size()
+	}
+	c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "written": written})
+}
+
+// restoreStatus handles GET /databases/:id/restore-status?upload_id=… — the
+// async-finalize poll target. Returns {status: restoring|done|failed}.
+func (h *databaseHandler) restoreStatus(c *gin.Context) {
+	if _, ok := h.loadRestoreDatabase(c); !ok {
+		return
+	}
+	claims := ginctx.Claims(c)
+	uploadID := c.Query("upload_id")
+	if uploadID == "" || strings.ContainsAny(uploadID, "/\\.") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	b, err := os.ReadFile(restoreOutcomePath(claims.UserID, uploadID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "unknown_upload"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	var o restoreOutcome
+	if json.Unmarshal(b, &o) != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	// A "restoring" marker older than the restore ceiling means the worker died
+	// (panel restart) — report failed so the client stops polling forever.
+	if o.Status == "restoring" && time.Since(time.Unix(o.TS, 0)) > restoreAgentTimeout {
+		o.Status = "failed"
+	}
+	c.JSON(http.StatusOK, gin.H{"status": o.Status})
+}
+
+// restoreChunk handles POST /databases/:id/restore-chunk?upload_id=…&offset=…[&final=1].
+// The body is a raw octet-stream chunk appended at `offset`. On `final=1` the
+// assembled dump is restored ASYNCHRONOUSLY (see file header).
+func (h *databaseHandler) restoreChunk(c *gin.Context) {
+	d, ok := h.loadRestoreDatabase(c)
+	if !ok {
+		return
+	}
+	claims := ginctx.Claims(c)
+	// A slow uplink can take >30 s to stream a 10 MB chunk; lift the server's
+	// Read/Write deadlines for the whole request so a chunk (or the finalize) is
+	// never guillotined mid-body.
+	clearRequestDeadlines(c)
+
+	uploadID := c.Query("upload_id")
+	offsetStr := c.Query("offset")
+	isFinal := c.Query("final") == "1"
+	if uploadID == "" || offsetStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing_upload_params"})
+		return
+	}
+	if strings.ContainsAny(uploadID, "/\\.") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	var offset int64
+	if _, err := fmt.Sscanf(offsetStr, "%d", &offset); err != nil || offset < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_offset"})
+		return
+	}
+	if err := createDir(restoreStagingDir()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	tmpPath := restoreChunkStagingPath(claims.UserID, uploadID)
+	maxUploadSize := h.resolveMaxRestoreBytes(c.Request.Context())
+
+	// New upload (offset 0, no staging yet): evict this user's stale partials,
+	// then enforce the per-user in-flight cap.
+	if offset == 0 {
+		if _, statErr := os.Stat(tmpPath); errors.Is(statErr, os.ErrNotExist) {
+			evictStaleRestoreStaging(claims.UserID)
+			if len(globUserRestoreStaging(claims.UserID)) >= maxInFlightRestoreUploads {
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "too_many_uploads"})
+				return
+			}
+		}
+	}
+
+	// O_EXCL on the first chunk (fresh session); later chunks require the file to
+	// exist and the offset to equal its current size — no holes, no mid-file
+	// overwrite, no cross-session injection.
+	openFlags := os.O_WRONLY
+	if offset == 0 {
+		openFlags |= os.O_CREATE | os.O_EXCL
+	}
+	f, err := os.OpenFile(tmpPath, openFlags, 0o600)
+	if err != nil {
+		if offset == 0 && errors.Is(err, os.ErrExist) {
+			f, err = os.OpenFile(tmpPath, os.O_WRONLY, 0o600) // idempotent first-chunk retry
+		}
+		if err != nil {
+			if offset > 0 && errors.Is(err, os.ErrNotExist) {
+				c.JSON(http.StatusConflict, gin.H{"error": "upload_not_found"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+	}
+	fi, statErr := f.Stat()
+	if statErr != nil {
+		f.Close()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if offset != fi.Size() {
+		f.Close()
+		c.JSON(http.StatusConflict, gin.H{"error": "bad_offset", "expected": fi.Size()})
+		return
+	}
+	if _, err := f.Seek(offset, 0); err != nil {
+		f.Close()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	// Cap the assembled upload at the admin-configured restore limit. LimitReader
+	// bounds the write; the post-write size check rejects an over-cap total. A
+	// copy error truncates back to the last good size (resumable) rather than
+	// deleting the whole staged upload — a slow-link blip must not lose it.
+	written, copyErr := io.Copy(f, io.LimitReader(c.Request.Body, maxUploadSize-offset+1))
+	if cerr := f.Close(); copyErr == nil {
+		copyErr = cerr
+	}
+	if copyErr != nil {
+		_ = os.Truncate(tmpPath, offset)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if offset+written > maxUploadSize {
+		_ = os.Remove(tmpPath)
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+			"error":    "file_too_large",
+			"max_size": fmt.Sprintf("%dMB", maxUploadSize/(1024*1024)),
+			"detail": "Upload exceeds the panel's restore cap (Server Settings → Uploads). " +
+				"A larger request may also be blocked upstream by nginx or Cloudflare.",
+		})
+		return
+	}
+
+	if !isFinal {
+		c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "written": written})
+		return
+	}
+
+	// Final chunk. Need the agent to actually restore.
+	if h.cfg.Agent == nil {
+		_ = os.Remove(tmpPath)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if err := createDir(restoreRoot); err != nil {
+		_ = os.Remove(tmpPath)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	restorePath := filepath.Join(restoreRoot, ids.NewULID()+".sql")
+	if err := os.Rename(tmpPath, restorePath); err != nil {
+		_ = os.Remove(tmpPath)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	// Async: record the outcome and run the restore detached from this request so
+	// the 202 returns immediately (Cloudflare's ~100 s origin timeout can't span a
+	// multi-minute restore). The client polls restore-status. Snapshot everything
+	// the goroutine needs — the request is done once we respond.
+	outcomePath := restoreOutcomePath(claims.UserID, uploadID)
+	writeRestoreOutcome(outcomePath, "restoring")
+	go func() {
+		// context.Background(): fully detached; doDatabaseRestore applies its own
+		// restoreAgentTimeout ceiling.
+		if err := h.doDatabaseRestore(context.Background(), d, restorePath); err != nil {
+			slog.Error("chunked restore failed", "db_id", d.ID, "err", err)
+			writeRestoreOutcome(outcomePath, "failed")
+			return
+		}
+		writeRestoreOutcome(outcomePath, "done")
+	}()
+	c.JSON(http.StatusAccepted, gin.H{"upload_id": uploadID, "status": "restoring"})
+}

--- a/panel-api/internal/api/databases_restore_chunk_test.go
+++ b/panel-api/internal/api/databases_restore_chunk_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1323 — chunked "Restore from file" upload.
+
+func useTempRestoreRoot(t *testing.T) {
+	t.Helper()
+	orig := restoreRoot
+	t.Cleanup(func() { restoreRoot = orig })
+	restoreRoot = t.TempDir()
+}
+
+func TestRestoreChunk_AssembleAndAsyncFinalize(t *testing.T) {
+	useTempRestoreRoot(t)
+	// The restore runs on a detached goroutine; the channel publishes the agent
+	// call race-free (channel receive is the happens-before edge).
+	gotCh := make(chan string, 1)
+	agent := &mockAgent{callFn: func(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+		path := ""
+		if m, ok := params.(map[string]any); ok {
+			path, _ = m["path"].(string)
+		}
+		gotCh <- cmd + "|" + path
+		return json.RawMessage(`{}`), nil
+	}}
+	r, dbRepo := databaseRouterWithAgent("user1", false, agent)
+	dbRepo.databases = []models.Database{{ID: "db1", UserID: "user1", Name: "alice_db", Engine: "mysql"}}
+
+	c1 := []byte("CREATE TABLE t (id INT);\n")
+	c2 := []byte("INSERT INTO t VALUES (1);\n")
+
+	// Chunk 1 (not final).
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/databases/db1/restore-chunk?upload_id=up-abc&offset=0", bytes.NewReader(c1))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Status reflects the bytes staged so far.
+	ws := httptest.NewRecorder()
+	r.ServeHTTP(ws, httptest.NewRequest("GET", "/api/v1/databases/db1/restore-chunk-status?upload_id=up-abc", nil))
+	require.Equal(t, http.StatusOK, ws.Code)
+	var st map[string]any
+	require.NoError(t, json.Unmarshal(ws.Body.Bytes(), &st))
+	assert.Equal(t, float64(len(c1)), st["written"])
+
+	// Chunk 2 (final) → 202 immediately (restore is async).
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/api/v1/databases/db1/restore-chunk?upload_id=up-abc&offset=25&final=1", bytes.NewReader(c2))
+	req2.Header.Set("Content-Type", "application/octet-stream")
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusAccepted, w2.Code)
+	var fin map[string]any
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &fin))
+	assert.Equal(t, "restoring", fin["status"])
+
+	// The detached restore runs the mysql load against the assembled dump.
+	select {
+	case got := <-gotCh:
+		parts := strings.SplitN(got, "|", 2)
+		assert.Equal(t, "db.restore", parts[0])
+		require.Len(t, parts, 2)
+		data, err := os.ReadFile(parts[1])
+		require.NoError(t, err)
+		assert.Equal(t, string(c1)+string(c2), string(data), "assembled dump must be chunk1+chunk2 in order")
+	case <-time.After(3 * time.Second):
+		t.Fatal("detached restore did not call the agent")
+	}
+
+	// restore-status transitions to done.
+	var status string
+	for i := 0; i < 200; i++ {
+		wr := httptest.NewRecorder()
+		r.ServeHTTP(wr, httptest.NewRequest("GET", "/api/v1/databases/db1/restore-status?upload_id=up-abc", nil))
+		if wr.Code == http.StatusOK {
+			var s map[string]any
+			_ = json.Unmarshal(wr.Body.Bytes(), &s)
+			if status, _ = s["status"].(string); status == "done" || status == "failed" {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(t, "done", status)
+}
+
+func TestRestoreStatus_UnknownUpload(t *testing.T) {
+	useTempRestoreRoot(t)
+	r, dbRepo := databaseRouterWithAgent("user1", false, &mockAgent{})
+	dbRepo.databases = []models.Database{{ID: "db1", UserID: "user1", Name: "alice_db"}}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/api/v1/databases/db1/restore-status?upload_id=never", nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRestoreChunk_NonOwnerForbidden(t *testing.T) {
+	useTempRestoreRoot(t)
+	agent := &mockAgent{}
+	r, dbRepo := databaseRouterWithAgent("user2", false, agent) // caller is user2
+	dbRepo.databases = []models.Database{{ID: "db1", UserID: "user1", Name: "alice_db"}}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/databases/db1/restore-chunk?upload_id=up-x&offset=0", bytes.NewReader([]byte("x")))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, 0, agent.callCount, "a forbidden request must never reach the agent")
+}
+
+func TestRestoreChunk_BadOffsetConflict(t *testing.T) {
+	useTempRestoreRoot(t)
+	r, dbRepo := databaseRouterWithAgent("user1", false, &mockAgent{})
+	dbRepo.databases = []models.Database{{ID: "db1", UserID: "user1", Name: "alice_db"}}
+
+	// First chunk establishes 5 bytes.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/databases/db1/restore-chunk?upload_id=up-o&offset=0", bytes.NewReader([]byte("hello")))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// A second chunk at the wrong offset (10, not 5) is rejected — no holes.
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/api/v1/databases/db1/restore-chunk?upload_id=up-o&offset=10", bytes.NewReader([]byte("world")))
+	req2.Header.Set("Content-Type", "application/octet-stream")
+	r.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusConflict, w2.Code)
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2806,6 +2806,53 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /databases/{id}/restore-chunk:
+    post:
+      tags: [Databases]
+      summary: Upload one chunk of a restore dump; final=1 finalizes and restores (GH #1323)
+      description: |
+        Chunked "Restore from file" upload — beats the Cloudflare 100 MB request
+        cap by sending the dump as sequential octet-stream chunks appended at
+        `offset`. `final=1` on the last chunk assembles and runs the restore.
+      security: [ { KratosSession: [] } ]
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+        - { in: query, name: upload_id, required: true, schema: { type: string } }
+        - { in: query, name: offset, required: true, schema: { type: integer } }
+        - { in: query, name: final, required: false, schema: { type: string, enum: ["1"] } }
+      requestBody: { required: true, content: { application/octet-stream: { schema: { type: string, format: binary } } } }
+      responses:
+        "200": { description: Chunk stored, content: { application/json: { schema: { type: object, properties: { upload_id: { type: string }, written: { type: integer } } } } } }
+        "204": { description: Final chunk — restore complete }
+        "413": { description: Over the restore cap, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
+  /databases/{id}/restore-chunk-status:
+    get:
+      tags: [Databases]
+      summary: Bytes already staged for a chunked restore upload — resume point (GH #1323)
+      security: [ { KratosSession: [] } ]
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+        - { in: query, name: upload_id, required: true, schema: { type: string } }
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { type: object, properties: { upload_id: { type: string }, written: { type: integer } } } } } }
+
+  /databases/{id}/restore-status:
+    get:
+      tags: [Databases]
+      summary: Poll the async chunked-restore outcome after final=1 (GH #1323)
+      description: |
+        After the final chunk returns 202 the restore runs detached; the client
+        polls this until status is done or failed (so no request spans Cloudflare's
+        ~100s origin timeout).
+      security: [ { KratosSession: [] } ]
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string } }
+        - { in: query, name: upload_id, required: true, schema: { type: string } }
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { type: object, properties: { status: { type: string, enum: [restoring, done, failed] } } } } } }
+        "404": { description: Unknown upload_id, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
 
   # --- Disclaimer (auto) ---
 

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -299,6 +299,157 @@ export async function restoreDatabaseUpload(
   });
 }
 
+// GH #1323: chunked restore upload. Cloudflare's Free plan rejects any single
+// request body over 100 MB, so a large dump 413s at the edge regardless of the
+// panel's own cap. Above this threshold we upload the dump as sequential 10 MB
+// octet-stream chunks (like the File Manager), reassembled server-side, so no
+// single request approaches 100 MB. Small dumps keep the one-shot multipart path.
+const RESTORE_CHUNK_SIZE = 10 * 1024 * 1024;
+const RESTORE_CHUNK_THRESHOLD = 90 * 1024 * 1024;
+
+function lsGet(k: string): string | null {
+  try {
+    return localStorage.getItem(k);
+  } catch {
+    return null;
+  }
+}
+function lsSet(k: string, v: string): void {
+  try {
+    localStorage.setItem(k, v);
+  } catch {
+    /* private mode / quota — resume is a nicety, not required */
+  }
+}
+function lsDel(k: string): void {
+  try {
+    localStorage.removeItem(k);
+  } catch {
+    /* noop */
+  }
+}
+
+/**
+ * Restore a database from a large dump via chunked upload (GH #1323).
+ * Sends the file as sequential 10 MB octet-stream POSTs to /restore-chunk; the
+ * final chunk (final=1) assembles and runs the restore server-side. Resumable:
+ * an interrupted upload (keyed by db + file identity) reuses the upload_id and
+ * skips ahead to the bytes already staged. `onProgress` reports cumulative
+ * upload across chunks; once it reaches 1 the final request holds for the
+ * server-side restore (the modal shows "Restoring…" then).
+ */
+export async function restoreDatabaseUploadChunked(
+  databaseId: string,
+  file: File,
+  onProgress?: (p: RestoreUploadProgress) => void,
+): Promise<void> {
+  const chunkSize = RESTORE_CHUNK_SIZE;
+  const totalChunks = Math.max(1, Math.ceil(file.size / chunkSize));
+  const resumeKey = `jabali:dbrestore:${databaseId}|${file.name}|${file.size}|${file.lastModified}`;
+  let uploadId = lsGet(resumeKey);
+  let startChunk = 0;
+  if (uploadId) {
+    try {
+      const r = await apiClient.get<{ written: number }>(
+        `/databases/${databaseId}/restore-chunk-status`,
+        { params: { upload_id: uploadId } },
+      );
+      // Round DOWN so a partial chunk is re-sent in full (the server seeks to
+      // the offset before writing, so re-sending is safe).
+      startChunk = Math.floor((r.data.written || 0) / chunkSize);
+    } catch {
+      uploadId = null;
+      lsDel(resumeKey);
+    }
+  }
+  if (!uploadId) {
+    uploadId =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    lsSet(resumeKey, uploadId);
+  }
+
+  const started = Date.now();
+  const report = (loaded: number) => {
+    if (!onProgress) return;
+    const elapsed = (Date.now() - started) / 1000;
+    const rate = elapsed > 0 ? loaded / elapsed : undefined;
+    const estimated = rate && rate > 0 ? (file.size - loaded) / rate : undefined;
+    onProgress({
+      frac: file.size > 0 ? Math.min(1, loaded / file.size) : 1,
+      loaded: Math.min(loaded, file.size),
+      total: file.size,
+      rate,
+      estimated,
+    });
+  };
+  report(startChunk * chunkSize);
+
+  for (let i = startChunk; i < totalChunks; i++) {
+    const start = i * chunkSize;
+    const end = Math.min(start + chunkSize, file.size);
+    const blob = file.slice(start, end);
+    const isLast = i === totalChunks - 1;
+    const params = new URLSearchParams({
+      upload_id: uploadId,
+      offset: String(start),
+      ...(isLast ? { final: "1" } : {}),
+    });
+    await apiClient.post(
+      `/databases/${databaseId}/restore-chunk?${params.toString()}`,
+      blob,
+      {
+        headers: { "Content-Type": "application/octet-stream" },
+        timeout: 0,
+        onUploadProgress: (e) => report(start + (e.loaded ?? 0)),
+      },
+    );
+    report(end);
+  }
+
+  // GH #1323: the final chunk returned 202 — the restore now runs detached
+  // server-side (so no single request spans Cloudflare's ~100s origin timeout).
+  // Poll restore-status until it finishes; the modal's "Restoring…" leg (frac is
+  // already 1) reflects the real outcome. Ceiling matches the server's 60-min cap.
+  report(file.size);
+  const deadline = Date.now() + 65 * 60 * 1000;
+  for (;;) {
+    await new Promise((res) => setTimeout(res, 2000));
+    let status = "restoring";
+    try {
+      const s = await apiClient.get<{ status: string }>(
+        `/databases/${databaseId}/restore-status`,
+        { params: { upload_id: uploadId } },
+      );
+      status = s.data.status;
+    } catch {
+      // Transient poll error — keep trying until the deadline.
+    }
+    if (status === "done") break;
+    if (status === "failed") throw new Error("restore_failed");
+    if (Date.now() > deadline) throw new Error("restore_timeout");
+  }
+  lsDel(resumeKey);
+}
+
+/**
+ * Restore a database from an uploaded dump, picking the transport by size
+ * (GH #1323): a one-shot multipart POST for small dumps, chunked upload above
+ * the threshold so large dumps aren't rejected by Cloudflare's 100 MB request
+ * cap. Both drive the same RestoreUploadProgress modal.
+ */
+export async function restoreDatabaseUploadAuto(
+  databaseId: string,
+  file: File,
+  onProgress?: (p: RestoreUploadProgress) => void,
+): Promise<void> {
+  if (file.size > RESTORE_CHUNK_THRESHOLD) {
+    return restoreDatabaseUploadChunked(databaseId, file, onProgress);
+  }
+  return restoreDatabaseUpload(databaseId, file, onProgress);
+}
+
 // === PHP Settings API ===
 
 export interface DomainPHPSettings {

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -17,7 +17,7 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("../../../apiClient", () => ({
   downloadDatabaseBackup: vi.fn(),
-  restoreDatabaseUpload: vi.fn(),
+  restoreDatabaseUploadAuto: vi.fn(),
   ssoAdminer: vi.fn(),
   ssoPhpMyAdmin: vi.fn(),
 }));
@@ -65,11 +65,11 @@ vi.mock("../../../hooks/useTableURL", () => ({
 
 import {
   downloadDatabaseBackup,
-  restoreDatabaseUpload,
+  restoreDatabaseUploadAuto,
 } from "../../../apiClient";
 
 const mockedDownload = downloadDatabaseBackup as ReturnType<typeof vi.fn>;
-const mockedRestore = restoreDatabaseUpload as ReturnType<typeof vi.fn>;
+const mockedRestore = restoreDatabaseUploadAuto as ReturnType<typeof vi.fn>;
 
 /** Opens the row's overflow menu (first action renders as a button, the
  * rest collapse into the "more" dropdown). Generous timeouts — under CI

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -25,7 +25,7 @@ import { sorterToParams } from "../../../utils/tableSorter";
 
 import {
   downloadDatabaseBackup,
-  restoreDatabaseUpload,
+  restoreDatabaseUploadAuto,
   ssoAdminer,
   ssoPhpMyAdmin,
 } from "../../../apiClient";
@@ -237,7 +237,7 @@ export const UserDatabaseList = () => {
       loaded: 0,
     });
     try {
-      await restoreDatabaseUpload(row.id, file, (pr) => {
+      await restoreDatabaseUploadAuto(row.id, file, (pr) => {
         setRestoreProgress((prev) =>
           prev
             ? {


### PR DESCRIPTION
## Summary

GH #1323 — chunked, async "Restore from file" upload. The single-request restore 413s at Cloudflare (Free plan caps request bodies at **100 MB**) before it reaches the panel, no matter how high the panel/nginx caps are — the reporter's remaining #1044 pain. The File Manager already uploads >100 MB files as sequential 10 MB chunks; this brings the same to database restore, and finalizes **async** so it also clears Cloudflare's **~100 s origin timeout (524)** that a multi-minute restore would otherwise trip.

**Client** (`restoreDatabaseUploadAuto`): one-shot multipart for small dumps; above ~90 MB, chunked 10 MB octet-stream POSTs (resumable via `localStorage`). The final chunk returns `202`; the client then **polls `restore-status`** until done/failed, so no single request spans the 100 s origin timeout. Reuses the existing `RestoreUploadProgress` modal (upload leg → "Restoring…").

**Server**: `POST /databases/:id/restore-chunk` appends each chunk at `offset` into a **panel-controlled** staging path derived from the authenticated user id + `upload_id` (a tenant can never target another's staging file); no holes / mid-file overwrite; capped at `upload_max_size_mb`; per-user in-flight cap with **stale-partial (>24 h) eviction**. Read/Write deadlines are cleared at the **top** so a slow uplink isn't guillotined at 30 s (and a copy blip **truncates-to-resume**, not destroys). `final=1` renames the assembled dump under a panel ULID and runs the **same detached restore** (`doDatabaseRestore`, extracted from the single-upload path) on a goroutine, recording the outcome to a marker. `GET /restore-status` polls it (a stale "restoring" marker past the 60-min ceiling reports failed). `GET /restore-chunk-status` returns the resume offset.

## Why async (the CF-524 gap)

A synchronous finalize would hold the connection through the whole restore; Cloudflare Free 524s at ~100 s and can't be raised — so the reporter's 545 MB test would upload fine, then show a **false failure** while the restore quietly completed. Async finalize + polling keeps every request short, so it actually works behind Cloudflare.

## Test plan

- Server (race-clean): assemble two chunks + async finalize restores the concatenation via the agent and `restore-status` reaches `done`; non-owner `403`; bad-offset `409`; unknown upload `404`. `openapi` coverage + full `panel-api/internal/api` suite + `go vet`/gofmt green.
- Client: `tsc -b` + `vite build` green; the existing restore UI test passes against the auto-dispatcher.
- **Box drill (jabalitest) pending** — a LAN drill can't reproduce CF-524 or a slow link (both handled by design), but should confirm a real chunked assemble + real MySQL and Postgres restore through the deployed endpoints, resume after a killed chunk, and the 429/eviction path.

## Notes

- The reporter's other #1044 items already shipped (#1269 limits, #1319 modal + async single-restore). This closes the Cloudflare piece.
- `restoreRoot` is now a package var (test override); the single-upload path is unchanged behaviorally (refactored to share `doDatabaseRestore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
