### PR TITLE
feat(backups): opt-in automatic daily local backups for all users (GH #1240)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1056,6 +1056,31 @@ seed_module_flags() {
   fi
 }
 
+# seed_default_local_backups — GH #1240. Optional opt-in: automatic daily local
+# backups for EVERY user. OFF by default (the operator prefers remote; local uses
+# disk + IO). Enable via JABALI_DEFAULT_LOCAL_BACKUPS=1 (non-interactive / TUI) or
+# a y/N prompt on an interactive install. Only writes when opted in — the DB
+# default (0) covers the off case. Best-effort: a SQL failure warns, never aborts.
+seed_default_local_backups() {
+  command -v mariadb >/dev/null 2>&1 || return 0
+  local enable=0
+  if [[ "${JABALI_DEFAULT_LOCAL_BACKUPS:-}" == "1" ]]; then
+    enable=1
+  elif [[ "${_cli_yes:-}" != "1" && -t 0 ]]; then
+    local ans=""
+    # 30s timeout so an unattended TTY install falls through to OFF (the default)
+    # instead of blocking forever on this new question.
+    read -t 30 -rp "Enable automatic daily local backups for all users? (local disk; off by default) [y/N]: " ans || true
+    [[ "$ans" =~ ^[Yy] ]] && enable=1
+  fi
+  [[ "$enable" == "1" ]] || return 0
+  if mariadb jabali_panel -e "UPDATE server_settings SET default_local_backups_enabled=1 WHERE id=1;" 2>/dev/null; then
+    _ok "automatic daily local backups enabled (GH #1240) — manage in Server Settings → Backups"
+  else
+    _warn "could not enable default local backups (server_settings) — set it in Server Settings → Backups"
+  fi
+}
+
 # print_module_plan — dry-run output (--dry-run). Shows exactly which optional
 # modules would be installed vs skipped for the current JABALI_MODULES, and the
 # server_settings flags that would be seeded — WITHOUT touching the system. Lets
