### PR TITLE
fix(ui): instant mobile nav-Drawer close — mount only while open (GH #1066)

### DIFF
--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -166,17 +166,21 @@ export function AdminLayout() {
               {menu}
             </div>
           </Sider>
-        ) : (
+        ) : drawerOpen ? (
           <Drawer
-            open={drawerOpen}
+            open
             onClose={() => setDrawerOpen(false)}
             placement="left"
             width={256}
             closable
             title={<JabaliTitle />}
-            // GH #1066: unmount the drawer portal on close so no residual
-            // full-viewport `position: fixed` .ant-drawer element is left in
-            // the DOM. See UserLayout for the reproduced detail.
+            // GH #1066: mount the nav Drawer only while open, so on dismiss it
+            // unmounts on the same tick — no leave animation holding AntD v6's
+            // residual full-viewport `position: fixed` .ant-drawer portal in
+            // the DOM (#1250), which also removes the ~1s that animation kept
+            // the mobile layout's bottom space reserved. Slide-in on open is
+            // preserved. destroyOnHidden stays as a belt-and-braces net.
+            // See UserLayout for the reproduced detail.
             destroyOnHidden
             styles={{
               body: { padding: 8, background: siderBg },
@@ -185,7 +189,7 @@ export function AdminLayout() {
           >
             {menu}
           </Drawer>
-        )}
+        ) : null}
         <Layout style={isDesktop ? { height: "100%", overflowY: "auto" } : undefined}>
           <Content
             style={{

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -163,22 +163,22 @@ export function UserLayout() {
               {menu}
             </div>
           </Sider>
-        ) : (
+        ) : drawerOpen ? (
           <Drawer
-            open={drawerOpen}
+            open
             onClose={() => setDrawerOpen(false)}
             placement="left"
             width={256}
             closable
             title={<JabaliTitle />}
-            // GH #1066: AntD v6 leaves the .ant-drawer portal mounted after
-            // close — a full-viewport `position: fixed; inset: 0` element that
-            // lingers in the DOM. Reproduced on a mobile viewport: this element
-            // is present exactly in the state where the reporter sees the
-            // residual bottom bar (after opening the menu) and absent after a
-            // refresh (when there is no bar). destroyOnHidden makes rc-drawer
-            // return null once closed, unmounting the portal so no fixed
-            // element is left behind.
+            // GH #1066: mount the nav Drawer only while it's open. On dismiss it
+            // unmounts on the same tick, so there's no leave animation holding
+            // AntD v6's full-viewport `position: fixed; inset: 0` portal in the
+            // DOM — that lingering portal was the residual bottom bar (#1250),
+            // and the ~1s the exit animation kept it mounted was the remaining
+            // delay before the mobile layout reclaimed the space. The slide-in
+            // on open is preserved (appear motion still plays on mount).
+            // destroyOnHidden stays as a belt-and-braces net.
             destroyOnHidden
             styles={{
               body: { padding: 8, background: siderBg },
@@ -187,7 +187,7 @@ export function UserLayout() {
           >
             {menu}
           </Drawer>
-        )}
+        ) : null}
         <Layout>
           <Content
             style={{


### PR DESCRIPTION
## Summary

Closes out the last remaining item on GH #1066 — the ~1s delay before the mobile
layout reclaims the bottom space after the nav menu is dismissed.

Recap of the thread:
- The original "residual black/white bar at the bottom, gone after refresh, back on
  menu-nav" was AntD v6 leaving the Drawer's full-viewport `position: fixed; inset: 0`
  portal mounted after close. **#1250** (`destroyOnHidden`) fixed that — the reporter
  confirmed on their device the bar no longer persists.
- What was left: after closing the menu the space still took **~1s** to disappear.
  That's the Drawer's leave animation holding the fixed portal alive for its duration,
  after which the mobile browser reclaims the toolbar gap.

## Fix

Mount the nav Drawer **only while `drawerOpen`** in both shells (`UserLayout`,
`AdminLayout`). On dismiss it unmounts on the same tick — no exit animation keeps the
fixed portal alive — so the layout reclaims the space immediately. The **slide-in on
open is preserved** (AntD's appear motion still plays on mount). `destroyOnHidden` stays
as a belt-and-braces net.

AntD v6 has no per-instance close-motion prop (confirmed via the Drawer API — motion is
theme-token or CSS only), so gating the mount is the cleanest way to drop the exit
animation for just this Drawer without disabling animations globally.

Desktop is unaffected — it renders a persistent `<Sider>`, not the Drawer.

## Honest caveat

The residual bar is a **real-device-only** symptom: no desktop emulator reproduces the
collapsing mobile address bar (this is why #1198's viewport-height fix looked right but
wasn't). This change removes the part we control — the exit animation holding the fixed
portal — but the mobile browser's own toolbar-reclaim latency is outside our control, so
it should be much closer to instant rather than guaranteed-zero. **Needs a device re-test
to confirm.**

## Test plan

- `npx tsc -b` clean.
- Full ui-unit suite: 63 files / 303 tests pass.
- Production build green.
- @lxsdevcode to re-test on device: open the mobile menu → navigate/close → confirm the
  bottom space returns immediately (no ~1s lag), and the drawer still slides in on open.
