### PR TITLE
fix(apps): refresh stored WordPress version after an update (GH #1237)

### DIFF
--- a/panel-agent/internal/commands/wordpress_version_probe.go
+++ b/panel-agent/internal/commands/wordpress_version_probe.go
@@ -1,0 +1,56 @@
+// wordpress.version_probe — read <dir>/wp-includes/version.php at a WordPress
+// root and report whether it exists plus the parsed $wp_version.
+//
+// Used by the reconciler's ready-install probe (GH #1237): it both detects drift
+// (version.php gone → the install is broken) and refreshes the stored version
+// after a WordPress core update / auto-update, which the panel otherwise never
+// learned about (the version was captured once at install and never re-read).
+//
+// Privileged path-only, like fs.stat: the caller passes a system-derived docroot
+// path, never user input, and version.php is a world-readable WP core file.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type wpVersionProbeParams struct {
+	// Dir is the WordPress root (docroot [+ subdir]); version.php is read from
+	// <Dir>/wp-includes/version.php.
+	Dir string `json:"dir"`
+}
+
+type wpVersionProbeResponse struct {
+	Exists  bool   `json:"exists"`
+	Version string `json:"version,omitempty"`
+}
+
+func wpVersionProbeHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p wpVersionProbeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
+	if p.Dir == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "dir required"}
+	}
+	vp := filepath.Join(p.Dir, "wp-includes", "version.php")
+	if _, err := os.Lstat(vp); err != nil {
+		if os.IsNotExist(err) {
+			return wpVersionProbeResponse{Exists: false}, nil
+		}
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	}
+	// readWPVersion parses $wp_version from <dir>/wp-includes/version.php; it
+	// returns "" if the file is unreadable/unparseable, which the caller treats
+	// as "leave the stored version as-is".
+	return wpVersionProbeResponse{Exists: true, Version: readWPVersion(p.Dir)}, nil
+}
+
+func init() {
+	Default.Register("wordpress.version_probe", wpVersionProbeHandler)
+}

