### PR TITLE
feat(system): add a Reboot Server action (GH #1330)

### DIFF
--- a/panel-agent/internal/commands/system_reboot.go
+++ b/panel-agent/internal/commands/system_reboot.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// system.reboot — schedule a host reboot a few seconds out (GH #1330). Kernel
+// and libc security updates leave /var/run/reboot-required, which the panel
+// already surfaces; this is the action that finishes the job.
+//
+// The reboot is DETACHED from this agent call via a transient systemd timer, so
+// the call returns immediately — the panel records its audit event and answers
+// the UI before the box goes down ~5s later, rather than the connection being
+// severed mid-response by an instant `systemctl reboot`. The panel gates the
+// call behind admin + recent-auth step-up (JAB-380).
+func systemRebootHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	// --on-active=5s creates a one-shot transient timer + service that runs
+	// `systemctl reboot` in five seconds; --collect garbage-collects the unit.
+	cmd := execCommandContext(ctx, "systemd-run", "--collect", "--on-active=5s",
+		"--timer-property=AccuracySec=1s", "systemctl", "reboot")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("schedule reboot: %v: %s", err, strings.TrimSpace(string(out))),
+		}
+	}
+	return map[string]any{"scheduled": true, "delay_seconds": 5}, nil
+}
+
+func init() {
+	Default.Register("system.reboot", systemRebootHandler)
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5322,6 +5322,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /system/reboot:
+    post:
+      tags: [System]
+      summary: Reboot the server (admin, recent-auth step-up)
+      security: [ { KratosSession: [] } ]
+      responses: { "202": { description: Reboot scheduled } }
+
   /system/services:
     get:
       tags: [System]

--- a/panel-api/internal/api/system.go
+++ b/panel-api/internal/api/system.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 )
@@ -39,7 +40,7 @@ type resolverSetRequest struct {
 // RegisterSystemRoutes mounts admin-only system endpoints under the
 // given router group. The group is expected to already carry RequireAuth
 // middleware; we add RequireAdmin ourselves.
-func RegisterSystemRoutes(rg *gin.RouterGroup, cli agent.AgentInterface) {
+func RegisterSystemRoutes(rg *gin.RouterGroup, cli agent.AgentInterface, kc *kratosclient.Client) {
 	sys := rg.Group("/system", middleware.RequireAdmin())
 
 	sys.GET("/info", func(c *gin.Context) {
@@ -116,6 +117,29 @@ func RegisterSystemRoutes(rg *gin.RouterGroup, cli agent.AgentInterface) {
 	registerServiceAction("stop", true)
 	registerServiceAction("enable", false)
 	registerServiceAction("disable", true) // disable = won't auto-start on next boot; same class of foot-gun
+
+	// POST /system/reboot — GH #1330. Schedule a host reboot (kernel/security
+	// updates leave /var/run/reboot-required; the panel already surfaces that
+	// banner). A destructive root op, so beyond RequireAdmin it requires
+	// recent-auth step-up (JAB-380, same bar as the File Manager / Root Terminal)
+	// and the global audit middleware records it. The agent schedules the reboot
+	// a few seconds out so this response returns cleanly before the box goes down.
+	sys.POST("/reboot", func(c *gin.Context) {
+		if !requireRecentAuth(c, kc, stepUpWindow) {
+			return
+		}
+		c.Set("audit_target", "server reboot")
+		c.Set("audit_target_type", "system")
+		ctx, cancel := context.WithTimeout(c.Request.Context(), systemCallTimeout)
+		defer cancel()
+		raw, err := cli.Call(ctx, "system.reboot", nil)
+		if err != nil {
+			status, body := translateAgentError(err)
+			c.JSON(status, body)
+			return
+		}
+		c.Data(http.StatusAccepted, "application/json; charset=utf-8", raw)
+	})
 
 	// DNS resolvers — truth lives on disk (systemd-resolved drop-in) so we
 	// round-trip to the agent for both read and write; no DB involvement.

--- a/panel-api/internal/api/system_test.go
+++ b/panel-api/internal/api/system_test.go
@@ -29,7 +29,7 @@ func adminRouter(cli agent.AgentInterface) *gin.Engine {
 		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "test-admin", IsAdmin: true})
 		c.Next()
 	})
-	api.RegisterSystemRoutes(v1, cli)
+	api.RegisterSystemRoutes(v1, cli, nil)
 	return r
 }
 
@@ -41,7 +41,7 @@ func userRouter(cli agent.AgentInterface) *gin.Engine {
 		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "test-user", IsAdmin: false})
 		c.Next()
 	})
