### PR TITLE
fix(ui): records-per-page selection sticks on client-side tables (GH #1232)

### DIFF
--- a/panel-ui/src/components/pagesizeChanger.test.tsx
+++ b/panel-ui/src/components/pagesizeChanger.test.tsx
@@ -1,0 +1,90 @@
+// GH #1232 — "Records per page selection is broken across the board."
+//
+// Root cause: AntD treats `pagination.pageSize` as a CONTROLLED value. A
+// client-side table that hardcodes a literal `pageSize: N` re-passes that same
+// literal on every render, so when the user picks a new size the page-size
+// changer snaps straight back to N. (In v6 the changer auto-appears once total
+// > 50 — `totalBoundaryShowSizeChanger` — so any list long enough to page is
+// affected, whether or not `showSizeChanger` is set.)
+//
+// The fix for client-side tables (full dataSource, no server paging) is to seed
+// the size with the UNCONTROLLED `defaultPageSize` and let AntD own it. These
+// tests pin both halves so the controlled-literal pattern can't creep back in.
+import { render, screen, fireEvent, within, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { Table } from "antd";
+
+afterEach(cleanup);
+
+const rows = Array.from({ length: 60 }, (_, i) => ({ id: i, name: `row-${i}` }));
+const columns = [{ title: "Name", dataIndex: "name", key: "name" }];
+
+function countBodyRows(container: HTMLElement): number {
+  return container.querySelectorAll("tbody tr.ant-table-row").length;
+}
+
+// Open the page-size changer and click the "<size> / page" option.
+function pickPageSize(container: HTMLElement, size: number) {
+  const selector = container.querySelector(
+    ".ant-pagination-options-size-changer .ant-select-content",
+  );
+  if (!selector) throw new Error("page-size changer not rendered");
+  fireEvent.mouseDown(selector);
+  // Options render in a portal on document.body.
+  const option = screen.getByText(`${size} / page`);
+  fireEvent.click(option);
+}
+
+describe("GH #1232 — records-per-page selection sticks", () => {
+  it("controlled literal pageSize SNAPS BACK — the bug", () => {
+    const { container } = render(
+      <Table
+        rowKey="id"
+        dataSource={rows}
+        columns={columns}
+        pagination={{ pageSize: 25, showSizeChanger: true }}
+      />,
+    );
+    expect(countBodyRows(container)).toBe(25);
+    pickPageSize(container, 50);
+    // Parent re-passes the same literal 25 → size reverts, still 25 rows.
+    expect(countBodyRows(container)).toBe(25);
+  });
+
+  it("uncontrolled defaultPageSize STICKS — the fix", () => {
+    const { container } = render(
+      <Table
+        rowKey="id"
+        dataSource={rows}
+        columns={columns}
+        pagination={{ defaultPageSize: 25, showSizeChanger: true }}
+      />,
+    );
+    expect(countBodyRows(container)).toBe(25);
+    pickPageSize(container, 50);
+    // AntD owns the size now → 50 rows render and stay.
+    expect(countBodyRows(container)).toBe(50);
+  });
+
+  it("a default size of 25 (absent from AntD's 10/20/50/100 options) stays selectable", () => {
+    const { container } = render(
+      <Table
+        rowKey="id"
+        dataSource={rows}
+        columns={columns}
+        pagination={{ defaultPageSize: 25, showSizeChanger: true }}
+      />,
+    );
+    const selector = container.querySelector(
+      ".ant-pagination-options-size-changer .ant-select-content",
+    ) as HTMLElement;
+    // The changer shows the seeded 25 as its current value…
+    expect(within(selector).getByText("25 / page")).toBeInTheDocument();
+    fireEvent.mouseDown(selector);
+    // …and rc-pagination injects 25 into the option list, so the user can
+    // always return to it. If this regresses, the affected tables need an
+    // explicit pageSizeOptions that includes 25.
+    expect(screen.getByText("50 / page")).toBeInTheDocument();
+    expect(screen.getAllByText("25 / page").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -567,7 +567,7 @@ export const SSLManagerTable = ({
             columns={columns}
             rowKey="id"
             loading={isLoading}
-            pagination={{ pageSize: 25, showSizeChanger: true }}
+            pagination={{ defaultPageSize: 25, showSizeChanger: true }}
             scroll={{ x: "max-content" }}
           />
         </Space>

--- a/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
+++ b/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
@@ -311,7 +311,7 @@ export const SharedCertificatesCard = ({ embedded = false }: { embedded?: boolea
           columns={columns}
           rowKey="id"
           loading={isLoading}
-          pagination={{ pageSize: 10, showSizeChanger: true }}
+          pagination={{ defaultPageSize: 10, showSizeChanger: true }}
           scroll={{ x: "max-content" }}
         />
       )}

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -535,7 +535,7 @@ export const AdminBackupsPage = () => {
             rowKey="rowKey"
             loading={loading}
             dataSource={tableRows}
-            pagination={{ pageSize: 25 }}
+            pagination={{ defaultPageSize: 25 }}
             scroll={{ x: "max-content" }}
             expandable={{
               expandedRowKeys: expandedKeys,

--- a/panel-ui/src/shells/admin/cache/CacheOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/cache/CacheOverviewPage.tsx
@@ -53,7 +53,7 @@ export function CacheOverviewPage() {
         rowKey="domain"
         loading={loading}
         dataSource={rows}
-        pagination={{ pageSize: 20, hideOnSinglePage: true }}
+        pagination={{ defaultPageSize: 20, hideOnSinglePage: true }}
         scroll={{ x: "max-content" }}
         columns={[
           { title: "Domain", dataIndex: "domain" },

--- a/panel-ui/src/shells/admin/cache/FleetCacheDoctor.tsx
+++ b/panel-ui/src/shells/admin/cache/FleetCacheDoctor.tsx
@@ -253,7 +253,7 @@ export function FleetCacheDoctor() {
               style={{ marginTop: 12 }}
               columns={itemColumns}
               dataSource={run.results}
-              pagination={{ pageSize: 10, hideOnSinglePage: true }}
+              pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
             />
           ) : null}
         </div>
@@ -265,7 +265,7 @@ export function FleetCacheDoctor() {
         size="small"
         loading={history.isLoading}
         dataSource={history.data ?? []}
-        pagination={{ pageSize: 10, hideOnSinglePage: true }}
+        pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
         onRow={(r) => ({ onClick: () => setActiveRunId(r.id), style: { cursor: "pointer" } })}
         columns={[
           { title: "When", dataIndex: "created_at", render: (v: string) => shortDateTime(v) },

--- a/panel-ui/src/shells/admin/cron/AdminCronList.tsx
+++ b/panel-ui/src/shells/admin/cron/AdminCronList.tsx
@@ -159,7 +159,7 @@ export const AdminCronList = () => {
             size="small"
             loading={isLoading}
             dataSource={filteredJobs}
-            pagination={{ pageSize: 25, showSizeChanger: true }}
+            pagination={{ defaultPageSize: 25, showSizeChanger: true }}
             scroll={{ x: "max-content" }}
             locale={{
               emptyText: (

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -224,7 +224,7 @@ export const AdminDockerAppsPage = () => {
                 })}
                 scroll={{ x: 1100 }}
                 pagination={{
-                  pageSize: 25,
+                  defaultPageSize: 25,
                   showTotal: (total, range) => `Showing ${range[0]} to ${range[1]} of ${total} results`,
                 }}
                 locale={{

--- a/panel-ui/src/shells/admin/docker-apps/BackupsDrawer.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/BackupsDrawer.tsx
@@ -84,7 +84,7 @@ export const BackupsDrawer = ({ open, appId, onClose }: Props) => {
           size="small"
           loading={backupsQ.isLoading}
           dataSource={backupsQ.data?.backups ?? []}
-          pagination={{ pageSize: 20 }}
+          pagination={{ defaultPageSize: 20 }}
           columns={[
             {
               title: "Snapshot",

--- a/panel-ui/src/shells/admin/logs/UpdatesLogTab.tsx
+++ b/panel-ui/src/shells/admin/logs/UpdatesLogTab.tsx
@@ -29,7 +29,7 @@ export const UpdatesLogTab = () => {
         loading={isLoading}
         dataSource={rows}
         scroll={{ x: "max-content" }}
-        pagination={{ pageSize: 20, showTotal: (t) => `${t} runs` }}
+        pagination={{ defaultPageSize: 20, showTotal: (t) => `${t} runs` }}
         columns={[
           {
             title: "Time",

--- a/panel-ui/src/shells/admin/mail/AdminGroupsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminGroupsTab.tsx
@@ -82,7 +82,7 @@ export function AdminGroupsTab() {
         scroll={{ x: "max-content" }}
         rowKey="id"
         dataSource={rows ?? []}
-        pagination={{ pageSize: 25, showSizeChanger: true }}
+        pagination={{ defaultPageSize: 25, showSizeChanger: true }}
         locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("admingroupstab.no_groups")} /> }}
         columns={[
           {

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -184,7 +184,7 @@ export function AdminMailPage() {
           rowKey="id"
           dataSource={filtered}
           loading={isLoading}
-          pagination={{ pageSize: 25, showSizeChanger: true }}
+          pagination={{ defaultPageSize: 25, showSizeChanger: true }}
           locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminmailpage.no_mailboxes")} /> }}
           columns={[
             {

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
@@ -378,7 +378,7 @@ export const AdminMigrationsPage = () => {
           dataSource={rows}
           rowKey="id"
           loading={list.isLoading}
-          pagination={{ pageSize: 50, hideOnSinglePage: true }}
+          pagination={{ defaultPageSize: 50, hideOnSinglePage: true }}
           scroll={{ x: "max-content" }}
           locale={{
             emptyText: (

--- a/panel-ui/src/shells/admin/security/AdminSecurityAide.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityAide.tsx
@@ -253,7 +253,7 @@ export const AdminSecurityAide = () => {
         size="small"
         tableLayout="fixed"
         scroll={{ x: "max-content" }}
-        pagination={{ pageSize: 25 }}
+        pagination={{ defaultPageSize: 25 }}
         columns={[
           {
             title: "Change",

--- a/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
@@ -113,7 +113,7 @@ export const AdminSecurityEgress = () => {
         <Table<UserRow>
           dataSource={nonAdminUsers}
           rowKey="id"
-          pagination={{ pageSize: 50, hideOnSinglePage: true }}
+          pagination={{ defaultPageSize: 50, hideOnSinglePage: true }}
           loading={usersQuery.isLoading}
           scroll={{ x: "max-content" }}
         >

--- a/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
@@ -743,7 +743,7 @@ function ManualScanCard() {
               loading={usersQ.isLoading}
               dataSource={filteredUsers}
               columns={userColumns}
-              pagination={{ pageSize: 10, size: "small" }}
+              pagination={{ defaultPageSize: 10, size: "small" }}
               scroll={{ x: "max-content" }}
               rowSelection={{
                 selectedRowKeys: filteredUsers
@@ -1320,7 +1320,7 @@ function ExecAuditCard() {
         tableLayout="fixed"
         scroll={{ x: "max-content" }}
         size="small"
-        pagination={{ pageSize: 50 }}
+        pagination={{ defaultPageSize: 50 }}
         columns={[
           { title: "Time", dataIndex: "ts", width: 200, render: (v: string) => v || "—" },
           { title: "User", dataIndex: "username", width: 140, render: (v?: string, r?) => v || r?.auid || "—" },

--- a/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
@@ -156,7 +156,7 @@ export function AdminSecuritySnuffleupagus() {
             dataSource={incidents.data?.data ?? []}
             pagination={{
               total: incidents.data?.total ?? 0,
-              pageSize: 50,
+              defaultPageSize: 50,
             }}
             columns={[
               {
@@ -214,7 +214,7 @@ export function AdminSecuritySnuffleupagus() {
           rowKey="name"
           loading={rules.isLoading}
           dataSource={rules.data ?? []}
-          pagination={{ pageSize: 25 }}
+          pagination={{ defaultPageSize: 25 }}
           columns={[
             { title: "Rule", dataIndex: "name", ellipsis: true },
             {

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -778,7 +778,7 @@ function SystemPackagesCard({ check }: { check: ReturnType<typeof useAptCheck> }
             rowKey="name"
             size="small"
             dataSource={rows}
-            pagination={rows.length > 8 ? { pageSize: 8, size: "small" } : false}
+            pagination={rows.length > 8 ? { defaultPageSize: 8, size: "small" } : false}
             scroll={{ x: "max-content" }}
             columns={[
               { title: "Package", dataIndex: "name" },

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -198,7 +198,7 @@ export const MyProfileBackupCard = () => {
         rowKey="id"
         loading={query.isLoading}
         dataSource={query.items ?? []}
-        pagination={{ pageSize: 10 }}
+        pagination={{ defaultPageSize: 10 }}
         scroll={{ x: "max-content" }}
         columns={[
           {

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
@@ -458,7 +458,7 @@ export function DiskUsagePage() {
                     rowKey={(r) => `${b.key}:${r.name}`}
                     columns={b.cols}
                     dataSource={b.cat.items}
-                    pagination={b.cat.items.length > 8 ? { pageSize: 8, size: "small" } : false}
+                    pagination={b.cat.items.length > 8 ? { defaultPageSize: 8, size: "small" } : false}
                     scroll={{ x: "max-content" }}
                   />
                 )}

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -205,7 +205,7 @@ export const UserDockerAppsPage = () => {
                   })}
                   scroll={{ x: 1000 }}
                   pagination={{
-                    pageSize: 25,
+                    defaultPageSize: 25,
                     showTotal: (total, range) => `Showing ${range[0]} to ${range[1]} of ${total} results`,
                   }}
                   locale={{

--- a/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
@@ -137,7 +137,7 @@ export const ForwardersTab = () => {
           dataSource={filteredForwarders}
           searchPlaceholder="Search forwarders…"
           onSearchChange={setSearch}
-          pagination={{ pageSize: 20 }}
+          pagination={{ defaultPageSize: 20 }}
           columns={[
             {
               title: "Source",
@@ -298,7 +298,7 @@ function DomainScopedForwarders() {
         rowKey="id"
         loading={isLoading}
         dataSource={rows}
-        pagination={{ pageSize: 20 }}
+        pagination={{ defaultPageSize: 20 }}
         scroll={{ x: "max-content" }}
         columns={[
           {

--- a/panel-ui/src/shells/user/mail/tabs/GroupsTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/GroupsTab.tsx
@@ -108,7 +108,7 @@ export function GroupsTab() {
           searchPlaceholder="Search group name…"
           initialSearch={search}
           onSearchChange={setSearch}
-          pagination={{ pageSize: 25 }}
+          pagination={{ defaultPageSize: 25 }}
           locale={{
             emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("groupstab.no_groups")} />,
           }}

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -236,7 +236,7 @@ export const MailboxesTab = () => {
         searchPlaceholder="Search email, name, domain…"
         initialSearch={search}
         onSearchChange={setSearch}
-        pagination={{ pageSize: 20 }}
+        pagination={{ defaultPageSize: 20 }}
         locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("mailboxestab.no_mailboxes")} /> }}
         columns={[
           {

--- a/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
@@ -143,7 +143,7 @@ export const SharedFoldersTab = () => {
           searchPlaceholder="Search owner or shared-with…"
           initialSearch={search}
           onSearchChange={setSearch}
-          pagination={{ pageSize: 20 }}
+          pagination={{ defaultPageSize: 20 }}
           scroll={{ x: "max-content" }}
           columns={[
             {


### PR DESCRIPTION
## Summary

Fixes GH #1232 — "Records per page selection is broken across the board." Selecting e.g. 50 / page snapped straight back to the default (25 on Admin > Mail > Mailboxes).

## Root cause

AntD treats `pagination.pageSize` as a **controlled** value. Any client-side table that hardcoded a literal `pageSize: N` re-passed that same literal on every render, so when the user picked a new size the page-size changer reverted to N. In AntD v6 the changer **auto-appears once the row count exceeds 50** (`totalBoundaryShowSizeChanger`), independent of `showSizeChanger` — so every list long enough to page was affected. That's the "across the board".

The earlier pass (GH #232, June) fixed the **server-controlled** list views (URL-backed `pageSize` + `onChange` that persists it). It didn't touch the **client-side** tables — the reporter's page among them — which is why it re-surfaced.

## Fix

For each client-side table (full `dataSource`, no server paging), seed the size with the **uncontrolled** `defaultPageSize` and let AntD own it. Per-site edits keyed on the literal — the server-controlled tables (which read `pageSize` from query/URL state and persist it via `onChange`) are deliberately left alone.

24 tables across mail, backups, security, cache, cron, docker-apps, SSL, migrations, disk-usage and updates.

Verified `rc-pagination` injects the current size into the options list, so a table seeded at 25 (not one of AntD's default 10/20/50/100 options) can still return to 25 — no explicit `pageSizeOptions` required.

## Regression test

This bug already survived one "fixed" pass, so it now has a deterministic guard (`pagesizeChanger.test.tsx`) pinning all three facts:
- controlled literal `pageSize` **snaps back** (reproduces the bug),
- `defaultPageSize` **sticks** (the fix),
- a seeded 25 **stays selectable** in the changer.

## Skipped (correctly)

- Tables with `showSizeChanger: false` — no changer, no bug.
- `params: { pageSize: N }` — that's a data-fetch limit, not a pagination prop.
- Server-controlled tables — already persist `pageSize` via `onChange`.

## Test plan

- `npx tsc -b` clean.
- Full ui-unit suite: **64 files / 306 tests** pass (was 63/303; +3 new).
- Production build green.
- Reproduces on desktop, so no device retest needed — the mechanism test covers it.
