### PR TITLE
fix(panel-cert): regenerate self-signed panel cert on hostname change (JAB-389)

### DIFF
--- a/panel-agent/internal/commands/ssl_panel_selfsign.go
+++ b/panel-agent/internal/commands/ssl_panel_selfsign.go
@@ -1,0 +1,272 @@
+package commands
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// ssl.panel.selfsign regenerates the panel's self-signed hostname cert at
+// /etc/jabali/tls/panel.{crt,key} for the CURRENT panel FQDN, then reloads
+// nginx and restarts jabali-panel so the new cert is actually served on
+// :8443. It is the live equivalent of install.sh's provision_tls_cert
+// self-sign step.
+//
+// Why it exists (JAB-389): changing the panel hostname/FQDN through the
+// panel Settings updates the OS hostname and the panel_certificate DB rows,
+// but nothing regenerates the openssl self-signed cert on disk or restarts
+// the Go TLS listener that caches it — so :8443 keeps presenting the OLD
+// hostname's cert (a name mismatch every browser rejects) until Let's
+// Encrypt is enabled. The panel-cert reconciler dispatches this verb
+// whenever the on-disk cert has drifted from server_settings.hostname while
+// the panel is in self-signed mode.
+//
+// Invariants ported verbatim from install.sh provision_tls_cert:
+//   - PRESERVE any cert whose issuer Organization is neither empty nor
+//     panelSelfSignOrg ("Jabali Panel"): that is a deployed Let's Encrypt
+//     or custom cert. The 2026-05-09 regression clobbered a live LE cert
+//     with a self-signed one; the reconciler's drift check applies the same
+//     guard, and this handler re-checks so a stale reconciler dispatch can
+//     never destroy a real CA cert.
+//   - No-churn: when the existing self-signed cert already covers the FQDN
+//     (CN + the hostname and mail.<hostname> SANs) and is unexpired, do
+//     nothing — no regenerate, no nginx reload, no panel restart.
+//   - SAN set identical to install.sh:
+//     [hostname, mail.hostname, localhost, 127.0.0.1, <ip>].
+type sslPanelSelfSignParams struct {
+	Hostname string `json:"hostname"`
+	IP       string `json:"ip,omitempty"`
+}
+
+type sslPanelSelfSignResponse struct {
+	Regenerated bool   `json:"regenerated"`
+	Reason      string `json:"reason,omitempty"`
+	CertPath    string `json:"cert_path"`
+	ExpiresAt   string `json:"expires_at,omitempty"`
+}
+
+// Overridable in tests.
+var (
+	panelSelfSignCertPath = "/etc/jabali/tls/panel.crt"
+	panelSelfSignKeyPath  = "/etc/jabali/tls/panel.key"
+	// panelSelfSignReloadFn applies the freshly written cert to the running
+	// services. Seam so unit tests don't spawn systemctl.
+	panelSelfSignReloadFn = defaultPanelSelfSignReload
+)
+
+// panelSelfSignOrg is the Subject/Issuer Organization stamped onto our
+// self-signed panel cert (matches install.sh's -subj "…/O=Jabali Panel").
+// The preserve-guard keys off this exact string, so it MUST stay in sync
+// with install.sh provision_tls_cert.
+const panelSelfSignOrg = "Jabali Panel"
+
+// defaultPanelSelfSignReload reloads nginx and restarts jabali-panel.
+//
+// The context is deliberately DETACHED from the caller's RPC context: this
+// restarts jabali-panel, which — when the panel-cert reconciler dispatched
+// us — is the very process that opened the panel→agent RPC. Tying the
+// restart to the request ctx would let the panel dying mid-restart cancel
+// the systemctl call and strand jabali-panel stopped. nginx only reloads
+// (re-reads the cert on the next handshake); jabali-panel is a Go server
+// that caches the cert in memory at startup and does NOT SIGHUP-reread, so
+// a full restart is required to serve the new cert on :8443.
+func defaultPanelSelfSignReload(_ context.Context) {
+	bg, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	_ = execCommandContext(bg, "systemctl", "reload", "nginx").Run()
+	_ = execCommandContext(bg, "systemctl", "restart", "jabali-panel").Run()
+}
+
+func sslPanelSelfSignHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p sslPanelSelfSignParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	p.Hostname = strings.ToLower(strings.TrimSpace(p.Hostname))
+	if !sslDomainRegex.MatchString(p.Hostname) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid hostname %q", p.Hostname),
+		}
+	}
+	var ip net.IP
+	if p.IP != "" {
+		if ip = net.ParseIP(p.IP); ip == nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInvalidArgument,
+				Message: fmt.Sprintf("invalid ip %q", p.IP),
+			}
+		}
+	}
+
+	dnsSANs := []string{p.Hostname, "mail." + p.Hostname, "localhost"}
+	ipSANs := []net.IP{net.IPv4(127, 0, 0, 1)}
+	if ip != nil {
+		ipSANs = append(ipSANs, ip)
+	}
+
+	// Inspect the current cert: preserve a real CA cert; skip a self-signed
+	// cert that already covers the FQDN and is unexpired.
+	if data, err := os.ReadFile(panelSelfSignCertPath); err == nil {
+		if block, _ := pem.Decode(data); block != nil {
+			if cert, perr := x509.ParseCertificate(block.Bytes); perr == nil {
+				if o := panelCertIssuerOrg(cert); o != "" && o != panelSelfSignOrg {
+					return sslPanelSelfSignResponse{
+						Regenerated: false,
+						Reason:      "preserved: cert issued by " + o,
+						CertPath:    panelSelfSignCertPath,
+					}, nil
+				}
+				if panelSelfSignedCertCovers(cert, p.Hostname) && cert.NotAfter.After(time.Now()) {
+					return sslPanelSelfSignResponse{
+						Regenerated: false,
+						Reason:      "up to date for " + p.Hostname,
+						CertPath:    panelSelfSignCertPath,
+						ExpiresAt:   cert.NotAfter.UTC().Format(time.RFC3339),
+					}, nil
+				}
+			}
+		}
+	}
+
+	expiresAt, err := generatePanelSelfSignedCert(p.Hostname, dnsSANs, ipSANs, panelSelfSignCertPath, panelSelfSignKeyPath)
+	if err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("failed to generate panel self-signed cert: %v", err),
+		}
+	}
+
+	// Ownership + mode identical to install.sh provision_tls_cert: cert is
+	// public (0644 root:root), the key is group-readable by nginx and the
+	// panel (0640 root:www-data). Best-effort — www-data may not exist in a
+	// container/CI, where the temp path used by tests needs no chown.
+	_ = os.Chmod(panelSelfSignCertPath, 0o644)
+	applyPanelKeyOwnership(panelSelfSignKeyPath)
+
+	panelSelfSignReloadFn(ctx)
+
+	return sslPanelSelfSignResponse{
+		Regenerated: true,
+		CertPath:    panelSelfSignCertPath,
+		ExpiresAt:   expiresAt.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// panelCertIssuerOrg returns the first issuer Organization of cert, trimmed,
+// or "" when absent. Empty and "Jabali Panel" both mean "our self-signed
+// bootstrap" (regenerable); anything else is a real CA cert to preserve.
+func panelCertIssuerOrg(cert *x509.Certificate) string {
+	if len(cert.Issuer.Organization) > 0 {
+		return strings.TrimSpace(cert.Issuer.Organization[0])
+	}
+	return ""
+}
+
+// panelSelfSignedCertCovers reports whether cert already presents the panel
+// FQDN: CN == hostname AND the hostname + mail.<hostname> SANs are present.
+func panelSelfSignedCertCovers(cert *x509.Certificate, hostname string) bool {
+	if !strings.EqualFold(cert.Subject.CommonName, hostname) {
+		return false
+	}
+	have := make(map[string]struct{}, len(cert.DNSNames))
+	for _, d := range cert.DNSNames {
+		have[strings.ToLower(d)] = struct{}{}
+	}
+	for _, need := range []string{hostname, "mail." + hostname} {
+		if _, ok := have[strings.ToLower(need)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// generatePanelSelfSignedCert writes an ECDSA P-256 self-signed cert +
+// PKCS#8 key to certPath/keyPath, valid 10 years, Subject CN=cn
+// O="Jabali Panel", with the given DNS and IP SANs. Mirrors the openssl
+// invocation in install.sh provision_tls_cert (EC prime256v1, /O=Jabali
+// Panel) so the two paths produce interchangeable certs.
+func generatePanelSelfSignedCert(cn string, dnsSANs []string, ipSANs []net.IP, certPath, keyPath string) (time.Time, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("generate EC key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("generate serial: %w", err)
+	}
+	now := time.Now()
+	notAfter := now.AddDate(10, 0, 0)
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   cn,
+			Organization: []string{panelSelfSignOrg},
+		},
+		NotBefore:             now,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              dnsSANs,
+		IPAddresses:           ipSANs,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("create certificate: %w", err)
+	}
+
+	// Dir is install-provisioned in production; MkdirAll is a cheap guard so
+	// a missing /etc/jabali/tls (or a test temp dir) doesn't fail the write.
+	if err := os.MkdirAll(filepath.Dir(certPath), 0o755); err != nil {
+		return time.Time{}, fmt.Errorf("ensure cert dir: %w", err)
+	}
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644); err != nil {
+		return time.Time{}, fmt.Errorf("write cert: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("marshal key: %w", err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		return time.Time{}, fmt.Errorf("write key: %w", err)
+	}
+	return notAfter, nil
+}
+
+// applyPanelKeyOwnership sets the key to 0640 root:www-data (best-effort).
+func applyPanelKeyOwnership(keyPath string) {
+	_ = os.Chmod(keyPath, 0o640)
+	grp, err := user.LookupGroup("www-data")
+	if err != nil {
+		return
+	}
+	gid, err := strconv.Atoi(grp.Gid)
+	if err != nil {
+		return
+	}
+	_ = os.Chown(keyPath, 0, gid)
+}
+
+func init() {
+	Default.Register("ssl.panel.selfsign", sslPanelSelfSignHandler)
+}

--- a/panel-agent/internal/commands/ssl_panel_selfsign_test.go
+++ b/panel-agent/internal/commands/ssl_panel_selfsign_test.go
@@ -1,0 +1,238 @@
+package commands
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCert writes a self-signed cert+key with the given issuer/subject
+// Organization, CN, and DNS SANs — a test double for "a cert already on
+// disk". org=="" produces a cert whose issuer Organization is empty.
+func writeTestCert(t *testing.T, certPath, keyPath, org, cn string, dnsSANs []string, notAfter time.Time) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	subj := pkix.Name{CommonName: cn}
+	if org != "" {
+		subj.Organization = []string{org}
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               subj,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              dnsSANs,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	keyDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+}
+
+// setupPanelSelfSign points the package paths at a temp dir and stubs the
+// reload/restart seam, returning the paths and a pointer to a "reload was
+// called" flag. Restores the globals on cleanup.
+func setupPanelSelfSign(t *testing.T) (certPath, keyPath string, reloaded *bool) {
+	t.Helper()
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "panel.crt")
+	keyPath = filepath.Join(dir, "panel.key")
+
+	oc, ok, or := panelSelfSignCertPath, panelSelfSignKeyPath, panelSelfSignReloadFn
+	called := false
+	panelSelfSignCertPath = certPath
+	panelSelfSignKeyPath = keyPath
+	panelSelfSignReloadFn = func(context.Context) { called = true }
+	t.Cleanup(func() {
+		panelSelfSignCertPath, panelSelfSignKeyPath, panelSelfSignReloadFn = oc, ok, or
+	})
+	return certPath, keyPath, &called
+}
+
+func callPanelSelfSign(t *testing.T, hostname, ip string) (sslPanelSelfSignResponse, error) {
+	t.Helper()
+	params, _ := json.Marshal(sslPanelSelfSignParams{Hostname: hostname, IP: ip})
+	raw, err := sslPanelSelfSignHandler(context.Background(), params)
+	if err != nil {
+		return sslPanelSelfSignResponse{}, err
+	}
+	b, _ := json.Marshal(raw)
+	var resp sslPanelSelfSignResponse
+	if e := json.Unmarshal(b, &resp); e != nil {
+		t.Fatalf("unmarshal resp: %v", e)
+	}
+	return resp, nil
+}
+
+func readCertCN_SANs(t *testing.T, certPath string) (*x509.Certificate, string) {
+	t.Helper()
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	block, _ := pem.Decode(data)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert, cert.Subject.CommonName
+}
+
+// TestPanelSelfSign_PreservesLECert is the #1 regression guard (advisor):
+// a deployed Let's Encrypt cert (issuer O="Let's Encrypt") must NEVER be
+// clobbered by the self-signed regen, even when its CN doesn't match the
+// requested hostname.
+func TestPanelSelfSign_PreservesLECert(t *testing.T) {
+	certPath, keyPath, reloaded := setupPanelSelfSign(t)
+	writeTestCert(t, certPath, keyPath, "Let's Encrypt", "old.example.com",
+		[]string{"old.example.com"}, time.Now().AddDate(0, 3, 0))
+	before, _ := os.ReadFile(certPath)
+
+	resp, err := callPanelSelfSign(t, "new.example.com", "")
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if resp.Regenerated {
+		t.Fatalf("LE cert was regenerated — must be preserved")
+	}
+	after, _ := os.ReadFile(certPath)
+	if string(before) != string(after) {
+		t.Fatalf("LE cert bytes changed — must be untouched")
+	}
+	if *reloaded {
+		t.Fatalf("reload/restart fired for a preserved cert (needless churn)")
+	}
+}
+
+// TestPanelSelfSign_RegeneratesOnHostnameDrift: a self-signed cert for the
+// old hostname is replaced with one for the new hostname (CN + mail SAN),
+// and services are reloaded.
+func TestPanelSelfSign_RegeneratesOnHostnameDrift(t *testing.T) {
+	certPath, keyPath, reloaded := setupPanelSelfSign(t)
+	writeTestCert(t, certPath, keyPath, panelSelfSignOrg, "old.example.com",
+		[]string{"old.example.com", "mail.old.example.com", "localhost"}, time.Now().AddDate(5, 0, 0))
+
+	resp, err := callPanelSelfSign(t, "new.example.com", "203.0.113.9")
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if !resp.Regenerated {
+		t.Fatalf("expected regenerated=true, got reason %q", resp.Reason)
+	}
+	if !*reloaded {
+		t.Fatalf("reload/restart was not fired after regen")
+	}
+	cert, cn := readCertCN_SANs(t, certPath)
+	if cn != "new.example.com" {
+		t.Fatalf("CN not updated: %q", cn)
+	}
+	wantSAN := map[string]bool{"new.example.com": false, "mail.new.example.com": false, "localhost": false}
+	for _, d := range cert.DNSNames {
+		if _, ok := wantSAN[d]; ok {
+			wantSAN[d] = true
+		}
+	}
+	for name, seen := range wantSAN {
+		if !seen {
+			t.Fatalf("missing DNS SAN %q (have %v)", name, cert.DNSNames)
+		}
+	}
+	// IP SANs: loopback + the passed public IP.
+	var haveLoop, havePub bool
+	for _, ip := range cert.IPAddresses {
+		if ip.String() == "127.0.0.1" {
+			haveLoop = true
+		}
+		if ip.String() == "203.0.113.9" {
+			havePub = true
+		}
+	}
+	if !haveLoop || !havePub {
+		t.Fatalf("IP SANs wrong: %v", cert.IPAddresses)
+	}
+	// Issuer Organization must carry our marker so a later run treats it as
+	// regenerable (and install.sh's preserve-guard classifies it correctly).
+	if got := panelCertIssuerOrg(cert); got != panelSelfSignOrg {
+		t.Fatalf("issuer O = %q, want %q", got, panelSelfSignOrg)
+	}
+}
+
+// TestPanelSelfSign_NoChurnWhenCovered: an unexpired self-signed cert that
+// already covers the FQDN is left as-is and no reload fires.
+func TestPanelSelfSign_NoChurnWhenCovered(t *testing.T) {
+	certPath, keyPath, reloaded := setupPanelSelfSign(t)
+	writeTestCert(t, certPath, keyPath, panelSelfSignOrg, "host.example.com",
+		[]string{"host.example.com", "mail.host.example.com", "localhost"}, time.Now().AddDate(5, 0, 0))
+	before, _ := os.ReadFile(certPath)
+
+	resp, err := callPanelSelfSign(t, "host.example.com", "")
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if resp.Regenerated {
+		t.Fatalf("cert regenerated despite already covering the FQDN")
+	}
+	if *reloaded {
+		t.Fatalf("reload fired for a no-op")
+	}
+	after, _ := os.ReadFile(certPath)
+	if string(before) != string(after) {
+		t.Fatalf("cert bytes changed on a no-op")
+	}
+}
+
+// TestPanelSelfSign_RegeneratesWhenMissing: no cert on disk → generate one.
+func TestPanelSelfSign_RegeneratesWhenMissing(t *testing.T) {
+	certPath, _, reloaded := setupPanelSelfSign(t)
+	resp, err := callPanelSelfSign(t, "fresh.example.com", "")
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if !resp.Regenerated {
+		t.Fatalf("expected regenerated=true for missing cert")
+	}
+	if !*reloaded {
+		t.Fatalf("reload not fired")
+	}
+	if _, cn := readCertCN_SANs(t, certPath); cn != "fresh.example.com" {
+		t.Fatalf("CN = %q", cn)
+	}
+}
+
+func TestPanelSelfSign_InvalidHostname(t *testing.T) {
+	setupPanelSelfSign(t)
+	if _, err := callPanelSelfSign(t, "not a host", ""); err == nil {
+		t.Fatalf("expected error for invalid hostname")
+	}
+}
+
+func TestPanelSelfSign_InvalidIP(t *testing.T) {
+	setupPanelSelfSign(t)
+	if _, err := callPanelSelfSign(t, "host.example.com", "999.999.1.1"); err == nil {
+		t.Fatalf("expected error for invalid ip")
+	}
+}

--- a/panel-api/internal/reconciler/panel_certificate_reconciler.go
+++ b/panel-api/internal/reconciler/panel_certificate_reconciler.go
@@ -285,6 +285,13 @@ func (r *Reconciler) panelSelfSignedCertDrifted(certPath, hostname string) (bool
 			return true, "missing SAN " + need
 		}
 	}
