### PR TITLE
fix(test): de-flake nightly ui-unit — 5s findBy timeout for the webmail launcher button

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.test.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.test.tsx
@@ -266,7 +266,15 @@ describe("DomainMailboxesSection — webmail SSO opener isolation (JAB-330)", ()
 
     try {
       renderSection();
-      const btn = await screen.findByRole("button", { name: /open webmail/i });
+      // Default findBy timeout is 1s; the initial fetches + render cross it on
+      // the resource-starved nightly runner (same flake the waitFors above bump
+      // to 5s — run #3089). 5s is a wide margin that still catches a real
+      // never-renders regression.
+      const btn = await screen.findByRole(
+        "button",
+        { name: /open webmail/i },
+        { timeout: 5000 },
+      );
       fireEvent.click(btn);
 
       // Popup opened blank (blocker-dodge) and opener severed synchronously.


### PR DESCRIPTION
## Summary

De-flakes the nightly **ui-unit** job. The JAB-330 webmail opener-isolation test —
`DomainMailboxesSection … severs popup.opener synchronously, before the async SSO mint` —
awaited its button with a bare `screen.findByRole("button", { name: /open webmail/i })`,
which carries testing-library's **default 1 s** timeout. The button renders only after the
section's initial fetches resolve; on the resource-starved self-hosted nightly runner that
crosses 1 s, so the button isn't in the DOM yet and the assertion fails intermittently
(`Unable to find role="button" and name /open webmail/i`).

This is the **same flake** the other `waitFor`s in this very file already bump to 5 s — see
their inline note *"crossed the default 1s waitFor in run #3089"*. This one call was missed.

## Fix

Give that `findByRole` an explicit `{ timeout: 5000 }`, matching the file's established
pattern. A genuine never-renders regression still fails well within 5 s.

## Not the cause (ruled out)

The `TypeError: URL is not a constructor` line in the failed log is interleaved noise from a
different worker — no code path behind the webmail button constructs a `URL`. (Separately,
several suites `vi.stubGlobal(...)` without an `afterEach` teardown; that's latent hygiene,
not this failure, and is left for its own change.)

## Test plan

- `npx vitest run …/DomainMailboxesSection.test.tsx` → 8/8 pass.
- Full `npm test` → 63 files / 303 tests pass.
- Failure was never reproducible locally (fast machine, sub-1s render) — consistent with a
  runner-contention timeout rather than a logic bug.
