### PR TITLE
fix(ssl): clearer Force Retry errors + show SANs pending DNS (GH #1221)

### DIFF
--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -18,6 +18,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -58,6 +59,10 @@ type SSLResponse struct {
 	Staging       bool       `json:"staging"`
 	CertPath      *string    `json:"cert_path,omitempty"`
 	KeyPath       *string    `json:"key_path,omitempty"`
+	// PendingSANs are configured SANs the issued cert doesn't cover yet — no
+	// public DNS at issuance; the drift pass adds them once they resolve (GH
+	// #1221). Empty for non-issued certs.
+	PendingSANs []string `json:"pending_sans,omitempty"`
 }
 
 // newSSLHandler creates a new SSL handler.
@@ -127,6 +132,7 @@ func (h *sslHandler) getSSL(c *gin.Context) {
 		Staging:       cert.Staging,
 		CertPath:      cert.CertPath,
 		KeyPath:       cert.KeyPath,
+		PendingSANs:   pendingWebSANs(cert.Status, cert.CertPath, domain.Name, webCertSANsForDomain(domain)),
 	}
 
 	c.JSON(http.StatusOK, gin.H{"ssl": resp})
@@ -341,9 +347,20 @@ func (h *sslHandler) retrySSL(c *gin.Context) {
 		return
 	}
 
-	// Only allow retry on failed or pending_acme_retry statuses
+	// Only allow retry on failed or pending_acme_retry statuses. GH #1221: a
+	// stale UI can offer "Force retry now" on a row the ticker has since moved to
+	// `pending` (actively issuing) or that reached `issued` — return the CURRENT
+	// status + an actionable detail so the client shows why, instead of a generic
+	// "failed to queue". An already-issuing/issued cert needs no retry.
 	if cert.Status != models.SSLStatusFailed && cert.Status != models.SSLStatusPendingACMERetry {
-		c.JSON(http.StatusConflict, gin.H{"error": "cannot_retry"})
+		detail := "This certificate is not in a retryable state (" + cert.Status + ")."
+		switch cert.Status {
+		case models.SSLStatusPending, models.SSLStatusIssuing:
+			detail = "This certificate is already being issued — no retry is needed."
+		case models.SSLStatusIssued:
+			detail = "This certificate is already issued."
+		}
+		c.JSON(http.StatusConflict, gin.H{"error": "cannot_retry", "status": cert.Status, "detail": detail})
 		return
 	}
 
@@ -509,6 +526,12 @@ type sslListRow struct {
 	// struct's internal `json:"-"` field. Empty for panel-cert:*/mail-cert:*
 	// synthetic rows, which have no domain ssl_mode.
 	SSLMode string `json:"ssl_mode,omitempty"`
+	// PendingSANs are configured SAN hostnames the ISSUED cert does not yet
+	// cover (GH #1221): resolvableSANs drops names with no public DNS at
+	// issuance so one unresolvable helper can't tank the whole cert, and the
+	// SAN-drift pass adds them automatically once they resolve. Surfaced so the
+	// operator knows why e.g. autoconfig/autodiscover aren't on the cert yet.
+	PendingSANs []string `json:"pending_sans,omitempty"`
 }
 
 // enrichCertRows attaches Service + SANs to every cert row. SANs are
@@ -531,8 +554,10 @@ func (h *sslHandler) enrichCertRows(ctx context.Context, certs []repository.SSLC
 			row.SANs = h.mailCertSANs(ctx, c)
 		default:
 			row.Service = "HTTPS"
-			row.SANs = h.webCertSANs(ctx, c)
+			desired := h.webCertSANs(ctx, c)
+			row.SANs = desired
 			row.SSLMode = c.SSLMode
+			row.PendingSANs = pendingWebSANs(c.Status, c.CertPath, c.DomainName, desired)
 		}
 		out = append(out, row)
 	}
@@ -576,6 +601,39 @@ func webCertSANsForDomain(d *models.Domain) []string {
 		sans = append(sans, "mta-sts."+d.Name)
 	}
 	return sans