+	// Expiry symmetry with the agent's no-churn check: an expired self-signed
+	// cert still covering the hostname must self-heal, else the reconciler
+	// would say "no drift" and never ask the agent to regenerate. The fresh
+	// cert passes this check, so there is no per-tick regen loop.
+	if !cert.NotAfter.After(time.Now()) {
+		return true, "cert expired"
+	}
 	return false, ""
 }
 

--- a/panel-api/internal/reconciler/panel_certificate_reconciler.go
+++ b/panel-api/internal/reconciler/panel_certificate_reconciler.go
@@ -2,7 +2,10 @@ package reconciler
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -40,6 +43,17 @@ func (r *Reconciler) reconcilePanelCertificate(ctx context.Context) {
 	// Single admin intent: the hostname row's use_le toggle governs
 	// both certs.
 	if !hostRow.UseLE {
+		// Self-signed mode (no Let's Encrypt): converge the on-disk panel
+		// cert to the CURRENT hostname (JAB-389). On a panel hostname change
+		// nothing else regenerates the openssl cert install.sh produced, so
+		// :8443 keeps serving the OLD hostname's cert until LE is enabled.
+		// Disk state is the ONLY state here — we deliberately never touch the
+		// panel_certificate row, so the panel restart the agent performs (the
+		// Go TLS listener caches the cert and must restart to serve the new
+		// one) can kill this reconciler mid-RPC without stranding a row
+		// status: the next tick's drift check on the regenerated cert is the
+		// success signal.
+		r.reconcilePanelSelfSignedCert(ctx, hostRow, settings.Hostname, settings.PublicIPv4)
 		return
 	}
 	if settings.Hostname == "" || settings.AdminEmail == "" {
@@ -184,4 +198,101 @@ func (r *Reconciler) reconcileOnePanelCert(ctx context.Context, kind string, row
 		return
 	}
 	r.log.Info("panel-cert issued", "kind", kind, "name", name, "expires_at", expiresAt)
+}
+
+
+// panelSelfSignOrgMarker is the issuer Organization our self-signed panel
+// cert carries (ssl.panel.selfsign / install.sh provision_tls_cert stamp
+// "/O=Jabali Panel"). A cert whose issuer Organization is neither empty nor
+// this marker is a real CA cert (Let's Encrypt / custom) and must never be
+// clobbered — the same guard install.sh applies after the 2026-05-09
+// LE-clobber incident.
+const panelSelfSignOrgMarker = "Jabali Panel"
+
+// reconcilePanelSelfSignedCert converges /etc/jabali/tls/panel.crt to the
+// panel's current hostname while the panel is in self-signed mode (JAB-389).
+// It reads and parses the cert locally — no agent round-trip to DECIDE — and
+// dispatches ssl.panel.selfsign only when the cert has drifted from hostname.
+// It is stateless with respect to the panel_certificate row (see the caller):
+// the on-disk cert is the only convergence signal.
+func (r *Reconciler) reconcilePanelSelfSignedCert(ctx context.Context, row *models.PanelCertificate, hostname, publicIPv4 string) {
+	if r.agent == nil || hostname == "" {
+		return
+	}
+	certPath := row.CertPEMPath
+	if certPath == "" {
+		certPath = "/etc/jabali/tls/panel.crt"
+	}
+	drift, reason := r.panelSelfSignedCertDrifted(certPath, hostname)
+	if !drift {
+		return
+	}
+	if _, err := r.agent.Call(ctx, "ssl.panel.selfsign", map[string]any{
+		"hostname": hostname,
+		"ip":       publicIPv4,
+	}); err != nil {
+		// Transient, or an old agent without the verb during a fleet
+		// rollout. Warn once per (hostname,error) so a persistently
+		// failing dispatch doesn't spam every tick; the next tick retries
+		// naturally.
+		key := hostname + "|" + err.Error()
+		if r.panelSelfSignLastErr == key {
+			r.log.Debug("panel self-signed cert regen still failing", "hostname", hostname, "error", err)
+			return
+		}
+		r.panelSelfSignLastErr = key
+		r.log.Warn("panel self-signed cert regen dispatch failed", "hostname", hostname, "error", err)
+		return
+	}
+	r.panelSelfSignLastErr = ""
+	r.log.Info("panel self-signed cert regen dispatched", "hostname", hostname, "reason", reason)
+}
+
+// panelSelfSignedCertDrifted reports whether the self-signed panel cert at
+// certPath needs regenerating for hostname, plus a short reason for logging.
+// A missing/unparseable cert drifts (regenerate). A cert issued by a real CA
+// (issuer Organization neither empty nor panelSelfSignOrgMarker) is PRESERVED
+// — never reported as drift — so a stale self-signed dispatch cannot clobber
+// a deployed Let's Encrypt cert.
+func (r *Reconciler) panelSelfSignedCertDrifted(certPath, hostname string) (bool, string) {
+	data, err := r.readCertFile(certPath)
+	if err != nil {
+		return true, "cert missing or unreadable"
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return true, "cert not PEM"
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return true, "cert unparseable"
+	}
+	if o := panelCertIssuerOrg(cert); o != "" && o != panelSelfSignOrgMarker {
+		return false, ""
+	}
+	if !strings.EqualFold(cert.Subject.CommonName, hostname) {
+		return true, "CN " + cert.Subject.CommonName + " != " + hostname
+	}
+	for _, need := range []string{hostname, "mail." + hostname} {
+		found := false
+		for _, d := range cert.DNSNames {
+			if strings.EqualFold(d, need) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return true, "missing SAN " + need
+		}
+	}
+	return false, ""
+}
+
+// panelCertIssuerOrg returns the first issuer Organization of cert, trimmed,
+// or "" when absent.
+func panelCertIssuerOrg(cert *x509.Certificate) string {
+	if len(cert.Issuer.Organization) > 0 {
+		return strings.TrimSpace(cert.Issuer.Organization[0])
+	}
+	return ""
 }

--- a/panel-api/internal/reconciler/panel_selfsign_reconcile_test.go
+++ b/panel-api/internal/reconciler/panel_selfsign_reconcile_test.go
@@ -159,3 +159,21 @@ func TestPanelSelfSignedDrift_MissingCertDispatches(t *testing.T) {
 		t.Fatalf("expected dispatch for missing cert, got %d", n)
 	}
 }
