### PR TITLE
feat(php-settings): per-version Performance tuning + domain-scoped Resource Limits (GH #1332)

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3777,6 +3777,11 @@ paths:
       responses: { "200": { description: OK } }
 
   /me/php-pool-tuning:
+    get:
+      tags: [Me]
+      summary: Get per-version PHP pool tuning + policy
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
     put:
       tags: [Me]
       summary: Update php pool tuning

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -32,8 +32,68 @@ type phpUserTuningHandler struct{ cfg PHPUserTuningHandlerConfig }
 func RegisterPHPUserTuningRoutes(g *gin.RouterGroup, cfg PHPUserTuningHandlerConfig) {
 	h := &phpUserTuningHandler{cfg: cfg}
 	g.GET("/me/php-fpm-policy", h.policy)
+	g.GET("/me/php-pool-tuning", h.tuning)
 	g.PUT("/me/php-performance-mode", h.setMode)
 	g.PUT("/me/php-pool-tuning", h.setTuning)
+}
+
+// poolTuningRow is one of the caller's PHP pools, with its current per-version
+// tuning (GH #1332). The UI drives its version selector + the Advanced form off
+// these so switching version shows THAT version's stored values, not defaults.
+type poolTuningRow struct {
+	PHPVersion                     string `json:"php_version"`
+	PmMode                         string `json:"pm_mode"`
+	PmMaxChildren                  uint32 `json:"pm_max_children"`
+	PmStartServers                 uint32 `json:"pm_start_servers"`
+	PmMinSpareServers              uint32 `json:"pm_min_spare_servers"`
+	PmMaxSpareServers              uint32 `json:"pm_max_spare_servers"`
+	PmMaxRequests                  uint32 `json:"pm_max_requests"`
+	RequestTerminateTimeoutSeconds uint32 `json:"request_terminate_timeout_seconds"`
+	ProcessIdleTimeoutSeconds      uint32 `json:"process_idle_timeout_seconds"`
+	PerformanceMode                string `json:"performance_mode"`
+	IsDefault                      bool   `json:"is_default"`
+}
+
+// tuning returns the caller's package policy plus their per-version pools'
+// current tuning (GH #1332). Each PHP version a user's domains run has its own
+// pool (GH #329); this lets the Performance card load and display each version's
+// own pm_* + performance_mode instead of static defaults.
+func (h *phpUserTuningHandler) tuning(c *gin.Context) {
+	user, pkg := h.ownerPackage(c)
+	canEdit, advanced := false, false
+	var childCap, mem uint32
+	if pkg != nil {
+		canEdit, advanced = pkg.FpmUserCanEdit, pkg.FpmAdvancedMode
+		childCap, mem = pkg.FpmMaxChildrenCap, pkg.FpmWorkerMemMb
+	}
+	modes, _ := h.cfg.Modes.GetAll(c.Request.Context())
+	rows := []poolTuningRow{}
+	if user != nil {
+		if pools, err := h.cfg.PHPPools.ListByUserID(c.Request.Context(), user.ID); err == nil {
+			// ListByUserID orders the default pool (earliest created) first.
+			for i := range pools {
+				p := &pools[i]
+				rows = append(rows, poolTuningRow{
+					PHPVersion:                     p.PHPVersion,
+					PmMode:                         p.PmMode,
+					PmMaxChildren:                  p.PmMaxChildren,
+					PmStartServers:                 p.PmStartServers,
+					PmMinSpareServers:              p.PmMinSpareServers,
+					PmMaxSpareServers:              p.PmMaxSpareServers,
+					PmMaxRequests:                  p.PmMaxRequests,
+					RequestTerminateTimeoutSeconds: p.RequestTerminateTimeoutSeconds,
+					ProcessIdleTimeoutSeconds:      p.ProcessIdleTimeoutSeconds,
+					PerformanceMode:                p.PerformanceMode,
+					IsDefault:                      i == 0,
+				})
+			}
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"can_edit": canEdit, "advanced": advanced,
+		"max_children_cap": childCap, "worker_mem_mb": mem, "modes": modes,
+		"pools": rows,
+	})
 }
 
 // ownerPackage resolves the caller's hosting package. Returns nil pkg (not an
@@ -69,13 +129,18 @@ func (h *phpUserTuningHandler) policy(c *gin.Context) {
 	})
 }
 