+}
+
+// pendingWebSANs returns the configured SAN hostnames an ISSUED website cert
+// does not yet cover, by diffing the policy (desired) against the cert's ACTUAL
+// leaf SANs on disk (GH #1221). Empty for a non-issued cert (no file yet), an
+// unreadable file, or a cert that already covers everything.
+func pendingWebSANs(status string, certPath *string, baseName string, desired []string) []string {
+	if status != models.SSLStatusIssued || certPath == nil || *certPath == "" {
+		return nil
+	}
+	actual, err := reconciler.CertDNSNames(*certPath)
+	if err != nil {
+		return nil // unreadable cert → don't invent a pending list
+	}
+	return sansNotCovered(desired, actual, baseName)
+}
+
+// sansNotCovered returns the desired hostnames not present in covered (the
+// cert's actual SANs), case-insensitively. baseName is always treated as
+// covered (the agent adds it at issuance). Pure — unit-tested without a cert.
+func sansNotCovered(desired, covered []string, baseName string) []string {
+	have := make(map[string]struct{}, len(covered)+1)
+	for _, s := range covered {
+		have[strings.ToLower(s)] = struct{}{}
+	}
+	have[strings.ToLower(baseName)] = struct{}{}
+	var pending []string
+	for _, d := range desired {
+		if _, ok := have[strings.ToLower(d)]; !ok {
+			pending = append(pending, d)
+		}
+	}
+	return pending
 }
 
 // mailCertSANs returns the SAN list of a per-domain Stalwart mail cert.

--- a/panel-api/internal/api/ssl_pending_sans_test.go
+++ b/panel-api/internal/api/ssl_pending_sans_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+// GH #1221: the SSL Manager must show which configured SANs an issued cert does
+// not yet cover, so a partial cert (autoconfig/autodiscover dropped for lack of
+// public DNS at issuance) doesn't read as a bug.
+func TestSANsNotCovered(t *testing.T) {
+	base := "example.com"
+	desired := []string{"example.com", "www.example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}
+
+	// Cert issued with only base + www + mail (autoconfig/autodiscover dropped).
+	covered := []string{"example.com", "www.example.com", "mail.example.com"}
+	got := sansNotCovered(desired, covered, base)
+	want := []string{"autoconfig.example.com", "autodiscover.example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pending = %v, want %v", got, want)
+	}
+
+	// Fully-covered cert → nothing pending. Base counts as covered even if the
+	// cert's DNSNames omit it (the agent adds it at issuance).
+	if p := sansNotCovered(desired, []string{"www.example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}, base); len(p) != 0 {
+		t.Fatalf("fully covered should be empty, got %v", p)
+	}
+
+	// Case-insensitive match.
+	if p := sansNotCovered([]string{"WWW.example.com"}, []string{"www.EXAMPLE.com"}, base); len(p) != 0 {
+		t.Fatalf("case-insensitive match failed, got %v", p)
+	}
+}

--- a/panel-api/internal/reconciler/ssl_observe.go
+++ b/panel-api/internal/reconciler/ssl_observe.go
@@ -105,6 +105,11 @@ func certDNSNames(path string) ([]string, error) {
 	return out, nil
 }
 
+// CertDNSNames is the exported form of certDNSNames — the SSL Manager uses it to
+// show which SANs a cert ACTUALLY covers vs the ones still pending public DNS
+// (GH #1221), matching the drift pass's own view.
+func CertDNSNames(path string) ([]string, error) { return certDNSNames(path) }
+
 // observeSSLCerts compares each issued certificate's row against its file and
 // reports what it found. Pure apart from reading the files: the caller does the
 // database writes and the alerting, so the comparison is testable on its own.

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -35,6 +35,9 @@ interface SSLCertificate {
   retry_count: number;
   service: string;
   sans?: string[];
+  // GH #1221: configured SANs the issued cert doesn't cover yet (no public DNS
+  // at issuance); the drift pass adds them once they resolve.
+  pending_sans?: string[];
   // Domain ssl_mode (le/self/custom/none/shared) — absent on the synthetic
   // panel-cert:*/mail-cert:* rows (Certificate console Mode column).
   ssl_mode?: string;
@@ -202,12 +205,18 @@ export const SSLManagerTable = ({
       queryClient.invalidateQueries({ queryKey: ["ssl-manager", endpoint] });
     },
     onError: (error: unknown) => {
-      const status = (error as { response?: { status?: number; data?: { error?: string } } })?.response;
-      if (status?.status === 409) {
-        feedback.message.info("Already retryable — will attempt on next tick");
+      // GH #1221: the list can be stale — the ticker may have moved the cert to
+      // `pending` (already issuing) since the row rendered. Show the server's
+      // real reason instead of a blanket "failed", and refetch so the row
+      // reflects the true status.
+      const resp = (error as { response?: { status?: number; data?: { detail?: string } } })?.response;
+      const detail = resp?.data?.detail;
+      if (resp?.status === 409) {
+        feedback.message.info(detail ?? "This certificate isn't in a retryable state right now.");
       } else {
-        feedback.message.error("Failed to queue retry");
+        feedback.message.error(detail ?? "Failed to queue retry");
       }
+      queryClient.invalidateQueries({ queryKey: ["ssl-manager", endpoint] });
     },
   });
 
@@ -280,6 +289,15 @@ export const SSLManagerTable = ({
                   </Tooltip>
                 )}
               </Typography.Text>
+            )}
+            {(record.pending_sans?.length ?? 0) > 0 && (
+              <Tooltip
+                title={`Configured but not on the certificate yet — added automatically once their DNS resolves publicly: ${record.pending_sans!.join(", ")}`}
+              >
+                <Tag color="orange" style={{ fontSize: 11, marginTop: 2 }}>
+                  {record.pending_sans!.length} SAN{record.pending_sans!.length === 1 ? "" : "s"} pending DNS
+                </Tag>
+              </Tooltip>
             )}
           </Space>
         );

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -27,6 +27,9 @@ type SSLCertificate = {
   staging: boolean;
   cert_path?: string;
   key_path?: string;
+  // GH #1221: configured SANs the issued cert doesn't cover yet (no public DNS
+  // at issuance); added automatically once they resolve.
+  pending_sans?: string[];
   next_retry_at?: string;
   retry_count: number;
 };
