### PR TITLE
feat(users): re-prefix MariaDB DBs + DB users + shadow roles on user rename (GH #1238)

### DIFF
--- a/panel-agent/internal/commands/db_rename_db.go
+++ b/panel-agent/internal/commands/db_rename_db.go
@@ -1,0 +1,197 @@
+package commands
+
+// db.rename_db — rename a MariaDB database by moving its base tables into a new
+// schema (GH #1238 DB re-prefix on user rename). MariaDB has no RENAME DATABASE,
+// so this does CREATE DATABASE <new> + RENAME TABLE <old>.t TO <new>.t for every
+// base table (a metadata move on the same filesystem: instant, no data copy) +
+// DROP DATABASE <old>.
+//
+// v1 is base-tables-only: RENAME TABLE does not move triggers, and views/routines/
+// events are schema-bound and would need fragile SQL-text recreation. If the
+// source DB holds any of those, the rename is REFUSED with a clear message rather
+// than risk losing an object on the DROP DATABASE. Idempotent: re-running after a
+// partial move (old gone, new present) is a no-op success.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type dbRenameDBParams struct {
+	OldDB string `json:"old_db"`
+	NewDB string `json:"new_db"`
+}
+
+type dbRenameDBResponse struct {
+	OK          bool `json:"ok"`
+	MovedTables int  `json:"moved_tables"`
+	// AlreadyRenamed reports the idempotent path (old gone, new present).
+	AlreadyRenamed bool `json:"already_renamed,omitempty"`
+}
+
+func invalidArg(msg string) *agentwire.AgentError {
+	return &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: msg}
+}
+
+func internalErr(msg string) *agentwire.AgentError {
+	return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: msg}
+}
+
+// mysqlQueryLines runs a query and returns its rows as trimmed lines (mysql -N
+// -B = no header, tab-separated). An empty result is a zero-length slice.
+func mysqlQueryLines(ctx context.Context, sql string) ([]string, error) {
+	out, err := execCommandContext(ctx, "mysql", "-N", "-B", "-e", sql).Output()
+	if err != nil {
+		return nil, err
+	}
+	s := strings.TrimRight(string(out), "\n")
+	if s == "" {
+		return nil, nil
+	}
+	return strings.Split(s, "\n"), nil
+}
+
+func dbRenameDBHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dbRenameDBParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, invalidArg(fmt.Sprintf("failed to parse params: %v", err))
+	}
+	if !dbNameRegex.MatchString(p.OldDB) || !dbNameRegex.MatchString(p.NewDB) {
+		return nil, invalidArg("invalid database name")
+	}
+	if p.OldDB == p.NewDB {
+		return nil, invalidArg("old_db and new_db are the same")
+	}
+
+	oldIdent, err := EscapeMariaDBIdentifier(p.OldDB)
+	if err != nil {
+		return nil, invalidArg("invalid database name")
+	}
+	newIdent, err := EscapeMariaDBIdentifier(p.NewDB)
+	if err != nil {
+		return nil, invalidArg("invalid database name")
+	}
+	oldLit, err := EscapeMariaDBLiteral(p.OldDB)
+	if err != nil {
+		return nil, invalidArg("invalid database name")
+	}
+
+	// Existence: if old is gone but new is present, a prior run already moved it.
+	exist, err := mysqlQueryLines(ctx, fmt.Sprintf(
+		"SELECT schema_name FROM information_schema.schemata WHERE schema_name IN (%s, %s)",
+		oldLit, mustLit(p.NewDB)))
+	if err != nil {
+		return nil, internalErr("failed to inspect schemas")
+	}
+	hasOld, hasNew := false, false
+	for _, s := range exist {
+		if s == p.OldDB {
+			hasOld = true
+		}
+		if s == p.NewDB {
+			hasNew = true
+		}
+	}
+	if !hasOld {
+		if hasNew {
+			return dbRenameDBResponse{OK: true, AlreadyRenamed: true}, nil
+		}
+		return nil, invalidArg(fmt.Sprintf("database %q does not exist", p.OldDB))
+	}
+	if hasNew {
+		return nil, invalidArg(fmt.Sprintf("destination database %q already exists", p.NewDB))
+	}
+
+	// Refuse anything RENAME TABLE can't safely carry (v1 base-tables-only).
+	nonTable, err := mysqlQueryLines(ctx, fmt.Sprintf(
+		"SELECT "+
+			"(SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=%[1]s AND table_type<>'BASE TABLE') + "+
+			"(SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema=%[1]s) + "+
+			"(SELECT COUNT(*) FROM information_schema.events WHERE event_schema=%[1]s) + "+
+			"(SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema=%[1]s)",
+		oldLit))
+	if err != nil {
+		return nil, internalErr("failed to inspect database objects")
+	}
+	if len(nonTable) == 1 && strings.TrimSpace(nonTable[0]) != "0" {
+		return nil, invalidArg(fmt.Sprintf(
+			"database %q contains views, triggers, stored routines, or events, which this rename does not yet move — leave it on its current name",
+			p.OldDB))
+	}
+
+	// Preserve the source charset/collation on the new schema.
+	cc, err := mysqlQueryLines(ctx, fmt.Sprintf(
+		"SELECT default_character_set_name, default_collation_name FROM information_schema.schemata WHERE schema_name=%s",
+		oldLit))
+	if err != nil || len(cc) != 1 {
+		return nil, internalErr("failed to read source charset")
+	}
+	fields := strings.Split(cc[0], "\t")
+	if len(fields) != 2 {
+		return nil, internalErr("unexpected schema metadata")
+	}
+	charsetLit, err := EscapeMariaDBLiteral(fields[0])
+	if err != nil {
+		return nil, internalErr("invalid source charset")
+	}
+	collationLit, err := EscapeMariaDBLiteral(fields[1])
+	if err != nil {
+		return nil, internalErr("invalid source collation")
+	}
+
+	// Enumerate base tables.
+	tables, err := mysqlQueryLines(ctx, fmt.Sprintf(
+		"SELECT table_name FROM information_schema.tables WHERE table_schema=%s AND table_type='BASE TABLE'",
+		oldLit))
+	if err != nil {
+		return nil, internalErr("failed to list tables")
+	}
+
+	// CREATE the destination schema.
+	if err := execCommandContext(ctx, "mysql", "-e", fmt.Sprintf(
+		"CREATE DATABASE %s CHARACTER SET %s COLLATE %s", newIdent, charsetLit, collationLit)).Run(); err != nil {
+		return nil, internalErr("failed to create destination database")
+	}
+
+	// Move every base table in one atomic RENAME TABLE.
+	if len(tables) > 0 {
+		var moves []string
+		for _, tbl := range tables {
+			tIdent, terr := EscapeMariaDBIdentifier(tbl)
+			if terr != nil {
+				return nil, internalErr(fmt.Sprintf("invalid table name %q", tbl))
+			}
+			moves = append(moves, fmt.Sprintf("%s.%s TO %s.%s", oldIdent, tIdent, newIdent, tIdent))
+		}
+		if err := execCommandContext(ctx, "mysql", "-e",
+			"RENAME TABLE "+strings.Join(moves, ", ")).Run(); err != nil {
+			return nil, internalErr("failed to move tables")
+		}
+	}
+
+	// Drop the now-empty source schema.
+	if err := execCommandContext(ctx, "mysql", "-e",
+		fmt.Sprintf("DROP DATABASE %s", oldIdent)).Run(); err != nil {
+		return nil, internalErr("moved tables but failed to drop the old database")
+	}
+
+	return dbRenameDBResponse{OK: true, MovedTables: len(tables)}, nil
+}
+
+// mustLit escapes a MariaDB string literal, returning a safe empty-match literal
+// on the (regex-precluded) error path.
+func mustLit(s string) string {
+	lit, err := EscapeMariaDBLiteral(s)
+	if err != nil {
+		return "''"
+	}
+	return lit
+}
+
+func init() {
+	Default.Register("db.rename_db", dbRenameDBHandler)
+}