-// userPool loads the caller's pool for a version (own only).
+// userPool loads the caller's pool for a version (own only). GH #1332: when a
+// version is given it resolves EXACTLY that (user, version) pool and never falls
+// back to a different-version pool — the old fallback wrote e.g. 8.5's tuning
+// onto the 8.4 default pool (cross-version bleed). A missing version pool is a
+// clean not-found; the UI only offers versions the user actually has pools for.
 func (h *phpUserTuningHandler) userPool(c *gin.Context, userID, version string) (*models.PHPPool, bool) {
 	ctx := c.Request.Context()
 	if version != "" {
 		if p, err := h.cfg.PHPPools.FindByUserAndVersion(ctx, userID, version); err == nil && p != nil {
 			return p, true
 		}
+		return nil, false
 	}
 	if p, err := h.cfg.PHPPools.FindByUserID(ctx, userID); err == nil && p != nil {
 		return p, true

--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.test.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.test.tsx
@@ -1,0 +1,98 @@
+// GH #1332 item 4: the Performance card must drive off the caller's per-version
+// pools (GET /me/php-pool-tuning) — showing each version's own tuning — and
+// version-scope its writes, instead of the old static-defaults / default-pool
+// behaviour.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), put: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+};
+
+function pool(v: string, isDefault: boolean, maxChildren: number, perf: string) {
+  return {
+    php_version: v,
+    pm_mode: "dynamic",
+    pm_max_children: maxChildren,
+    pm_start_servers: 2,
+    pm_min_spare_servers: 1,
+    pm_max_spare_servers: 3,
+    pm_max_requests: 0,
+    request_terminate_timeout_seconds: 0,
+    process_idle_timeout_seconds: 60,
+    performance_mode: perf,
+    is_default: isDefault,
+  };
+}
+
+function mockTuning() {
+  mocked.get.mockReset().mockResolvedValue({
+    data: {
+      can_edit: true,
+      advanced: true,
+      max_children_cap: 20,
+      worker_mem_mb: 128,
+      modes: [
+        { mode: "balanced", label: "Balanced" },
+        { mode: "custom", label: "Custom" },
+      ],
+      pools: [pool("8.4", true, 5, "balanced"), pool("8.5", false, 15, "custom")],
+    },
+  });
+}
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <UserPHPPerformanceCard />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockTuning();
+  mocked.put.mockReset().mockResolvedValue({ data: {} });
+});
+
+describe("GH #1332 — UserPHPPerformanceCard per-version tuning", () => {
+  it("loads the per-version pools endpoint and lists each version", async () => {
+    renderCard();
+    await waitFor(() =>
+      expect(mocked.get).toHaveBeenCalledWith("/me/php-pool-tuning"),
+    );
+    // The old policy-only endpoint is no longer the driver.
+    expect(mocked.get).not.toHaveBeenCalledWith("/me/php-fpm-policy");
+    // The version selector renders (2 pools) with the default preselected, and
+    // the per-version helper text is shown.
+    await screen.findByText("PHP 8.4 (default)");
+    await screen.findByText("Each PHP version keeps its own tuning.");
+  });
+
+  it("version-scopes the performance-mode write to the selected (default) version", async () => {
+    renderCard();
+    // Wait for the pools to load (default selector resolves to 8.4).
+    await screen.findByText("PHP 8.4 (default)");
+    const applyMode = await screen.findByRole("button", { name: /apply mode/i });
+    fireEvent.click(applyMode);
+    await waitFor(() =>
+      expect(mocked.put).toHaveBeenCalledWith("/me/php-performance-mode", {
+        php_version: "8.4",
+        mode: "balanced",
+      }),
+    );
+  });
+});