--- a/panel-api/internal/reconciler/wordpress_reconcile.go
+++ b/panel-api/internal/reconciler/wordpress_reconcile.go
@@ -131,30 +131,50 @@ func (r *Reconciler) probeOneWordPressInstall(ctx context.Context, install model
 	if subdir != "" && subdir[0] != '/' {
 		subdir = "/" + subdir
 	}
-	probePath := dom.DocRoot + subdir + "/wp-includes/version.php"
+	wpRoot := dom.DocRoot + subdir
 
 	callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	raw, err := r.agent.Call(callCtx, "fs.stat", map[string]any{"path": probePath})
+	raw, err := r.agent.Call(callCtx, "wordpress.version_probe", map[string]any{"dir": wpRoot})
 	if err != nil {
-		r.log.Warn("reconcile: WordPress probe agent.fs.stat failed",
-			"id", install.ID, "path", probePath, "err", err)
+		r.log.Warn("reconcile: WordPress version probe failed",
+			"id", install.ID, "dir", wpRoot, "err", err)
 		return
 	}
-	var stat struct {
-		Exists bool `json:"exists"`
+	var probe struct {
+		Exists  bool   `json:"exists"`
+		Version string `json:"version"`
 	}
-	if err := json.Unmarshal(raw, &stat); err != nil {
+	if err := json.Unmarshal(raw, &probe); err != nil {
 		r.log.Warn("reconcile: WordPress probe parse failed", "id", install.ID, "err", err)
 		return
 	}
-	if !stat.Exists {
+	if !probe.Exists {
 		errMsg := "wp-includes/version.php missing — install drifted"
 		r.log.Warn("reconcile: WordPress install drift detected; marking failed",
-			"id", install.ID, "path", probePath)
+			"id", install.ID, "dir", wpRoot)
 		if err := r.wordPressInstalls.UpdateStatus(ctx, install.ID, "failed", &errMsg, nil); err != nil {
 			r.log.Error("reconcile: failed to flip drifted install to failed",
 				"id", install.ID, "err", err)
+		}
+		return
+	}
+	// GH #1237: refresh the stored version when the site was updated (WP core
+	// auto-update or an in-app update). The panel captured the version once at
+	// install and never re-read it, so the Applications UI kept showing a stale
+	// number. Write only on drift to avoid needless updated_at churn.
+	if probe.Version != "" && (install.Version == nil || *install.Version != probe.Version) {
+		newVer := probe.Version
+		if err := r.wordPressInstalls.UpdateStatus(ctx, install.ID, "ready", nil, &newVer); err != nil {
+			r.log.Warn("reconcile: failed to refresh WordPress version",
+				"id", install.ID, "version", newVer, "err", err)
+		} else {
+			old := ""
+			if install.Version != nil {
+				old = *install.Version
+			}
+			r.log.Info("reconcile: refreshed WordPress version",
+				"id", install.ID, "from", old, "to", newVer)
 		}
 	}
 }

--- a/panel-api/internal/reconciler/wordpress_reconcile_test.go
+++ b/panel-api/internal/reconciler/wordpress_reconcile_test.go
@@ -20,6 +20,7 @@ func newTestLogger(t *testing.T) *slog.Logger {
 // mockWordPressInstallRepo is a minimal mock for testing.
 type mockWordPressInstallRepo struct {
 	installs    []models.WordPressInstall
+	ready       []models.WordPressInstall // returned by ListReadyByUpdatedAtAsc
 	updateCalls []struct {
 		id      string
 		status  string
@@ -71,7 +72,7 @@ func (m *mockWordPressInstallRepo) List(ctx context.Context, opts repository.Lis
 }
 
 func (m *mockWordPressInstallRepo) ListReadyByUpdatedAtAsc(_ context.Context, _ int) ([]models.WordPressInstall, error) {
-	return nil, nil
+	return m.ready, nil
 }
 
 func (m *mockWordPressInstallRepo) CountCacheEnabledByUserID(_ context.Context, _, _ string) (int64, error) {

--- a/panel-api/internal/reconciler/wordpress_version_refresh_test.go
+++ b/panel-api/internal/reconciler/wordpress_version_refresh_test.go
@@ -1,0 +1,141 @@
+package reconciler
+
+// GH #1237 — after a WordPress core update / auto-update the Applications UI kept
+// showing the old version, because the reconciler probe only stat'd version.php
+// for existence and never re-read the version. These tests cover the refresh:
+// the probe now reports the parsed version and the reconciler writes it on drift.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/config"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeWPProbeAgent answers wordpress.version_probe with a canned payload and
+// records what it was called with.
+type fakeWPProbeAgent struct {
+	resp      []byte
+	err       error
+	gotMethod string
+	gotDir    string
+}
+
+func (f *fakeWPProbeAgent) Call(_ context.Context, method string, params interface{}) (json.RawMessage, error) {
+	f.gotMethod = method
+	if m, ok := params.(map[string]any); ok {
+		if d, ok := m["dir"].(string); ok {
+			f.gotDir = d
+		}
+	}
+	return f.resp, f.err
+}
+
+// fakeWPDomains satisfies DomainRepository via embedding; only FindByID is used.
+type fakeWPDomains struct {
+	repository.DomainRepository
+	docRoot string
+}
+
+func (f *fakeWPDomains) FindByID(_ context.Context, _ string) (*models.Domain, error) {
+	return &models.Domain{DocRoot: f.docRoot}, nil
+}
+
+func probeReconciler(t *testing.T, ready []models.WordPressInstall, agent *fakeWPProbeAgent, docRoot string) (*Reconciler, *mockWordPressInstallRepo) {
+	t.Helper()
+	mock := &mockWordPressInstallRepo{ready: ready}
+	r := &Reconciler{
+		wordPressInstalls: mock,
+		domains:           &fakeWPDomains{docRoot: docRoot},
+		agent:             agent,
+		cfg: &config.Config{
+			WordPress: config.WordPressConfig{
+				InstallTimeout: 10 * time.Minute,
+				CloneTimeout:   30 * time.Minute,
+				DeleteTimeout:  5 * time.Minute,
+				ProbeBatch:     100,
+			},
+		},
+		log: newTestLogger(t),
+	}
+	return r, mock
+}
+
+func wpProbeResp(t *testing.T, exists bool, version string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"exists": exists, "version": version})
+	if err != nil {
+		t.Fatalf("marshal probe resp: %v", err)
+	}
+	return b
+}
+
+func TestProbe_RefreshesVersionOnDrift(t *testing.T) {
+	ready := []models.WordPressInstall{
+		{ID: "w1", Status: "ready", AppType: "wordpress", DomainID: "d1", Version: stringPtr("6.4.10"), UpdatedAt: time.Now()},
+	}
+	agent := &fakeWPProbeAgent{resp: wpProbeResp(t, true, "6.7.1")}
+	r, mock := probeReconciler(t, ready, agent, "/home/u/public_html")
+
+	r.reconcileWordPressInstalls(context.Background())
+
+	if agent.gotMethod != "wordpress.version_probe" {
+		t.Fatalf("expected wordpress.version_probe, got %q", agent.gotMethod)
+	}
+	if agent.gotDir != "/home/u/public_html" {
+		t.Fatalf("probe dir = %q, want the docroot", agent.gotDir)
+	}
+	if len(mock.updateCalls) != 1 {
+		t.Fatalf("expected 1 update (version refresh), got %d", len(mock.updateCalls))
+	}
+	u := mock.updateCalls[0]
+	if u.id != "w1" || u.status != "ready" || u.version == nil || *u.version != "6.7.1" {
+		t.Fatalf("bad refresh update: %+v (version=%v)", u, u.version)
+	}
+}
+
+func TestProbe_NoUpdateWhenVersionUnchanged(t *testing.T) {
+	ready := []models.WordPressInstall{
+		{ID: "w1", Status: "ready", AppType: "wordpress", DomainID: "d1", Version: stringPtr("6.7.1"), UpdatedAt: time.Now()},
+	}
+	agent := &fakeWPProbeAgent{resp: wpProbeResp(t, true, "6.7.1")}
+	r, mock := probeReconciler(t, ready, agent, "/home/u/public_html")
+
+	r.reconcileWordPressInstalls(context.Background())
+
+	if len(mock.updateCalls) != 0 {
+		t.Fatalf("no drift → expected 0 updates, got %d", len(mock.updateCalls))
+	}
+}
+
+func TestProbe_BackfillsNullVersion(t *testing.T) {
+	ready := []models.WordPressInstall{
+		{ID: "w1", Status: "ready", AppType: "wordpress", DomainID: "d1", Version: nil, UpdatedAt: time.Now()},
+	}
+	agent := &fakeWPProbeAgent{resp: wpProbeResp(t, true, "6.7.1")}
+	r, mock := probeReconciler(t, ready, agent, "/home/u/public_html")
+
+	r.reconcileWordPressInstalls(context.Background())
+
+	if len(mock.updateCalls) != 1 || mock.updateCalls[0].version == nil || *mock.updateCalls[0].version != "6.7.1" {
+		t.Fatalf("expected NULL version to be backfilled to 6.7.1, got %+v", mock.updateCalls)
+	}
+}
+
+func TestProbe_MissingVersionPhpMarksFailed(t *testing.T) {
+	ready := []models.WordPressInstall{
+		{ID: "w1", Status: "ready", AppType: "wordpress", DomainID: "d1", Version: stringPtr("6.7.1"), UpdatedAt: time.Now()},
+	}
+	agent := &fakeWPProbeAgent{resp: wpProbeResp(t, false, "")}
+	r, mock := probeReconciler(t, ready, agent, "/home/u/public_html")
+
+	r.reconcileWordPressInstalls(context.Background())
+
+	if len(mock.updateCalls) != 1 || mock.updateCalls[0].status != "failed" {
+		t.Fatalf("missing version.php must flip to failed, got %+v", mock.updateCalls)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes GH #1237 — after updating WordPress, the Applications UI kept showing the old version.

## Cause

The panel captured the WordPress version **once at install** and never re-read it. The reconciler's ready-install probe only stat'd `wp-includes/version.php` for **existence** (missing → mark the install failed) and never parsed the version — so a WP core update or auto-update never made it back into the stored `version` column, and the UI stayed stale.

## Fix

- **New agent verb `wordpress.version_probe`** — stat + parse `$wp_version` from `<dir>/wp-includes/version.php` in one call, reusing the existing `readWPVersion` parser that `app.scan` already relies on. Privileged path-only, like `fs.stat`; the caller passes a system-derived docroot, and `version.php` is a world-readable WP core file.
- **Reconciler probe** now calls it instead of `fs.stat`: a missing `version.php` still flips the install to `failed`; when present, it **refreshes the stored version if it drifted** from what's on disk (and backfills a NULL version). Written only on drift, so there's no `updated_at` churn.
- The user Applications list already auto-refetches (`refetchInterval`), so the new number surfaces without a manual refresh once the probe runs.

## Tests

Reconciler probe cases:
- refresh-on-drift (6.4.10 → 6.7.1 → `UpdateStatus(ready, "6.7.1")`),
- no-op when unchanged,
- NULL version backfilled,
- missing `version.php` → `failed`.

`go build` + `vet` + reconciler + api suites green; agent builds + vets.

## Box verification (proposed)

This is a reconciler + agent feature, so a live check is warranted (`.60` has real WP installs). Proposed drill: deploy the new agent + panel, set an install's `version` to a wrong value to simulate post-update drift, let the probe run, and confirm it self-corrects to the real `version.php` value (then restore). Happy to run it before merge — say the word.
