### PR TITLE
fix(mail): show mail-disabled domains in the Mail Stats storage drilldown (GH #1234)

### DIFF
--- a/panel-api/internal/api/admin_mail_stats_test.go
+++ b/panel-api/internal/api/admin_mail_stats_test.go
@@ -50,7 +50,10 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 			{Metric: "queue_size", SampledAt: t0, Value: 4},
 		},
 		storage: []repository.MailboxStorageRow{
-			{Username: "notary", DomainName: "n.example", Email: "a@n.example", UsageBytes: 1024, QuotaBytes: 4096},
+			{Username: "notary", DomainName: "n.example", MailEnabled: true, Email: "a@n.example", UsageBytes: 1024, QuotaBytes: 4096},
+			// GH #1234: a mail-disabled domain rides along with an empty email + 0
+			// usage so the drilldown can show + tag it.
+			{Username: "notary", DomainName: "off.example", MailEnabled: false, Email: "", UsageBytes: 0, QuotaBytes: 0},
 		},
 		// Two windows of per-domain deltas; the handler sums them per domain and
 		// orders busiest-first (by sent+received).
@@ -97,8 +100,13 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 	}
 	assert.Equal(t, float64(25), resp.Current["message_ingest"])
 	assert.Equal(t, float64(4), resp.Current["queue_size"])
