### PR TITLE
fix(db): sanitize user pg_dumps so PostgreSQL restore accepts stock dumps (GH #1044)

### DIFF
--- a/panel-agent/internal/commands/db_postgres_restore.go
+++ b/panel-agent/internal/commands/db_postgres_restore.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -217,9 +218,37 @@ END $$;`, shadow, shadow, pwd, shadow, pwd)
 		"-U", shadow, "-d", tmpDB)
 	load.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}}
 	load.Env = append(os.Environ(), "PGPASSWORD="+pwd)
-	load.Stdin = f // escape-proof fd; nobody reads the inherited fd, not the path
-	if out, err := load.CombinedOutput(); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "restore load failed (check the dump is a plain-SQL pg_dump): " + strings.TrimSpace(string(out))}
+
+	// Stream the dump through the ownership/privilege sanitizer (GH #1044) into
+	// psql's stdin via a pipe: a stock `pg_dump` carries `ALTER ... OWNER TO` /
+	// GRANT / SET SESSION AUTHORIZATION that the unprivileged shadow role can't
+	// replay ("must be able to SET ROLE ..."), which ON_ERROR_STOP turns into a
+	// whole-restore abort. psql (as `nobody`) reads the inherited pipe fd, never
+	// the dump path — the same escape-proof property as handing it the file fd,
+	// and the raw file is still only ever opened by root. The post-pass below
+	// re-establishes tenant ownership + panel-tracked grants, so nothing dropped
+	// here is lost.
+	pr, pw, perr := os.Pipe()
+	if perr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore pipe: " + perr.Error()}
+	}
+	load.Stdin = pr
+	var out bytes.Buffer
+	load.Stdout = &out
+	load.Stderr = &out
+	if err := load.Start(); err != nil {
+		_ = pr.Close()
+		_ = pw.Close()
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore start: " + err.Error()}
+	}
+	_ = pr.Close() // child holds its own copy; parent closes so psql sees EOF
+	sanErr := sanitizePgPlainDump(f, pw)
+	_ = pw.Close() // signal EOF to psql whatever the sanitize outcome
+	if waitErr := load.Wait(); waitErr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "restore load failed (check the dump is a plain-SQL pg_dump): " + strings.TrimSpace(out.String())}
+	}
+	if sanErr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore stream: " + sanErr.Error()}
 	}
 
 	// (4) Superuser post-pass on the STAGING db — ownership + grants, none of it

--- a/panel-agent/internal/commands/db_postgres_restore_sanitize.go
+++ b/panel-agent/internal/commands/db_postgres_restore_sanitize.go
@@ -1,0 +1,164 @@
+package commands
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// sanitizePgPlainDump streams a plain-format pg_dump from r to w, dropping the
+// top-level ownership/role/privilege statements that a default `pg_dump` emits
+// but the restore's unprivileged shadow loader cannot execute (GH #1044).
+//
+// A dump made by the panel's own backup already carries `--no-owner
+// --no-privileges`, so it loads clean; a dump the tenant made themselves with a
+// stock `pg_dump` includes `ALTER ... OWNER TO <role>`, `GRANT`/`REVOKE`, and
+// (with --use-set-session-authorization) `SET SESSION AUTHORIZATION` — all of
+// which fail under ON_ERROR_STOP when replayed as the non-superuser shadow role
+// ("must be able to SET ROLE ..."), aborting the whole restore. The existing
+// superuser post-pass reassigns ownership to the tenant role and re-applies the
+// panel-tracked grants, so dropping these directives here loses nothing the
+// restore did not already re-establish.
+//
+// The filter is deliberately structural, not a blind line grep: it never drops a
+// line inside a `COPY ... FROM stdin` data block or inside a dollar-quoted body
+// (a function source can legitimately contain the words GRANT / OWNER TO), which
+// a naive sed would corrupt. Only a complete single-statement line (ends in `;`)
+// at top level is eligible to be dropped — pg_dump emits every one of these
+// targets on its own line, so a multi-line statement is never half-cut.
+func sanitizePgPlainDump(r io.Reader, w io.Writer) error {
+	br := bufio.NewReaderSize(r, 1<<20)
+	bw := bufio.NewWriterSize(w, 1<<20)
+
+	inCopy := false   // between `COPY ... FROM stdin;` and its terminating `\.`
+	dollarTag := ""   // non-empty while inside a $tag$ ... $tag$ quoted body
+
+	for {
+		line, readErr := br.ReadString('\n')
+		if len(line) > 0 {
+			keep := true
+			switch {
+			case inCopy:
+				// Raw COPY data — pass verbatim; the block ends at a line that
+				// is exactly `\.`.
+				if strings.TrimRight(line, "\r\n") == `\.` {
+					inCopy = false
+				}
+			case dollarTag != "":
+				// Inside a dollar-quoted body — pass verbatim, tracking the close.
+				dollarTag = scanDollarQuote(line, dollarTag)
+			default:
+				trimmed := strings.TrimSpace(line)
+				if isCopyFromStdin(trimmed) {
+					inCopy = true
+				} else if tag := scanDollarQuote(line, ""); tag != "" {
+					// This line opens a dollar-quoted body that stays open — it
+					// is part of a CREATE FUNCTION/DO block, never a droppable
+					// ownership statement.
+					dollarTag = tag
+				} else if isDroppableDumpStmt(trimmed) {
+					keep = false
+				}
+			}
+			if keep {
+				if _, err := bw.WriteString(line); err != nil {
+					return err
+				}
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return readErr
+		}
+	}
+	return bw.Flush()
+}
+
+// isCopyFromStdin reports whether a top-level line begins a `COPY ... FROM stdin`
+// data block (the only COPY form pg_dump emits for table data).
+func isCopyFromStdin(trimmed string) bool {
+	up := strings.ToUpper(trimmed)
+	return strings.HasPrefix(up, "COPY ") &&
+		strings.Contains(up, " FROM STDIN") &&
+		strings.HasSuffix(strings.TrimRight(trimmed, " \t\r\n"), ";")
+}
+
+// isDroppableDumpStmt reports whether a complete top-level statement line is one
+// of the ownership/role/privilege directives the shadow loader cannot run. Only
+// single-line, semicolon-terminated statements qualify, so a multi-line
+// statement is never partially removed.
+func isDroppableDumpStmt(trimmed string) bool {
+	if !strings.HasSuffix(strings.TrimRight(trimmed, " \t\r\n"), ";") {
+		return false
+	}
+	up := strings.ToUpper(trimmed)
+	switch {
+	case strings.HasPrefix(up, "ALTER ") && strings.Contains(up, " OWNER TO "):
+		return true
+	case strings.HasPrefix(up, "GRANT "):
+		return true
+	case strings.HasPrefix(up, "REVOKE "):
+		return true
+	case strings.HasPrefix(up, "SET SESSION AUTHORIZATION"):
+		return true
+	case strings.HasPrefix(up, "RESET SESSION AUTHORIZATION"):
+		return true
+	case strings.HasPrefix(up, "SET ROLE "):
+		return true
+	default:
+		return false
+	}
+}
+
+// scanDollarQuote walks one line and returns the dollar-quote tag left open at
+// end of line. openTag is the tag already open at line start ("" if none). A
+// tag is `$` + [A-Za-z0-9_]* + `$` (so `$$` and `$body$`); a lone `$` with no
+// closing `$` on the same run is treated as a literal, never as an opener.
+func scanDollarQuote(line, openTag string) string {
+	i := 0
+	n := len(line)
+	for i < n {
+		if line[i] != '$' {
+			i++
+			continue
+		}
+		if openTag == "" {
+			tag, ok := dollarTagAt(line, i)
+			if ok {
+				openTag = tag
+				i += len(tag)
+				continue
+			}
+			i++
+		} else {
+			// Looking for the matching close tag.
+			if strings.HasPrefix(line[i:], openTag) {
+				i += len(openTag)
+				openTag = ""
+				continue
+			}
+			i++
+		}
+	}
+	return openTag
+}
+
+// dollarTagAt parses a dollar-quote delimiter starting at line[i] (which is '$').
+// Returns the full delimiter (e.g. "$$" or "$func$") and true, or false if the
+// run is not a complete delimiter.
+func dollarTagAt(line string, i int) (string, bool) {
+	j := i + 1
+	for j < len(line) {
+		c := line[j]
+		if c == '$' {
+			return line[i : j+1], true
+		}
+		if !(c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+			return "", false
+		}
+		j++
+	}
+	return "", false
+}

--- a/panel-agent/internal/commands/db_postgres_restore_sanitize_test.go
+++ b/panel-agent/internal/commands/db_postgres_restore_sanitize_test.go
@@ -1,0 +1,139 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func sanitize(t *testing.T, in string) string {
+	t.Helper()
+	var sb strings.Builder
+	if err := sanitizePgPlainDump(strings.NewReader(in), &sb); err != nil {
+		t.Fatalf("sanitizePgPlainDump: %v", err)
+	}
+	return sb.String()
+}
+
+func TestSanitize_DropsOwnershipAndPrivilegeStatements(t *testing.T) {
+	in := strings.Join([]string{
+		"SET statement_timeout = 0;",
+		"SET search_path = public;",
+		"CREATE TABLE public.widgets (id integer NOT NULL, name text);",
+		"ALTER TABLE public.widgets OWNER TO postgres;",
+		"ALTER SCHEMA public OWNER TO pg_database_owner;",
+		"GRANT ALL ON TABLE public.widgets TO some_role;",
+		"REVOKE ALL ON SCHEMA public FROM PUBLIC;",
+		"SET SESSION AUTHORIZATION 'postgres';",
+		"RESET SESSION AUTHORIZATION;",
+		"SET ROLE postgres;",
+		"CREATE INDEX widgets_name_idx ON public.widgets (name);",
+		"",
+	}, "\n")
+	got := sanitize(t, in)
+
+	for _, dropped := range []string{"OWNER TO", "GRANT ALL", "REVOKE ALL", "SESSION AUTHORIZATION", "SET ROLE postgres"} {
+		if strings.Contains(got, dropped) {
+			t.Errorf("expected %q to be stripped, still present:\n%s", dropped, got)
+		}
+	}
+	for _, kept := range []string{"statement_timeout", "search_path", "CREATE TABLE public.widgets", "CREATE INDEX widgets_name_idx"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("expected %q to be preserved, missing:\n%s", kept, got)
+		}
+	}
+}
+
+func TestSanitize_PreservesCopyDataLookalikes(t *testing.T) {
+	// A COPY data block whose ROWS contain text that looks like droppable
+	// statements MUST pass through verbatim — dropping it would corrupt data.
+	in := strings.Join([]string{
+		"COPY public.audit (id, msg) FROM stdin;",
+		"1\tALTER TABLE x OWNER TO postgres;",
+		"2\tGRANT ALL ON y TO z;",
+		"3\tSET ROLE postgres;",
+		`\.`,
+		"ALTER TABLE public.audit OWNER TO postgres;", // this one (real stmt) drops
+		"",
+	}, "\n")
+	got := sanitize(t, in)
+
+	if !strings.Contains(got, "1\tALTER TABLE x OWNER TO postgres;") ||
+		!strings.Contains(got, "2\tGRANT ALL ON y TO z;") ||
+		!strings.Contains(got, "3\tSET ROLE postgres;") {
+		t.Errorf("COPY data rows were altered:\n%s", got)
+	}
+	// The real ALTER OWNER after the block must be gone.
+	if strings.Contains(got, "ALTER TABLE public.audit OWNER TO postgres;") {
+		t.Errorf("real ALTER OWNER after COPY block not stripped:\n%s", got)
+	}
+}
+
+func TestSanitize_PreservesDollarQuotedFunctionBody(t *testing.T) {
+	// A function body legitimately containing GRANT / OWNER TO must survive.
+	in := strings.Join([]string{
+		"CREATE FUNCTION public.f() RETURNS void AS $func$",
+		"BEGIN",
+		"  -- GRANT ALL ON t TO r;",
+		"  EXECUTE 'ALTER TABLE t OWNER TO r';",
+		"END;",
+		"$func$ LANGUAGE plpgsql;",
+		"ALTER FUNCTION public.f() OWNER TO postgres;", // real, drops
+		"",
+	}, "\n")
+	got := sanitize(t, in)
+
+	for _, kept := range []string{
+		"-- GRANT ALL ON t TO r;",
+		"EXECUTE 'ALTER TABLE t OWNER TO r';",
+		"$func$ LANGUAGE plpgsql;",
+	} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("function body line dropped: %q\n%s", kept, got)
+		}
+	}
+	if strings.Contains(got, "ALTER FUNCTION public.f() OWNER TO postgres;") {
+		t.Errorf("real ALTER FUNCTION OWNER not stripped:\n%s", got)
+	}
+}
+
+func TestSanitize_DollarDollarBody(t *testing.T) {
+	in := strings.Join([]string{
+		"CREATE FUNCTION g() RETURNS int AS $$",
+		"  SELECT 1; -- GRANT nonsense here",
+		"$$ LANGUAGE sql;",
+		"",
+	}, "\n")
+	got := sanitize(t, in)
+	if !strings.Contains(got, "SELECT 1; -- GRANT nonsense here") {
+		t.Errorf("$$-quoted body corrupted:\n%s", got)
+	}
+}
+
+func TestSanitize_KeepsMultiLineLookalike(t *testing.T) {
+	// A line that matches a prefix but does NOT terminate the statement (no
+	// trailing ';') must be kept — never half-cut a multi-line statement.
+	in := "GRANT ALL ON TABLE x\n  TO some_role;\n"
+	got := sanitize(t, in)
+	if !strings.Contains(got, "GRANT ALL ON TABLE x") {
+		t.Errorf("multi-line GRANT first line wrongly dropped:\n%s", got)
+	}
+}
+
+func TestSanitize_PanelStyleDumpUnchanged(t *testing.T) {
+	// A panel-style dump (already --no-owner --no-privileges) has nothing to
+	// strip and must pass through byte-for-byte.
+	in := strings.Join([]string{
+		"SET statement_timeout = 0;",
+		"CREATE TABLE public.t (id integer);",
+		"COPY public.t (id) FROM stdin;",
+		"1",
+		"2",
+		`\.`,
+		"CREATE INDEX t_id ON public.t (id);",
+		"",
+	}, "\n")
+	got := sanitize(t, in)
+	if got != in {
+		t.Errorf("panel-style dump was modified:\nwant:\n%s\ngot:\n%s", in, got)
+	}
+}


