### PR TITLE
fix(files): preserve folder structure on File Manager folder upload (GH #1243)

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1511,6 +1511,7 @@
     "apply": "Apply",
     "create": "Create",
     "empty_directory": "Empty directory",
+    "folder_read_failed": "Couldn't read the dropped folder",
     "folders": "Folders",
     "move": "Move",
     "new_file": "New File",

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -257,6 +257,59 @@ export interface FileManagerPageProps {
   rootPath?: string;
 }
 
+// collectDroppedEntries walks dropped file-system entries (files + folders)
+// into a flat list, each file tagged with its subfolder path relative to the
+// drop root (GH #1243). Directory reads are batched by the browser, so
+// readEntries is looped until it returns an empty batch. Exported for tests.
+export async function collectDroppedEntries(
+  roots: FileSystemEntry[],
+): Promise<{ file: File; relDir: string }[]> {
+  const out: { file: File; relDir: string }[] = [];
+  const readAll = (reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> => {
+    const all: FileSystemEntry[] = [];
+    const step = (): Promise<FileSystemEntry[]> =>
+      new Promise<FileSystemEntry[]>((resolve, reject) =>
+        reader.readEntries(resolve, reject),
+      ).then((batch) => {
+        if (batch.length === 0) return all;
+        all.push(...batch);
+        return step();
+      });
+    return step();
+  };
+  const walk = async (entry: FileSystemEntry, relDir: string): Promise<void> => {
+    if (entry.isFile) {
+      const file = await new Promise<File>((resolve, reject) =>
+        (entry as FileSystemFileEntry).file(resolve, reject),
+      );
+      out.push({ file, relDir });
+      return;
+    }
+    if (entry.isDirectory) {
+      const childRel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const children = await readAll((entry as FileSystemDirectoryEntry).createReader());
+      for (const child of children) await walk(child, childRel);
+    }
+  };
+  for (const root of roots) await walk(root, "");
+  return out;
+}
+
+// ancestorDirs expands a set of subfolder paths to every directory level that
+// must exist, shallow → deep (GH #1243). A deeply-nested-only folder (files only
+// at the bottom) still yields every intermediate level, so each can be created
+// as its own single-level mkdir (and thus chowned to the tenant). Exported for
+// tests.
+export function ancestorDirs(relDirs: readonly string[]): string[] {
+  const set = new Set<string>();
+  for (const rd of relDirs) {
+    if (!rd) continue;
+    const parts = rd.split("/");
+    for (let i = 1; i <= parts.length; i++) set.add(parts.slice(0, i).join("/"));
+  }
+  return [...set].sort((a, b) => a.split("/").length - b.split("/").length);
+}
+
 export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }: FileManagerPageProps = {}) => {
   const { t } = useTranslation();
   // Pull live theme tokens so the bulk-action bar (and any other
@@ -737,9 +790,46 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
   // → enqueue into the UploadDrawer, which owns concurrency, per-file
   // progress bars, and error reporting. The drawer auto-opens on the
   // first enqueue.
-  const enqueueUpload = useCallback((file: File) => {
-    uploadDrawerRef.current?.enqueue(file);
+  const enqueueUpload = useCallback((file: File, relDir?: string) => {
+    uploadDrawerRef.current?.enqueue(file, relDir);
   }, []);
+
+  // GH #1243: dropping a FOLDER must recreate its tree, not write a binary file
+  // named after the folder. dataTransfer.files flattens a directory to a single
+  // contentless entry; the entries API (webkitGetAsEntry) exposes the real
+  // structure. Roots are extracted synchronously in onDrop (the DataTransfer is
+  // only valid during the event); here we walk them, mkdir -p each subfolder,
+  // then enqueue every file into its subfolder.
+  const handleFolderAwareDrop = useCallback(
+    async (roots: FileSystemEntry[]) => {
+      if (!currentPath) return;
+      let collected: { file: File; relDir: string }[];
+      try {
+        collected = await collectDroppedEntries(roots);
+      } catch {
+        feedback.message.error(t("filemanagerpage.folder_read_failed"));
+        return;
+      }
+      if (collected.length === 0) return;
+      // Create every directory level individually, shallow → deep. Each mkdir is
+      // a single level (its own leaf), so the agent chowns it to the tenant — a
+      // one-shot mkdir -p of a deep path leaves the intermediate levels
+      // root-owned and unusable (GH #1243). Expand each file's subdir to all of
+      // its ancestors so a deeply-nested-only folder still gets every level made.
+      const dirs = ancestorDirs(collected.map((c) => c.relDir));
+      const base = currentPath.replace(/\/+$/, "");
+      for (const d of dirs) {
+        try {
+          await api.mkdir(`${base}/${d}`);
+        } catch {
+          // A collision with an existing dir is fine; a genuine failure will
+          // surface when a file upload into it fails.
+        }
+      }
+      for (const c of collected) enqueueUpload(c.file, c.relDir || undefined);
+    },
+    [currentPath, api, enqueueUpload, t],
+  );
 
   // --- drag-to-move state ---
   // draggedPath is set on dragstart from a table row; consumed on drop
@@ -1502,8 +1592,24 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
             if (!e.dataTransfer.types.includes("Files")) return;
             e.preventDefault();
             if (!currentPath) return;
-            for (const f of Array.from(e.dataTransfer.files)) {
-              enqueueUpload(f);
+            // GH #1243: prefer the entries API so dropped FOLDERS keep their
+            // structure. The DataTransferItemList is only valid during this
+            // event, so extract the entry roots synchronously, then walk them
+            // async. Fall back to the flat file list when it's unavailable.
+            const dtItems = e.dataTransfer.items;
+            const roots: FileSystemEntry[] = [];
+            if (dtItems && dtItems.length > 0) {
+              for (const it of Array.from(dtItems)) {
+                const entry = it.webkitGetAsEntry?.();
+                if (entry) roots.push(entry);
+              }
+            }
+            if (roots.length > 0) {
+              void handleFolderAwareDrop(roots);
+            } else {
+              for (const f of Array.from(e.dataTransfer.files)) {
+                enqueueUpload(f);
+              }
             }
           }}
         >

--- a/panel-ui/src/shells/user/files/UploadDrawer.tsx
+++ b/panel-ui/src/shells/user/files/UploadDrawer.tsx
@@ -35,8 +35,12 @@ import { tenantFilesApi, type FilesApi } from "./filesApi";
 import type { UploadOpts } from "./filesApi";
 
 export interface UploadDrawerHandle {
-  /** Enqueue a file for upload and open the drawer if closed. */
-  enqueue: (file: File) => void;
+  /**
+   * Enqueue a file for upload and open the drawer if closed. `relDir` is an
+   * optional subfolder under currentPath (GH #1243 folder upload) — the caller
+   * must have already created that directory tree.
+   */
+  enqueue: (file: File, relDir?: string) => void;
 }
 
 type UploadStatus = "queued" | "uploading" | "success" | "error";
@@ -44,6 +48,9 @@ type UploadStatus = "queued" | "uploading" | "success" | "error";
 interface UploadItem {
   id: string;
   file: File;
+  // relDir = subfolder under currentPath this file belongs in (GH #1243 folder
+  // upload), e.g. "my-folder/assets". Empty for a plain file drop.
+  relDir?: string;
   status: UploadStatus;
   progress: number;
   errorMessage?: string;
@@ -171,11 +178,16 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
         if (item.file.size > maxBytes) {
           throw new Error(`exceeds the ${formatBytes(maxBytes)} upload limit`);
         }
+        // GH #1243: a folder-upload file lands in currentPath/<relDir>. The
+        // drop handler has already created that directory tree (mkdir -p).
+        const destDir = item.relDir
+          ? `${currentPath.replace(/\/+$/, "")}/${item.relDir}`
+          : currentPath;
         const doUpload = (opts?: UploadOpts) => {
           const onp = (frac: number) => updateItem(item.id, { progress: frac });
           return item.file.size <= SINGLE_MULTIPART_CEILING
-            ? api.upload(currentPath, item.file, onp, opts)
-            : api.uploadChunked(currentPath, item.file, CHUNK_SIZE, onp, opts);
+            ? api.upload(destDir, item.file, onp, opts)
+            : api.uploadChunked(destDir, item.file, CHUNK_SIZE, onp, opts);
         };
         let mode: "ask" | "overwrite" | "rename" = alwaysOverwriteRef.current
           ? "overwrite"
@@ -244,11 +256,12 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
   }, [running, runOne, onUploaded]);
 
   const enqueue = useCallback(
-    (file: File) => {
+    (file: File, relDir?: string) => {
       const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
       const item: UploadItem = {
         id,
         file,
+        relDir,
         status: "queued",
         progress: 0,
       };

--- a/panel-ui/src/shells/user/files/folderUpload.test.ts
+++ b/panel-ui/src/shells/user/files/folderUpload.test.ts
@@ -1,0 +1,90 @@
+// GH #1243 — dropping a folder must preserve its structure, not write a binary
+// file named after the folder. collectDroppedEntries is the traversal that turns
+// dropped file-system entries into a flat list of files, each tagged with its
+// subfolder path. This pins the reporter's exact example.
+import { describe, it, expect } from "vitest";
+import { collectDroppedEntries, ancestorDirs } from "./FileManagerPage";
+
+// Minimal FileSystemEntry fakes matching the browser's entries API.
+function fileEntry(name: string): FileSystemEntry {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    file: (ok: (f: File) => void) => ok(new File(["x"], name)),
+  } as unknown as FileSystemEntry;
+}
+
+function dirEntry(name: string, children: FileSystemEntry[]): FileSystemEntry {
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    // Each createReader() gets its own "served" latch: readEntries returns the
+    // batch once, then an empty array (the browser's end-of-directory signal).
+    createReader: () => {
+      let served = false;
+      return {
+        readEntries: (ok: (e: FileSystemEntry[]) => void) => {
+          if (served) return ok([]);
+          served = true;
+          ok(children);
+        },
+      };
+    },
+  } as unknown as FileSystemEntry;
+}
+
+describe("GH #1243 — collectDroppedEntries", () => {
+  it("flattens a dropped folder into files tagged with their subfolder", async () => {
+    // my-folder/
+    // ├── index.php
+    // ├── test.txt
+    // └── assets/
+    //     └── style.css
+    const roots = [
+      dirEntry("my-folder", [
+        fileEntry("index.php"),
+        fileEntry("test.txt"),
+        dirEntry("assets", [fileEntry("style.css")]),
+      ]),
+    ];
+
+    const out = await collectDroppedEntries(roots);
+    const byName = Object.fromEntries(out.map((o) => [o.file.name, o.relDir]));
+
+    expect(out).toHaveLength(3);
+    expect(byName["index.php"]).toBe("my-folder");
+    expect(byName["test.txt"]).toBe("my-folder");
+    expect(byName["style.css"]).toBe("my-folder/assets");
+  });
+
+  it("leaves a plain dropped file at the root (empty relDir)", async () => {
+    const out = await collectDroppedEntries([fileEntry("readme.md")]);
+    expect(out).toEqual([{ file: expect.any(File), relDir: "" }]);
+  });
+});
+
+describe("GH #1243 — ancestorDirs (every level created individually)", () => {
+  it("expands to each level, shallow first", () => {
+    expect(ancestorDirs(["my-folder", "my-folder/assets"])).toEqual([
+      "my-folder",
+      "my-folder/assets",
+    ]);
+  });
+
+  it("fills in intermediates for a deeply-nested-only folder", () => {
+    // Files only at the bottom — every level must still be created (each as its
+    // own single-level mkdir, so the agent chowns it to the tenant; a one-shot
+    // mkdir -p would leave my-folder + my-folder/a root-owned).
+    expect(ancestorDirs(["my-folder/a/b"])).toEqual([
+      "my-folder",
+      "my-folder/a",
+      "my-folder/a/b",
+    ]);
+  });
+
+  it("dedupes and ignores empty (root) entries", () => {
+    expect(ancestorDirs(["", "x/y", "x/y", "x"])).toEqual(["x", "x/y"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes GH #1243 — dropping a **folder** on the File Manager created a single binary file named after the folder instead of recreating the folder and its contents.

## Cause

The OS-file drop handler read `e.dataTransfer.files`, which **flattens a dropped directory to one contentless entry** — so the folder was enqueued as if it were a file. The browser's entries API (`webkitGetAsEntry`) is what exposes the real structure.

## Fix (frontend only)

The drop handler now:
1. extracts the entry roots **synchronously** (the `DataTransferItemList` is only valid during the event),
2. walks them (`collectDroppedEntries`) into a flat list of files, each tagged with its subfolder path,
3. creates each directory level, then enqueues every file into its subfolder.

`UploadDrawer.enqueue` gains an optional `relDir`. A plain file drop is unchanged.

```text
my-folder/
├── index.php
├── test.txt
└── assets/
    └── style.css
```

now recreates that exact tree in the destination.

## Why one level at a time (a box drill caught this)

The first cut used the agent's `files.mkdir` **`parents` (mkdir -p)** mode. Drilling on a test box surfaced a real bug: that mode **chowns only the leaf**, so `mkdir -p my-folder/a/b/c` leaves `my-folder`, `a`, `b` as **`root:root 0700`** — unusable by the tenant (a deeply-nested-only folder would upload into inaccessible dirs).

So the fix creates **each level as its own single-level mkdir** — `ancestorDirs` expands every file's subdir to all of its ancestors (shallow → deep) — and each dir is a leaf, which the existing handler chowns to the tenant. Verified on the box: every level of a deep tree comes out `<user>:www-data 0750`. **No backend/agent change** — the latent `parents`-chown bug is left untouched and unexposed.

## Tests

- `collectDroppedEntries` flattens the reporter's exact folder shape into `{file, relDir}`.
- `ancestorDirs` fills in the intermediates for a deeply-nested-only folder (`["my-folder/a/b"] → ["my-folder","my-folder/a","my-folder/a/b"]`).
- `tsc -b` + full ui suite (68 files / 315 tests) + build green.

## Scope

Covers **drag-and-drop** (the reported path). Drag-and-drop directory traversal is a browser interaction, so a device re-test by the reporter is the real confirmation — @lxsdevcode, once this lands, please drop your `my-folder/` example and confirm the tree comes through with its files.

Follow-up (optional): a folder picker on the **Upload** button (`webkitdirectory`).
