### PR TITLE
fix(ui): Enable Docker Apps for users stops spinning the confirm dialog (GH #1236)

### DIFF
--- a/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.test.tsx
+++ b/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.test.tsx
@@ -1,0 +1,90 @@
+// GH #1236 — "Enable Docker Apps for users just spins forever until you refresh."
+//
+// The confirm dialog's onOk returned setForUsersFlag(true), which polls host
+// state for up to 8 minutes. AntD keeps the confirm modal's OK button spinning
+// until an onOk promise resolves, so the dialog looked stuck for the whole poll.
+// The fix detaches the poll (onOk returns void) so the dialog closes at once and
+// progress shows on the card's own Switch. This test pins that: after confirming,
+// the dialog must close promptly rather than block on the long poll.
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { App } from "antd";
+
+const get = vi.fn();
+const patch = vi.fn();
+vi.mock("../../../apiClient", () => ({
+  apiClient: {
+    get: (...a: unknown[]) => get(...a),
+    patch: (...a: unknown[]) => patch(...a),
+  },
+}));
+
+function mockApi() {
+  get.mockImplementation((url: string) => {
+    if (url === "/admin/settings")
+      return Promise.resolve({
+        data: {
+          docker_marketplace_enabled: true,
+          docker_apps_for_users_enabled: false,
+          docker_tenant_apps: "",
+        },
+      });
+    if (url === "/admin/docker-apps/catalog")
+      return Promise.resolve({ data: { items: [] } });
+    if (url === "/me/server-capabilities")
+      // Never flips within the test — simulates a slow host setup. The dialog
+      // must NOT wait on this.
+      return Promise.resolve({ data: { docker_apps_user_enabled: false } });
+    return Promise.resolve({ data: {} });
+  });
+  patch.mockResolvedValue({ data: {} });
+}
+
+beforeEach(mockApi);
+afterEach(() => {
+  cleanup();
+  get.mockReset();
+  patch.mockReset();
+});
+
+async function renderCard() {
+  const { DockerMarketplaceCard } = await import("./DockerMarketplaceCard");
+  return render(
+    <App>
+      <DockerMarketplaceCard />
+    </App>,
+  );
+}
+
+describe("GH #1236 — Enable Docker Apps for users doesn't hang the dialog", () => {
+  it("closes the confirm dialog immediately instead of spinning on the 8-min poll", async () => {
+    await renderCard();
+
+    // Two switches render once the marketplace is enabled: [0] marketplace,
+    // [1] "Enable Docker Apps for users".
+    const switches = await screen.findAllByRole("switch");
+    expect(switches.length).toBeGreaterThanOrEqual(2);
+    fireEvent.click(switches[1]);
+
+    // The confirm dialog's OK button ("Enable") appears — click it.
+    const okBtn = await screen.findByRole("button", { name: /^Enable$/ });
+    fireEvent.click(okBtn);
+
+    // The detached flow runs (flag persisted immediately)…
+    await waitFor(() =>
+      expect(patch).toHaveBeenCalledWith("/admin/settings", {
+        docker_apps_for_users_enabled: true,
+      }),
+    );
+
+    // …and crucially the confirm's OK button is NOT left spinning on the
+    // up-to-8-minute poll (the GH #1236 bug). With the buggy onOk-returns-promise
+    // it would carry `ant-btn-loading`; the fix keeps it clear and moves the
+    // progress spinner onto the card's own Switch instead.
+    expect(screen.getByRole("button", { name: /^Enable$/ })).not.toHaveClass(
+      "ant-btn-loading",
+    );
+    const switchesAfter = screen.getAllByRole("switch");
+    expect(switchesAfter[1].className).toContain("ant-switch-loading");
+  });
+});

--- a/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.tsx
@@ -173,7 +173,15 @@ export function DockerMarketplaceCard() {
           "the Docker daemon — running containers briefly go down and previously pulled " +
           "images must be re-pulled. The tenant Docker Apps tab then appears for users. " +
           "This can take a few minutes.",
-        onOk: () => setForUsersFlag(true),
+        // GH #1236: do NOT return the promise — setForUsersFlag polls host state
+        // for up to 8 minutes, and AntD keeps the confirm modal's OK button
+        // spinning until an onOk promise resolves (looked like "spins forever
+        // until you refresh"). Close the modal immediately; progress then shows
+        // on the card's Switch (loading={forUsersBusy}) + busyLabel, matching the
+        // marketplace Enable toggle.
+        onOk: () => {
+          void setForUsersFlag(true);
+        },
       });
     } else {
       void setForUsersFlag(false);


### PR DESCRIPTION
## Summary

Fixes GH #1236 — clicking **Enable Docker Apps for users** "just spins forever until you refresh."

## Cause

The toggle opens a confirm dialog, and its `onOk` returned `setForUsersFlag(true)` — which PATCHes the setting and then **polls `/me/server-capabilities` for up to 8 minutes** waiting for the host to become tenant-ready. AntD keeps a confirm modal's OK button in a loading spinner until the `onOk` promise resolves, so the dialog looked stuck for the entire poll. (The marketplace **Enable** toggle didn't have this — it's a plain Switch, not a modal-wrapped promise.)

## Fix

Detach the long poll from `onOk` (return `void`) so the confirm dialog closes immediately. Progress then shows on the card's own Switch (`loading={forUsersBusy}`) and its status label — the same place the marketplace Enable toggle already reports progress. One-line behavioural change; the poll/settings logic is untouched.

## Regression test

`DockerMarketplaceCard.test.tsx`: renders the card with the marketplace enabled, toggles "Enable Docker Apps for users", confirms, and asserts:
- the confirm's OK button is **not** left with `ant-btn-loading` (the bug), and
- the card's Switch takes the progress spinner instead.

Verified RED→GREEN: with the old `onOk: () => setForUsersFlag(true)` the OK button spins (test fails); with the fix it's clear (test passes).

## Test plan

- `npx tsc -b` clean.
- Full ui-unit suite: **65 files / 307 tests** pass.
- Production build green.
