### PR TITLE
feat(users): monthly bandwidth + at-a-glance resource counts on admin User list (GH #1242)

### DIFF
--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -39,6 +39,9 @@ type UserHandlerConfig struct {
 	DatabaseUsers   repository.DatabaseUserRepository
 	// DBUserGrants drives the GH #1238 grant re-point on rename.
 	DBUserGrants repository.DatabaseUserGrantRepository
+	// ResourceStats batch-computes the GH #1242 at-a-glance per-user counts +
+	// monthly bandwidth for the Users list. Optional; nil omits the stats.
+	ResourceStats repository.UserResourceStatsRepository
 	// FtpAccounts is reaped on user delete (JAB-265). It's also the GH #1238
 	// rename preflight's refusal check (a tenant with FTP/SFTP subaccounts is
 	// refused in v1 — their jails are bind-mounted under the home).
@@ -190,10 +193,18 @@ type reprovisionRequest struct {
 }
 
 type listUsersResponse struct {
-	Data     []models.User `json:"data"`
+	Data     []userListRow `json:"data"`
 	Total    int64         `json:"total"`
 	Page     int           `json:"page"`
 	PageSize int           `json:"page_size"`
+}
+
+// userListRow is a Users-list row: the user, plus the GH #1242 at-a-glance
+// resource roll-up (counts + monthly bandwidth). The embedded User inlines its
+// JSON fields, so the shape is the old user object with an extra `resources`.
+type userListRow struct {
+	models.User
+	Resources repository.UserResourceStats `json:"resources"`
 }
 
 // ---------- handlers ----------
@@ -225,8 +236,31 @@ func (h *userHandler) list(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
+
+	// GH #1242: attach the at-a-glance per-user counts + monthly bandwidth,
+	// batched over the page's ids. Non-fatal — a stats failure still renders the
+	// list (rows just carry zero resources).
+	var stats map[string]repository.UserResourceStats
+	if h.cfg.ResourceStats != nil && len(users) > 0 {
+		ids := make([]string, len(users))
+		for i := range users {
+			ids[i] = users[i].ID
+		}
+		now := time.Now()
+		monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+		if s, serr := h.cfg.ResourceStats.Fetch(c.Request.Context(), ids, monthStart); serr == nil {
+			stats = s
+		} else {
+			h.log().WarnContext(c.Request.Context(), "users list: resource stats failed", "error", serr)
+		}
+	}
+
+	rows := make([]userListRow, len(users))
+	for i := range users {
+		rows[i] = userListRow{User: users[i], Resources: stats[users[i].ID]}
+	}
 	c.JSON(http.StatusOK, listUsersResponse{
-		Data:     users,
+		Data:     rows,
 		Total:    total,
 		Page:     page,
 		PageSize: pageSize,

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -633,7 +633,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				DatabaseUsers:   deps.DatabaseUsers,
 				// GH #1238: grant re-point on rename.
 				DBUserGrants: repository.NewDatabaseUserGrantRepository(deps.DB),
-				FtpAccounts:  deps.FtpAccounts,
+				// GH #1242: at-a-glance per-user counts + monthly bandwidth.
+				ResourceStats: repository.NewUserResourceStatsRepository(deps.DB),
+				FtpAccounts:   deps.FtpAccounts,
 				// GH #1238: the rename preflight refuses a tenant with Python apps.
 				PythonApps:      repository.NewPythonAppRepository(deps.DB),
 				DockerApps:      deps.DockerApps,

--- a/panel-api/internal/repository/user_resource_stats_repository.go
+++ b/panel-api/internal/repository/user_resource_stats_repository.go
@@ -1,0 +1,107 @@
+package repository
+
+// UserResourceStatsRepository batch-computes the "at a glance" per-user counts +
+// monthly bandwidth for the admin Users list (GH #1242 follow-up). One GROUP BY
+// query per metric over the page's user ids — never N+1 — so a 200-row page costs
+// a handful of aggregate reads.
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// UserResourceStats is the per-user roll-up shown on the admin Users list.
+type UserResourceStats struct {
+	Domains        int64  `json:"domains"`
+	Mailboxes      int64  `json:"mailboxes"`
+	Databases      int64  `json:"databases"`
+	DockerApps     int64  `json:"docker_apps"`
+	Backups        int64  `json:"backups"`
+	BandwidthBytes uint64 `json:"bandwidth_bytes"`
+}
+
+type UserResourceStatsRepository interface {
+	// Fetch returns stats keyed by user id. Users with no rows for a metric
+	// simply have zero there; a user with no artifacts at all is absent from the
+	// map (the caller treats a missing key as all-zero). monthStart bounds the
+	// bandwidth sum to the current billing month.
+	Fetch(ctx context.Context, userIDs []string, monthStart time.Time) (map[string]UserResourceStats, error)
+}
+
+type userResourceStatsRepo struct{ db *gorm.DB }
+
+func NewUserResourceStatsRepository(db *gorm.DB) UserResourceStatsRepository {
+	return &userResourceStatsRepo{db: db}
+}
+
+type urStatRow struct {
+	UserID string `gorm:"column:user_id"`
+	N      int64  `gorm:"column:n"`
+}
+
+func (r *userResourceStatsRepo) Fetch(ctx context.Context, userIDs []string, monthStart time.Time) (map[string]UserResourceStats, error) {
+	out := make(map[string]UserResourceStats, len(userIDs))
+	if len(userIDs) == 0 {
+		return out, nil
+	}
+	db := r.db.WithContext(ctx)
+
+	assign := func(query string, args []any, set func(*UserResourceStats, int64)) error {
+		var rows []urStatRow
+		if err := db.Raw(query, args...).Scan(&rows).Error; err != nil {
+			return translate(err)
+		}
+		for _, row := range rows {
+			s := out[row.UserID]
+			set(&s, row.N)
+			out[row.UserID] = s
+		}
+		return nil
+	}
+
+	if err := assign(
+		"SELECT user_id, COUNT(*) AS n FROM domains WHERE user_id IN ? GROUP BY user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Domains = n }); err != nil {
+		return nil, err
+	}
+	if err := assign(
+		"SELECT user_id, COUNT(*) AS n FROM databases WHERE user_id IN ? GROUP BY user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Databases = n }); err != nil {
+		return nil, err
+	}
+	if err := assign(
+		"SELECT user_id, COUNT(*) AS n FROM docker_apps WHERE user_id IN ? AND status <> ? GROUP BY user_id",
+		[]any{userIDs, models.DockerAppStatusDeleted}, func(s *UserResourceStats, n int64) { s.DockerApps = n }); err != nil {
+		return nil, err
+	}
+	// Mailboxes belong to a domain, which belongs to a user.
+	if err := assign(
+		"SELECT d.user_id AS user_id, COUNT(*) AS n FROM mailboxes m JOIN domains d ON d.id = m.domain_id WHERE d.user_id IN ? GROUP BY d.user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Mailboxes = n }); err != nil {
+		return nil, err
+	}
+	// Retained account backups (same filter as CountRetainedForUser).
+	if err := assign(
+		"SELECT user_id, COUNT(*) AS n FROM backup_jobs WHERE user_id IN ? AND kind = ? AND status IN ? GROUP BY user_id",
+		[]any{userIDs, models.BackupJobKindAccountBackup, []string{
+			models.BackupJobStatusQueued, models.BackupJobStatusRunning,
+			models.BackupJobStatusSucceeded, models.BackupJobStatusPartial,
+		}}, func(s *UserResourceStats, n int64) { s.Backups = n }); err != nil {
+		return nil, err
+	}
+	// Monthly bandwidth = SUM of the user's domains' daily bytes since monthStart.
+	if err := assign(
+		"SELECT d.user_id AS user_id, COALESCE(SUM(b.bytes_total),0) AS n FROM bw_daily b JOIN domains d ON d.id = b.domain_id WHERE d.user_id IN ? AND b.day >= ? GROUP BY d.user_id",
+		[]any{userIDs, monthStart}, func(s *UserResourceStats, n int64) {
+			if n > 0 {
+				s.BandwidthBytes = uint64(n)
+			}
+		}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/panel-api/internal/repository/user_resource_stats_repository_test.go
+++ b/panel-api/internal/repository/user_resource_stats_repository_test.go
@@ -1,0 +1,65 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+// Reuses newMockBackupDB from backup_job_repository_test.go (same package).
+// Fetch runs one GROUP BY per metric in a fixed order:
+// domains, databases, docker_apps, mailboxes, backup_jobs, bw_daily.
+
+func urStatRows(pairs ...any) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"user_id", "n"})
+	for i := 0; i+1 < len(pairs); i += 2 {
+		rows.AddRow(pairs[i], pairs[i+1])
+	}
+	return rows
+}
+
+func TestUserResourceStats_Fetch_EmptyInputSkipsQueries(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewUserResourceStatsRepository(db)
+
+	out, err := repo.Fetch(context.Background(), nil, time.Now())
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserResourceStats_Fetch_MergesPerMetric(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewUserResourceStatsRepository(db)
+
+	const u1, u2 = "01USER0000000000000000001", "01USER0000000000000000002"
+
+	mock.ExpectQuery("FROM domains").WillReturnRows(urStatRows(u1, 3, u2, 1))
+	mock.ExpectQuery("FROM databases").WillReturnRows(urStatRows(u1, 2))
+	mock.ExpectQuery("FROM docker_apps").WillReturnRows(urStatRows(u2, 4))
+	mock.ExpectQuery("FROM mailboxes").WillReturnRows(urStatRows(u1, 5))
+	mock.ExpectQuery("FROM backup_jobs").WillReturnRows(urStatRows(u1, 6))
+	mock.ExpectQuery("FROM bw_daily").WillReturnRows(urStatRows(u1, 7340032))
+
+	monthStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	out, err := repo.Fetch(context.Background(), []string{u1, u2}, monthStart)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(3), out[u1].Domains)
+	require.Equal(t, int64(2), out[u1].Databases)
+	require.Equal(t, int64(5), out[u1].Mailboxes)
+	require.Equal(t, int64(6), out[u1].Backups)
+	require.Equal(t, uint64(7340032), out[u1].BandwidthBytes)
+	require.Equal(t, int64(0), out[u1].DockerApps)
+
+	require.Equal(t, int64(1), out[u2].Domains)
+	require.Equal(t, int64(4), out[u2].DockerApps)
+	require.Equal(t, uint64(0), out[u2].BandwidthBytes)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -191,7 +191,16 @@
       "package": "Package",
       "created": "Created",
       "disk_usage": "Disk usage",
+      "resources": "Resources",
+      "bandwidth_month": "Bandwidth this month",
       "actions": "Actions"
+    },
+    "res": {
+      "domains": "Domains",
+      "mailboxes": "Mailboxes",
+      "databases": "Databases",
+      "docker": "Docker apps",
+      "backups": "Retained backups"
     },
     "suspended": "Suspended",
     "suspended_on": "on {{date}}",

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -56,6 +56,15 @@ type User = {
   disk_limit_kb?: number;
   disk_checked_at?: string | null;
   created_at: string;
+  // GH #1242: at-a-glance per-user roll-up (counts + this month's bandwidth).
+  resources?: {
+    domains: number;
+    mailboxes: number;
+    databases: number;
+    docker_apps: number;
+    backups: number;
+    bandwidth_bytes: number;
+  };
 };
 
 type HostingPackage = { id: string; name: string };
@@ -69,6 +78,14 @@ const renderCreated = (ts: string) => shortDateTime(ts);
 // users-spec E2E asserts on `getByRole("cell", { name: email })`, and
 // if the action cell's accessible name contained the email too, the
 // matcher would hit both cells and fail with a strict-mode violation.
+// Compact byte formatter for the monthly-bandwidth line (GH #1242).
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
 function UserRowActions({
   user,
   onEdit,
@@ -386,17 +403,57 @@ function UsersShellTable({
           // per-row fetch was impossible — it only ever held the current
           // page's resolved rows.
           sorter
-          render={(_: unknown, r: User) =>
-            r.disk_checked_at ? (
-              <UserDiskUsageCell usedKB={r.disk_used_kb ?? 0} limitKB={r.disk_limit_kb ?? 0} />
-            ) : (
-              // Never swept (fresh upgrade, or the sweeper has not reached
-              // this row yet) — fall back to the live per-row fetch so the
-              // column is never blank.
-              <UserDiskUsage userId={r.id} />
-            )
-          }
+          render={(_: unknown, r: User) => (
+            <div>
+              {r.disk_checked_at ? (
+                <UserDiskUsageCell usedKB={r.disk_used_kb ?? 0} limitKB={r.disk_limit_kb ?? 0} />
+              ) : (
+                // Never swept (fresh upgrade, or the sweeper has not reached
+                // this row yet) — fall back to the live per-row fetch so the
+                // column is never blank.
+                <UserDiskUsage userId={r.id} />
+              )}
+              {r.resources && r.resources.bandwidth_bytes > 0 && (
+                <Tooltip title={t("users.col.bandwidth_month")}>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: 11, whiteSpace: "nowrap", display: "block" }}
+                  >
+                    ↕ {fmtBytes(r.resources.bandwidth_bytes)} /mo
+                  </Typography.Text>
+                </Tooltip>
+              )}
+            </div>
+          )}
         />
+      )}
+      {showDiskUsageColumn && (
+      <Table.Column<User>
+        title={t("users.col.resources")}
+        key="resources"
+        render={(_: unknown, r: User) => {
+          const R = r.resources;
+          if (!R) return <Typography.Text type="secondary">—</Typography.Text>;
+          const chips: Array<[string, string, number]> = [
+            [t("users.res.domains"), "Dom", R.domains],
+            [t("users.res.mailboxes"), "Mbx", R.mailboxes],
+            [t("users.res.databases"), "DB", R.databases],
+            [t("users.res.docker"), "Dkr", R.docker_apps],
+            [t("users.res.backups"), "Bkp", R.backups],
+          ];
+          return (
+            <Space size={8} wrap>
+              {chips.map(([full, abbr, n]) => (
+                <Tooltip key={abbr} title={full}>
+                  <span style={{ fontSize: 12, whiteSpace: "nowrap" }}>
+                    <Typography.Text type="secondary">{abbr}</Typography.Text> {n}
+                  </span>
+                </Tooltip>
+              ))}
+            </Space>
+          );
+        }}
+      />
       )}
       <Table.Column
         title={t("users.col.actions")}


### PR DESCRIPTION
## What

Follow-up to the disk-usage fix (#1347) for **GH #1242**. johnnyq asked for two
more things on the admin **Users** list:

1. **Monthly bandwidth** shown under the disk-usage cell.
2. **At-a-glance resource counts** — how many domains, mailboxes, databases,
   docker apps and retained backups each tenant has.

## How

**Backend — one batched aggregator, never N+1.** New
`UserResourceStatsRepository.Fetch(userIDs, monthStart)` runs one `GROUP BY`
query per metric over the current page's user ids and returns a
`map[userID]UserResourceStats`. Filters mirror the existing per-user
repositories so the numbers match the rest of the panel:

| Metric | Source | Filter |
|---|---|---|
| Domains | `domains` | `user_id IN (…)` |
| Databases | `databases` | `user_id IN (…)` |
| Docker apps | `docker_apps` | `status <> deleted` |
| Mailboxes | `mailboxes` ⋈ `domains` | by domain owner |
| Backups | `backup_jobs` | same as `CountRetainedForUser` (kind=account_backup, status IN queued/running/succeeded/partial) |
| Bandwidth | `bw_daily` ⋈ `domains` | `day >= first-of-month`, `SUM(bytes_total)` |

The list handler attaches the stats to each row (`userListRow` = the user +
`resources`). A stats failure is **non-fatal** — the list still renders, rows
just carry zero resources.

**Frontend.** The Disk column gains a secondary `↕ N /mo` bandwidth line; a new
**Resources** column renders compact tooltipped chips (Dom / Mbx / DB / Dkr /
Bkp). Both are gated to the tenant Users tab (same flag as disk usage) — the
Admins tab is unchanged.

## Testing

- New aggregator unit test: ordered per-metric queries + cross-metric merge, and
  the empty-input short-circuit.
- `go build ./...`, `panel-api` api + repository + openapi-coverage suites green.
- `panel-ui` `tsc -b`, user-shell vitest, and production `vite build` green.
- Read-only: no reconciler/agent path touched, so no box drill — every query's
  table/column/status filter was cross-checked against the existing
  `CountByUserID` / `CountRetainedForUser` / mailbox-inventory repositories.

## Notes

- en-only i18n (keys `users.col.resources`, `users.col.bandwidth_month`,
  `users.res.*`); other locales fall back to en, matching prior PRs.
- No API route added — `GET /admin/users` response body gains a `resources`
  object per row; the openapi entry for that route is untyped (`description: OK`),
  so nothing to regenerate.

GH #1242