### PR DESCRIPTION
## What

**GH #1044** — @lxsdevcode reported a **<200 KB schema-only PostgreSQL dump**
failing to restore. Reproduced on a test box: a dump the tenant made themselves
with a **stock `pg_dump`** fails server-side with

```
restore load failed: ERROR: must be able to SET ROLE "postgres"
```

while a dump **downloaded from the panel** restores fine.

## Root cause

The PG restore (GH #1205) loads the dump as an **unprivileged shadow role**
running as OS `nobody` — the isolation that stops malicious dump content (`\!`,
`COPY … FROM PROGRAM`, `CREATE FUNCTION … LANGUAGE C`) from executing as a
superuser. A default `pg_dump` emits `ALTER … OWNER TO <role>`, `GRANT`/`REVOKE`
and (with `--use-set-session-authorization`) `SET SESSION AUTHORIZATION`.
Replayed as the non-superuser shadow, those hit *"must be able to SET ROLE …"*
and `ON_ERROR_STOP=1` aborts the whole restore. The panel's own backups avoid
this by dumping with `--no-owner --no-privileges` — which is why panel backups
restore but a user's own dump doesn't.

## Fix

Stream the plain-SQL dump through a **sanitizer** before the shadow load that
drops those top-level ownership/role/privilege statements. The existing
superuser post-pass already **reassigns ownership** to the tenant role and
**re-applies the panel-tracked grants**, so nothing dropped is lost.

- The dump is piped into `psql`'s stdin — `psql` (as `nobody`) reads the
  inherited **pipe fd**, never the path, so the escape-proof property is
  unchanged and the raw file is still only ever opened by root.
- The filter is **structural, not a blind grep**: it never touches a line inside
  a `COPY … FROM stdin` data block or a **dollar-quoted function body** (both can
  legitimately contain the words `GRANT` / `OWNER TO`), and only drops a
  **complete single-statement line** (ends in `;`), so a multi-line statement is
  never half-cut.

## Testing

- Unit tests: ownership/grant/`SET ROLE` stripping; COPY-data lookalikes and
  dollar-quoted function bodies passed through verbatim; multi-line guard;
  byte-for-byte passthrough of an already-clean panel-style dump.
- `panel-agent` `go build ./...` + `internal/commands` suite green.
- **Live box (.60, jabalitest), behavior not deploy:**
  - Before: raw `pg_dump` → `must be able to SET ROLE "postgres"` (reproduced).
  - After: raw `pg_dump` (schema-only **and** with 5000 rows of COPY data whose
    values literally contain `GRANT ALL OWNER TO postgres`) restores **ok**, with
    **matching row count + md5 before/after** — real statements stripped, data
    untouched.

## Scope

This is the PostgreSQL restore-logic half of #1044 (the reporter's small-dump
failure). The large-file **"request body too large"** half is the separate
body-limit exemption in #1366. Agent verbs changed → **fleet agent redeploy on
release.**

GH #1044
