### PR TITLE
fix(php-settings): full responsive page width, not an 800px centered box (GH #1332)

### DIFF
--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -271,7 +271,9 @@ export function UserPHPSettingsPage() {
   ];
 
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto" }}>
+    // GH #1332 item 1: the page was clamped to 800px and centred, unlike every
+    // other settings page. Use the shell's full responsive width like its peers.
+    <div>
       <Space direction="vertical" size="large" style={{ width: "100%" }}>
         <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
           <CodeOutlined /> PHP Settings


### PR DESCRIPTION
## What

GH #1332 item 1 — the per-domain **PHP Settings** page renders as a narrow centered column instead of following the responsive layout of the other settings pages.

## Fix

The page wrapped its content in `<div style={{ maxWidth: 800, margin: "0 auto" }}>`. Every sibling page (Cron, FTP, Docker, …) uses a plain full-width container. Dropped the clamp so it uses the shell's full responsive width.

## Testing

- `tsc -b` clean.
- UI-only, single container style; the inner `Row`/`Col` grid (`xs={24} sm={12}`) already handles responsiveness.

Part of the #1332 series (items 2 and 3/4 are separate PRs). GH #1332