@@ -268,8 +271,18 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
       await apiClient.post(`/domains/${domainId}/ssl/retry`);
       feedback.message.success("Retry queued");
       await fetchCert();
-    } catch {
-      feedback.message.error("Failed to queue retry");
+    } catch (err) {
+      // GH #1221: surface the server's real reason (e.g. the cert is already
+      // being issued) instead of a blanket "failed", and refetch so the panel
+      // reflects the true status.
+      const e = err as { response?: { status?: number; data?: { detail?: string } } };
+      const detail = e.response?.data?.detail;
+      if (e.response?.status === 409) {
+        feedback.message.info(detail ?? "This certificate isn't in a retryable state right now.");
+      } else {
+        feedback.message.error(detail ?? "Failed to queue retry");
+      }
+      await fetchCert();
     } finally {
       setRenewing(false);
     }
@@ -408,6 +421,21 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
           </Button>
         )}
       </Space>
+
+      {/* GH #1221: an issued cert can legitimately be missing some configured
+          SANs — Let's Encrypt validation drops names with no public DNS at
+          issuance so one unresolvable helper (e.g. autoconfig) can't fail the
+          whole cert. Tell the operator, so a partial cert doesn't read as a bug;
+          the drift pass re-adds them once their DNS resolves. */}
+      {status === "issued" && (cert?.pending_sans?.length ?? 0) > 0 && (
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginTop: 12 }}
+          message={`Not on the certificate yet: ${cert!.pending_sans!.join(", ")}`}
+          description="These hostnames don't resolve publicly yet, so Let's Encrypt couldn't validate them at issuance. They're added to the certificate automatically once their DNS resolves — no action needed."
+        />
+      )}
 
       {/* GH #738: the "Let's Encrypt" option greys out with no explanation when
           no admin email is set (it's the required ACME contact). Tell the


### PR DESCRIPTION
## What

Two follow-ups after #1298, from @johnnyq's reopened report.

### 1. "Force Retry now" → "Failed to queue retry"

The SSL list can be **stale**: the retry ticker (or the operator's own prior click) moves the cert to `pending` while the row still shows `pending_acme_retry` with the button. `POST /ssl/retry` then **409s** (`pending` isn't retryable), and the UI collapsed every error into one generic toast.

- The 409 now carries the **current status + an actionable detail** ("This certificate is already being issued — no retry is needed.").
- Both retry call sites (SSL Manager + domain SSL section) surface that detail and **refetch** so the row reflects the true status.

### 2. Re-issue "only assigned LE for www + apex, not autoconfig/autodiscover even though SAN is enabled"

Working-as-designed but **invisible**: `resolvableSANs` drops SANs with no public DNS at issuance so one unresolvable helper can't tank the whole cert, and the SAN-drift pass re-adds them once they resolve. The panel was showing the **desired** SAN policy, so a partial cert looked broken.

- The SSL Manager and the domain SSL section now compute **`pending_sans`** = configured SANs **not on the actual issued cert** (read via the exported `reconciler.CertDNSNames`, the same view the drift pass uses) and surface them: a **"N SANs pending DNS"** tag + an info note *"Not on the certificate yet … added automatically once their DNS resolves."*
- **No issuance behaviour changed** — the `resolvableSANs` drop (puzzle.linux-hosting.net scar) stays.

## Testing

- `sansNotCovered` diff test (base always covered, case-insensitive).
- `panel-api` api + reconciler suites green; `tsc -b` + vite build green; DomainSSLSection test green.

Panel-api + UI only — **no agent verb, no migration**. GH #1221