-	if assert.Len(t, resp.Storage, 1) {
+	if assert.Len(t, resp.Storage, 2) {
 		assert.Equal(t, "a@n.example", resp.Storage[0].Email)
+		assert.True(t, resp.Storage[0].MailEnabled)
+		// GH #1234: the mail-off domain rides along, tagged and empty.
+		assert.Equal(t, "off.example", resp.Storage[1].DomainName)
+		assert.False(t, resp.Storage[1].MailEnabled)
+		assert.Empty(t, resp.Storage[1].Email)
 	}
 	// Per-domain traffic: summed across windows, busiest first.
 	if assert.Len(t, resp.Traffic, 2) {

--- a/panel-api/internal/repository/mail_stats_repository.go
+++ b/panel-api/internal/repository/mail_stats_repository.go
@@ -22,13 +22,17 @@ type MailStatSample struct {
 func (MailStatSample) TableName() string { return "mail_stats_samples" }
 
 // MailboxStorageRow is one mailbox with its owner chain, for the
-// Global -> User -> Domain -> Mailbox storage drilldown.
+// Global -> User -> Domain -> Mailbox storage drilldown. GH #1234: the query is
+// domain-anchored (LEFT JOIN mailboxes), so a domain with no mailboxes — mail
+// disabled, or mail-enabled but empty — still yields a single row with an empty
+// Email and zero usage. MailEnabled lets the UI tag the mail-off ones.
 type MailboxStorageRow struct {
-	Username   string `gorm:"column:username"    json:"username"`
-	DomainName string `gorm:"column:domain_name" json:"domain_name"`
-	Email      string `gorm:"column:email"       json:"email"`
-	UsageBytes uint64 `gorm:"column:usage_bytes" json:"usage_bytes"`
-	QuotaBytes uint64 `gorm:"column:quota_bytes" json:"quota_bytes"`
+	Username    string `gorm:"column:username"     json:"username"`
+	DomainName  string `gorm:"column:domain_name"  json:"domain_name"`
+	MailEnabled bool   `gorm:"column:mail_enabled" json:"mail_enabled"`
+	Email       string `gorm:"column:email"        json:"email"`
+	UsageBytes  uint64 `gorm:"column:usage_bytes"  json:"usage_bytes"`
+	QuotaBytes  uint64 `gorm:"column:quota_bytes"  json:"quota_bytes"`
 }
 
 // DomainStatSample is one per-domain traffic delta point (GH #873 round 3).
@@ -222,13 +226,18 @@ func (r *mailStatsRepo) PruneDomain(ctx context.Context, olderThan time.Time) (i
 
 func (r *mailStatsRepo) StorageDrilldown(ctx context.Context) ([]MailboxStorageRow, error) {
 	var rows []MailboxStorageRow
+	// GH #1234: anchor on domains (LEFT JOIN mailboxes) so a domain with no
+	// mailboxes — mail disabled, or mail-enabled but empty — still returns a row
+	// (empty email, 0 usage) and shows up in the drilldown instead of vanishing.
 	err := r.db.WithContext(ctx).Raw(`
 		SELECT u.username AS username, d.name AS domain_name,
-		       m.email_cached AS email, m.last_usage_bytes AS usage_bytes,
-		       m.quota_bytes AS quota_bytes
-		FROM mailboxes m
-		JOIN domains d ON d.id = m.domain_id
-		JOIN users   u ON u.id = d.user_id
+		       d.email_enabled AS mail_enabled,
+		       COALESCE(m.email_cached, '')    AS email,
+		       COALESCE(m.last_usage_bytes, 0) AS usage_bytes,
+		       COALESCE(m.quota_bytes, 0)      AS quota_bytes
+		FROM domains d
+		JOIN users     u ON u.id = d.user_id
+		LEFT JOIN mailboxes m ON m.domain_id = d.id
 		ORDER BY u.username, d.name, m.email_cached`).Scan(&rows).Error
 	return rows, err
 }

--- a/panel-ui/src/shells/admin/mail/MailStatsTab.storage.test.tsx
+++ b/panel-ui/src/shells/admin/mail/MailStatsTab.storage.test.tsx
@@ -1,0 +1,80 @@
+// GH #1234 — the Mail Stats storage drilldown was mailbox-anchored, so a domain
+// with no mailboxes (mail disabled) never appeared. It is now domain-anchored and
+// tags the mail-off ones. This pins that a mail-disabled domain shows up under
+// its owner with a "Mail off" tag.
+//
+// Only apiClient is mocked; the real AntD Table + expandable rows run.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apiClient", () => ({ apiClient: { get: vi.fn() } }));
+import { apiClient } from "../../../apiClient";
+import { MailStatsTab } from "./MailStatsTab";
+
+const mocked = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+const payload = {
+  points: {},
+  rates: {},
+  current: {},
+  storage: [
+    {
+      username: "alice",
+      domain_name: "shop.example",
+      mail_enabled: true,
+      email: "a@shop.example",
+      usage_bytes: 1024,
+      quota_bytes: 4096,
+    },
+    // Mail-disabled domain: arrives as one row with an empty email + 0 usage.
+    {
+      username: "alice",
+      domain_name: "off.example",
+      mail_enabled: false,
+      email: "",
+      usage_bytes: 0,
+      quota_bytes: 0,
+    },
+  ],
+  traffic: [],
+  by_user: [],
+};
+
+afterEach(cleanup);
+
+function renderTab() {
+  mocked.get.mockResolvedValue({ data: payload });
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <MailStatsTab />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+describe("GH #1234 — mail-off domains show in the storage drilldown", () => {
+  it("lists a mail-disabled domain under its owner, tagged 'Mail off'", async () => {
+    const { container } = renderTab();
+
+    // Owner row renders once the stats load.
+    await screen.findByText("alice");
+
+    // Expand the owner row to reveal its domains (storage is the only table
+    // with rows, so the first expand icon is alice's).
+    const expandIcon = container.querySelector(
+      ".ant-table-row-expand-icon",
+    ) as HTMLElement;
+    expect(expandIcon).toBeTruthy();
+    fireEvent.click(expandIcon);
+
+    // Both the mail-consuming domain AND the mail-off domain appear…
+    await screen.findByText("shop.example");
+    expect(screen.getByText("off.example")).toBeInTheDocument();
+    // …and the disabled one is tagged.
+    expect(screen.getByText("Mail off")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
@@ -12,7 +12,7 @@
 // delivery_dsn_perm_fail. Do not add a chart for a name you have not seen
 // in mail_stats_samples.
 import { useMemo, useState } from "react";
-import { Alert, Card, Col, Radio, Row, Statistic, Table, Typography } from "antd";
+import { Alert, Card, Col, Radio, Row, Space, Statistic, Table, Tag, Typography } from "antd";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -27,6 +27,10 @@ type MailStats = {
   storage: {
     username: string;
     domain_name: string;
+    // GH #1234: the drilldown is domain-anchored, so a domain with no mailboxes
+    // arrives as a single row with an empty email + 0 usage. mail_enabled tags
+    // the mail-off ones.
+    mail_enabled: boolean;
     email: string;
     usage_bytes: number;
     quota_bytes: number;
@@ -53,6 +57,22 @@ type DomainTraffic = {
   received: number;
   delivered: number;
   failed: number;
+};
+
+// Storage drilldown nodes (User → Domain → Mailbox), grouped client-side.
+type MailboxNode = MailStats["storage"][number];
+type StorageDomainNode = {
+  key: string;
+  domain: string;
+  usage: number;
+  mailEnabled: boolean;
+  boxes: MailboxNode[];
+};
+type StorageUserNode = {
+  key: string;
+  username: string;
+  usage: number;
+  domains: StorageDomainNode[];
 };
 
 const TRAFFIC_COLUMNS = [
@@ -123,17 +143,28 @@ export const MailStatsTab = () => {
   const s = stats.data;
 
   // Storage drilldown: rows grouped client-side User → Domain → Mailbox.
+  // GH #1234: the payload is domain-anchored, so a domain with no mailboxes
+  // arrives as one row with an empty email — keep the domain (tagged by
+  // mailEnabled) but don't push that placeholder as a mailbox leaf.
   const storageTree = useMemo(() => {
     const users = new Map<
       string,
-      { usage: number; domains: Map<string, { usage: number; boxes: MailStats["storage"] }> }
+      {
+        usage: number;
+        domains: Map<string, { usage: number; mailEnabled: boolean; boxes: MailStats["storage"] }>;
+      }
     >();
     for (const row of s?.storage ?? []) {
       const u = users.get(row.username) ?? { usage: 0, domains: new Map() };
       u.usage += row.usage_bytes;
-      const d = u.domains.get(row.domain_name) ?? { usage: 0, boxes: [] };
+      const d = u.domains.get(row.domain_name) ?? {
+        usage: 0,
+        mailEnabled: row.mail_enabled,
+        boxes: [],
+      };
       d.usage += row.usage_bytes;
-      d.boxes.push(row);
+      d.mailEnabled = row.mail_enabled;
+      if (row.email) d.boxes.push(row); // skip the empty-email domain placeholder
       u.domains.set(row.domain_name, d);
       users.set(row.username, u);
     }
@@ -145,6 +176,7 @@ export const MailStatsTab = () => {
         key: `${username}/${domain}`,
         domain,
         usage: d.usage,
+        mailEnabled: d.mailEnabled,
         boxes: d.boxes,
       })),
     }));
@@ -369,7 +401,7 @@ export const MailStatsTab = () => {
       </Card>
 
       <Card size="small" title="Storage drilldown" loading={stats.isLoading}>
-        <Table
+        <Table<StorageUserNode>
           size="small"
           rowKey="key"
           pagination={false}
@@ -385,13 +417,24 @@ export const MailStatsTab = () => {
           ]}
           expandable={{
             expandedRowRender: (user) => (
-              <Table
+              <Table<StorageDomainNode>
                 size="small"
                 rowKey="key"
                 pagination={false}
                 dataSource={user.domains}
                 columns={[
-                  { title: "Domain", dataIndex: "domain" },
+                  {
+                    title: "Domain",
+                    dataIndex: "domain",
+                    // GH #1234: mail-disabled domains now appear (0 usage); tag
+                    // them so they're not mistaken for empty mail consumers.
+                    render: (v: string, row: StorageDomainNode) => (
+                      <Space size={8}>
+                        <span>{v}</span>
+                        {!row.mailEnabled && <Tag>Mail off</Tag>}
+                      </Space>
+                    ),
+                  },
                   {
                     title: "Usage",
                     dataIndex: "usage",
@@ -400,8 +443,10 @@ export const MailStatsTab = () => {
                   },
                 ]}
                 expandable={{
+                  // No mailbox leaf to open for a mail-off / empty domain.
+                  rowExpandable: (dom) => dom.boxes.length > 0,
                   expandedRowRender: (dom) => (
-                    <Table
+                    <Table<MailboxNode>
                       size="small"
                       rowKey="email"
                       pagination={false}


### PR DESCRIPTION
## Summary

Fixes GH #1234 — the admin **Mail Stats → Storage drilldown** didn't show domains that don't have mail enabled.

## Cause

The drilldown was built from a **mailbox-anchored** query:

```sql
FROM mailboxes m JOIN domains d ... JOIN users u ...
```

A domain with no mailboxes — mail disabled, or mail-enabled but empty — produced no rows, so it vanished from the drilldown entirely.

## Fix

Anchor the query on **domains** and LEFT JOIN mailboxes, carrying the domain's `email_enabled` flag:

```sql
FROM domains d JOIN users u ... LEFT JOIN mailboxes m ON m.domain_id = d.id
```

A domain with no mailboxes now returns one row (empty email, 0 usage), so it appears in the drilldown. The UI keeps the **User → Domain → Mailbox** grouping and:

- skips the empty-email placeholder as a mailbox leaf (it's the domain, not a mailbox),
- tags mail-disabled domains **`Mail off`**,
- doesn't offer a pointless expander for a domain with no mailboxes.

```
alice
  shop.example        1.2 GiB
  off.example  [Mail off]  0 B
```

## Tests

- **Backend** (`admin_mail_stats_test`): the response passes the new mail-off row + `MailEnabled` flag through.
- **Frontend** (`MailStatsTab.storage.test.tsx`): renders the tab, expands the owner row, and asserts the mail-disabled domain appears tagged `Mail off`.
- `go build` + `vet` + api/repository suites green; `tsc -b` + full ui suite (66 files / 308 tests) + build green.
- The raw `LEFT JOIN` SQL was validated **read-only against the live DB** (the `email_enabled` column and the join resolve). `.60` currently has no mail-disabled domain to demo live, but the mail-off row is standard LEFT-JOIN semantics and is exercised end-to-end by the unit tests above.
