### PR TITLE
feat(users): admin WebUI action to rename a tenant's username (GH #1238)

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5601,6 +5601,19 @@ paths:
         "200": { description: OK, content: { application/json: { schema: { type: object, properties: { ssh_forwarding_enabled: { type: boolean }, ssh_enabled: { type: boolean } } } } } }
         "422": { description: Not a hosting user, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
 
+  /admin/users/{id}/rename:
+    post:
+      tags: [Users]
+      summary: Rename a tenant's Linux/login username in place (admin, JAB-380 step-up, GH #1238)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { new_username: { type: string } }, required: [new_username] } } } }
+      responses:
+        "200": { description: Renamed, content: { application/json: { schema: { type: object, properties: { id: { type: string }, username: { type: string } } } } } }
+        "403": { description: Recent-auth step-up required (JAB-380), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "404": { description: User not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "422": { description: Rename refused — invalid name, a v1 refusal (FTP subaccounts / Python apps / cross-filesystem), or the name is taken, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
   /me/ssh-forwarding:
     get:
       tags: [Users]

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -37,11 +37,16 @@ type UserHandlerConfig struct {
 	Domains         repository.DomainRepository
 	Databases       repository.DatabaseRepository
 	DatabaseUsers   repository.DatabaseUserRepository
-	// FtpAccounts is reaped on user delete (JAB-265).
+	// FtpAccounts is reaped on user delete (JAB-265). It's also the GH #1238
+	// rename preflight's refusal check (a tenant with FTP/SFTP subaccounts is
+	// refused in v1 — their jails are bind-mounted under the home).
 	FtpAccounts repository.FtpAccountRepository
-	DockerApps  repository.DockerAppRepository
-	Mailboxes   repository.MailboxRepository
-	Packages    repository.PackageRepository
+	// PythonApps is the other GH #1238 rename refusal check (a tenant with
+	// Python apps is refused in v1 — their app-roots need move handling).
+	PythonApps repository.PythonAppRepository
+	DockerApps repository.DockerAppRepository
+	Mailboxes  repository.MailboxRepository
+	Packages   repository.PackageRepository
 	// PortAllocations frees a domain's reverse-proxy loopback port (GH #1175)
 	// during the account-delete cascade. Optional.
 	PortAllocations repository.PortAllocationRepository
@@ -126,6 +131,11 @@ func RegisterUserRoutes(g *gin.RouterGroup, cfg UserHandlerConfig) {
 	// Remote-SSH). Admin-only to flip; the tenant can read their own status.
 	g.GET("/admin/users/:id/ssh-forwarding", middleware.RequireAdmin(), h.getSSHForwarding)
 	g.POST("/admin/users/:id/ssh-forwarding", middleware.RequireAdmin(), h.setSSHForwarding)
+
+	// GH #1238: rename a tenant's Linux/login username in place. Admin-only,
+	// and JAB-380 recent-auth step-up is enforced inside the handler (it's a
+	// data-moving, login-changing operation).
+	g.POST("/admin/users/:id/rename", middleware.RequireAdmin(), h.rename)
 	g.GET("/me/ssh-forwarding", h.mySSHForwarding)
 }
 

--- a/panel-api/internal/api/users_rename.go
+++ b/panel-api/internal/api/users_rename.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+// users_rename.go — admin action to rename a tenant's Linux/login username in
+// place (GH #1238, WebUI follow-up to the `jabali user rename` CLI).
+//
+// The heavy lifting lives in userops.RenameUser (shared with the CLI): the agent
+// does usermod -l / -d -m, the panel repoints the DB + Kratos login, and the
+// owned domains re-render. This handler is the thin admin surface: it's a
+// data-moving, login-changing operation, so it's admin-only AND gated behind the
+// JAB-380 recent-auth step-up, same as the root File Manager. The Reconciler is
+// left nil (as the CLI does) so the owned domains re-render on the periodic
+// reconcile rather than blocking the HTTP request on a long synchronous pass.
+
+type renameUserRequest struct {
+	NewUsername string `json:"new_username"`
+}
+
+// rename handles POST /admin/users/:id/rename { new_username }.
+func (h *userHandler) rename(c *gin.Context) {
+	// Root-privileged surface: require a recently-authenticated interactive
+	// session (JAB-380). A stale session gets a 403 the SPA turns into a
+	// re-auth + retry.
+	if !requireRecentAuth(c, h.cfg.KratosClient, stepUpWindow) {
+		return
+	}
+
+	userID := c.Param("id")
+	if userID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user id required"})
+		return
+	}
+	var req renameUserRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+
+	// Rename touches the OS account + home move; bound it so a wedged agent
+	// can't pin the request forever (same 5-min ceiling the CLI uses).
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Minute)
+	defer cancel()
+
+	target, err := h.cfg.Repo.FindByID(ctx, userID)
+	if err != nil || target == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	d := userops.Deps{
+		Users:        h.cfg.Repo,
+		Domains:      h.cfg.Domains,
+		KratosClient: h.cfg.KratosClient,
+		Agent:        h.cfg.Agent,
+		Log:          h.log(),
+	}
+	rd := userops.RenameDeps{
+		FtpAccounts: h.cfg.FtpAccounts,
+		PythonApps:  h.cfg.PythonApps,
+		// Reconciler nil: the periodic reconcile re-renders the owned domains
+		// (mirrors the CLI), keeping the HTTP request off a long re-render.
+	}
+
+	if err := userops.RenameUser(ctx, d, rd, target, req.NewUsername); err != nil {
+		h.auditRename(c, userID, req.NewUsername, models.AuditResultError)
+		// userops.RenameUser's errors are user-actionable (invalid name, v1
+		// refusals like "has FTP subaccounts", cross-fs, already-taken) — pass
+		// the message through so the admin sees exactly why.
+		status := http.StatusUnprocessableEntity
+		if errors.Is(err, repository.ErrConflict) {
+			status = http.StatusConflict
+		}
+		c.JSON(status, gin.H{"error": "rename_failed", "detail": err.Error()})
+		return
+	}
+	h.auditRename(c, userID, req.NewUsername, models.AuditResultOK)
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":       userID,
+		"username": req.NewUsername,
+	})
+}
+
+// auditRename records the admin rename of a tenant account. No-op when the audit
+// repo isn't wired (dev binaries).
+func (h *userHandler) auditRename(c *gin.Context, userID, newName, result string) {
+	if h.cfg.AuditEvents == nil {
+		return
+	}
+	meta, _ := json.Marshal(map[string]string{"new_username": newName})
+	subject := userID
+	ev := &models.AuditEvent{
+		ID:            ids.NewULID(),
+		TS:            time.Now().UTC(),
+		ActorKind:     models.AuditActorAdmin,
+		SubjectUserID: &subject,
+		Action:        "admin.user.rename",
+		TargetType:    "user",
+		TargetID:      userID,
+		Result:        result,
+		Meta:          meta,
+	}
+	if claims := ginctx.Claims(c); claims != nil && claims.UserID != "" {
+		actor := claims.UserID
+		ev.ActorUserID = &actor
+	}
+	if ip := c.ClientIP(); ip != "" {
+		ev.SourceIP = &ip
+	}
+	if reqID := ginctx.RequestID(c); reqID != "" {
+		ev.RequestID = &reqID
+	}
+	_ = h.cfg.AuditEvents.Create(c.Request.Context(), ev)
+}

--- a/panel-api/internal/api/users_rename_test.go
+++ b/panel-api/internal/api/users_rename_test.go
@@ -1,0 +1,116 @@
+package api
+
+// GH #1238 — admin rename endpoint. The rename logic itself is covered in the
+// userops package; these pin the handler's contract: the JAB-380 step-up gate,
+// request validation, and that a userops refusal is surfaced with its message.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- minimal mocks (embed the interface, override only what rename touches) ---
+
+type renameUsersRepo struct {
+	repository.UserRepository
+	byID   *models.User
+	byName *models.User
+}
+
+func (r renameUsersRepo) FindByID(context.Context, string) (*models.User, error) {
+	if r.byID == nil {
+		return nil, repository.ErrNotFound
+	}
+	return r.byID, nil
+}
+
+func (r renameUsersRepo) FindByUsername(context.Context, string) (*models.User, error) {
+	if r.byName == nil {
+		return nil, repository.ErrNotFound
+	}
+	return r.byName, nil
+}
+
+type renameFtpRepo struct {
+	repository.FtpAccountRepository
+	count int64
+}
+
+func (r renameFtpRepo) CountByUserID(context.Context, string) (int64, error) { return r.count, nil }
+
+type renameStubAgent struct{}
+
+func (renameStubAgent) Call(context.Context, string, any) (json.RawMessage, error) {
+	return []byte("{}"), nil
+}
+
+func rsp(s string) *string { return &s }
+
+func renameCtx(claims *auth.AccessClaims, id, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+id+"/rename", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	if claims != nil {
+		ginctx.SetClaims(c, claims)
+	}
+	return c, w
+}
+
+func recentAdmin() *auth.AccessClaims {
+	return &auth.AccessClaims{UserID: "admin1", IsAdmin: true, Source: auth.SourceKratos, AuthenticatedAt: time.Now().Add(-1 * time.Minute)}
+}
+
+func TestRename_StepUpRequiredWhenStale(t *testing.T) {
+	stale := &auth.AccessClaims{UserID: "admin1", IsAdmin: true, Source: auth.SourceKratos, AuthenticatedAt: time.Now().Add(-2 * time.Hour)}
+	h := &userHandler{cfg: UserHandlerConfig{}} // KratosClient nil: stale fast-path → 403
+	c, w := renameCtx(stale, "u1", `{"new_username":"bob"}`)
+	h.rename(c)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "stepup_required")
+}
+
+func TestRename_InvalidBody(t *testing.T) {
+	h := &userHandler{cfg: UserHandlerConfig{}}
+	c, w := renameCtx(recentAdmin(), "u1", `not json`)
+	h.rename(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid_body")
+}
+
+func TestRename_SurfacesFtpRefusal(t *testing.T) {
+	uid := uint32(1001)
+	target := &models.User{ID: "u1", Username: rsp("alice"), LinuxUID: &uid}
+	h := &userHandler{cfg: UserHandlerConfig{
+		Repo:        renameUsersRepo{byID: target},
+		Agent:       renameStubAgent{},
+		FtpAccounts: renameFtpRepo{count: 2},
+	}}
+	c, w := renameCtx(recentAdmin(), "u1", `{"new_username":"bob"}`)
+	h.rename(c)
+	// Refused before the agent runs → 422 with the user-actionable reason.
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assert.Contains(t, w.Body.String(), "rename_failed")
+	assert.Contains(t, w.Body.String(), "FTP")
+}
+
+func TestRename_UserNotFound(t *testing.T) {
+	h := &userHandler{cfg: UserHandlerConfig{Repo: renameUsersRepo{}}} // byID nil → not found
+	c, w := renameCtx(recentAdmin(), "ghost", `{"new_username":"bob"}`)
+	h.rename(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -632,6 +632,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Databases:       deps.Databases,
 				DatabaseUsers:   deps.DatabaseUsers,
 				FtpAccounts:     deps.FtpAccounts,
+				// GH #1238: the rename preflight refuses a tenant with Python apps.
+				PythonApps:      repository.NewPythonAppRepository(deps.DB),
 				DockerApps:      deps.DockerApps,
 				DomainTeardowns: deps.DomainTeardowns,
 				PortAllocations: repository.NewPortAllocationRepository(deps.DB),

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -164,6 +164,7 @@
       "edit": "Edit",
       "reset_2fa": "Reset 2FA",
       "reset_password": "Reset password",
+      "rename": "Rename username",
       "suspend": "Suspend",
       "unsuspend": "Unsuspend",
       "delete": "Delete"

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -33,6 +33,7 @@ import { UserDiskUsage, UserDiskUsageCell } from "./UserDiskUsage";
 import { UserReset2FAAction } from "./UserReset2FAAction";
 import { UserResetPasswordAction } from "./UserResetPasswordAction";
 import { UserSuspendAction } from "./UserSuspendAction";
+import { UserRenameAction } from "./UserRenameAction";
 import { AdminSessionsPage } from "../sessions/AdminSessionsPage";
 
 type User = {
@@ -79,6 +80,7 @@ function UserRowActions({
   const [reset2faOpen, setReset2faOpen] = useState(false);
   const [resetPwOpen, setResetPwOpen] = useState(false);
   const [suspendOpen, setSuspendOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   // ADR-0128 — start act-as, then full-reload into the user shell so /me
@@ -107,6 +109,16 @@ function UserRowActions({
     { key: "edit", label: t("users.actions.edit"), icon: <EditOutlined />, onClick: () => onEdit(user.id) },
     { key: "reset2fa", label: t("users.actions.reset_2fa"), icon: <SafetyOutlined />, onClick: () => setReset2faOpen(true) },
     { key: "resetpw", label: t("users.actions.reset_password"), icon: <SafetyOutlined />, onClick: () => setResetPwOpen(true) },
+    ...(!user.is_admin
+      ? [
+          {
+            key: "rename",
+            label: t("users.actions.rename"),
+            icon: <EditOutlined />,
+            onClick: () => setRenameOpen(true),
+          },
+        ]
+      : []),
     ...(!user.is_admin
       ? [
           {
@@ -143,6 +155,15 @@ function UserRowActions({
           suspended={!!user.suspended}
           open={suspendOpen}
           onClose={() => setSuspendOpen(false)}
+        />
+      )}
+      {!user.is_admin && (
+        <UserRenameAction
+          userId={user.id}
+          currentUsername={user.username}
+          userLabel={userLabel(user)}
+          open={renameOpen}
+          onClose={() => setRenameOpen(false)}
         />
       )}
       <UserDeleteAction

--- a/panel-ui/src/shells/admin/users/UserRenameAction.test.tsx
+++ b/panel-ui/src/shells/admin/users/UserRenameAction.test.tsx
@@ -1,0 +1,75 @@
+// GH #1238 — admin rename modal. Pins the client-side validation gate and that
+// confirming POSTs the rename to the admin endpoint. Only apiClient is mocked.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apiClient", () => ({ apiClient: { post: vi.fn() } }));
+import { apiClient } from "../../../apiClient";
+import { UserRenameAction } from "./UserRenameAction";
+
+const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+afterEach(() => {
+  cleanup();
+  mocked.post.mockReset();
+});
+
+function renderModal() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <UserRenameAction
+          userId="u1"
+          currentUsername="alice"
+          userLabel="alice"
+          open
+          onClose={() => {}}
+        />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+describe("GH #1238 — UserRenameAction", () => {
+  it("gates the Rename button on a valid, changed username and POSTs on confirm", async () => {
+    renderModal();
+    await screen.findByText("Rename user");
+
+    const input = screen.getByPlaceholderText("e.g. acme");
+    const renameBtn = () => screen.getByRole("button", { name: /^Rename$/ });
+
+    // Invalid (uppercase/space) → disabled.
+    fireEvent.change(input, { target: { value: "Bad Name" } });
+    expect(renameBtn()).toBeDisabled();
+
+    // Unchanged (same as current) → disabled.
+    fireEvent.change(input, { target: { value: "alice" } });
+    expect(renameBtn()).toBeDisabled();
+
+    // Valid + changed → enabled.
+    fireEvent.change(input, { target: { value: "acme" } });
+    expect(renameBtn()).not.toBeDisabled();
+
+    mocked.post.mockResolvedValue({ data: {} });
+    fireEvent.click(renameBtn());
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/admin/users/u1/rename", {
+        new_username: "acme",
+      }),
+    );
+  });
+
+  it("does not POST while the username is invalid", async () => {
+    renderModal();
+    await screen.findByText("Rename user");
+    const input = screen.getByPlaceholderText("e.g. acme");
+    fireEvent.change(input, { target: { value: "9bad" } }); // must start with a letter/_
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    // onPressEnter → handleSubmit, but okDisabled short-circuits it.
+    expect(mocked.post).not.toHaveBeenCalled();
+  });
+});

--- a/panel-ui/src/shells/admin/users/UserRenameAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserRenameAction.tsx
@@ -1,0 +1,138 @@
+// UserRenameAction — controlled modal that renames a tenant's Linux/login
+// username in place (GH #1238, WebUI for `jabali user rename`).
+//
+// The uid is preserved, so files aren't re-chowned; the account name + home
+// path move and the owned domains re-render (on the reconciler's next tick).
+// POST /admin/users/:id/rename is admin-only AND behind the JAB-380 step-up —
+// a stale session gets a 403 that apiClient turns into a re-auth + retry.
+//
+// v1 refuses a tenant with FTP/SFTP subaccounts or Python apps; databases + DB
+// SSO roles keep the old-username prefix (keyed by id, so they keep working).
+// The backend returns those refusals as a 422 with a `detail` message, which we
+// surface verbatim.
+import { useState } from "react";
+import { Alert, Form, Input, Modal, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../../apiClient";
+
+// Mirror of the agent/userops POSIX-username rule.
+const USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/;
+
+interface UserRenameActionProps {
+  userId: string;
+  currentUsername?: string | null;
+  userLabel: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const UserRenameAction = ({
+  userId,
+  currentUsername,
+  userLabel,
+  open,
+  onClose,
+}: UserRenameActionProps) => {
+  const qc = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [newUsername, setNewUsername] = useState("");
+
+  const trimmed = newUsername.trim();
+  const invalid = !USERNAME_RE.test(trimmed);
+  const unchanged = !!currentUsername && trimmed === currentUsername;
+  const okDisabled = trimmed === "" || invalid || unchanged;
+
+  const handleClose = () => {
+    setNewUsername("");
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (okDisabled) return;
+    setIsLoading(true);
+    try {
+      await apiClient.post(`/admin/users/${encodeURIComponent(userId)}/rename`, {
+        new_username: trimmed,
+      });
+      feedback.message.success(
+        `Renamed "${currentUsername ?? userLabel}" → "${trimmed}". Their sites re-render within about a minute.`,
+      );
+      qc.invalidateQueries({ queryKey: ["list", "users"] });
+      handleClose();
+    } catch (err: unknown) {
+      // 403 stepup_required is handled globally (apiClient redirects to re-auth).
+      const errMsg =
+        (err as { response?: { data?: { detail?: string; error?: string } } })
+          ?.response?.data?.detail ??
+        (err as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error ??
+        (err instanceof Error ? err.message : "Rename failed");
+      feedback.message.error(errMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Rename user"
+      open={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText="Rename"
+      okButtonProps={{ danger: true, disabled: okDisabled }}
+      confirmLoading={isLoading}
+      destroyOnHidden
+    >
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        Renames the Linux account and login for <b>{currentUsername ?? userLabel}</b> in
+        place — same uid, so files aren't re-chowned. The home directory moves
+        (<code>/home/{currentUsername ?? "…"}</code> → <code>/home/{trimmed || "…"}</code>)
+        and their sites re-render under the new path.
+      </Typography.Paragraph>
+
+      <Form layout="vertical">
+        <Form.Item
+          label="New username"
+          validateStatus={trimmed !== "" && (invalid || unchanged) ? "error" : undefined}
+          help={
+            trimmed !== "" && invalid
+              ? "Must match ^[a-z_][a-z0-9_-]{0,31}$ (lowercase, starts with a letter or _)."
+              : trimmed !== "" && unchanged
+                ? "That's already the current username."
+                : undefined
+          }
+        >
+          <Input
+            autoFocus
+            value={newUsername}
+            placeholder="e.g. acme"
+            onChange={(e) => setNewUsername(e.target.value)}
+            onPressEnter={handleSubmit}
+          />
+        </Form.Item>
+      </Form>
+
+      <Alert
+        type="warning"
+        showIcon
+        message="Before you rename"
+        description={
+          <ul style={{ margin: 0, paddingInlineStart: 18 }}>
+            <li>
+              Refused (v1) if the user has <b>FTP/SFTP subaccounts</b> or{" "}
+              <b>Python apps</b> — remove those first.
+            </li>
+            <li>
+              Their <b>databases and DB users keep the old-username prefix</b> (they're
+              keyed internally by id, so they keep working). Mail is unaffected.
+            </li>
+            <li>You'll be asked to re-authenticate the first time in a session.</li>
+          </ul>
+        }
+      />
+    </Modal>
+  );
+};


### PR DESCRIPTION
## Summary

Adds the admin-panel action for GH #1238 that @johnnyq asked for ("should also be implemented on the WebUI"). The `jabali user rename` CLI shipped in #1305; this is the WebUI over the **same** `userops.RenameUser` — the agent does `usermod -l` / `-d -m` (uid preserved, so files aren't re-chowned), the panel repoints the DB + Kratos login, and the owned domains re-render on the reconciler's tick.

Scope per the plan file: **rename first, owner-change as its own follow-up PR.**

## Backend

`POST /admin/users/:id/rename { new_username }`

- **Admin-only + JAB-380 recent-auth step-up** (a data-moving, login-changing operation, same gate as the File Manager / Root Terminal). A stale session → 403 → the SPA runs a re-auth and retries.
- `userops.RenameUser` refusals (invalid name, the v1 FTP/Python refusals, already-taken) are surfaced as **422 with a `detail`** the admin sees verbatim.
- Audited as `admin.user.rename`.
- The Reconciler is left nil (as the CLI does), so the domain re-render happens on the periodic tick rather than blocking the HTTP request.
- Wires the `PythonApps` repo into the users handler for the preflight; documents the route in `openapi.yaml`.

## Frontend

A **"Rename username"** row action (non-admin users) → a modal with:
- a POSIX-username-validated input (`^[a-z_][a-z0-9_-]{0,31}$`, and blocks "same as current"),
- a warning about the v1 limits (FTP/Python refusal, DB prefix kept, mail unaffected, re-auth prompt),
- backend refusals surfaced verbatim; the users list invalidates on success.

## Tests

- Handler: step-up-required (stale → 403), invalid body (400), user-not-found (404), and a userops refusal surfaced (FTP subaccounts → 422 with the reason).
- Modal: the validation gate (invalid / unchanged disable Rename) and that confirming POSTs `{ new_username }` to the endpoint.
- `go build` + `vet` + api/app suites green; `tsc -b` + full ui suite (67 files / 310 tests) + build green.

## Box verification (proposed)

The rename *logic* was drilled when the CLI (#1305) shipped; the new surface here is the endpoint + step-up + UI. Proposed drill on `.60`: deploy, rename a throwaway test tenant through the UI (exercising the step-up prompt), confirm the account + home move + the row reflects the new name, then rename it back. Happy to run it before merge — say the word.

## Follow-up

Domain-owner-change UI (mrlp57's request) ships next as its own PR.