@@ -16170,6 +16195,9 @@ main() {
   # + seeded the server_settings row). Only acts when JABALI_MODULES is set; a
   # plain install leaves every flag default-on, so existing flows are unchanged.
   seed_module_flags
+  # GH #1240: optional opt-in for automatic daily local backups (same point —
+  # the server_settings row exists after first boot). Off unless chosen.
+  seed_default_local_backups
   # First-phase Stalwart bootstrap (binary download, service user,
   # stalwart-cli, admin token, MariaDB password file, apply plan render,
   # unit file install). Safe to run after start_and_verify — doesn't

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -201,6 +201,9 @@ type updateServerSettingsRequest struct {
 	TenantBackupWindowEnd   *string `json:"tenant_backup_window_end,omitempty"`
 	// TenantBackupWindowEnforce (GH #1097) — opt-in gate for the window above.
 	TenantBackupWindowEnforce *bool `json:"tenant_backup_window_enforce,omitempty"`
+	// DefaultLocalBackupsEnabled (GH #1240) — opt-in automatic daily local
+	// backups for every user; the scheduler converges the managed schedule.
+	DefaultLocalBackupsEnabled *bool `json:"default_local_backups_enabled,omitempty"`
 
 	// M13 SSH shell sandbox.
 	SSHSandboxMode            *string `json:"ssh_sandbox_mode,omitempty"`
@@ -653,6 +656,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.TenantBackupWindowEnforce != nil {
 		current.TenantBackupWindowEnforce = *req.TenantBackupWindowEnforce
+	}
+	if req.DefaultLocalBackupsEnabled != nil {
+		current.DefaultLocalBackupsEnabled = *req.DefaultLocalBackupsEnabled
 	}
 	if req.SSHSandboxMode != nil {
 		current.SSHSandboxMode = strings.TrimSpace(*req.SSHSandboxMode)

--- a/panel-api/internal/backupscheduler/default_local.go
+++ b/panel-api/internal/backupscheduler/default_local.go
@@ -1,0 +1,165 @@
+package backupscheduler
+
+// GH #1240 — opt-in automatic daily local backups for all users.
+//
+// When server_settings.default_local_backups_enabled is ON, the panel keeps a
+// single MANAGED schedule (backup_schedules.is_managed_default = 1) that backs up
+// every tenant to the local repo daily. It's a normal account_backup schedule
+// with an EMPTY user list — which the scheduler already fans out to "all non-admin
+// users" at tick time, so new tenants are covered automatically. When the flag is
+// OFF the managed schedule is disabled; admin/tenant-created schedules are never
+// touched. The provisioner converges this from the flag on boot and on every
+// enqueue tick (idempotent + cheap), so flipping the setting takes effect within
+// one tick without any extra wiring.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+const (
+	// defaultLocalBackupCron is the daily local-backup time (05:00), matching the
+	// reporter's request in GH #1240. The admin can adjust it after creation — the
+	// provisioner only creates + enables/disables, it doesn't re-clobber the time.
+	defaultLocalBackupCron = "0 5 * * *"
+	defaultLocalBackupKeep = 3 // 3-day versioning (GH #1240); older pruned.
+	defaultLocalDestName   = "Local"
+)
+
+// ensureDefaultLocalBackup converges the managed default-local-backup schedule
+// from the flag. Best-effort: logs and returns on any error (a transient DB blip
+// just retries next tick).
+func (s *Scheduler) ensureDefaultLocalBackup(ctx context.Context) {
+	if s.deps.Settings == nil {
+		return
+	}
+	st, err := s.deps.Settings.Get(ctx)
+	if err != nil || st == nil {
+		return
+	}
+
+	all, err := s.deps.Schedules.List(ctx)
+	if err != nil {
+		s.deps.Log.WarnContext(ctx, "default-local-backup: list schedules", "error", err)
+		return
+	}
+	var managed *models.BackupSchedule
+	for i := range all {
+		if all[i].IsManagedDefault {
+			managed = &all[i]
+			break
+		}
+	}
+
+	if !st.DefaultLocalBackupsEnabled {
+		// OFF: disable the managed schedule if present + enabled. Keep the row so
+		// re-enabling is a clean flip, and NEVER touch other schedules.
+		if managed != nil && managed.Enabled {
+			managed.Enabled = false
+			if err := s.deps.Schedules.Update(ctx, managed); err != nil {
+				s.deps.Log.WarnContext(ctx, "default-local-backup: disable", "error", err)
+			} else {
+				s.deps.Log.InfoContext(ctx, "default-local-backup: disabled (setting off)")
+			}
+		}
+		return
+	}
+
+	// ON: ensure a local destination exists, then the managed schedule.
+	destID, err := s.ensureLocalDestination(ctx)
+	if err != nil {
+		s.deps.Log.WarnContext(ctx, "default-local-backup: ensure local destination", "error", err)
+		return
+	}
+
+	if managed == nil {
+		keep := defaultLocalBackupKeep
+		// A NULL next_run_at is NEVER due (ListDue filters it out), so the schedule
+		// would never fire — set the first run from the cron now.
+		next, nerr := internalbackup.NextFire(defaultLocalBackupCron, time.Now().UTC())
+		if nerr != nil {
+			s.deps.Log.WarnContext(ctx, "default-local-backup: parse cron", "cron", defaultLocalBackupCron, "error", nerr)
+			return
+		}
+		m := &models.BackupSchedule{
+			ID:               ids.NewULID(),
+			Kind:             models.BackupScheduleKindAccount,
+			UserID:           nil, // admin-owned; fan-out driven by the (empty) user list
+			CronExpr:         defaultLocalBackupCron,
+			Content:          "full",
+			Cadence:          "", // legacy cron-governed (not window-guarded)
+			Enabled:          true,
+			KeepDaily:        &keep,
+			NextRunAt:        &next,
+			IsManagedDefault: true,
+		}
+		if err := s.deps.Schedules.Create(ctx, m); err != nil {
+			// A concurrent panel instance won the race — the unique index on
+			// is_managed_default rejects the second insert. Benign: the winner's
+			// row is found + converged on the next tick.
+			if errors.Is(err, repository.ErrConflict) {
+				return
+			}
+			s.deps.Log.WarnContext(ctx, "default-local-backup: create schedule", "error", err)
+			return
+		}
+		// Empty user list = all non-admin tenants at tick time (auto-covers new
+		// users); link the local destination.
+		if err := s.deps.Schedules.ReplaceUsers(ctx, m.ID, nil); err != nil {
+			s.deps.Log.WarnContext(ctx, "default-local-backup: set users", "error", err)
+		}
+		if err := s.deps.Schedules.ReplaceDestinations(ctx, m.ID, []string{destID}); err != nil {
+			s.deps.Log.WarnContext(ctx, "default-local-backup: set destination", "error", err)
+		}
+		s.deps.Log.InfoContext(ctx, "default-local-backup: created managed schedule", "cron", defaultLocalBackupCron, "keep_daily", keep)
+		return
+	}
+
+	// Exists: re-enable if disabled, and heal a missing destination link. Don't
+	// clobber cron/content/keep so an admin's later tweak sticks.
+	if !managed.Enabled {
+		managed.Enabled = true
+		if err := s.deps.Schedules.Update(ctx, managed); err != nil {
+			s.deps.Log.WarnContext(ctx, "default-local-backup: re-enable", "error", err)
+			return
+		}
+		s.deps.Log.InfoContext(ctx, "default-local-backup: re-enabled (setting on)")
+	}
+	if dests, err := s.deps.Schedules.GetDestinations(ctx, managed.ID); err == nil && len(dests) == 0 {
+		if err := s.deps.Schedules.ReplaceDestinations(ctx, managed.ID, []string{destID}); err != nil {
+			s.deps.Log.WarnContext(ctx, "default-local-backup: relink destination", "error", err)
+		}
+	}
+}
+
+// ensureLocalDestination returns the id of a local backup destination, creating a
+// shared "Local" one (empty URL → the agent's default repo, legacy shared restic
+// password) if none exists.
+func (s *Scheduler) ensureLocalDestination(ctx context.Context) (string, error) {
+	dests, err := s.deps.Destinations.List(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, d := range dests {
+		if d.Kind == models.BackupDestinationKindLocal {
+			return d.ID, nil
+		}
+	}
+	d := &models.BackupDestination{
+		ID:      ids.NewULID(),
+		Name:    defaultLocalDestName,
+		Kind:    models.BackupDestinationKindLocal,
+		URL:     "", // empty = the agent's default local repo /var/lib/jabali-backups/repo
+		Enabled: true,
+	}
+	if err := s.deps.Destinations.Create(ctx, d); err != nil {
+		return "", err
+	}
+	return d.ID, nil
+}

--- a/panel-api/internal/backupscheduler/default_local_test.go
+++ b/panel-api/internal/backupscheduler/default_local_test.go
@@ -1,0 +1,141 @@
+package backupscheduler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type dlFakeSettings struct {
+	repository.ServerSettingsRepository
+	enabled bool
+}
+
+func (f dlFakeSettings) Get(context.Context) (*models.ServerSettings, error) {
+	return &models.ServerSettings{DefaultLocalBackupsEnabled: f.enabled}, nil
+}
+
+type dlFakeScheds struct {
+	repository.BackupScheduleRepository
+	rows      []models.BackupSchedule
+	created   *models.BackupSchedule
+	updated   *models.BackupSchedule
+	setUsers  bool
+	setDests  bool
+	dests     []models.BackupDestination
+	createErr error
+}
+
+func (f *dlFakeScheds) List(context.Context) ([]models.BackupSchedule, error) { return f.rows, nil }
+func (f *dlFakeScheds) Create(_ context.Context, s *models.BackupSchedule) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created = s
+	f.rows = append(f.rows, *s)
+	return nil
+}
+func (f *dlFakeScheds) Update(_ context.Context, s *models.BackupSchedule) error {
+	f.updated = s
+	return nil
+}
+func (f *dlFakeScheds) ReplaceUsers(_ context.Context, _ string, _ []string) error {
+	f.setUsers = true
+	return nil
+}
+func (f *dlFakeScheds) ReplaceDestinations(_ context.Context, _ string, _ []string) error {
+	f.setDests = true
+	return nil
+}
+func (f *dlFakeScheds) GetDestinations(context.Context, string) ([]models.BackupDestination, error) {
+	return f.dests, nil
+}
+
+type dlFakeDests struct {
+	repository.BackupDestinationRepository
+	rows    []models.BackupDestination
+	created *models.BackupDestination
+}
+
+func (f *dlFakeDests) List(context.Context) ([]models.BackupDestination, error) { return f.rows, nil }
+func (f *dlFakeDests) Create(_ context.Context, d *models.BackupDestination) error {
+	f.created = d
+	f.rows = append(f.rows, *d)
+	return nil
+}
+
+func dlScheduler(enabled bool, sch *dlFakeScheds, dst *dlFakeDests) *Scheduler {
+	return &Scheduler{deps: Deps{
+		Settings:     dlFakeSettings{enabled: enabled},
+		Schedules:    sch,
+		Destinations: dst,
+		Log:          slog.Default(),
+	}}
+}
+
+func TestEnsureDefaultLocalBackup_CreatesWhenOn(t *testing.T) {
+	sch := &dlFakeScheds{}
+	dst := &dlFakeDests{}
+	dlScheduler(true, sch, dst).ensureDefaultLocalBackup(context.Background())
+
+	require.NotNil(t, sch.created, "managed schedule must be created")
+	assert.True(t, sch.created.IsManagedDefault)
+	assert.Equal(t, models.BackupScheduleKindAccount, sch.created.Kind)
+	assert.Nil(t, sch.created.UserID)
+	assert.Equal(t, "0 5 * * *", sch.created.CronExpr)
+	assert.Equal(t, "full", sch.created.Content)
+	assert.True(t, sch.created.Enabled)
+	require.NotNil(t, sch.created.KeepDaily)
+	assert.Equal(t, 3, *sch.created.KeepDaily)
+	// NextRunAt MUST be set — a NULL next_run_at is never due (ListDue filters it),
+	// so the schedule would never fire.
+	require.NotNil(t, sch.created.NextRunAt, "NextRunAt must be set from the cron")
+	assert.True(t, sch.created.NextRunAt.After(time.Now()), "first run should be in the future")
+	assert.True(t, sch.setUsers, "empty user list (all tenants) must be set")
+	assert.True(t, sch.setDests, "local destination must be linked")
+	require.NotNil(t, dst.created, "a Local destination must be created")
+	assert.Equal(t, models.BackupDestinationKindLocal, dst.created.Kind)
+}
+
+func TestEnsureDefaultLocalBackup_ReusesExistingLocalDest(t *testing.T) {
+	sch := &dlFakeScheds{}
+	dst := &dlFakeDests{rows: []models.BackupDestination{{ID: "d1", Kind: models.BackupDestinationKindLocal}}}
+	dlScheduler(true, sch, dst).ensureDefaultLocalBackup(context.Background())
+	assert.Nil(t, dst.created, "an existing local destination must be reused, not re-created")
+	require.NotNil(t, sch.created)
+}
+
+func TestEnsureDefaultLocalBackup_DisablesWhenOff(t *testing.T) {
+	keep := 3
+	sch := &dlFakeScheds{rows: []models.BackupSchedule{
+		{ID: "m1", IsManagedDefault: true, Enabled: true, KeepDaily: &keep},
+		{ID: "t1", IsManagedDefault: false, Enabled: true}, // a tenant schedule — must NOT be touched
+	}}
+	dlScheduler(false, sch, &dlFakeDests{}).ensureDefaultLocalBackup(context.Background())
+	require.NotNil(t, sch.updated, "the managed schedule must be disabled")
+	assert.Equal(t, "m1", sch.updated.ID)
+	assert.False(t, sch.updated.Enabled)
+}
+
+func TestEnsureDefaultLocalBackup_OffNoManaged_NoOp(t *testing.T) {
+	sch := &dlFakeScheds{}
+	dlScheduler(false, sch, &dlFakeDests{}).ensureDefaultLocalBackup(context.Background())
+	assert.Nil(t, sch.created)
+	assert.Nil(t, sch.updated)
+}
+
+func TestEnsureDefaultLocalBackup_ConcurrentCreateConflictIsBenign(t *testing.T) {
+	// A second panel instance loses the create race → the unique index rejects it
+	// with ErrConflict. The provisioner must swallow it (the winner's row exists),
+	// not spin or wire up a phantom schedule.
+	sch := &dlFakeScheds{createErr: repository.ErrConflict}
+	dlScheduler(true, sch, &dlFakeDests{}).ensureDefaultLocalBackup(context.Background())
+	assert.False(t, sch.setUsers, "on conflict, bail before wiring users/destinations")
+}

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -186,6 +186,10 @@ func (s *Scheduler) tickEnqueue(ctx context.Context) {
 	if s.standbyInert(ctx) {
 		return
 	}
+	// GH #1240: converge the managed default-local-backup schedule from the flag
+	// before scanning due schedules, so a just-enabled default is picked up the
+	// same tick. Idempotent + cheap; skipped on standbys by the gate above.
+	s.ensureDefaultLocalBackup(ctx)
 	now := time.Now().UTC()
 	due, err := s.deps.Schedules.ListDue(ctx, now, MaxDuePerTick)
 	if err != nil {

--- a/panel-api/internal/db/migrations/000276_default_local_backups.down.sql
+++ b/panel-api/internal/db/migrations/000276_default_local_backups.down.sql
@@ -1,0 +1,6 @@
+-- Revert GH #1240 default-local-backups opt-in.
+ALTER TABLE backup_schedules
+    DROP KEY uk_backup_schedules_managed_default,
+    DROP COLUMN managed_default_uk;
+ALTER TABLE backup_schedules DROP COLUMN is_managed_default;
+ALTER TABLE server_settings DROP COLUMN default_local_backups_enabled;

--- a/panel-api/internal/db/migrations/000276_default_local_backups.up.sql
+++ b/panel-api/internal/db/migrations/000276_default_local_backups.up.sql
@@ -1,0 +1,28 @@
+-- GH #1240: opt-in automatic daily local backups for all users.
+--
+-- default_local_backups_enabled (server-wide, default OFF — local backups are an
+-- opt-in the admin turns on at install or in Server Settings; the operator
+-- prefers remote and dislikes local by default). When ON, a single admin-owned
+-- managed schedule (backup_schedules.is_managed_default) backs up every tenant to
+-- the local repo daily; when OFF it's disabled and tenant-created schedules are
+-- untouched.
+--
+-- is_managed_default marks THAT one panel-managed schedule so the provisioner can
+-- find + converge it idempotently without touching admin/tenant schedules.
+--
+-- Both TINYINT(1) — 1 byte each, no server_settings row-size (ERROR 1118) concern.
+ALTER TABLE server_settings
+    ADD COLUMN default_local_backups_enabled TINYINT(1) NOT NULL DEFAULT 0;
+
+ALTER TABLE backup_schedules
+    ADD COLUMN is_managed_default TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Enforce AT MOST ONE managed default schedule: a concurrent create race (two
+-- panel instances, or a CLI tick vs the 60s tick) must not produce duplicate
+-- all-tenants schedules. A virtual column that is 1 only for the managed row and
+-- NULL otherwise, with a unique index (NULLs are not unique in MariaDB), permits
+-- exactly one is_managed_default=1 row; the loser's INSERT gets a dup-key error
+-- the provisioner treats as "someone else won".
+ALTER TABLE backup_schedules
+    ADD COLUMN managed_default_uk TINYINT GENERATED ALWAYS AS (IF(is_managed_default = 1, 1, NULL)) VIRTUAL,
+    ADD UNIQUE KEY uk_backup_schedules_managed_default (managed_default_uk);

--- a/panel-api/internal/models/backup_schedule.go
+++ b/panel-api/internal/models/backup_schedule.go
@@ -19,8 +19,13 @@ type BackupSchedule struct {
 	// fires a system.backup job alongside the per-user account fan-out
 	// every time the schedule ticks. Ignored on kind=system_backup
 	// (those always back up the system by definition).
-	IncludeSystemBackup bool   `gorm:"not null;default:0" json:"include_system_backup"`
-	CronExpr            string `gorm:"type:varchar(64);not null" json:"cron_expr"`
+	IncludeSystemBackup bool `gorm:"not null;default:0" json:"include_system_backup"`
+	// IsManagedDefault marks the single panel-managed default-local-backup
+	// schedule (GH #1240). The provisioner finds + converges exactly this row
+	// from server_settings.default_local_backups_enabled; admin/tenant schedules
+	// always have it 0 and are never touched. Default 0 = false (no flip trap).
+	IsManagedDefault bool   `gorm:"column:is_managed_default;type:tinyint(1);not null;default:0" json:"is_managed_default"`
+	CronExpr         string `gorm:"type:varchar(64);not null" json:"cron_expr"`
 	// Content is what a firing of this schedule backs up: full / files /
 	// database / folders (GH #454). Default 'full' preserves the pre-feature
 	// behaviour. Used by the scheduler fan-out (wired in a follow-up) and set by

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -347,6 +347,15 @@ type ServerSettings struct {
 	// written explicitly (no GORM default-tag zero-value trap).
 	TenantBackupWindowEnforce bool `gorm:"column:tenant_backup_window_enforce;type:tinyint(1);not null;default:0" json:"tenant_backup_window_enforce"`
 
+	// DefaultLocalBackupsEnabled (GH #1240) turns on an opt-in server-wide default:
+	// a single panel-managed schedule that backs up EVERY tenant to the local repo
+	// daily. OFF by default (local backups are opt-in — chosen at install or here;
+	// remote is preferred). The provisioner converges the managed schedule
+	// (backup_schedules.is_managed_default) from this flag; flipping it OFF disables
+	// that schedule and never touches admin/tenant-created schedules. Persisted via
+	// the repo's Select("*") update so the false zero-value is written explicitly.
+	DefaultLocalBackupsEnabled bool `gorm:"column:default_local_backups_enabled;type:tinyint(1);not null;default:0" json:"default_local_backups_enabled"`
+
 	// DR / standby (GH #331). ServerRole is 'primary' (default — box is fully
 	// active) or 'standby' (a one-way async replica: pulls the primary's state,
 	// serves no live traffic until manually promoted). The whole DR feature is

--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -23,6 +23,8 @@ interface BackupSettingsShape {
   // GH #1097: the window is an OPT-IN restriction, off by default. When off the
   // tenant scheduler ignores it and runs each schedule on its chosen interval.
   tenant_backup_window_enforce: boolean;
+  // GH #1240: opt-in automatic daily local backups for every user.
+  default_local_backups_enabled: boolean;
 }
 
 interface ServerSettingsResponse {
@@ -31,6 +33,7 @@ interface ServerSettingsResponse {
   tenant_backup_window_start?: string;
   tenant_backup_window_end?: string;
   tenant_backup_window_enforce?: boolean;
+  default_local_backups_enabled?: boolean;
 }
 
 // HH:MM (24h) — the format the API validates (internalbackup.ValidHHMM).
@@ -56,6 +59,7 @@ export const BackupSettingsTab = () => {
           tenant_backup_window_start: resp.data.tenant_backup_window_start ?? "02:00",
           tenant_backup_window_end: resp.data.tenant_backup_window_end ?? "05:00",
           tenant_backup_window_enforce: resp.data.tenant_backup_window_enforce ?? false,
+          default_local_backups_enabled: resp.data.default_local_backups_enabled ?? false,
         });
       } catch (err) {
         feedback.message.error(extractApiError(err, "Load failed"));
@@ -88,6 +92,14 @@ export const BackupSettingsTab = () => {
         onFinish={handleSubmit}
         style={{ maxWidth: 480 }}
       >
+        <Form.Item
+          name="default_local_backups_enabled"
+          valuePropName="checked"
+          label="Automatic daily local backups for all users"
+          tooltip="Off by default. When on, the panel keeps a managed schedule that backs up every user (files + databases + mail) to the local repo daily at 05:00 UTC, keeping 3 days. New users are covered automatically. Uses local disk + IO — prefer a remote destination if disk is tight. Turning it off disables the managed schedule but never removes users' own schedules."
+        >
+          <Switch />
+        </Form.Item>
         <Form.Item
           name="backup_max_concurrent_jobs"
           label={t("backupsettingstab.max_concurrent_backup_jobs")}


### PR DESCRIPTION
## Summary

GH #1240 — opt-in automatic daily local backups for all users. Off by default (the operator prefers remote; local uses disk + IO). When enabled, the panel keeps **one managed schedule** (`backup_schedules.is_managed_default`) that backs up **every tenant** to the local repo daily at **05:00**, **3-day** retention (older pruned). It's a normal `account_backup` schedule with an **empty user list** — which the scheduler already fans out to all non-admin users at tick time, so **new tenants are covered automatically** with no backfill. Turning it off disables that schedule and **never touches** admin/tenant-created schedules.

## Design

- **Setting** `server_settings.default_local_backups_enabled` (migration 000276, TINYINT default 0), plus `backup_schedules.is_managed_default` with a **unique functional index** so a concurrent create (two instances / a CLI tick) can't produce duplicate managed schedules — the loser gets a dup-key the provisioner treats as benign.
- **Provisioner** `backupscheduler.ensureDefaultLocalBackup` converges the managed schedule (+ a shared "Local" destination, + `NextRunAt` from the cron so it actually fires) from the flag, on boot and every enqueue tick (idempotent, standby-gated). Flipping the setting takes effect within one tick — no extra wiring.
- **Opt-in surfaces:** an **install prompt** (`seed_default_local_backups`; default N, 30 s timeout, `JABALI_DEFAULT_LOCAL_BACKUPS=1` for non-interactive) **and** a **Server Settings → Backups toggle**.

## Advisor review — fixed before merge

- **Concurrent duplicate managed schedules** → unique functional index + benign dup-key handling (+ test).
- **`NextRunAt` was nil** → `ListDue` filters NULL `next_run_at`, so the schedule would **never fire**. Now set from the cron at create (+ test asserts it).
- **Install prompt could hang** an unattended TTY install → 30 s timeout → OFF.
- **Restic password** on the no-sealed-password "Local" dest → verified via code: it falls back to the agent's shared local-repo password (backup_create.go), the same path the proven on-demand local backup uses.

## Test plan

- Provisioner (5 tests): creates managed schedule with `NextRunAt` set + Local dest + empty users; reuses an existing local dest; disables when off (leaving tenant schedules untouched); off-no-managed no-op; concurrent-conflict benign.
- Build + `go vet` + gofmt + api + openapi coverage + repository suites + SPA `tsc`/build green; `bash -n install.sh` clean.
- **Box drill (jabalitest) pending** — enable the flag, confirm the provisioner rows, and fire one real backup completing against the auto-created Local destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
