### PR TITLE
fix(users): show disk usage for users with no hosting package (GH #1242)

### DIFF
--- a/panel-api/internal/diskusagesweeper/sweeper.go
+++ b/panel-api/internal/diskusagesweeper/sweeper.go
@@ -159,6 +159,14 @@ func (s *Sweeper) reportOne(ctx context.Context, username string) (usedKB, limit
 	raw, err := s.deps.Agent.Call(callCtx, "user.limits.report", map[string]any{
 		"username":    username,
 		"quota_mount": s.deps.QuotaMount,
+		// GH #1242: du-fallback for users whose quota has no answer — a user
+		// with no hosting package has no quota, so quota reports nothing and the
+		// list showed a blank cell. The agent only walks du when quota is absent
+		// or 0, so packaged users with real usage still take the fast quota path;
+		// the extra du lands on quota-less / empty homes only, and this sweep is
+		// serialized + paced (InterUserDelay) off the request path, so it doesn't
+		// reintroduce the read-path du storm that made this on-demand-only.
+		"measure_disk": true,
 	})
 	if err != nil {
 		s.deps.Log.Debug("disk usage sweep: agent report failed",

--- a/panel-api/internal/diskusagesweeper/sweeper_test.go
+++ b/panel-api/internal/diskusagesweeper/sweeper_test.go
@@ -25,11 +25,12 @@ func quietLogger() *slog.Logger {
 }
 
 type stubAgent struct {
-	mu       sync.Mutex
-	calls    []string
-	reply    string
-	err      error
-	replyFor map[string]string
+	mu             sync.Mutex
+	calls          []string
+	reply          string
+	err            error
+	replyFor       map[string]string
+	sawMeasureDisk bool
 }
 
 func (a *stubAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
@@ -38,6 +39,9 @@ func (a *stubAgent) Call(_ context.Context, cmd string, params any) (json.RawMes
 	name := ""
 	if m, ok := params.(map[string]any); ok {
 		name, _ = m["username"].(string)
+		if md, _ := m["measure_disk"].(bool); md {
+			a.sawMeasureDisk = true
+		}
 	}
 	a.calls = append(a.calls, cmd+":"+name)
 	if a.err != nil {
@@ -127,6 +131,23 @@ func TestSweepOnce_PersistsReportedUsage(t *testing.T) {
 	}
 	if got.used != 1800000 || got.limit != 51200000 {
 		t.Errorf("persisted %+v, want used=1800000 limit=51200000", got)
+	}
+}
+
+// GH #1242: the sweep must request the du-fallback so a user with no hosting
+// package (hence no quota) still gets a real disk number instead of a blank cell.
+func TestSweepOnce_RequestsDuFallback(t *testing.T) {
+	repo := &stubUserRepo{rows: []models.User{userWith("u1", "alice")}}
+	ag := &stubAgent{reply: `{"disk":{"used_kb":4200,"limit_kb":0}}`}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	if !ag.sawMeasureDisk {
+		t.Fatal("sweep must call user.limits.report with measure_disk=true (GH #1242)")
+	}
+	// A quota-less user (limit 0) with real bytes still persists its usage.
+	if got := repo.written["u1"]; got.used != 4200 {
+		t.Fatalf("persisted %+v, want used=4200 for the no-package user", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes GH #1242 — the admin Users list disk-usage column was blank for a user with **no hosting package**.

## Cause

Disk usage is measured via `quota`. A user without a package has no quota set, so the **automatic** report returns 0 KB and the cell renders "—". The agent already has a `du -sk /home/<user>` fallback for exactly this (quota absent or 0), but it was **on-demand-only** (the "Measure" button) — an automatic per-request `du` walk was removed because it could storm the disk at peak (it ran on every `/usage` read, including for every 0-looking user).

## Fix

Have the **background disk-usage sweeper** request that `du`-fallback (`measure_disk: true`). This is the right place:

- The agent still takes the **fast quota path** for packaged users with real usage — `du` only lands on quota-less / empty homes.
- The sweep is **serialized + paced** (`InterUserDelay`, 15-min `Interval`, `PerUserTimeout` 30 s) and **off the request path**, so it doesn't reintroduce the read-path `du` storm.

A no-package user's real usage now lands in `users.disk_used_kb`, and the list column reads it. (Fresh no-package users show "—" until the next sweep, ≤15 min.)

## Test

`TestSweepOnce_RequestsDuFallback`: the sweep calls `user.limits.report` with `measure_disk=true` and persists a quota-less (limit 0) user's `used_kb`. `go build` + `vet` + sweeper suite green.

## Not in scope

The reporter also mentioned **monthly bandwidth** in that column — there's no bandwidth column today, so that's a separate feature request. This PR fixes the disk blank.

## Box verification (proposed)

Sweeper + agent behavior change → a live check is warranted. Proposed drill on `.60`: deploy, ensure a user with no package exists, trigger a sweep, and confirm `users.disk_used_kb` populates from `du` (and the column renders the number). Happy to run it before merge — say the word.