--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
@@ -1,44 +1,87 @@
 // UserPHPPerformanceCard — GH #339 phase 2, Steps 5+6. The SAFE user-facing FPM
 // tuning: a "PHP Performance Mode" dropdown (L1) and, when the package allows,
-// clamped advanced pm.* knobs (L2). Driven entirely by GET /me/php-fpm-policy —
-// if the package doesn't allow editing, the whole card renders a hint instead.
-// This replaces the old raw UserPHPPoolCard (removed in PR #34) with the
-// package-gated, preset-based model.
+// clamped advanced pm.* knobs (L2).
+//
+// GH #1332: each PHP version a user's domains run has its OWN pool (GH #329) with
+// its own pm_* + performance_mode. The card loads GET /me/php-pool-tuning (policy
+// + the caller's per-version pools) and, on the version selector, shows THAT
+// version's stored values instead of static defaults — so switching version
+// reflects the real per-version configuration.
 import { useTranslation } from "react-i18next";
 import { Alert, Button, Card, Collapse, Form, InputNumber, Select, Space, Spin, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { apiClient } from "../../../apiClient";
 
 type Mode = { mode: string; label: string };
-type Policy = {
+type PoolRow = {
+  php_version: string;
+  pm_mode: string;
+  pm_max_children: number;
+  pm_start_servers: number;
+  pm_min_spare_servers: number;
+  pm_max_spare_servers: number;
+  pm_max_requests: number;
+  request_terminate_timeout_seconds: number;
+  process_idle_timeout_seconds: number;
+  performance_mode: string;
+  is_default: boolean;
+};
+type Tuning = {
   can_edit: boolean;
   advanced: boolean;
   max_children_cap: number;
   worker_mem_mb: number;
   modes: Mode[];
+  pools: PoolRow[];
 };
 
-export const UserPHPPerformanceCard = ({
-  versions,
-}: {
-  versions: string[];
-}) => {
+export const UserPHPPerformanceCard = () => {
   const { t } = useTranslation();
   const qc = useQueryClient();
-  const [version, setVersion] = useState<string>(versions[0] ?? "");
+  const [version, setVersion] = useState<string>("");
   const [mode, setMode] = useState<string>("balanced");
   const [saving, setSaving] = useState(false);
   const [advForm] = Form.useForm();
 
-  const { data: policy, isLoading } = useQuery<Policy>({
-    queryKey: ["me-fpm-policy"],
-    queryFn: async () => (await apiClient.get<Policy>("/me/php-fpm-policy")).data,
+  const { data, isLoading } = useQuery<Tuning>({
+    queryKey: ["me-php-pool-tuning"],
+    queryFn: async () => (await apiClient.get<Tuning>("/me/php-pool-tuning")).data,
   });
 
+  const pools = data?.pools ?? [];
+  const selectedPool =
+    pools.find((p) => p.php_version === version) ??
+    pools.find((p) => p.is_default) ??
+    pools[0];
+
+  // Once data arrives (or after a refetch that created a new version pool),
+  // default the selector to the user's default pool version.
+  useEffect(() => {
+    if (!version && pools.length > 0) {
+      setVersion((pools.find((p) => p.is_default) ?? pools[0]).php_version);
+    }
+  }, [pools, version]);
+
+  // Load the selected version pool's own values into the mode + Advanced form,
+  // so switching version shows THAT version's stored tuning (GH #1332).
+  useEffect(() => {
+    if (!selectedPool) return;
+    setMode(selectedPool.performance_mode || "balanced");
+    advForm.setFieldsValue({
+      pm_mode: selectedPool.pm_mode,
+      pm_max_children: selectedPool.pm_max_children,
+      pm_start_servers: selectedPool.pm_start_servers,
+      pm_min_spare_servers: selectedPool.pm_min_spare_servers,
+      pm_max_spare_servers: selectedPool.pm_max_spare_servers,
+      pm_max_requests: selectedPool.pm_max_requests,
+    });
+    // selectedPool identity changes with version/data; fields depend only on it.
+  }, [selectedPool, advForm]);
+
   if (isLoading) return <Spin />;
-  if (!policy || !policy.can_edit) {
+  if (!data || !data.can_edit) {
     return (
       <Alert
         type="info"
@@ -49,12 +92,14 @@ export const UserPHPPerformanceCard = ({
     );
   }
 
+  const refresh = () => qc.invalidateQueries({ queryKey: ["me-php-pool-tuning"] });
+
   const applyMode = async () => {
     setSaving(true);
     try {
       await apiClient.put("/me/php-performance-mode", { php_version: version, mode });
       feedback.message.success(`Performance mode set to ${mode}`);
-      qc.invalidateQueries({ queryKey: ["me-fpm-policy"] });
+      refresh();
     } catch (e) {
       const err = e as { response?: { data?: { error?: string; detail?: string } } };
       feedback.message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
@@ -69,7 +114,7 @@ export const UserPHPPerformanceCard = ({
     try {
       await apiClient.put("/me/php-pool-tuning", { php_version: version, ...vals });
       feedback.message.success("Advanced FPM settings applied (clamped to your plan)");
-      qc.invalidateQueries({ queryKey: ["me-fpm-policy"] });
+      refresh();
     } catch (e) {
       const err = e as { response?: { data?: { error?: string; detail?: string } } };
       feedback.message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
@@ -78,25 +123,31 @@ export const UserPHPPerformanceCard = ({
     }
   };
 
-  const cap = policy.max_children_cap;
+  const cap = data.max_children_cap;
 
   return (
     <Card title={t("userphpperformancecard.php_performance")}>
       <Space direction="vertical" size="large" style={{ width: "100%", maxWidth: 560 }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           Pick how your PHP workers scale. Values are capped for your plan (max{" "}
-          {cap} workers, ~{policy.worker_mem_mb} MB each).
+          {cap} workers, ~{data.worker_mem_mb} MB each).
         </Typography.Paragraph>
 
-        {versions.length > 1 && (
+        {pools.length > 1 && (
           <div>
             <Typography.Text>PHP version</Typography.Text>
             <Select
               style={{ width: 200, display: "block", marginTop: 4 }}
               value={version}
               onChange={setVersion}
-              options={versions.map((v) => ({ value: v, label: `PHP ${v}` }))}
+              options={pools.map((p) => ({
+                value: p.php_version,
+                label: `PHP ${p.php_version}${p.is_default ? " (default)" : ""}`,
+              }))}
             />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Each PHP version keeps its own tuning.
+            </Typography.Text>
           </div>
         )}
 
@@ -106,21 +157,21 @@ export const UserPHPPerformanceCard = ({
             style={{ width: "100%", marginTop: 4 }}
             value={mode}
             onChange={setMode}
-            options={policy.modes.map((m) => ({ value: m.mode, label: m.label || m.mode }))}
+            options={data.modes.map((m) => ({ value: m.mode, label: m.label || m.mode }))}
           />
           <Button type="primary" loading={saving} onClick={applyMode} style={{ marginTop: 12 }}>
             Apply mode
           </Button>
         </div>
 
-        {policy.advanced && (
+        {data.advanced && (
           <Collapse
             items={[
               {
                 key: "adv",
                 label: "Advanced (raw pm.* — clamped to your plan)",
                 children: (
-                  <Form form={advForm} layout="vertical" initialValues={{ pm_mode: "dynamic", pm_max_children: Math.min(10, cap) }}>
+                  <Form form={advForm} layout="vertical">
                     <Form.Item name="pm_mode" label={t("userphpperformancecard.process_manager")}>
                       <Select
                         options={[

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Tabs, Alert, Button, Card, Form, Row, Col, Select, Space, Spin, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
 import { apiClient } from "../../../apiClient";
@@ -96,6 +97,7 @@ const MAX_INPUT_TIME_OPTIONS = [
 
 export function UserPHPSettingsPage() {
   const { t } = useTranslation();
+  const qc = useQueryClient();
   const [, setMe] = useState<Identity | null>(null);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
@@ -183,6 +185,10 @@ export function UserPHPSettingsPage() {
         `/domains/${selectedDomain}/php-settings`,
       );
       setPhpSettings(resp.data);
+      // GH #1332: switching a domain's version may have created a new
+      // per-version pool — refresh the Performance card so its version list +
+      // per-version values reflect it.
+      qc.invalidateQueries({ queryKey: ["me-php-pool-tuning"] });
     } catch (err) {
       const e = err as {
         response?: { data?: { error?: string } };
@@ -364,7 +370,16 @@ export function UserPHPSettingsPage() {
                     />
                   </Form.Item>
 
-                  <Typography.Title level={5}>Resource Limits</Typography.Title>
+                  <Typography.Title level={5} style={{ marginBottom: 0 }}>
+                    Resource Limits
+                  </Typography.Title>
+                  {/* GH #1332 item 3: these are DOMAIN-level php.ini overrides,
+                      applied to this domain regardless of which PHP version it
+                      runs — not per-version. Label it so that's clear. */}
+                  <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+                    Applied to this domain across all PHP versions. Per-version
+                    worker tuning lives under Performance.
+                  </Typography.Paragraph>
                   <Row gutter={[16, 16]}>
                     <Col xs={24} sm={12}>
                       <Form.Item
@@ -481,7 +496,7 @@ export function UserPHPSettingsPage() {
             {
               key: "perf",
               label: "Performance",
-              children: <UserPHPPerformanceCard versions={availableVersions} />,
+              children: <UserPHPPerformanceCard />,
             },
           ]}
         />


### PR DESCRIPTION
## What

GH #1332 **items 3 + 4** of the per-domain PHP Settings review.

## Item 4 — Performance → Advanced isn't per-version

Each PHP version a user's domains run has its own pool (GH #329) with its own `pm_*` + `performance_mode`, but the Performance card:
- **never loaded** those values — its version selector listed *all installed* versions and the Advanced form used **static defaults**, so switching version showed identical values;
- its writes **fell back to the default pool** when the selected version had no pool yet — a cross-version bleed (8.5's tuning landed on the 8.4 default pool).

Fix:
- New **`GET /me/php-pool-tuning`** returns the package policy + the caller's per-version pools with their current tuning. The card drives its version selector + Advanced form off these, so each version shows its **own** stored `pm_*`/`performance_mode`, and reloads on version switch. The page invalidates the query after a domain version change (which may create a new version pool).
- `userPool` no longer falls back across versions — a given version resolves **exactly** its `(user, version)` pool, so a write can never bleed onto another version.

## Item 3 — Resource Limits isn't per-version

These (`memory_limit`, `upload_max_filesize`, …) are **domain-level** php.ini overrides (`domains.php_*`), applied to the domain regardless of version — intentionally not version-scoped. Added a caption making that explicit ("Applied to this domain across all PHP versions") rather than restructuring domain properties into per-version storage.

## Not changed

The domain version switch itself already binds to a find-or-created per-version pool (`POST /domains/:id/php-pool`, GH #329) — that part wasn't broken. The reconciler/agent pool→FPM-master path is unchanged.

## Testing

- New card test: drives off `/me/php-pool-tuning` (not the old policy-only endpoint), lists the per-version pools, version-scopes the write.
- `panel-api` api + app + **openapi-coverage** suites green; `tsc -b` + vite build green.

Part of the #1332 series (item 1 = #1368, item 2 = #1369; item 5 preset transparency deferred). GH #1332