### PR TITLE
feat(php-settings): show what each Performance preset applies + preview in Advanced (GH #1332 item 5)

### DIFF
--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.test.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.test.tsx
@@ -44,8 +44,26 @@ function mockTuning() {
       max_children_cap: 20,
       worker_mem_mb: 128,
       modes: [
-        { mode: "balanced", label: "Balanced" },
-        { mode: "custom", label: "Custom" },
+        {
+          mode: "balanced",
+          label: "Balanced",
+          pm_mode: "dynamic",
+          pm_max_children: 5,
+          pm_start_servers: 2,
+          pm_min_spare_servers: 1,
+          pm_max_spare_servers: 3,
+          pm_max_requests: 0,
+        },
+        {
+          mode: "highmem",
+          label: "High traffic",
+          pm_mode: "static",
+          pm_max_children: 40,
+          pm_start_servers: 0,
+          pm_min_spare_servers: 0,
+          pm_max_spare_servers: 0,
+          pm_max_requests: 500,
+        },
       ],
       pools: [pool("8.4", true, 5, "balanced"), pool("8.5", false, 15, "custom")],
     },
@@ -80,6 +98,14 @@ describe("GH #1332 — UserPHPPerformanceCard per-version tuning", () => {
     // the per-version helper text is shown.
     await screen.findByText("PHP 8.4 (default)");
     await screen.findByText("Each PHP version keeps its own tuning.");
+  });
+
+  it("shows what the selected preset actually applies (item 5)", async () => {
+    renderCard();
+    // Default pool 8.4's performance_mode is "balanced" (pm_max_children 5,
+    // clamped to the cap of 20). The preset summary must spell out the values.
+    await screen.findByText(/5 max\s*workers/i);
+    await screen.findByText(/2 start/i);
   });
 
   it("version-scopes the performance-mode write to the selected (default) version", async () => {

--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
@@ -14,7 +14,18 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { apiClient } from "../../../apiClient";
 
-type Mode = { mode: string; label: string };
+// GH #1332 item 5: presets carry their full pm_* values (the backend already
+// returns them), so selecting a preset can populate + preview the Advanced form.
+type Mode = {
+  mode: string;
+  label: string;
+  pm_mode: string;
+  pm_max_children: number;
+  pm_start_servers: number;
+  pm_min_spare_servers: number;
+  pm_max_spare_servers: number;
+  pm_max_requests: number;
+};
 type PoolRow = {
   php_version: string;
   pm_mode: string;
@@ -43,6 +54,7 @@ export const UserPHPPerformanceCard = () => {
   const [version, setVersion] = useState<string>("");
   const [mode, setMode] = useState<string>("balanced");
   const [saving, setSaving] = useState(false);
+  const [advOpen, setAdvOpen] = useState<string[]>([]); // Advanced collapse (item 5)
   const [advForm] = Form.useForm();
 
   const { data, isLoading } = useQuery<Tuning>({
@@ -124,6 +136,41 @@ export const UserPHPPerformanceCard = () => {
   };
 
   const cap = data.max_children_cap;
+  const selectedPreset = data.modes.find((m) => m.mode === mode);
+
+  // One-line human summary of what a preset actually sets (item 5). Built as a
+  // single string so it reads naturally and is one text node.
+  const presetSummary = (p: Mode): string => {
+    const parts = [p.pm_mode, `${Math.min(cap, p.pm_max_children)} max workers`];
+    if (p.pm_mode === "dynamic") {
+      parts.push(
+        `${p.pm_start_servers} start`,
+        `${p.pm_min_spare_servers}–${p.pm_max_spare_servers} spare`,
+      );
+    }
+    if (p.pm_max_requests > 0) parts.push(`recycle every ${p.pm_max_requests} requests`);
+    return parts.join(", ");
+  };
+
+  // GH #1332 item 5 (Option B): picking a preset previews its actual pm_* values
+  // in the Advanced form (max children shown clamped to the plan cap, as it would
+  // apply) and opens the Advanced panel — so the user sees what the preset does
+  // and can still fine-tune before applying.
+  const onSelectMode = (m: string) => {
+    setMode(m);
+    const preset = data.modes.find((p) => p.mode === m);
+    if (preset && data.advanced) {
+      advForm.setFieldsValue({
+        pm_mode: preset.pm_mode,
+        pm_max_children: Math.min(cap, preset.pm_max_children),
+        pm_start_servers: preset.pm_start_servers,
+        pm_min_spare_servers: preset.pm_min_spare_servers,
+        pm_max_spare_servers: preset.pm_max_spare_servers,
+        pm_max_requests: preset.pm_max_requests,
+      });
+      setAdvOpen(["adv"]);
+    }
+  };
 
   return (
     <Card title={t("userphpperformancecard.php_performance")}>
@@ -156,9 +203,15 @@ export const UserPHPPerformanceCard = () => {
           <Select
             style={{ width: "100%", marginTop: 4 }}
             value={mode}
-            onChange={setMode}
+            onChange={onSelectMode}
             options={data.modes.map((m) => ({ value: m.mode, label: m.label || m.mode }))}
           />
+          {selectedPreset && (
+            <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: "6px 0 0" }}>
+              Sets {presetSummary(selectedPreset)}
+              {data.advanced ? " — shown below, tweak before applying." : "."}
+            </Typography.Paragraph>
+          )}
           <Button type="primary" loading={saving} onClick={applyMode} style={{ marginTop: 12 }}>
             Apply mode
           </Button>
@@ -166,6 +219,8 @@ export const UserPHPPerformanceCard = () => {
 
         {data.advanced && (
           <Collapse
+            activeKey={advOpen}
+            onChange={(k) => setAdvOpen(Array.isArray(k) ? k : [k])}
             items={[
               {
                 key: "adv",


### PR DESCRIPTION
## What

GH #1332 **item 5** — the four Performance Mode presets (Balanced / High traffic / Low memory / WordPress optimized) only showed a label; users couldn't see what `pm.*` values each applies. Reporter's **Option B** (populate Advanced with the actual values).

## How

The backend already returns each preset's full `pm_*` in `GET /me/php-pool-tuning`, so this is **UI-only**:

- A one-line **summary** under the preset dropdown spells out what the selected preset sets — pm mode, max workers (clamped to the plan cap), start/spare for `dynamic`, request recycling — visible without expanding anything.
- Selecting a preset **populates the Advanced form** with that preset's actual values and **opens the Advanced panel**, so the user sees exactly what it does and can fine-tune before applying. The Advanced collapse is now controlled.

## Testing

- Card test asserts the preset summary spells out the applied values (e.g. "5 max workers", "2 start").
- `tsc -b` + vite build green; existing per-version card tests still pass.

Completes the #1332 series (items 1–4 = #1368 / #1369 / #1370). GH #1332