+
+
+func TestPanelSelfSignedDrift_ExpiredCoveringCertDispatches(t *testing.T) {
+	// Cert covers the FQDN but is expired → must self-heal (symmetry with the
+	// agent's no-churn expiry check).
+	pem := makeSelfSignPEM(t, panelSelfSignOrgMarker, "host.example.com",
+		[]string{"host.example.com", "mail.host.example.com", "localhost"}, time.Now().Add(-time.Hour))
+	fa := &fakeAgent{}
+	r := newSelfSignReconciler(fa, pem, nil)
+	row := &models.PanelCertificate{CertPEMPath: "/etc/jabali/tls/panel.crt"}
+	if drift, reason := r.panelSelfSignedCertDrifted(row.CertPEMPath, "host.example.com"); !drift {
+		t.Fatalf("expected drift for expired cert, reason=%q", reason)
+	}
+	r.reconcilePanelSelfSignedCert(context.Background(), row, "host.example.com", "")
+	if n, _ := countCalls(fa, "ssl.panel.selfsign"); n != 1 {
+		t.Fatalf("expected dispatch for expired cert, got %d", n)
+	}
+}

--- a/panel-api/internal/reconciler/panel_selfsign_reconcile_test.go
+++ b/panel-api/internal/reconciler/panel_selfsign_reconcile_test.go
@@ -1,0 +1,161 @@
+package reconciler
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func selfSignTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// makeSelfSignPEM builds a PEM cert with the given issuer/subject Org, CN and
+// DNS SANs — a stand-in for a cert on disk. org=="" → empty issuer Org.
+func makeSelfSignPEM(t *testing.T, org, cn string, dnsSANs []string, notAfter time.Time) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	subj := pkix.Name{CommonName: cn}
+	if org != "" {
+		subj.Organization = []string{org}
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               subj,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              dnsSANs,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func newSelfSignReconciler(agent *fakeAgent, certPEM []byte, readErr error) *Reconciler {
+	return &Reconciler{
+		agent: agent,
+		log:   selfSignTestLogger(),
+		readCertFile: func(string) ([]byte, error) {
+			if readErr != nil {
+				return nil, readErr
+			}
+			return certPEM, nil
+		},
+	}
+}
+
+func countCalls(fa *fakeAgent, method string) (int, map[string]any) {
+	fa.mu.Lock()
+	defer fa.mu.Unlock()
+	var n int
+	var last map[string]any
+	for _, c := range fa.calls {
+		if c.method == method {
+			n++
+			if m, ok := c.params.(map[string]any); ok {
+				last = m
+			}
+		}
+	}
+	return n, last
+}
+
+func TestPanelSelfSignedDrift_CNMismatchDispatches(t *testing.T) {
+	pem := makeSelfSignPEM(t, panelSelfSignOrgMarker, "old.example.com",
+		[]string{"old.example.com", "mail.old.example.com", "localhost"}, time.Now().AddDate(5, 0, 0))
+	fa := &fakeAgent{}
+	r := newSelfSignReconciler(fa, pem, nil)
+	row := &models.PanelCertificate{CertPEMPath: "/etc/jabali/tls/panel.crt"}
+
+	if drift, _ := r.panelSelfSignedCertDrifted(row.CertPEMPath, "new.example.com"); !drift {
+		t.Fatalf("expected drift for CN mismatch")
+	}
+	r.reconcilePanelSelfSignedCert(context.Background(), row, "new.example.com", "203.0.113.9")
+
+	n, params := countCalls(fa, "ssl.panel.selfsign")
+	if n != 1 {
+		t.Fatalf("expected 1 ssl.panel.selfsign dispatch, got %d", n)
+	}
+	if params["hostname"] != "new.example.com" || params["ip"] != "203.0.113.9" {
+		t.Fatalf("dispatch params wrong: %v", params)
+	}
+}
+
+func TestPanelSelfSignedDrift_MissingSANDispatches(t *testing.T) {
+	// CN matches but the mail.<hostname> SAN is absent (pre-M6.4 style cert).
+	pem := makeSelfSignPEM(t, panelSelfSignOrgMarker, "host.example.com",
+		[]string{"host.example.com", "localhost"}, time.Now().AddDate(5, 0, 0))
+	fa := &fakeAgent{}
+	r := newSelfSignReconciler(fa, pem, nil)
+	if drift, reason := r.panelSelfSignedCertDrifted("/x", "host.example.com"); !drift {
+		t.Fatalf("expected drift for missing mail SAN, reason=%q", reason)
+	}
+}
+
+func TestPanelSelfSignedDrift_CoveredNoDispatch(t *testing.T) {
+	pem := makeSelfSignPEM(t, panelSelfSignOrgMarker, "host.example.com",
+		[]string{"host.example.com", "mail.host.example.com", "localhost"}, time.Now().AddDate(5, 0, 0))
+	fa := &fakeAgent{}
+	r := newSelfSignReconciler(fa, pem, nil)
+	row := &models.PanelCertificate{CertPEMPath: "/etc/jabali/tls/panel.crt"}
+
+	if drift, _ := r.panelSelfSignedCertDrifted(row.CertPEMPath, "host.example.com"); drift {
+		t.Fatalf("did not expect drift for a covering cert")
+	}
+	r.reconcilePanelSelfSignedCert(context.Background(), row, "host.example.com", "")
+	if n, _ := countCalls(fa, "ssl.panel.selfsign"); n != 0 {
+		t.Fatalf("expected no dispatch, got %d", n)
+	}
+}
+
+// LE cert (issuer O="Let's Encrypt") must be preserved even in self-signed
+// mode: never reported as drift, never dispatched over.
+func TestPanelSelfSignedDrift_PreservesLECert(t *testing.T) {
+	pem := makeSelfSignPEM(t, "Let's Encrypt", "old.example.com",
+		[]string{"old.example.com"}, time.Now().AddDate(0, 3, 0))
+	fa := &fakeAgent{}
+	r := newSelfSignReconciler(fa, pem, nil)
+	row := &models.PanelCertificate{CertPEMPath: "/etc/jabali/tls/panel.crt"}
+
+	if drift, _ := r.panelSelfSignedCertDrifted(row.CertPEMPath, "new.example.com"); drift {
+		t.Fatalf("LE cert reported as drift — must be preserved")
+	}
+	r.reconcilePanelSelfSignedCert(context.Background(), row, "new.example.com", "")
+	if n, _ := countCalls(fa, "ssl.panel.selfsign"); n != 0 {
+		t.Fatalf("dispatched over an LE cert (%d calls) — must be preserved", n)
+	}
+}
+
+func TestPanelSelfSignedDrift_MissingCertDispatches(t *testing.T) {
+	fa := &fakeAgent{}
+	r := newSelfSignReconciler(fa, nil, os.ErrNotExist)
+	row := &models.PanelCertificate{CertPEMPath: "/etc/jabali/tls/panel.crt"}
+	if drift, _ := r.panelSelfSignedCertDrifted(row.CertPEMPath, "host.example.com"); !drift {
+		t.Fatalf("expected drift for missing cert")
+	}
+	r.reconcilePanelSelfSignedCert(context.Background(), row, "host.example.com", "")
+	if n, _ := countCalls(fa, "ssl.panel.selfsign"); n != 1 {
+		t.Fatalf("expected dispatch for missing cert, got %d", n)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -90,6 +90,13 @@ type Reconciler struct {
 	queue chan string
 	// socketReady is a function that checks if a Unix socket is ready. Mockable for testing.
 	socketReady func(ctx context.Context, socketPath string, timeout, pollInterval time.Duration) bool
+	// readCertFile reads a cert file for the JAB-389 panel self-signed drift
+	// check. Mockable for tests (default os.ReadFile).
+	readCertFile func(string) ([]byte, error)
+	// panelSelfSignLastErr debounces JAB-389 self-signed regen dispatch
+	// warnings so a mid-rollout agent (missing ssl.panel.selfsign) does not
+	// log at Warn every tick.
+	panelSelfSignLastErr string
 	// paused is an atomic flag to pause reconciliation (for SSO key rotation)
 	paused atomic.Bool
 
@@ -493,6 +500,8 @@ func New(domains repository.DomainRepository, users repository.UserRepository, a
 	}
 	// Initialize default socketReady function
 	r.socketReady = r.waitSocketReady
+	// JAB-389: default cert reader for the panel self-signed drift check.
+	r.readCertFile = os.ReadFile
 	return r
 }
 


### PR DESCRIPTION
## JAB-389 — self-signed panel cert not regenerated on a hostname change (defect 1, cert half)

### Problem
Changing the panel FQDN via Settings (`aramapp.com` → `mx.aramapp.com`) applied
the OS hostname and updated the `panel_certificate` DB rows, but **nothing
regenerated the on-disk self-signed cert or restarted the Go TLS listener that
caches it** — so `https://<new-fqdn>:8443` kept presenting the OLD hostname's
cert (a name mismatch every browser rejects). The only fix was enabling Let's
Encrypt. The panel-cert reconciler returned early in self-signed mode
(`if !hostRow.UseLE { return }`) and did no convergence at all.

### Fix
Reconciler-convergence + a new agent verb. On every reconcile tick, the
self-signed branch now converges the on-disk panel cert to
`server_settings.hostname`.

**panel-agent — new `ssl.panel.selfsign` verb** (live equivalent of install.sh
`provision_tls_cert`):
- Regenerates `/etc/jabali/tls/panel.{crt,key}` — ECDSA P-256, `CN=<host>`,
  `O="Jabali Panel"`, SANs `[host, mail.host, localhost, 127.0.0.1, <ip>]` —
  then reloads nginx and **restarts jabali-panel** (the Go server caches the
  cert in memory and does not SIGHUP-reread).
- **Preserve guard (ported verbatim):** never touches a cert whose issuer
  Organization is neither empty nor `"Jabali Panel"` — i.e. a deployed Let's
  Encrypt / custom cert (the 2026-05-09 LE-clobber incident).
- **No-churn:** if the existing self-signed cert already covers the FQDN and is
  unexpired, does nothing (no regen, no reload/restart).
- Reload/restart runs on a context **detached** from the RPC ctx on purpose: it
  restarts the very process (jabali-panel) that dispatched the RPC.

**panel-api — reconciler self-signed convergence:**
- Parses the cert **locally** (no agent round-trip to decide), re-applies the
  same LE-preserve guard, and dispatches `ssl.panel.selfsign` only on drift
  (CN mismatch / missing `host`|`mail.host` SAN / missing cert).
- **Stateless w.r.t. the `panel_certificate` row** — disk state is the only
  convergence signal, so the panel restart the agent performs can kill the
  reconciler mid-RPC without stranding a row status; the next tick's drift
  check is the success signal.
- Warns once per `(hostname,error)` so a mid-rollout agent without the verb
  doesn't spam every tick.

Converges on the next reconcile tick (same model as the LE panel-cert path),
not as a synchronous `set_hostname` side effect.

### Deliberately out of scope (JAB-389 stays open)
- **nginx :443 hostname vhost re-render** (`server_name` + landing docroot):
  today only install.sh / `jabali update` render `jabali-default.conf`; a live
  re-render needs that template ported to an agent verb — separate chunk.
- **Defect 2** — panel mail cert cascading `mail.<old>` → `mail.<new-fqdn>`:
  a product decision (keep decoupled / follow silently / explicit Settings
  choice), flagged "arguable" by the ticket author.
- **A deployed LE cert is never replaced by self-signed regen.** If an operator
  flips `use_le` off and then changes the hostname, the LE-preserve guard keeps
  the old LE cert on `:8443` (mismatched) rather than regenerating self-signed —
  the conservative install.sh-parity choice. Re-enable LE to reissue for the new
  name.

### Test plan
- [x] `panel-agent` unit: LE-preserve (no clobber, no reload), regen updates
  CN + DNS/IP SANs + issuer marker, no-churn when covered, regen when missing,
  invalid hostname/IP rejected.
- [x] `panel-api` reconciler unit: drift on CN mismatch → dispatch with
  `{hostname, ip}`; missing mail SAN → drift; covered → no dispatch;
  LE cert preserved (no dispatch); missing cert → dispatch.
- [x] `go vet` + full `panel-agent/internal/commands` and
  `panel-api/internal/reconciler` suites green.
- [x] **Live box drill — PASSED on .86** (2026-08-28). Nginx-fronted box, panel
  self-signed, `server_settings.hostname=mx.jabali-panel.com` while disk cert was
  `CN=jabali-panel.local`. Flipped `use_le=0` → within one 60s reconcile tick the
  reconciler dispatched `ssl.panel.selfsign` and the **served** `:8443` cert
  converged `CN=jabali-panel.local` → `CN=mx.jabali-panel.com` with SANs
  `[mx.jabali-panel.com, mail.mx.jabali-panel.com, localhost, 127.0.0.1, <ip>]`,
  then quiesced (no per-tick loop). Restored afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