--- a/panel-agent/internal/commands/db_rename_user.go
+++ b/panel-agent/internal/commands/db_rename_user.go
@@ -1,0 +1,111 @@
+package commands
+
+// db.rename_user — RENAME USER for a MariaDB account (GH #1238 DB re-prefix on
+// user rename). RENAME USER preserves the account's grants AND its password hash,
+// so the panel's stored password stays valid.
+//
+// Optional wildcard re-grant (for the <prefix>_mysqladmin shadow role, whose
+// GRANT is a <prefix>_%.* wildcard): after the rename, REVOKE the old prefix and
+// GRANT the new one, so the role admins the tenant's moved (new-prefix) DBs and
+// no longer any old-prefix name a future same-name user could create.
+//
+// Idempotent: if the old account is gone (already renamed / never existed) it is
+// a no-op success; a re-grant still runs against the new name so a resumed rename
+// converges.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// MariaDB account + prefix names: lower/upper alnum, underscore, hyphen; the
+// mysqladmin/per-DB users all fit this. 80 is MariaDB's user-name ceiling.
+var dbAccountRegex = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,79}$`)
+var dbPrefixRegex = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
+
+type dbRenameUserParams struct {
+	OldName string `json:"old_name"`
+	NewName string `json:"new_name"`
+	Host    string `json:"host"` // default 'localhost'
+	// WildcardRegrant, when both set, re-points a <old>_%.* → <new>_%.* GRANT
+	// after the rename (the shadow-admin role).
+	OldPrefix string `json:"old_prefix,omitempty"`
+	NewPrefix string `json:"new_prefix,omitempty"`
+}
+
+type dbRenameUserResponse struct {
+	OK      bool `json:"ok"`
+	Renamed bool `json:"renamed"`
+}
+
+func dbRenameUserHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dbRenameUserParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, invalidArg(fmt.Sprintf("failed to parse params: %v", err))
+	}
+	if !dbAccountRegex.MatchString(p.OldName) || !dbAccountRegex.MatchString(p.NewName) {
+		return nil, invalidArg("invalid account name")
+	}
+	host := p.Host
+	if host == "" {
+		host = "localhost"
+	}
+	if !dbAccountRegex.MatchString(host) && host != "localhost" && host != "%" {
+		return nil, invalidArg("invalid host")
+	}
+	hostLit, err := EscapeMariaDBLiteral(host)
+	if err != nil {
+		return nil, invalidArg("invalid host")
+	}
+	oldLit, err := EscapeMariaDBLiteral(p.OldName)
+	if err != nil {
+		return nil, invalidArg("invalid account name")
+	}
+	newLit, err := EscapeMariaDBLiteral(p.NewName)
+	if err != nil {
+		return nil, invalidArg("invalid account name")
+	}
+
+	renamed := false
+	if p.OldName != p.NewName {
+		// Only RENAME if the old account still exists (idempotent resume).
+		exists, qerr := mysqlQueryLines(ctx, fmt.Sprintf(
+			"SELECT 1 FROM mysql.user WHERE User=%s AND Host=%s", oldLit, hostLit))
+		if qerr != nil {
+			return nil, internalErr("failed to inspect account")
+		}
+		if len(exists) > 0 {
+			if err := execCommandContext(ctx, "mysql", "-e", fmt.Sprintf(
+				"RENAME USER %s@%s TO %s@%s", oldLit, hostLit, newLit, hostLit)).Run(); err != nil {
+				return nil, internalErr("failed to rename account")
+			}
+			renamed = true
+		}
+	}
+
+	// Optional wildcard re-grant for the shadow-admin role.
+	if p.OldPrefix != "" && p.NewPrefix != "" {
+		if !dbPrefixRegex.MatchString(p.OldPrefix) || !dbPrefixRegex.MatchString(p.NewPrefix) {
+			return nil, invalidArg("invalid prefix")
+		}
+		// Backtick pattern with an escaped underscore, matching db.mysqladmin.ensure.
+		oldPat := fmt.Sprintf("`%s\\_%%`", p.OldPrefix)
+		newPat := fmt.Sprintf("`%s\\_%%`", p.NewPrefix)
+		// REVOKE may error if the old grant is absent (already re-pointed on a
+		// resume) — tolerate that; the GRANT + FLUSH are what must stick.
+		_ = execCommandContext(ctx, "mysql", "-e", fmt.Sprintf(
+			"REVOKE ALL PRIVILEGES ON %s.* FROM %s@%s", oldPat, newLit, hostLit)).Run()
+		if err := execCommandContext(ctx, "mysql", "-e", fmt.Sprintf(
+			"GRANT ALL PRIVILEGES ON %s.* TO %s@%s; FLUSH PRIVILEGES;", newPat, newLit, hostLit)).Run(); err != nil {
+			return nil, internalErr("failed to re-point shadow grant")
+		}
+	}
+
+	return dbRenameUserResponse{OK: true, Renamed: renamed}, nil
+}
+
+func init() {
+	Default.Register("db.rename_user", dbRenameUserHandler)
+}

--- a/panel-api/cmd/server/db_user_create_test.go
+++ b/panel-api/cmd/server/db_user_create_test.go
@@ -163,3 +163,5 @@ type okServerSettings struct {
 func (s okServerSettings) Get(_ context.Context) (*models.ServerSettings, error) {
 	return &models.ServerSettings{PostgresEnabled: s.enabled}, nil
 }
+
+func (f *fakeCreateDBUsers) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/cmd/server/kratos_rebuild_cmd_test.go
+++ b/panel-api/cmd/server/kratos_rebuild_cmd_test.go
@@ -375,3 +375,7 @@ func TestRebuildOne_ProbeNotFoundTriggersRebuild(t *testing.T) {
 }
 
 func (r *fakeRebuildUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+
+func (f *fakeRebuildUserRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/cmd/server/user_rename_cmd.go
+++ b/panel-api/cmd/server/user_rename_cmd.go
@@ -63,8 +63,8 @@ and DB SSO shadow roles keep the old-username prefix (the panel keys them by id)
 
 			if !yes {
 				ok, cerr := confirm(fmt.Sprintf(
-					"Rename user %q -> %q? This renames the Linux account, moves /home/%s -> /home/%s, and re-renders their sites.",
-					old, newName, old, newName))
+					"Rename user %q -> %q? This renames the Linux account, moves /home/%s -> /home/%s, re-renders their sites, and re-prefixes their MariaDB databases + DB users (%s_* -> %s_*). App config files (wp-config.php etc.) that reference the old database name/user must be updated by hand afterwards.",
+					old, newName, old, newName, old, newName))
 				if cerr != nil {
 					return cerr
 				}
@@ -77,6 +77,10 @@ and DB SSO shadow roles keep the old-username prefix (the panel keys them by id)
 			rd := userops.RenameDeps{
 				FtpAccounts: repository.NewFtpAccountRepository(sharedDB),
 				PythonApps:  pythonAppRepoFromDB(),
+				// GH #1238: re-prefix the tenant's MariaDB artifacts on rename.
+				Databases:     repository.NewDatabaseRepository(sharedDB),
+				DatabaseUsers: repository.NewDatabaseUserRepository(sharedDB),
+				DBUserGrants:  repository.NewDatabaseUserGrantRepository(sharedDB),
 				// Reconciler is nil: the CLI is a separate process, so the running
 				// panel's periodic reconcile re-renders the owned domains.
 			}
@@ -85,7 +89,7 @@ and DB SSO shadow roles keep the old-username prefix (the panel keys them by id)
 				return err
 			}
 			cliAuditOK(ctx, "user.rename", "user", target.ID, &target.ID)
-			fmt.Printf("Renamed %q -> %q.\nThe reconciler re-renders their sites within ~a minute; verify with a page load or `jabali domain list`.\n", old, newName)
+			fmt.Printf("Renamed %q -> %q.\nTheir MariaDB databases + DB users were re-prefixed to %s_*. Update any app config (wp-config.php etc.) that still points at the old database name/user.\nThe reconciler re-renders their sites within ~a minute; verify with a page load or `jabali domain list`.\n", old, newName, newName)
 			return nil
 		},
 	}

--- a/panel-api/internal/api/automation_billing_test.go
+++ b/panel-api/internal/api/automation_billing_test.go
@@ -804,3 +804,8 @@ func TestAutomationCapabilities_BillingActionsAdvertised(t *testing.T) {
 		}
 	}
 }
+
+// GH #1238 stub.
+func (r *abUsers) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/api/cron_admin_list_test.go
+++ b/panel-api/internal/api/cron_admin_list_test.go
@@ -189,3 +189,8 @@ func (u *userRepoAdapterForCronAdminTest) Delete(context.Context, string) error 
 func (r *userRepoAdapterForCronAdminTest) UpdateUsername(context.Context, string, string) error {
 	return nil
 }
+
+// GH #1238 stub.
+func (u *userRepoAdapterForCronAdminTest) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -805,3 +805,12 @@ func (f *pgUserFake) FindByID(_ context.Context, id string) (*models.DatabaseUse
 }
 
 func (r *mockUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+
+// GH #1238 stub.
+func (m *mockUserRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}
+
+func (m *mockDatabaseRepo) UpdateName(context.Context, string, string) error { return nil }
+
+func (m *mockDatabaseUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/api/domain_catchall_test.go
+++ b/panel-api/internal/api/domain_catchall_test.go
@@ -20,7 +20,10 @@ func buildCatchallRouter(dom *models.Domain) (*gin.Engine, *mockDomainRepo) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	v1 := r.Group("/api/v1")
-	v1.Use(func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: dom.UserID, IsAdmin: true}); c.Next() })
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: dom.UserID, IsAdmin: true})
+		c.Next()
+	})
 	repo := newMockDomainRepo()
 	repo.domains[dom.ID] = dom
 	RegisterDomainCatchallRoutes(v1, DomainCatchallHandlerConfig{Domains: repo})

--- a/panel-api/internal/api/malware_scan_op_test.go
+++ b/panel-api/internal/api/malware_scan_op_test.go
@@ -107,3 +107,8 @@ func TestRecordMalwareScanStart_NilScans_NoOp(t *testing.T) {
 		t.Fatalf("nil scans repo must be a no-op, got sid=%q err=%v", sid, err)
 	}
 }
+
+// GH #1238 stub.
+func (f fakeScanUsers) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"time"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/panel-api/internal/api/sso_phpmyadmin_validate_test.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate_test.go
@@ -425,3 +425,10 @@ func TestValidate_OwnerMismatchRefused(t *testing.T) {
 }
 
 func (m *mockUserRepoValidate) UpdateUsername(context.Context, string, string) error { return nil }
+
+// GH #1238 stub.
+func (m *mockUserRepoValidate) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}
+
+func (m *mockDatabaseRepoValidate) UpdateName(context.Context, string, string) error { return nil }

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -37,6 +37,8 @@ type UserHandlerConfig struct {
 	Domains         repository.DomainRepository
 	Databases       repository.DatabaseRepository
 	DatabaseUsers   repository.DatabaseUserRepository
+	// DBUserGrants drives the GH #1238 grant re-point on rename.
+	DBUserGrants repository.DatabaseUserGrantRepository
 	// FtpAccounts is reaped on user delete (JAB-265). It's also the GH #1238
 	// rename preflight's refusal check (a tenant with FTP/SFTP subaccounts is
 	// refused in v1 — their jails are bind-mounted under the home).

--- a/panel-api/internal/api/users_rename.go
+++ b/panel-api/internal/api/users_rename.go
@@ -72,6 +72,10 @@ func (h *userHandler) rename(c *gin.Context) {
 	rd := userops.RenameDeps{
 		FtpAccounts: h.cfg.FtpAccounts,
 		PythonApps:  h.cfg.PythonApps,
+		// GH #1238: re-prefix the tenant's MariaDB artifacts on rename.
+		Databases:     h.cfg.Databases,
+		DatabaseUsers: h.cfg.DatabaseUsers,
+		DBUserGrants:  h.cfg.DBUserGrants,
 		// Reconciler nil: the periodic reconcile re-renders the owned domains
 		// (mirrors the CLI), keeping the HTTP request off a long re-render.
 	}

--- a/panel-api/internal/api/users_rename_test.go
+++ b/panel-api/internal/api/users_rename_test.go
@@ -114,3 +114,8 @@ func TestRename_UserNotFound(t *testing.T) {
 	h.rename(c)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
+
+// GH #1238 stub.
+func (r renameUsersRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/api/users_test.go
+++ b/panel-api/internal/api/users_test.go
@@ -1161,3 +1161,8 @@ func TestUsers_Patch_MalformedEmailRejected(t *testing.T) {
 }
 
 func (r *memUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+
+// GH #1238 stub.
+func (m *memUserRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -631,7 +631,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Domains:         deps.Domains,
 				Databases:       deps.Databases,
 				DatabaseUsers:   deps.DatabaseUsers,
-				FtpAccounts:     deps.FtpAccounts,
+				// GH #1238: grant re-point on rename.
+				DBUserGrants: repository.NewDatabaseUserGrantRepository(deps.DB),
+				FtpAccounts:  deps.FtpAccounts,
 				// GH #1238: the rename preflight refuses a tenant with Python apps.
 				PythonApps:      repository.NewPythonAppRepository(deps.DB),
 				DockerApps:      deps.DockerApps,

--- a/panel-api/internal/auth/testhelpers_test.go
+++ b/panel-api/internal/auth/testhelpers_test.go
@@ -160,3 +160,8 @@ func seedUser(t *testing.T, users *fakeUserRepo, email, password string, admin b
 }
 
 func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+
+// GH #1238 stub.
+func (f *fakeUserRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/middleware/auth_kratos_test.go
+++ b/panel-api/internal/middleware/auth_kratos_test.go
@@ -72,7 +72,7 @@ func (f *fakeUsersRepo) CountAdmins(context.Context) (int64, error) {
 func (f *fakeUsersRepo) FindAdminsByEmail(context.Context) ([]*models.User, error) {
 	panic("FindAdminsByEmail not expected from middleware")
 }
-func (f *fakeUsersRepo) SetSuspended(context.Context, string, bool, string) error { return nil }
+func (f *fakeUsersRepo) SetSuspended(context.Context, string, bool, string) error    { return nil }
 func (f *fakeUsersRepo) SetSSHForwardingEnabled(context.Context, string, bool) error { return nil }
 func (f *fakeUsersRepo) Delete(context.Context, string) error {
 	panic("Delete not expected from middleware")
@@ -330,3 +330,8 @@ func TestRequireKratosSession_KratosUnreachable_Returns503(t *testing.T) {
 }
 
 func (r *fakeUsersRepo) UpdateUsername(context.Context, string, string) error { return nil }
+
+// GH #1238 stub.
+func (f *fakeUsersRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2436,3 +2436,8 @@ func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 
 func (r *fakeUserRepo) UpdateUsername(context.Context, string, string) error          { return nil }
 func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }
+
+// GH #1238 stub.
+func (f *fakeUserRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/repository/database_repository.go
+++ b/panel-api/internal/repository/database_repository.go
@@ -18,6 +18,9 @@ type DatabaseRepository interface {
 	Create(ctx context.Context, d *models.Database) error
 	Delete(ctx context.Context, id string) error
 	ExistsByUserAndName(ctx context.Context, userID, name string) (bool, error)
+	// UpdateName renames the database row in place (GH #1238 DB re-prefix). The
+	// on-disk rename is done by the agent; this repoints the panel row.
+	UpdateName(ctx context.Context, id, name string) error
 }
 
 type databaseRepo struct{ db *gorm.DB }
@@ -113,6 +116,11 @@ func (r *databaseRepo) Delete(ctx context.Context, id string) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *databaseRepo) UpdateName(ctx context.Context, id, name string) error {
+	return translate(r.db.WithContext(ctx).
+		Model(&models.Database{}).Where("id = ?", id).Update("name", name).Error)
 }
 
 func (r *databaseRepo) ExistsByUserAndName(ctx context.Context, userID, name string) (bool, error) {

--- a/panel-api/internal/repository/database_user_repository.go
+++ b/panel-api/internal/repository/database_user_repository.go
@@ -18,6 +18,8 @@ type DatabaseUserRepository interface {
 	Create(ctx context.Context, du *models.DatabaseUser) error
 	Delete(ctx context.Context, id string) error
 	UpdatePasswordHash(ctx context.Context, id string, hash string) error
+	// UpdateUsername renames the DB-user row in place (GH #1238 DB re-prefix).
+	UpdateUsername(ctx context.Context, id, username string) error
 	ExistsByUserAndUsername(ctx context.Context, userID string, username string) (bool, error)
 }
 
@@ -105,6 +107,10 @@ func (r *databaseUserRepo) Delete(ctx context.Context, id string) error {
 
 func (r *databaseUserRepo) UpdatePasswordHash(ctx context.Context, id string, hash string) error {
 	return r.db.WithContext(ctx).Model(&models.DatabaseUser{}).Where("id = ?", id).Update("password_hash", hash).Error
+}
+
+func (r *databaseUserRepo) UpdateUsername(ctx context.Context, id, username string) error {
+	return r.db.WithContext(ctx).Model(&models.DatabaseUser{}).Where("id = ?", id).Update("username", username).Error
 }
 
 func (r *databaseUserRepo) ExistsByUserAndUsername(ctx context.Context, userID string, username string) (bool, error) {

--- a/panel-api/internal/repository/user_repository.go
+++ b/panel-api/internal/repository/user_repository.go
@@ -41,6 +41,9 @@ type UserRepository interface {
 	// Dedicated method: the Select-allowlist Update excludes username, so a
 	// full-model Update would silently drop the rename.
 	UpdateUsername(ctx context.Context, id string, username string) error
+	// UpdateShadowDBUsernames repoints the mysqladmin/pgadmin shadow-role names
+	// after a rename (GH #1238). A nil arg leaves that column untouched.
+	UpdateShadowDBUsernames(ctx context.Context, id string, mysqladmin, pgadmin *string) error
 	// LinkKratosIdentity writes kratos_identity_id on the row. Deliberately
 	// separate from Update — Update's column allowlist excludes this field so
 	// a profile-edit handler can't accidentally overwrite it, but the M20
@@ -180,6 +183,21 @@ func (r *userRepo) UpdateUsername(ctx context.Context, id string, username strin
 		Model(&models.User{}).
 		Where("id = ?", id).
 		Update("username", username).Error)
+}
+
+func (r *userRepo) UpdateShadowDBUsernames(ctx context.Context, id string, mysqladmin, pgadmin *string) error {
+	updates := map[string]interface{}{}
+	if mysqladmin != nil {
+		updates["mysqladmin_username"] = *mysqladmin
+	}
+	if pgadmin != nil {
+		updates["pgadmin_username"] = *pgadmin
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return translate(r.db.WithContext(ctx).
+		Model(&models.User{}).Where("id = ?", id).Updates(updates).Error)
 }
 
 func (r *userRepo) UpdateCLIPHPVersion(ctx context.Context, id string, version *string) error {

--- a/panel-api/internal/sso/sso_test.go
+++ b/panel-api/internal/sso/sso_test.go
@@ -193,3 +193,8 @@ func ptrString(s string) *string {
 }
 
 func (r *mockUsersForSSO) UpdateUsername(context.Context, string, string) error { return nil }
+
+// GH #1238 stub.
+func (m *mockUsersForSSO) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-api/internal/userops/userops_rename.go
+++ b/panel-api/internal/userops/userops_rename.go
@@ -24,6 +24,12 @@ type RenameDeps struct {
 	FtpAccounts repository.FtpAccountRepository
 	PythonApps  repository.PythonAppRepository
 	Reconciler  RenameReconciler
+	// GH #1238 DB re-prefix: when all three are wired, the rename also moves the
+	// tenant's databases / DB users / shadow roles onto the new prefix. Nil (dev
+	// / CLI-without-DB) skips the DB step.
+	Databases     repository.DatabaseRepository
+	DatabaseUsers repository.DatabaseUserRepository
+	DBUserGrants  repository.DatabaseUserGrantRepository
 }
 
 // RenameUser renames a tenant's Linux/login username in place (GH #1238).
@@ -85,6 +91,11 @@ func RenameUser(ctx context.Context, d Deps, rd RenameDeps, target *models.User,
 			return fmt.Errorf("rename: %q has %d Python app(s) — remove them first (v1 does not move their app roots)", old, len(apps))
 		}
 	}
+	// GH #1238: v1 re-prefixes MariaDB artifacts only. Refuse if the tenant has
+	// any PostgreSQL database / role — re-prefixing those is a follow-up.
+	if perr := refusePostgresArtifacts(ctx, rd, target, old); perr != nil {
+		return perr
+	}
 
 	// --- Rename the OS account on the box ---
 	uid := int(*target.LinuxUID)
@@ -109,6 +120,13 @@ func RenameUser(ctx context.Context, d Deps, rd RenameDeps, target *models.User,
 		if err := d.KratosClient.UpdateUsernameTrait(ctx, *target.KratosIdentityID, newName); err != nil {
 			logWarn(d, "rename: could not update the Kratos username trait (login identifier may lag until next set)", "user_id", target.ID, "err", err)
 		}
+	}
+
+	// --- GH #1238: re-prefix the tenant's DBs / DB users / shadow roles so a
+	// reused old username can't inherit them. Fatal-on-error so a partial move
+	// resumes on re-run (every step is idempotent). ---
+	if err := renameUserDBArtifacts(ctx, d, rd, target, old, newName); err != nil {
+		return err
 	}
 
 	// --- Reconcile owned domains so vhosts re-render under the new path/pool ---

--- a/panel-api/internal/userops/userops_rename_db.go
+++ b/panel-api/internal/userops/userops_rename_db.go
@@ -1,0 +1,188 @@
+package userops
+
+// GH #1238 — re-prefix a tenant's DB artifacts when their username changes, so a
+// later same-name user can't inherit them (the mysqladmin GRANT is a
+// <prefix>_%.* wildcard) and a delete doesn't orphan a role.
+//
+// Order matters: databases first (the on-disk RENAME TABLE move), then DB users
+// (RENAME USER carries their grants — still on the OLD db names), then re-point
+// the per-DB grants onto the new names and REVOKE the stale ones, then the
+// mysqladmin/pgadmin shadow roles (rename + re-point the wildcard grant). Every
+// step is idempotent so a failure resumes on re-run.
+//
+// This MOVES tenant data and BREAKS app configs (the DB name + user change) —
+// the caller warns the operator. v1 covers MariaDB base-table DBs + Postgres;
+// the agent refuses a MariaDB DB with views/triggers/routines/events.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// renameUserDBArtifacts is best-effort-fatal: any error aborts the rename so a
+// re-run resumes (the OS account is already renamed by the caller at this point).
+// It no-ops cleanly when the DB repos aren't wired (dev/test paths).
+func renameUserDBArtifacts(ctx context.Context, d Deps, rd RenameDeps, target *models.User, oldName, newName string) error {
+	if d.Agent == nil || rd.Databases == nil || rd.DatabaseUsers == nil || rd.DBUserGrants == nil {
+		return nil
+	}
+	oldPrefix := oldName + "_"
+	newPrefix := newName + "_"
+	reprefix := func(name string) string {
+		if strings.HasPrefix(name, oldPrefix) {
+			return newPrefix + strings.TrimPrefix(name, oldPrefix)
+		}
+		return name
+	}
+
+	// 1. Rename each owned database. Keep old→new + engine keyed by db id for
+	//    the grant re-point below.
+	dbs, _, err := rd.Databases.ListByUserID(ctx, target.ID, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		return fmt.Errorf("rename: list databases: %w", err)
+	}
+	type dbInfo struct{ oldName, newName, engine string }
+	dbByID := make(map[string]dbInfo, len(dbs))
+	for i := range dbs {
+		db := &dbs[i]
+		nn := reprefix(db.Name)
+		dbByID[db.ID] = dbInfo{oldName: db.Name, newName: nn, engine: db.Engine}
+		if nn == db.Name || db.Engine != "mariadb" { // PG refused in preflight
+			continue
+		}
+		if _, err := d.Agent.Call(ctx, "db.rename_db", map[string]any{"old_db": db.Name, "new_db": nn}); err != nil {
+			return fmt.Errorf("rename: move database %q → %q: %w", db.Name, nn, err)
+		}
+		if err := rd.Databases.UpdateName(ctx, db.ID, nn); err != nil {
+			return fmt.Errorf("rename: persist database name (agent moved it — re-run to resync): %w", err)
+		}
+	}
+
+	// 2. Rename each owned DB user (RENAME USER carries its grants onto the new
+	//    account, still referencing the OLD db names — re-pointed in step 3).
+	dus, _, err := rd.DatabaseUsers.ListByUserID(ctx, target.ID, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		return fmt.Errorf("rename: list database users: %w", err)
+	}
+	type duInfo struct{ newName, engine string }
+	duByID := make(map[string]duInfo, len(dus))
+	var duIDs []string
+	for i := range dus {
+		du := &dus[i]
+		nn := reprefix(du.Username)
+		duByID[du.ID] = duInfo{newName: nn, engine: du.Engine}
+		duIDs = append(duIDs, du.ID)
+		if nn == du.Username || du.Engine != "mariadb" { // PG refused in preflight
+			continue
+		}
+		if _, err := d.Agent.Call(ctx, "db.rename_user", map[string]any{"old_name": du.Username, "new_name": nn}); err != nil {
+			return fmt.Errorf("rename: rename database user %q → %q: %w", du.Username, nn, err)
+		}
+		if err := rd.DatabaseUsers.UpdateUsername(ctx, du.ID, nn); err != nil {
+			return fmt.Errorf("rename: persist database-user name (re-run to resync): %w", err)
+		}
+	}
+
+	// 3. Re-point each grant onto the new db + user, then REVOKE the stale grant
+	//    the RENAME USER carried over on the old db name (MariaDB — PG grants
+	//    follow the role/db rename natively).
+	grants, err := rd.DBUserGrants.ListByDatabaseUserIDs(ctx, duIDs)
+	if err != nil {
+		return fmt.Errorf("rename: list grants: %w", err)
+	}
+	for i := range grants {
+		g := &grants[i]
+		db, okDB := dbByID[g.DatabaseID]
+		du, okDU := duByID[g.DatabaseUserID]
+		if !okDB || !okDU || db.engine != "mariadb" {
+			continue
+		}
+		privs := splitPrivileges(g.Privileges)
+		if _, err := d.Agent.Call(ctx, "db_user.grant", map[string]any{
+			"db_name": db.newName, "db_user_name": du.newName, "privileges": privs,
+		}); err != nil {
+			return fmt.Errorf("rename: re-grant %q on %q: %w", du.newName, db.newName, err)
+		}
+		if db.oldName != db.newName {
+			if _, err := d.Agent.Call(ctx, "db_user.revoke", map[string]any{
+				"db_name": db.oldName, "db_user_name": du.newName,
+			}); err != nil {
+				return fmt.Errorf("rename: revoke stale grant on %q: %w", db.oldName, err)
+			}
+		}
+	}
+
+	// 4. Shadow admin roles: rename + re-point the <prefix>_%.* wildcard grant.
+	//    RENAME USER preserves the password hash, so the panel's stored password
+	//    stays valid — only the row's name needs repointing.
+	// (PG pgadmin is refused in the preflight, so only mysqladmin is handled.)
+	if target.MysqladminUsername != nil && strings.HasPrefix(*target.MysqladminUsername, oldPrefix) {
+		nn := reprefix(*target.MysqladminUsername)
+		if _, err := d.Agent.Call(ctx, "db.rename_user", map[string]any{
+			"old_name": *target.MysqladminUsername, "new_name": nn,
+			"old_prefix": oldName, "new_prefix": newName,
+		}); err != nil {
+			return fmt.Errorf("rename: mysqladmin shadow role: %w", err)
+		}
+		if err := d.Users.UpdateShadowDBUsernames(ctx, target.ID, &nn, nil); err != nil {
+			return fmt.Errorf("rename: persist shadow-role name (re-run to resync): %w", err)
+		}
+	}
+	return nil
+}
+
+// refusePostgresArtifacts blocks the rename (before the OS mutation) if the
+// tenant has any PostgreSQL database / DB user / admin role — v1 re-prefixes
+// MariaDB only.
+func refusePostgresArtifacts(ctx context.Context, rd RenameDeps, target *models.User, old string) error {
+	if target.PgadminUsername != nil && *target.PgadminUsername != "" {
+		return fmt.Errorf("rename: %q has a PostgreSQL admin role — re-prefixing PostgreSQL on rename isn't supported yet; not renaming", old)
+	}
+	if rd.Databases != nil {
+		dbs, _, err := rd.Databases.ListByUserID(ctx, target.ID, repository.ListOptions{Limit: 10000})
+		if err != nil {
+			return fmt.Errorf("rename: checking databases: %w", err)
+		}
+		for i := range dbs {
+			if dbs[i].Engine == "postgres" {
+				return fmt.Errorf("rename: %q has a PostgreSQL database (%q) — re-prefixing PostgreSQL isn't supported yet; migrate or drop it first", old, dbs[i].Name)
+			}
+		}
+	}
+	if rd.DatabaseUsers != nil {
+		dus, _, err := rd.DatabaseUsers.ListByUserID(ctx, target.ID, repository.ListOptions{Limit: 10000})
+		if err != nil {
+			return fmt.Errorf("rename: checking database users: %w", err)
+		}
+		for i := range dus {
+			if dus[i].Engine == "postgres" {
+				return fmt.Errorf("rename: %q has a PostgreSQL database user (%q) — not supported yet", old, dus[i].Username)
+			}
+		}
+	}
+	return nil
+}
+
+// splitPrivileges turns a stored "ALL" / "SELECT,INSERT" string into the list
+// db_user.grant expects. Empty → ["ALL"] (the row default).
+func splitPrivileges(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{"ALL"}
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return []string{"ALL"}
+	}
+	return out
+}

--- a/panel-api/internal/userops/userops_rename_db.go
+++ b/panel-api/internal/userops/userops_rename_db.go
@@ -7,8 +7,12 @@ package userops
 // Order matters: databases first (the on-disk RENAME TABLE move), then DB users
 // (RENAME USER carries their grants — still on the OLD db names), then re-point
 // the per-DB grants onto the new names and REVOKE the stale ones, then the
-// mysqladmin/pgadmin shadow roles (rename + re-point the wildcard grant). Every
-// step is idempotent so a failure resumes on re-run.
+// mysqladmin/pgadmin shadow roles (rename + re-point the wildcard grant). Each
+// step skips work already done (rename verbs are idempotent), but note the
+// caller renames the OS account + panel username BEFORE this runs, so a failure
+// here leaves a partially re-prefixed tenant whose panel name is already the new
+// one — recovery is manual (the CLI can't be re-invoked with the old name). The
+// steps are ordered + logged so an operator can finish it by hand.
 //
 // This MOVES tenant data and BREAKS app configs (the DB name + user change) —
 // the caller warns the operator. v1 covers MariaDB base-table DBs + Postgres;
@@ -109,7 +113,7 @@ func renameUserDBArtifacts(ctx context.Context, d Deps, rd RenameDeps, target *m
 		}
 		if db.oldName != db.newName {
 			if _, err := d.Agent.Call(ctx, "db_user.revoke", map[string]any{
-				"db_name": db.oldName, "db_user_name": du.newName,
+				"db_name": db.oldName, "db_user_name": du.newName, "privileges": privs,
 			}); err != nil {
 				return fmt.Errorf("rename: revoke stale grant on %q: %w", db.oldName, err)
 			}

--- a/panel-api/internal/userops/userops_rename_db_test.go
+++ b/panel-api/internal/userops/userops_rename_db_test.go
@@ -1,0 +1,161 @@
+package userops
+
+// GH #1238 — the DB re-prefix orchestration is security-critical (a slip in the
+// grant re-point is the cross-tenant hole we're closing), so pin the full
+// sequence with fakes: DB renamed → DB user renamed → grant re-pointed onto the
+// new names AND the stale old-name grant revoked → shadow role renamed +
+// wildcard re-granted → panel rows updated.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type rdbCall struct {
+	method string
+	params map[string]any
+}
+
+type rdbAgent struct{ calls []rdbCall }
+
+func (a *rdbAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	m, _ := params.(map[string]any)
+	a.calls = append(a.calls, rdbCall{method, m})
+	return []byte("{}"), nil
+}
+func (a *rdbAgent) first(method string) *rdbCall {
+	for i := range a.calls {
+		if a.calls[i].method == method {
+			return &a.calls[i]
+		}
+	}
+	return nil
+}
+func (a *rdbAgent) count(method string) int {
+	n := 0
+	for i := range a.calls {
+		if a.calls[i].method == method {
+			n++
+		}
+	}
+	return n
+}
+
+type rdbDatabases struct {
+	repository.DatabaseRepository
+	rows    []models.Database
+	renamed map[string]string
+}
+
+func (r *rdbDatabases) ListByUserID(context.Context, string, repository.ListOptions) ([]models.Database, int64, error) {
+	return r.rows, int64(len(r.rows)), nil
+}
+func (r *rdbDatabases) UpdateName(_ context.Context, id, name string) error {
+	if r.renamed == nil {
+		r.renamed = map[string]string{}
+	}
+	r.renamed[id] = name
+	return nil
+}
+
+type rdbDBUsers struct {
+	repository.DatabaseUserRepository
+	rows    []models.DatabaseUser
+	renamed map[string]string
+}
+
+func (r *rdbDBUsers) ListByUserID(context.Context, string, repository.ListOptions) ([]models.DatabaseUser, int64, error) {
+	return r.rows, int64(len(r.rows)), nil
+}
+func (r *rdbDBUsers) UpdateUsername(_ context.Context, id, username string) error {
+	if r.renamed == nil {
+		r.renamed = map[string]string{}
+	}
+	r.renamed[id] = username
+	return nil
+}
+
+type rdbGrants struct {
+	repository.DatabaseUserGrantRepository
+	rows []models.DatabaseUserGrant
+}
+
+func (r *rdbGrants) ListByDatabaseUserIDs(context.Context, []string) ([]models.DatabaseUserGrant, error) {
+	return r.rows, nil
+}
+
+type rdbUsers struct {
+	repository.UserRepository
+	shadowM, shadowP *string
+}
+
+func (r *rdbUsers) UpdateShadowDBUsernames(_ context.Context, _ string, m, p *string) error {
+	r.shadowM, r.shadowP = m, p
+	return nil
+}
+
+func TestRenameDBArtifacts_MariaDB_FullReprefix(t *testing.T) {
+	agent := &rdbAgent{}
+	dbs := &rdbDatabases{rows: []models.Database{{ID: "db1", UserID: "u1", Name: "alice_wp_1", Engine: "mariadb"}}}
+	dus := &rdbDBUsers{rows: []models.DatabaseUser{{ID: "du1", UserID: "u1", Username: "alice_app", Engine: "mariadb"}}}
+	grants := &rdbGrants{rows: []models.DatabaseUserGrant{{ID: "g1", DatabaseID: "db1", DatabaseUserID: "du1", Privileges: "ALL"}}}
+	users := &rdbUsers{}
+	mysqladmin := "alice_mysqladmin"
+	target := &models.User{ID: "u1", MysqladminUsername: &mysqladmin}
+
+	d := Deps{Users: users, Agent: agent}
+	rd := RenameDeps{Databases: dbs, DatabaseUsers: dus, DBUserGrants: grants}
+	if err := renameUserDBArtifacts(context.Background(), d, rd, target, "alice", "bob"); err != nil {
+		t.Fatalf("orchestration: %v", err)
+	}
+
+	// Database moved + row repointed.
+	if c := agent.first("db.rename_db"); c == nil || c.params["old_db"] != "alice_wp_1" || c.params["new_db"] != "bob_wp_1" {
+		t.Fatalf("db.rename_db: %+v", c)
+	}
+	assert.Equal(t, "bob_wp_1", dbs.renamed["db1"])
+
+	// DB user renamed + row repointed (one non-shadow rename + the shadow one).
+	assert.Equal(t, "bob_app", dus.renamed["du1"])
+
+	// Grant re-pointed to the new names AND the stale old-name grant revoked.
+	if c := agent.first("db_user.grant"); c == nil || c.params["db_name"] != "bob_wp_1" || c.params["db_user_name"] != "bob_app" {
+		t.Fatalf("db_user.grant: %+v", c)
+	}
+	if c := agent.first("db_user.revoke"); c == nil || c.params["db_name"] != "alice_wp_1" || c.params["db_user_name"] != "bob_app" {
+		t.Fatalf("db_user.revoke (stale): %+v", c)
+	}
+
+	// Shadow role renamed with the wildcard re-grant prefixes, row repointed.
+	// Two db.rename_user calls: the per-DB user + the shadow role.
+	assert.Equal(t, 2, agent.count("db.rename_user"))
+	var shadow *rdbCall
+	for i := range agent.calls {
+		if agent.calls[i].method == "db.rename_user" && agent.calls[i].params["old_name"] == "alice_mysqladmin" {
+			shadow = &agent.calls[i]
+		}
+	}
+	if shadow == nil || shadow.params["new_name"] != "bob_mysqladmin" ||
+		shadow.params["old_prefix"] != "alice" || shadow.params["new_prefix"] != "bob" {
+		t.Fatalf("shadow rename_user: %+v", shadow)
+	}
+	if users.shadowM == nil || *users.shadowM != "bob_mysqladmin" {
+		t.Fatalf("shadow username not repointed: %v", users.shadowM)
+	}
+}
+
+func TestRefusePostgresArtifacts(t *testing.T) {
+	dbs := &rdbDatabases{rows: []models.Database{{ID: "db1", UserID: "u1", Name: "alice_pg", Engine: "postgres"}}}
+	rd := RenameDeps{Databases: dbs, DatabaseUsers: &rdbDBUsers{}}
+	err := refusePostgresArtifacts(context.Background(), rd, &models.User{ID: "u1"}, "alice")
+	if err == nil {
+		t.Fatal("expected refusal for a PostgreSQL database")
+	}
+	assert.Contains(t, err.Error(), "PostgreSQL")
+}

--- a/panel-api/internal/userops/userops_rename_db_test.go
+++ b/panel-api/internal/userops/userops_rename_db_test.go
@@ -128,8 +128,11 @@ func TestRenameDBArtifacts_MariaDB_FullReprefix(t *testing.T) {
 	if c := agent.first("db_user.grant"); c == nil || c.params["db_name"] != "bob_wp_1" || c.params["db_user_name"] != "bob_app" {
 		t.Fatalf("db_user.grant: %+v", c)
 	}
-	if c := agent.first("db_user.revoke"); c == nil || c.params["db_name"] != "alice_wp_1" || c.params["db_user_name"] != "bob_app" {
-		t.Fatalf("db_user.revoke (stale): %+v", c)
+	// The revoke MUST carry the privilege list — the agent verb rejects a revoke
+	// with neither privileges nor grant_level (the bug the box drill caught).
+	if c := agent.first("db_user.revoke"); c == nil || c.params["db_name"] != "alice_wp_1" ||
+		c.params["db_user_name"] != "bob_app" || c.params["privileges"] == nil {
+		t.Fatalf("db_user.revoke (stale, with privileges): %+v", c)
 	}
 
 	// Shadow role renamed with the wildcard re-grant prefixes, row repointed.

--- a/panel-api/internal/userops/userops_rename_test.go
+++ b/panel-api/internal/userops/userops_rename_test.go
@@ -177,3 +177,8 @@ func TestRenameUser_AgentFailureStopsBeforeDB(t *testing.T) {
 		t.Error("DB username must NOT be updated when the agent rename failed")
 	}
 }
+
+// GH #1238 stub.
+func (f *renameUsers) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
+	return nil
+}

--- a/panel-ui/src/shells/admin/users/UserRenameAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserRenameAction.tsx
@@ -126,8 +126,14 @@ export const UserRenameAction = ({
               <b>Python apps</b> — remove those first.
             </li>
             <li>
-              Their <b>databases and DB users keep the old-username prefix</b> (they're
-              keyed internally by id, so they keep working). Mail is unaffected.
+              Their <b>MariaDB databases and DB users are re-prefixed</b> to the new
+              name. <b>You must update any app config</b> (e.g. wp-config.php) that
+              references the old database name or user — the panel can't rewrite app
+              files. Mail is unaffected.
+            </li>
+            <li>
+              Refused if the user has any <b>PostgreSQL</b> database or role
+              (re-prefixing those isn't supported yet).
             </li>
             <li>You'll be asked to re-authenticate the first time in a session.</li>
           </ul>

--- a/plans/gh1238-db-reprefix-on-rename.md
+++ b/plans/gh1238-db-reprefix-on-rename.md
@@ -1,0 +1,81 @@
+# GH #1238 — Re-prefix tenant DBs / DB users / shadow roles on user rename
+
+**Why:** rename alice→bob keeps every DB artifact on the `alice_` prefix (v1 kept
+them because MariaDB has no `RENAME DATABASE`). johnnyq: a later new user "alice"
+then collides — and the `mysqladmin` GRANT is a `alice_%` wildcard, so a fresh
+`alice_mysqladmin` would reach bob's retained `alice_*` DBs (tenant-isolation
+gap). Operator picked the full re-prefix.
+
+**Contract change:** this reverses the original "DBs keep old prefix" decision.
+It MOVES tenant data and BREAKS every affected app's config (wp-config.php DB name
++ DB user) until the admin updates it — a loud warning is mandatory in the modal
++ CLI output + the issue reply.
+
+## Mechanism (the safety-critical choice)
+
+**MariaDB DB rename = `RENAME TABLE` across schemas, NOT dump/restore.**
+Per DB `alice_wp_1` → `bob_wp_1`:
+1. `CREATE DATABASE \`bob_wp_1\``
+2. For each base table: `RENAME TABLE \`alice_wp_1\`.\`t\` TO \`bob_wp_1\`.\`t\``
+   — a metadata move on the same filesystem: instant, no data copy, atomic.
+3. Recreate views (their definitions bind the old schema name), and MOVE any
+   triggers/events/routines (schema-bound).
+4. `DROP DATABASE \`alice_wp_1\`` (now empty).
+
+- **v1 boundary (open decision, below):** base tables + views + triggers are the
+  common WP/app shapes. Stored **routines/events** are rare; v1 either moves them
+  or REFUSES the rename with a clear message if present.
+- **Postgres is easier:** native `ALTER DATABASE x RENAME TO y` (requires no open
+  connections → terminate first, we already have db.postgres.terminate) and
+  `ALTER ROLE … RENAME TO`. No table shuffling.
+
+**DB users:** MariaDB `RENAME USER`, PG `ALTER ROLE … RENAME`; both preserve
+grants+hash (PG MD5 breaks → reset). Re-point per-DB grants at the new DB names.
+
+**Shadow roles (mysqladmin/pgadmin):** `RENAME USER`/`ALTER ROLE RENAME`, then
+re-grant on the NEW `bob_%` wildcard (the old `alice_%` grant no longer matches
+the moved DBs), and reset password if needed.
+
+## New agent verbs (none exist today)
+
+- `db.rename_db` (MariaDB): CREATE new + RENAME TABLE each + recreate views/
+  triggers + DROP old. Enumerate objects via information_schema.
+- `db.rename_user` (MariaDB): RENAME USER + optional re-grant.
+- `db.postgres.rename_db`, `db.postgres.rename_role` (native ALTER).
+- Re-grant reuses db.mysqladmin.ensure / db.postgres.grant with the new prefix.
+
+## Panel side
+
+- `userops.RenameUser` (shared by CLI #1305 + WebUI #1346): after the OS rename +
+  docroot repoint, iterate the owner's `databases` + `database_users`, rename each
+  (engine-aware), then the shadow roles; update `databases.name`,
+  `database_users.username`, `users.mysqladmin_username`/`pgadmin_username` via
+  dedicated setters (the `Update` allowlist drops these cols — see
+  [[feedback_domain_update_allowlist_silent_drop]]).
+- Idempotent + abort-with-resume: each rename checks "already at new name?" and
+  skips; a partial failure is recovered by re-running (the existing rename
+  contract). Order: DBs → DB users → shadow roles, so grants re-point correctly.
+- Preflight: keep the FTP/Python refusals; ADD a refusal if a MariaDB tenant DB
+  holds stored routines/events AND v1 doesn't move them (decision below).
+
+## UI / CLI
+
+- Rename modal + `jabali user rename` output: a prominent warning listing the old
+  → new DB name(s) + DB user(s), and "update your app config (wp-config.php etc.)
+  to the new database name and user — the panel can't rewrite app files."
+
+## Tests + box drill (MANDATORY — moves real tenant data)
+
+- Unit: userops orchestration with fake agent+repos (renames called in order,
+  panel rows updated, idempotent re-run no-ops).
+- Agent: RENAME TABLE enumeration/move (sqlmock or a scratch DB).
+- **Box drill on .60**: a tenant with a real WP DB → rename → verify the tables
+  moved into the new DB, the DB user + shadow role renamed, grants work under the
+  new names, and the panel rows updated. Confirm the app is reachable once its
+  config points at the new DB name/user.
+
+## OPEN decision to confirm before building
+
+MariaDB **stored routines/events** in a tenant DB (rare): v1 **moves** them, or
+**refuses** the whole rename with "this DB has stored routines; not yet supported"?
+Refusing is safer for v1; moving is more complete.


### PR DESCRIPTION
## Summary

Closes the tenant-isolation gap @johnnyq flagged on GH #1238: renaming a user used to keep every DB artifact on the old `<oldname>_` prefix. Because the `mysqladmin` GRANT is a **`<prefix>_%.*` wildcard**, a later same-name user would reach the renamed user's retained DBs — and delete orphaned the shadow role. The rename now **re-prefixes** the tenant's MariaDB databases, DB users, and shadow role.

Shared by the CLI (`jabali user rename`, #1305) and the WebUI action (#1346) via `userops.RenameUser`.

## What it does

- **New agent verbs:**
  - `db.rename_db` (MariaDB): `CREATE DATABASE <new>` + `RENAME TABLE <old>.t TO <new>.t` for each base table (a metadata move — instant, no dump/restore) + `DROP DATABASE <old>`. Refuses a DB with views / triggers / stored routines / events (v1 base-tables-only).
  - `db.rename_user` (MariaDB): `RENAME USER` (preserves grants + password hash), with an optional wildcard re-grant for the shadow role.
- **`userops` orchestration:** rename each owned database → each DB user → re-point every grant onto the new names **and REVOKE the stale old-name grant** → rename the `mysqladmin` shadow role + re-point its `_%` wildcard → update the panel rows (`databases.name`, `database_users.username`, `users.mysqladmin_username`).
- **v1 = MariaDB only.** A tenant with any PostgreSQL database/role is refused in the preflight (before any mutation); PG re-prefix is a follow-up.
- **This MOVES tenant data and BREAKS app configs** (DB name + user change). The CLI prompt/output and the WebUI modal warn to update `wp-config.php` etc.

## Box drill (.60) — a real tenant-data move

Set up `drrename3` with a MariaDB DB (seeded table + row), a DB user + grant, and the `mysqladmin` wildcard role, then `jabali user rename drrename3 drrename4`:

- **Data moved:** `drrename4_wp.posts` still holds the seeded row (RENAME TABLE).
- **Everything re-prefixed:** DB, DB user, shadow role, and all three panel rows.
- **`mysqladmin` wildcard grant re-pointed** to `drrename4_%` (was `drrename3_%`) — the isolation fix.
- **Stale grant revoked:** `drrename4_app` grants `drrename4_wp` only; the carried-over `drrename3_wp` grant is gone.
- **Delete cascade** then dropped the shadow role cleanly (the orphan the old behavior left).

The drill caught a real bug (the `REVOKE` needs `privileges`) — fixed and re-verified.

## Caveat (documented)

The OS account + panel username are renamed *before* the DB step, so a failure mid-DB-move leaves a partially re-prefixed tenant whose panel name is already the new one — recovery is manual (the steps are ordered + logged). The happy path is atomic-enough; failures should be rare now that the grant logic is correct.

## Tests

- `userops` orchestration with fakes: the full sequence (DB + user renamed, grant re-pointed **with the revoke carrying privileges**, shadow role renamed + wildcard re-granted, rows updated) + the PG refusal.
- Widened-interface test mocks stubbed.
- `go build` + `vet` + agent + `userops`/`api`/`repository`/`cmd` suites green; `tsc -b` + full ui suite (315 tests) + build green.
- **Box-drilled end-to-end on `.60`** (above).

Plan: `plans/gh1238-db-reprefix-on-rename.md`.
