### PR TITLE
fix(auth): widen root step-up window 10m→1h so File Manager stops re-prompting (GH #1184)

### DIFF
--- a/panel-api/internal/api/stepup.go
+++ b/panel-api/internal/api/stepup.go
@@ -24,8 +24,13 @@ import (
 )
 
 // stepUpWindow is how recently the Kratos session must have authenticated for a
-// root-privileged action to proceed without a fresh login (JAB-380).
-const stepUpWindow = 10 * time.Minute
+// root-privileged action to proceed without a fresh login (JAB-380). It is the
+// whole grace window (the check is stateless — see the file header), so this is
+// also how long a burst of admin work can run before one re-auth. Raised from
+// 10m to 1h (GH #1184): 10m re-prompted repeatedly during normal File Manager /
+// Root Terminal use, while 1h still bounds a walked-up / hijacked idle session
+// to an hour of root reach.
+const stepUpWindow = 1 * time.Hour
 
 // requireRecentAuth enforces JAB-380 recent-auth on a root-privileged request.
 // It returns true if the request may proceed; otherwise it has already written

--- a/panel-api/internal/api/stepup_test.go
+++ b/panel-api/internal/api/stepup_test.go
@@ -49,7 +49,7 @@ func TestRequireRecentAuth_FreshCachedClaimsPass(t *testing.T) {
 func TestRequireRecentAuth_StaleClaimsRequireStepUp(t *testing.T) {
 	c, w := newStepUpCtx(t, &auth.AccessClaims{
 		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
-		AuthenticatedAt: time.Now().Add(-30 * time.Minute),
+		AuthenticatedAt: time.Now().Add(-2 * stepUpWindow),
 	}, "")
 	if requireRecentAuth(c, nil, stepUpWindow) {
 		t.Fatalf("stale claims must not pass")
@@ -125,7 +125,7 @@ func TestRequireRecentAuth_CacheBypassSeesRefresh(t *testing.T) {
 
 	c, w := newStepUpCtx(t, &auth.AccessClaims{
 		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
-		AuthenticatedAt: time.Now().Add(-30 * time.Minute), // stale cached value
+		AuthenticatedAt: time.Now().Add(-2 * stepUpWindow), // stale cached value
 	}, "cookie-refreshed")
 
 	if !requireRecentAuth(c, kc, stepUpWindow) {
@@ -141,7 +141,7 @@ func TestRequireRecentAuth_CacheBypassStillStale(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":               "s",
 			"active":           true,
-			"authenticated_at": time.Now().Add(-45 * time.Minute).UTC().Format(time.RFC3339Nano),
+			"authenticated_at": time.Now().Add(-2 * stepUpWindow).UTC().Format(time.RFC3339Nano),
 			"identity":         map[string]any{"id": "u1"},
 		})
 	}))
@@ -150,7 +150,7 @@ func TestRequireRecentAuth_CacheBypassStillStale(t *testing.T) {
 
 	c, w := newStepUpCtx(t, &auth.AccessClaims{
 		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
-		AuthenticatedAt: time.Now().Add(-30 * time.Minute),
+		AuthenticatedAt: time.Now().Add(-2 * stepUpWindow),
 	}, "cookie-old")
 
 	if requireRecentAuth(c, kc, stepUpWindow) {


### PR DESCRIPTION
## Summary

Addresses @lxsdevcode's latest note on GH #1184: the recent-auth **step-up** on the Admin File Manager re-prompts for re-authentication too often — several times within a session.

## Cause

JAB-380 (#1244) gates the admin File Manager and Root Terminal on the Kratos session having authenticated within **10 minutes** (`stepUpWindow`). The check is deliberately **stateless** — the window IS the whole grace period, so a burst of edits inside it doesn't re-prompt, but once 10 minutes pass since login the next root action returns 403 and the SPA runs a Kratos `refresh=true` re-login. During sustained File Manager work that fires every ~10 minutes.

## Change

`stepUpWindow` 10m → **1h**.

- Re-prompts drop to about once an hour of active admin work.
- A walked-up / hijacked **idle** session is still bounded to ~1h of root reach — the point of the step-up. "Several hours" (the literal ask) would effectively neuter it, so 1h is the balance.
- One constant, shared by both root surfaces (File Manager + Root Terminal), so they stay consistent.

No SPA change: the 403→re-auth flow and its messaging don't hardcode the window.

## Tests

The step-up tests built their "stale" timestamps from hardcoded `-30m` / `-45m` offsets that assumed the 10m window (a `-30m` value is *fresh* under a 1h window). They're now expressed relative to the constant (`-2 * stepUpWindow`), so they stay correct at any window value.

- `go build` + `go vet` clean.
- Full `internal/api` suite green.

## Note on the rest of #1184

The #1244 regression (File Manager bounced to the dashboard + 403) is already fixed in #1328 and confirmed by the reporter. The deny-list stays as previously reasoned; that discussion remains open on the issue. This PR only tunes the step-up cadence.