-	api.RegisterSystemRoutes(v1, cli)
+	api.RegisterSystemRoutes(v1, cli, nil)
 	return r
 }
 

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1063,7 +1063,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			})
 		}
 		if deps.Agent != nil {
-			api.RegisterSystemRoutes(v1, deps.Agent)
+			api.RegisterSystemRoutes(v1, deps.Agent, deps.KratosClient)
 			api.RegisterPHPVersionRoutes(v1, deps.Agent)
 			// M26 Step 4 — admin Security tab. CrowdSec + UFW are pure
 			// agent passthroughs. ModSecurity removed 2026-04-26 (ADR-0055

--- a/panel-ui/src/shells/admin/server-status/RebootServerButton.test.tsx
+++ b/panel-ui/src/shells/admin/server-status/RebootServerButton.test.tsx
@@ -1,0 +1,47 @@
+// GH #1330: the reboot action must confirm first, then POST /system/reboot.
+import { App } from "antd";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RebootServerButton } from "./RebootServerButton";
+
+vi.mock("../../../apiClient", () => ({ apiClient: { post: vi.fn() } }));
+vi.mock("../../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+function renderBtn() {
+  render(
+    <App>
+      <RebootServerButton />
+    </App>,
+  );
+}
+
+beforeEach(() => {
+  mocked.post.mockReset().mockResolvedValue({ data: { scheduled: true } });
+});
+
+describe("GH #1330 — RebootServerButton", () => {
+  it("does not POST until the confirm is accepted", async () => {
+    renderBtn();
+    fireEvent.click(screen.getByRole("button", { name: /reboot server/i }));
+    // The confirm modal is open with its own "Reboot now" button.
+    await screen.findByRole("button", { name: /reboot now/i });
+    expect(mocked.post).not.toHaveBeenCalled();
+  });
+
+  it("POSTs /system/reboot after confirming", async () => {
+    renderBtn();
+    fireEvent.click(screen.getByRole("button", { name: /reboot server/i }));
+    const ok = await screen.findByRole("button", { name: /reboot now/i });
+    fireEvent.click(ok);
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/system/reboot"),
+    );
+  });
+});

--- a/panel-ui/src/shells/admin/server-status/RebootServerButton.tsx
+++ b/panel-ui/src/shells/admin/server-status/RebootServerButton.tsx
@@ -1,0 +1,64 @@
+// RebootServerButton — GH #1330. A gated "Reboot server" action.
+//
+// The action is admin-only and requires recent-auth step-up server-side; a stale
+// session returns 403 stepup_required, which apiClient handles globally by
+// redirecting to a Kratos refresh login. Here we just confirm, POST, and report.
+import { App, Button, Typography } from "antd";
+import type { ReactNode } from "react";
+import { apiClient } from "../../../apiClient";
+import { feedback } from "../../../lib/feedback";
+
+export const RebootServerButton = ({
+  block,
+  children,
+  type,
+}: {
+  block?: boolean;
+  children?: ReactNode;
+  type?: "primary" | "default";
+}) => {
+  const { modal } = App.useApp();
+
+  const confirm = () => {
+    modal.confirm({
+      title: "Reboot server?",
+      okText: "Reboot now",
+      okButtonProps: { danger: true },
+      cancelText: "Cancel",
+      content: (
+        <Typography.Paragraph style={{ marginBottom: 0 }}>
+          The server will reboot in a few seconds and be briefly unavailable while
+          it restarts. Every site and service on the host goes down until it's
+          back, and this panel connection will drop and reconnect. Only do this
+          when a reboot is actually required (e.g. after kernel/security updates).
+        </Typography.Paragraph>
+      ),
+      onOk: async () => {
+        try {
+          await apiClient.post("/system/reboot");
+          feedback.message.success(
+            "Reboot scheduled — the server will go down shortly and come back on its own.",
+          );
+        } catch (e) {
+          const err = e as { response?: { data?: { error?: string; detail?: string } } };
+          // stepup_required is handled globally (redirect to re-auth) — don't
+          // double-report it here.
+          if (err.response?.data?.error !== "stepup_required") {
+            feedback.message.error(
+              err.response?.data?.detail ??
+                err.response?.data?.error ??
+                "Failed to schedule reboot",
+            );
+          }
+          throw e; // keep the modal's OK spinner from resolving to success
+        }
+      },
+    });
+  };
+
+  return (
+    <Button danger block={block} type={type} onClick={confirm}>
+      {children ?? "Reboot server"}
+    </Button>
+  );
+};

