### PR TITLE
fix(db): exempt chunked-restore + admin File Manager uploads from the 1 MiB body cap (GH #1044)

### DIFF
--- a/panel-api/internal/app/body_limit_exempt.go
+++ b/panel-api/internal/app/body_limit_exempt.go
@@ -20,6 +20,21 @@ var bodyLimitExemptRoutes = map[string]struct{}{
 	"POST /api/v1/files/write": {},
 	// Own cap: http.MaxBytesReader against upload_max_size_mb.
 	"POST /api/v1/databases/:id/restore": {},
+	// Own cap: io.LimitReader against upload_max_size_mb per chunk (GH #1044).
+	// The chunked DB restore (GH #1323) sends 10 MB chunks; without this
+	// exemption the 1 MB global cap 413s every chunk ("request body too
+	// large") before the handler's own LimitReader runs, so any dump above the
+	// 90 MB chunk threshold could never restore.
+	"POST /api/v1/databases/:id/restore-chunk": {},
+	// GH #1184 admin File Manager — the SAME handlers as the tenant /files
+	// mount (which is exempt above), re-mounted under /admin/files, so they
+	// carry the same own caps and need the same exemptions (GH #1044).
+	// Own cap: filesUploadSizeLimit (server_settings.upload_max_size_mb).
+	"POST /api/v1/admin/files/upload": {},
+	// Own cap: io.LimitReader against upload_max_size_mb per chunk.
+	"POST /api/v1/admin/files/upload-chunk": {},
+	// Own cap: filesUploadSizeLimit — Monaco editor saves whole files.
+	"POST /api/v1/admin/files/write": {},
 	// Own cap: http.MaxBytesReader against upload_max_size_mb.
 	"POST /api/v1/admin/migrations/:id/tarball": {},
 	// Own cap: http.MaxBytesReader against MaxLogoBytes.

--- a/panel-api/internal/app/body_limit_exempt_test.go
+++ b/panel-api/internal/app/body_limit_exempt_test.go
@@ -54,3 +54,43 @@ func TestBodyLimit_EngineWide413(t *testing.T) {
 		t.Fatalf("oversized JSON through engine: got %d, want 413", w.Code)
 	}
 }
+
+// TestBodyLimitExempt_UploadRoutesNotCapped is the reverse-direction guard the
+// TestBodyLimitExemptRoutes_ExistInRouteTable pinning test lacked: it proves
+// each upload-family route is ACTUALLY exempt, by pushing a >1 MiB body through
+// the real engine and asserting the global cap does not 413 it. The cap runs
+// pre-auth (see TestBodyLimit_EngineWide413), so an exempt route falls through
+// to auth/handler (401/403/404/400 — anything but 413); a route that slipped
+// out of bodyLimitExemptRoutes 413s here. GH #1044: the chunked DB restore
+// (`/databases/:id/restore-chunk`, 10 MiB chunks) and the #1184 admin File
+// Manager upload routes were missing and 413'd every chunk.
+func TestBodyLimitExempt_UploadRoutesNotCapped(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Auth.Kratos.PublicURL = "http://127.0.0.1:4433"
+	cfg.Auth.Kratos.AdminURL = "http://127.0.0.1:4434"
+	r := NewWithDeps(cfg, fullDeps())
+
+	// One concrete request path per exempt upload-family route (":id"/variant
+	// filled with a dummy segment so Gin resolves the template + FullPath).
+	paths := []string{
+		"/api/v1/files/upload",
+		"/api/v1/files/upload-chunk",
+		"/api/v1/files/write",
+		"/api/v1/databases/x/restore",
+		"/api/v1/databases/x/restore-chunk",
+		"/api/v1/admin/files/upload",
+		"/api/v1/admin/files/upload-chunk",
+		"/api/v1/admin/files/write",
+		"/api/v1/admin/migrations/x/tarball",
+	}
+	big := strings.Repeat("x", 2<<20) // 2 MiB, over the 1 MiB global cap
+	for _, p := range paths {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, p, strings.NewReader(big))
+		req.Header.Set("Content-Type", "application/octet-stream")
+		r.ServeHTTP(w, req)
+		if w.Code == http.StatusRequestEntityTooLarge {
+			t.Errorf("%s 413'd a 2 MiB body — route is missing from bodyLimitExemptRoutes", p)
+		}
+	}
+}


### PR DESCRIPTION
## What

**GH #1044** — @lxsdevcode reported a **2.74 GB PostgreSQL restore** failing with
**"request body too large"**, while the same file uploads fine through the File
Manager.

## Root cause

`POST /databases/:id/restore-chunk` — the chunked DB restore added in GH #1323 —
was **never added to `bodyLimitExemptRoutes`**. So the global 1 MiB body-limit
middleware (JAB-246) `413`s **every 10 MiB chunk** *before* the handler's own
`io.LimitReader` runs. Any dump above the 90 MiB chunk threshold therefore could
never restore — **chunked restore has been broken since it shipped**. (My earlier
"verified end to end" note on this issue didn't cover a >90 MiB file through the
real middleware stack; that's the gap.)

The **same omission** hit the GH #1184 admin File Manager: `/admin/files/upload`,
`/admin/files/upload-chunk`, and `/admin/files/write` are the *same* own-capped
handlers as the exempt tenant `/files` mount, but were never exempted — so admin
large/chunked uploads and >1 MiB Monaco saves `413`'d too.

## Fix

Exempt all four (each already enforces its own cap — `filesUploadSizeLimit` /
`io.LimitReader` / `http.MaxBytesReader`).

**Reverse-direction regression test.** The existing pinning test only checked
`exempt → route exists`, so a body route slipping *out* of the exempt list
produced no signal. `TestBodyLimitExempt_UploadRoutesNotCapped` pushes a >1 MiB
body through the real engine at each upload-family route and asserts the global
cap does **not** 413 it (the cap runs pre-auth, so an exempt route falls through
to 401/404 — never 413). This test fails on `main` and passes with the fix.

## Testing

- `go build ./...`; `internal/app` body-limit suite green (incl. the new test).
- **Live box (.60, jabalitest), behavior not deploy — through real nginx + binary:**
  - BEFORE: `POST /databases/:id/restore-chunk` with 2 MiB → **413** (bug reproduced).
  - AFTER: `restore-chunk`, `admin/files/upload`, `admin/files/upload-chunk`,
    `admin/files/write` all → **401** (cap passed, reaches auth); control
    `POST /files/mkdir` (JSON) still → **413** (cap intact).

## Scope note

This fixes item 1's **"request body too large"** (the large-file path). The
reporter also hit a Cloudflare *"invalid/incomplete response from origin"* on a
**<200 KB** dump via the one-shot `/restore` path — a separate, still-synchronous
code path — which needs its own reproduction and is **not** addressed here.

GH #1044
