### PR TITLE
fix(python-apps): install MariaDB client dev headers so mysqlclient builds (GH #1352)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2794,9 +2794,19 @@ install_python_apps_runtime() {
   # Installs the default python3 venv tooling + build toolchain so user
   # virtualenvs can compile C-extension wheels (psycopg2, cryptography, lxml).
   # Cheap + idempotent; the feature itself stays opt-in (python_apps_enabled).
+  #
+  # GH #1352: mysqlclient — the standard Django/Wagtail MySQL/MariaDB driver —
+  # ships NO Linux wheels, so it always builds from source and needs the MariaDB
+  # client dev headers + `mysql_config`. Since the panel ships MariaDB as the
+  # default DB, a tenant Python app talking to it is mainstream; without these
+  # the build dies with "OSError: mysql_config not found". default-libmysqlclient-dev
+  # Depends: (not Recommends) libmariadb-dev + libmariadb-dev-compat, so the
+  # mysql_config symlink comes in even under --no-install-recommends. pkg-config
+  # is what newer mysqlclient (2.2+) uses to locate the client library.
   _log "installing Python app runtime prerequisites (venv + build toolchain)"
   DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
     python3 python3-venv python3-dev build-essential libffi-dev libssl-dev \
+    default-libmysqlclient-dev pkg-config \
     >>"${LOG_FILE:-/dev/null}" 2>&1 || {
       _warn "Python app runtime prereqs failed to install — Python apps may not build until resolved"
       return 0


### PR DESCRIPTION
## What

**GH #1352** — a tenant Python app (Django/Wagtail) that depends on `mysqlclient`
fails to provision:

```
OSError: mysql_config not found
ERROR: No matching distribution found for mysqlclient==2.1.1
```

## Root cause

`mysqlclient` ships **no Linux wheels** — only `win_amd64` wheels + the sdist —
so on Linux it *always* compiles from source, which needs the MariaDB client dev
headers and `mysql_config`. The old pip in the reporter's hand-built Python 3.8
is a red herring: no pip version can avoid the source build here.

The Python-app runtime toolchain (`install_python_apps_runtime`) installs
`build-essential` + `libffi-dev` + `libssl-dev` — enough for `psycopg2`,
`cryptography`, `lxml` — but **omits the MariaDB client dev package**. Since the
panel ships **MariaDB as the default DB**, a tenant app talking to it via
`mysqlclient` (the standard Django MySQL driver) is a mainstream case that could
never build out of the box.

## Fix

Add to the runtime toolchain:

- **`default-libmysqlclient-dev`** — `Depends:` (not Recommends) `libmariadb-dev-compat`,
  which provides `/usr/bin/mysql_config`, so it comes in even under
  `--no-install-recommends`.
- **`pkg-config`** — how `mysqlclient` 2.2+ locates the client library.

`install.sh` re-runs `install_python_apps_runtime` on every update when the
`python_apps` module is enabled (line ~16126), so **existing boxes pick this up
on their next update**; the Apps-enable toggle also re-dispatches it. `apt-get
install` is idempotent — a no-op where already present.

## Testing (D13 smoke box, live drill)

- `apt-cache depends default-libmysqlclient-dev` → `Depends: libmariadb-dev-compat`
  (confirms `mysql_config` lands under `--no-install-recommends`).
- Installed the exact package set: `mysql_config` and `mariadb_config` both
  resolve (11.8.6), `pkg-config` + `gcc` present.
- Scratch venv `pip install mysqlclient` (**latest, 2.2.8**) — builds from source
  and imports its C extension cleanly.
- `bash -n install.sh` clean; phantom-function lint / install.sh regression gates
  unaffected (one package added to an existing apt line).

GH #1352