--- a/panel-ui/src/shells/admin/server-status/SystemInfoCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/SystemInfoCard.tsx
@@ -4,9 +4,11 @@
 //
 // Categories: Server (host identity), Hardware (CPU/RAM), Network
 // (interfaces). Source data lives in envelope.host + envelope.network.
-import { Card, Table, Tag, Typography } from "antd";
+import { Card, Space, Table, Tag, Typography } from "antd";
 
 import { CheckCircleOutlined, ExclamationCircleOutlined, InfoCircleOutlined } from "@ant-design/icons";
+
+import { RebootServerButton } from "./RebootServerButton";
 
 import type {
   HostSlice,
@@ -167,6 +169,10 @@ export function SystemInfoCard({ host, network, software, asOf }: Props) {
           },
         ]}
       />
+      {/* GH #1330: server power action lives with the host identity it acts on. */}
+      <Space style={{ width: "100%", justifyContent: "flex-end", marginTop: 12 }}>
+        <RebootServerButton>Reboot server</RebootServerButton>
+      </Space>
     </Card>
   );
 }

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useState, type CSSProperties } from "react";
 import { Alert, Button, Card, Checkbox, Collapse, Col, Empty, Modal, Row, Segmented, Space, Spin, Switch, Table, Tag, TimePicker, Timeline, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { RebootServerButton } from "../server-status/RebootServerButton";
 import dayjs from "dayjs";
 
 import {
@@ -938,7 +939,13 @@ function AutomaticUpdatesCard() {
             />
           )}
           {rebootRequired && (
-            <Alert type="warning" showIcon message="Reboot required to finish applying updates" />
+            <Alert
+              type="warning"
+              showIcon
+              message="Reboot required to finish applying updates"
+              // GH #1330: offer the reboot right where it's detected.
+              action={<RebootServerButton>Reboot now</RebootServerButton>}
+            />
           )}
           <Row align="middle" gutter={[12, 12]}>
             <Col flex="auto">


### PR DESCRIPTION
## What

GH #1330 — the panel detects when a reboot is required (kernel/security updates leave `/var/run/reboot-required`; the Updates page already shows the banner) but had **no way to reboot from the UI**. @lxsdevcode asked for one; you noted cPanel/DirectAdmin both have it.

## How

- **Agent verb `system.reboot`** — schedules the reboot ~5s out via a transient `systemd-run` timer, **detached** from the agent call, so the panel returns a clean response + records its audit event before the box goes down (an instant `systemctl reboot` would sever the response). The box comes back on its own.
- **`POST /system/reboot`** — `RequireAdmin` + **recent-auth step-up** (JAB-380, same bar as the File Manager / Root Terminal; a stale session gets `stepup_required`, which the SPA turns into a Kratos refresh login) + the global audit middleware records it.
- **Reboot only, by design** — shutdown is intentionally *not* offered (a remote poweroff leaves no way to power back on).
- **UI** — a reusable `RebootServerButton` (confirm modal, danger-styled), surfaced on the Updates page's "Reboot required" banner (**Reboot now**) and in Server Status → System Information (**Reboot server**).

## Testing

- `go build` + `panel-api` api/app + **openapi-coverage** suites green; reboot-button test (confirms before POSTing); `tsc -b` + vite build green.
- **Live box (.60), behavior not deploy:** `system.reboot` → `{scheduled:true, delay_seconds:5}` → a transient timer fired → the box **rebooted** (uptime reset Aug 3 → Aug 29), came back on its own in ~40s, `jabali-agent`/`jabali-panel` active, panel login 200.

New agent verb → **fleet agent redeploy on release**. GH #1330