### PR TITLE
fix(users): Resources all-zeros + icons + Usage = total storage home+DB+mail (GH #1242)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -960,6 +960,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		go reconciler.StartMailboxUsageTicker(ctx, sharedAgent, deps.Mailboxes, log)
 	}
 
+	// GH #1242: tenant DB size sampler -> databases.size_bytes, so the admin
+	// Users list can sum total storage (home + DB + mail).
+	if sharedAgent != nil && deps.Databases != nil {
+		go reconciler.StartDBUsageTicker(ctx, sharedAgent, deps.Databases, log)
+	}
+
 	// Disk-usage sweeper: persists users.disk_used_kb so the admin Users
 	// list can sort by it. Optional — without it the column simply falls
 	// back to the per-row fetch and shows no sort control's worth of data.

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -812,5 +813,9 @@ func (m *mockUserRepo) UpdateShadowDBUsernames(context.Context, string, *string,
 }
 
 func (m *mockDatabaseRepo) UpdateName(context.Context, string, string) error { return nil }
+func (m *mockDatabaseRepo) ListAllMariaDB(context.Context) ([]models.Database, error) {
+	return nil, nil
+}
+func (m *mockDatabaseRepo) UpdateSize(context.Context, string, uint64, time.Time) error { return nil }
 
 func (m *mockDatabaseUserRepo) UpdateUsername(context.Context, string, string) error { return nil }

--- a/panel-api/internal/api/sso_phpmyadmin_validate_test.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate_test.go
@@ -229,6 +229,12 @@ type mockDatabaseRepoValidate struct {
 	databases map[string]*models.Database
 }
 
+func (m *mockDatabaseRepoValidate) ListAllMariaDB(context.Context) ([]models.Database, error) {
+	return nil, nil
+}
+func (m *mockDatabaseRepoValidate) UpdateSize(context.Context, string, uint64, time.Time) error {
+	return nil
+}
 func (m *mockDatabaseRepoValidate) Create(ctx context.Context, db *models.Database) error {
 	return nil
 }

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -248,10 +248,13 @@ func (h *userHandler) list(c *gin.Context) {
 		}
 		now := time.Now()
 		monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
-		if s, serr := h.cfg.ResourceStats.Fetch(c.Request.Context(), ids, monthStart); serr == nil {
-			stats = s
-		} else {
-			h.log().WarnContext(c.Request.Context(), "users list: resource stats failed", "error", serr)
+		// GH #1242: use whatever came back even on a partial error — the
+		// aggregator now returns the metrics that succeeded instead of nil, so one
+		// failing query no longer zeros the whole Resources column.
+		s, serr := h.cfg.ResourceStats.Fetch(c.Request.Context(), ids, monthStart)
+		stats = s
+		if serr != nil {
+			h.log().WarnContext(c.Request.Context(), "users list: resource stats partial", "error", serr)
 		}
 	}
 

--- a/panel-api/internal/db/migrations/000277_databases_size_bytes.down.sql
+++ b/panel-api/internal/db/migrations/000277_databases_size_bytes.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `databases`
+  DROP COLUMN `size_bytes`,
+  DROP COLUMN `size_checked_at`;

--- a/panel-api/internal/db/migrations/000277_databases_size_bytes.up.sql
+++ b/panel-api/internal/db/migrations/000277_databases_size_bytes.up.sql
@@ -1,0 +1,8 @@
+-- GH #1242: persist each tenant database's on-disk size so the admin User List
+-- can show total storage = home quota + DB + mail. The panel-api DB user is
+-- scoped to its own schema and cannot read tenant sizes from information_schema,
+-- so a sweeper asks the root agent (db.usage.by_schema) and writes size_bytes
+-- back here. `databases` is a MariaDB reserved word — backtick it.
+ALTER TABLE `databases`
+  ADD COLUMN `size_bytes` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  ADD COLUMN `size_checked_at` DATETIME(6) NULL DEFAULT NULL;

--- a/panel-api/internal/models/database.go
+++ b/panel-api/internal/models/database.go
@@ -10,7 +10,12 @@ type Database struct {
 	Engine    string `gorm:"type:enum('mariadb','postgres');not null;default:'mariadb'" json:"engine"`
 	Charset   string `gorm:"type:varchar(32);not null;default:'utf8mb4'" json:"charset"`
 	Collation string `gorm:"type:varchar(32);not null;default:'utf8mb4_unicode_ci'" json:"collation"`
-	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	// SizeBytes is the database's on-disk size (data+index), refreshed by the
+	// DB-usage sweeper (GH #1242) so the User List can sum total storage. 0 until
+	// first swept.
+	SizeBytes     uint64     `gorm:"type:bigint unsigned;not null;default:0" json:"size_bytes"`
+	SizeCheckedAt *time.Time `gorm:"type:datetime(6)" json:"size_checked_at,omitempty"`
+	CreatedAt     time.Time  `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 

--- a/panel-api/internal/reconciler/db_usage_ticker.go
+++ b/panel-api/internal/reconciler/db_usage_ticker.go
@@ -1,0 +1,124 @@
+// Package reconciler — tenant database size sampler (GH #1242).
+//
+// Keeps databases.size_bytes fresh so the admin User List can show total
+// storage = home quota + databases + mail. The panel-api DB user is scoped to
+// its own schema and cannot read tenant sizes from information_schema, so this
+// asks the root agent (db.usage.by_schema — one information_schema pass over
+// every schema) and maps the sizes back to the tenant database rows by name.
+//
+// Best-effort: a failed pass is logged and retried next interval; a schema with
+// no matching row is ignored, and a row whose schema is absent keeps its last
+// known size.
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+const (
+	dbUsageInterval = 15 * time.Minute
+	dbUsageCallTO   = 30 * time.Second
+)
+
+// StartDBUsageTicker runs the DB-size sampler until ctx is cancelled. Nil deps
+// disable it.
+func StartDBUsageTicker(ctx context.Context, ag agent.AgentInterface, databases repository.DatabaseRepository, log bwTickerLogger) {
+	if ag == nil || databases == nil {
+		return
+	}
+	log.Info("db-usage ticker starting", "interval", dbUsageInterval.String())
+
+	// First pass shortly after boot so the User List populates without waiting.
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(90 * time.Second):
+			sampleDBUsage(ctx, ag, databases, log)
+		}
+	}()
+
+	t := time.NewTicker(dbUsageInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			sampleDBUsage(ctx, ag, databases, log)
+		}
+	}
+}
+
+func sampleDBUsage(ctx context.Context, ag agent.AgentInterface, databases repository.DatabaseRepository, log bwTickerLogger) {
+	rows, err := databases.ListAllMariaDB(ctx)
+	if err != nil {
+		log.Warn("db-usage: list failed", "error", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	sizes, ok := dbSchemaSizes(ctx, ag)
+	if !ok {
+		log.Warn("db-usage: schema sizes unavailable")
+		return
+	}
+	now := time.Now().UTC()
+	updated := 0
+	for i := range rows {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		d := rows[i]
+		size, present := sizes[strings.ToLower(d.Name)]
+		if !present {
+			continue // schema not in information_schema (dropped out of band) — keep last
+		}
+		if d.SizeBytes == size && d.SizeCheckedAt != nil {
+			continue // unchanged → no write (idempotent)
+		}
+		if err := databases.UpdateSize(ctx, d.ID, size, now); err != nil {
+			log.Warn("db-usage: writeback failed", "db", d.Name, "error", err)
+			continue
+		}
+		updated++
+	}
+	log.Info("db-usage: pass complete", "updated", updated, "total", len(rows))
+}
+
+// dbSchemaSizes dispatches db.usage.by_schema and returns schema->bytes,
+// lower-cased. ok=false on any agent/decode error.
+func dbSchemaSizes(ctx context.Context, ag agent.AgentInterface) (map[string]uint64, bool) {
+	callCtx, cancel := context.WithTimeout(ctx, dbUsageCallTO)
+	defer cancel()
+	raw, err := ag.Call(callCtx, "db.usage.by_schema", nil)
+	if err != nil {
+		return nil, false
+	}
+	var v struct {
+		Schemas []struct {
+			Schema string `json:"schema"`
+			Bytes  int64  `json:"bytes"`
+		} `json:"schemas"`
+	}
+	if json.Unmarshal(raw, &v) != nil {
+		return nil, false
+	}
+	out := make(map[string]uint64, len(v.Schemas))
+	for _, s := range v.Schemas {
+		if s.Bytes < 0 {
+			continue
+		}
+		out[strings.ToLower(s.Schema)] = uint64(s.Bytes)
+	}
+	return out, true
+}

--- a/panel-api/internal/repository/database_repository.go
+++ b/panel-api/internal/repository/database_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -21,6 +22,11 @@ type DatabaseRepository interface {
 	// UpdateName renames the database row in place (GH #1238 DB re-prefix). The
 	// on-disk rename is done by the agent; this repoints the panel row.
 	UpdateName(ctx context.Context, id, name string) error
+	// ListAllMariaDB returns every MariaDB-engine database (id + name) for the
+	// DB-usage sweeper to map schema sizes back to rows (GH #1242).
+	ListAllMariaDB(ctx context.Context) ([]models.Database, error)
+	// UpdateSize writes the swept on-disk size (GH #1242).
+	UpdateSize(ctx context.Context, id string, sizeBytes uint64, at time.Time) error
 }
 
 type databaseRepo struct{ db *gorm.DB }
@@ -121,6 +127,22 @@ func (r *databaseRepo) Delete(ctx context.Context, id string) error {
 func (r *databaseRepo) UpdateName(ctx context.Context, id, name string) error {
 	return translate(r.db.WithContext(ctx).
 		Model(&models.Database{}).Where("id = ?", id).Update("name", name).Error)
+}
+
+func (r *databaseRepo) ListAllMariaDB(ctx context.Context) ([]models.Database, error) {
+	var out []models.Database
+	if err := r.db.WithContext(ctx).
+		Where("engine = ?", "mariadb").
+		Find(&out).Error; err != nil {
+		return nil, translate(err)
+	}
+	return out, nil
+}
+
+func (r *databaseRepo) UpdateSize(ctx context.Context, id string, sizeBytes uint64, at time.Time) error {
+	return translate(r.db.WithContext(ctx).
+		Model(&models.Database{}).Where("id = ?", id).
+		Updates(map[string]any{"size_bytes": sizeBytes, "size_checked_at": at}).Error)
 }
 
 func (r *databaseRepo) ExistsByUserAndName(ctx context.Context, userID, name string) (bool, error) {

--- a/panel-api/internal/repository/database_repository_test.go
+++ b/panel-api/internal/repository/database_repository_test.go
@@ -149,7 +149,7 @@ func TestCreate_Success(t *testing.T) {
 	// Expect INSERT query
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO `databases`").
-		WithArgs(d.ID, d.UserID, d.Name, d.Engine, d.Charset, d.Collation, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs(d.ID, d.UserID, d.Name, d.Engine, d.Charset, d.Collation, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/panel-api/internal/repository/user_resource_stats_repository.go
+++ b/panel-api/internal/repository/user_resource_stats_repository.go
@@ -23,6 +23,11 @@ type UserResourceStats struct {
 	DockerApps     int64  `json:"docker_apps"`
 	Backups        int64  `json:"backups"`
 	BandwidthBytes uint64 `json:"bandwidth_bytes"`
+	// DBBytes + MailBytes are the tenant's database + mailbox storage (GH #1242),
+	// so the Users list can show total usage = home (users.disk_used_kb) + DB +
+	// mail. Refreshed by the DB-usage + mailbox-usage sweepers.
+	DBBytes   uint64 `json:"db_bytes"`
+	MailBytes uint64 `json:"mail_bytes"`
 }
 
 type UserResourceStatsRepository interface {
@@ -97,6 +102,22 @@ func (r *userResourceStatsRepo) Fetch(ctx context.Context, userIDs []string, mon
 		[]any{userIDs, monthStart}, func(s *UserResourceStats, n int64) {
 			if n > 0 {
 				s.BandwidthBytes = uint64(n)
+			}
+		})
+	// DB storage = SUM of the user's tenant DB sizes (swept into size_bytes).
+	assign(
+		"SELECT user_id, COALESCE(SUM(size_bytes),0) AS n FROM `databases` WHERE user_id IN ? GROUP BY user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) {
+			if n > 0 {
+				s.DBBytes = uint64(n)
+			}
+		})
+	// Mail storage = SUM of the user's mailbox usage (swept into last_usage_bytes).
+	assign(
+		"SELECT d.user_id AS user_id, COALESCE(SUM(m.last_usage_bytes),0) AS n FROM `mailboxes` m JOIN `domains` d ON d.id = m.domain_id WHERE d.user_id IN ? GROUP BY d.user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) {
+			if n > 0 {
+				s.MailBytes = uint64(n)
 			}
 		})
 

--- a/panel-api/internal/repository/user_resource_stats_repository.go
+++ b/panel-api/internal/repository/user_resource_stats_repository.go
@@ -7,6 +7,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -50,58 +51,57 @@ func (r *userResourceStatsRepo) Fetch(ctx context.Context, userIDs []string, mon
 	}
 	db := r.db.WithContext(ctx)
 
-	assign := func(query string, args []any, set func(*UserResourceStats, int64)) error {
+	// Each metric is independent: a single failing query must NOT zero every
+	// count (GH #1242 — `databases` is a MariaDB reserved word and the unquoted
+	// raw query 1064'd, which aborted the whole Fetch and rendered the entire
+	// Resources column as 0s). Collect per-query errors and return the partial
+	// map so the caller still shows what succeeded. Table names are backticked —
+	// `databases` in particular is reserved.
+	var errs []error
+	assign := func(query string, args []any, set func(*UserResourceStats, int64)) {
 		var rows []urStatRow
 		if err := db.Raw(query, args...).Scan(&rows).Error; err != nil {
-			return translate(err)
+			errs = append(errs, translate(err))
+			return
 		}
 		for _, row := range rows {
 			s := out[row.UserID]
 			set(&s, row.N)
 			out[row.UserID] = s
 		}
-		return nil
 	}
 
-	if err := assign(
-		"SELECT user_id, COUNT(*) AS n FROM domains WHERE user_id IN ? GROUP BY user_id",
-		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Domains = n }); err != nil {
-		return nil, err
-	}
-	if err := assign(
-		"SELECT user_id, COUNT(*) AS n FROM databases WHERE user_id IN ? GROUP BY user_id",
-		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Databases = n }); err != nil {
-		return nil, err
-	}
-	if err := assign(
-		"SELECT user_id, COUNT(*) AS n FROM docker_apps WHERE user_id IN ? AND status <> ? GROUP BY user_id",
-		[]any{userIDs, models.DockerAppStatusDeleted}, func(s *UserResourceStats, n int64) { s.DockerApps = n }); err != nil {
-		return nil, err
-	}
+	assign(
+		"SELECT user_id, COUNT(*) AS n FROM `domains` WHERE user_id IN ? GROUP BY user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Domains = n })
+	assign(
+		"SELECT user_id, COUNT(*) AS n FROM `databases` WHERE user_id IN ? GROUP BY user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Databases = n })
+	assign(
+		"SELECT user_id, COUNT(*) AS n FROM `docker_apps` WHERE user_id IN ? AND status <> ? GROUP BY user_id",
+		[]any{userIDs, models.DockerAppStatusDeleted}, func(s *UserResourceStats, n int64) { s.DockerApps = n })
 	// Mailboxes belong to a domain, which belongs to a user.
-	if err := assign(
-		"SELECT d.user_id AS user_id, COUNT(*) AS n FROM mailboxes m JOIN domains d ON d.id = m.domain_id WHERE d.user_id IN ? GROUP BY d.user_id",
-		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Mailboxes = n }); err != nil {
-		return nil, err
-	}
+	assign(
+		"SELECT d.user_id AS user_id, COUNT(*) AS n FROM `mailboxes` m JOIN `domains` d ON d.id = m.domain_id WHERE d.user_id IN ? GROUP BY d.user_id",
+		[]any{userIDs}, func(s *UserResourceStats, n int64) { s.Mailboxes = n })
 	// Retained account backups (same filter as CountRetainedForUser).
-	if err := assign(
-		"SELECT user_id, COUNT(*) AS n FROM backup_jobs WHERE user_id IN ? AND kind = ? AND status IN ? GROUP BY user_id",
+	assign(
+		"SELECT user_id, COUNT(*) AS n FROM `backup_jobs` WHERE user_id IN ? AND kind = ? AND status IN ? GROUP BY user_id",
 		[]any{userIDs, models.BackupJobKindAccountBackup, []string{
 			models.BackupJobStatusQueued, models.BackupJobStatusRunning,
 			models.BackupJobStatusSucceeded, models.BackupJobStatusPartial,
-		}}, func(s *UserResourceStats, n int64) { s.Backups = n }); err != nil {
-		return nil, err
-	}
+		}}, func(s *UserResourceStats, n int64) { s.Backups = n })
 	// Monthly bandwidth = SUM of the user's domains' daily bytes since monthStart.
-	if err := assign(
-		"SELECT d.user_id AS user_id, COALESCE(SUM(b.bytes_total),0) AS n FROM bw_daily b JOIN domains d ON d.id = b.domain_id WHERE d.user_id IN ? AND b.day >= ? GROUP BY d.user_id",
+	assign(
+		"SELECT d.user_id AS user_id, COALESCE(SUM(b.bytes_total),0) AS n FROM `bw_daily` b JOIN `domains` d ON d.id = b.domain_id WHERE d.user_id IN ? AND b.day >= ? GROUP BY d.user_id",
 		[]any{userIDs, monthStart}, func(s *UserResourceStats, n int64) {
 			if n > 0 {
 				s.BandwidthBytes = uint64(n)
 			}
-		}); err != nil {
-		return nil, err
+		})
+
+	if len(errs) > 0 {
+		return out, errors.Join(errs...)
 	}
 	return out, nil
 }

--- a/panel-api/internal/repository/user_resource_stats_repository_test.go
+++ b/panel-api/internal/repository/user_resource_stats_repository_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -39,12 +40,14 @@ func TestUserResourceStats_Fetch_MergesPerMetric(t *testing.T) {
 
 	const u1, u2 = "01USER0000000000000000001", "01USER0000000000000000002"
 
-	mock.ExpectQuery("FROM domains").WillReturnRows(urStatRows(u1, 3, u2, 1))
-	mock.ExpectQuery("FROM databases").WillReturnRows(urStatRows(u1, 2))
-	mock.ExpectQuery("FROM docker_apps").WillReturnRows(urStatRows(u2, 4))
-	mock.ExpectQuery("FROM mailboxes").WillReturnRows(urStatRows(u1, 5))
-	mock.ExpectQuery("FROM backup_jobs").WillReturnRows(urStatRows(u1, 6))
-	mock.ExpectQuery("FROM bw_daily").WillReturnRows(urStatRows(u1, 7340032))
+	// Table names are backticked in the SQL (`databases` is a MariaDB reserved
+	// word) — \x60 is the backtick in these regex matchers.
+	mock.ExpectQuery("FROM \x60domains\x60 WHERE").WillReturnRows(urStatRows(u1, 3, u2, 1))
+	mock.ExpectQuery("FROM \x60databases\x60").WillReturnRows(urStatRows(u1, 2))
+	mock.ExpectQuery("FROM \x60docker_apps\x60").WillReturnRows(urStatRows(u2, 4))
+	mock.ExpectQuery("FROM \x60mailboxes\x60").WillReturnRows(urStatRows(u1, 5))
+	mock.ExpectQuery("FROM \x60backup_jobs\x60").WillReturnRows(urStatRows(u1, 6))
+	mock.ExpectQuery("FROM \x60bw_daily\x60").WillReturnRows(urStatRows(u1, 7340032))
 
 	monthStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	out, err := repo.Fetch(context.Background(), []string{u1, u2}, monthStart)
@@ -62,4 +65,31 @@ func TestUserResourceStats_Fetch_MergesPerMetric(t *testing.T) {
 	require.Equal(t, uint64(0), out[u2].BandwidthBytes)
 
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// GH #1242: one failing query (e.g. the `databases` reserved-word 1064 that
+// zeroed the whole Resources column) must NOT wipe the other metrics — Fetch
+// returns the partial map plus an error, and the caller keeps the successes.
+func TestUserResourceStats_Fetch_PartialOnQueryError(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewUserResourceStatsRepository(db)
+
+	const u1 = "01USER0000000000000000001"
+	mock.ExpectQuery("FROM \x60domains\x60 WHERE").WillReturnRows(urStatRows(u1, 3))
+	mock.ExpectQuery("FROM \x60databases\x60").WillReturnError(errors.New("1064 reserved word"))
+	mock.ExpectQuery("FROM \x60docker_apps\x60").WillReturnRows(urStatRows(u1, 1))
+	mock.ExpectQuery("FROM \x60mailboxes\x60").WillReturnRows(urStatRows(u1, 5))
+	mock.ExpectQuery("FROM \x60backup_jobs\x60").WillReturnRows(urStatRows(u1, 2))
+	mock.ExpectQuery("FROM \x60bw_daily\x60").WillReturnRows(urStatRows(u1, 1024))
+
+	out, err := repo.Fetch(context.Background(), []string{u1}, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err) // the failed metric is surfaced...
+	// ...but every other metric survived.
+	require.Equal(t, int64(3), out[u1].Domains)
+	require.Equal(t, int64(0), out[u1].Databases) // the one that failed
+	require.Equal(t, int64(1), out[u1].DockerApps)
+	require.Equal(t, int64(5), out[u1].Mailboxes)
+	require.Equal(t, int64(2), out[u1].Backups)
+	require.Equal(t, uint64(1024), out[u1].BandwidthBytes)
 }

--- a/panel-api/internal/repository/user_resource_stats_repository_test.go
+++ b/panel-api/internal/repository/user_resource_stats_repository_test.go
@@ -42,12 +42,16 @@ func TestUserResourceStats_Fetch_MergesPerMetric(t *testing.T) {
 
 	// Table names are backticked in the SQL (`databases` is a MariaDB reserved
 	// word) — \x60 is the backtick in these regex matchers.
+	// Ordered mock — one ExpectQuery per Fetch query, in order. The two
+	// `databases`/`mailboxes` passes are told apart by COUNT vs SUM(...).
 	mock.ExpectQuery("FROM \x60domains\x60 WHERE").WillReturnRows(urStatRows(u1, 3, u2, 1))
-	mock.ExpectQuery("FROM \x60databases\x60").WillReturnRows(urStatRows(u1, 2))
+	mock.ExpectQuery("COUNT.*FROM \x60databases\x60").WillReturnRows(urStatRows(u1, 2))
 	mock.ExpectQuery("FROM \x60docker_apps\x60").WillReturnRows(urStatRows(u2, 4))
-	mock.ExpectQuery("FROM \x60mailboxes\x60").WillReturnRows(urStatRows(u1, 5))
+	mock.ExpectQuery("COUNT.*FROM \x60mailboxes\x60").WillReturnRows(urStatRows(u1, 5))
 	mock.ExpectQuery("FROM \x60backup_jobs\x60").WillReturnRows(urStatRows(u1, 6))
 	mock.ExpectQuery("FROM \x60bw_daily\x60").WillReturnRows(urStatRows(u1, 7340032))
+	mock.ExpectQuery("SUM.size_bytes.").WillReturnRows(urStatRows(u1, 5000000))
+	mock.ExpectQuery("SUM.m.last_usage_bytes.").WillReturnRows(urStatRows(u1, 900000))
 
 	monthStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
 	out, err := repo.Fetch(context.Background(), []string{u1, u2}, monthStart)
@@ -58,6 +62,8 @@ func TestUserResourceStats_Fetch_MergesPerMetric(t *testing.T) {
 	require.Equal(t, int64(5), out[u1].Mailboxes)
 	require.Equal(t, int64(6), out[u1].Backups)
 	require.Equal(t, uint64(7340032), out[u1].BandwidthBytes)
+	require.Equal(t, uint64(5000000), out[u1].DBBytes)
+	require.Equal(t, uint64(900000), out[u1].MailBytes)
 	require.Equal(t, int64(0), out[u1].DockerApps)
 
 	require.Equal(t, int64(1), out[u2].Domains)
@@ -77,11 +83,13 @@ func TestUserResourceStats_Fetch_PartialOnQueryError(t *testing.T) {
 
 	const u1 = "01USER0000000000000000001"
 	mock.ExpectQuery("FROM \x60domains\x60 WHERE").WillReturnRows(urStatRows(u1, 3))
-	mock.ExpectQuery("FROM \x60databases\x60").WillReturnError(errors.New("1064 reserved word"))
+	mock.ExpectQuery("COUNT.*FROM \x60databases\x60").WillReturnError(errors.New("1064 reserved word"))
 	mock.ExpectQuery("FROM \x60docker_apps\x60").WillReturnRows(urStatRows(u1, 1))
-	mock.ExpectQuery("FROM \x60mailboxes\x60").WillReturnRows(urStatRows(u1, 5))
+	mock.ExpectQuery("COUNT.*FROM \x60mailboxes\x60").WillReturnRows(urStatRows(u1, 5))
 	mock.ExpectQuery("FROM \x60backup_jobs\x60").WillReturnRows(urStatRows(u1, 2))
 	mock.ExpectQuery("FROM \x60bw_daily\x60").WillReturnRows(urStatRows(u1, 1024))
+	mock.ExpectQuery("SUM.size_bytes.").WillReturnRows(urStatRows(u1, 5000000))
+	mock.ExpectQuery("SUM.m.last_usage_bytes.").WillReturnRows(urStatRows(u1, 900000))
 
 	out, err := repo.Fetch(context.Background(), []string{u1}, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
 	require.Error(t, err) // the failed metric is surfaced...
@@ -92,4 +100,6 @@ func TestUserResourceStats_Fetch_PartialOnQueryError(t *testing.T) {
 	require.Equal(t, int64(5), out[u1].Mailboxes)
 	require.Equal(t, int64(2), out[u1].Backups)
 	require.Equal(t, uint64(1024), out[u1].BandwidthBytes)
+	require.Equal(t, uint64(5000000), out[u1].DBBytes)
+	require.Equal(t, uint64(900000), out[u1].MailBytes)
 }

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -191,6 +191,7 @@
       "package": "Package",
       "created": "Created",
       "disk_usage": "Disk usage",
+      "usage": "Usage",
       "resources": "Resources",
       "bandwidth_month": "Bandwidth this month",
       "actions": "Actions"

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { Badge, Button, Card, Input, Segmented, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import { DeleteOutlined, EditOutlined, LoginOutlined, PauseCircleOutlined, PlayCircleOutlined, SafetyOutlined, SearchOutlined, TeamOutlined } from "@icons";
+import { ContainerOutlined, DatabaseOutlined, DeleteOutlined, EditOutlined, GlobalOutlined, LoginOutlined, MailOutlined, PauseCircleOutlined, PlayCircleOutlined, SafetyOutlined, SaveOutlined, SearchOutlined, TeamOutlined } from "@icons";
 import { RowActions, type RowAction } from "../../../components/RowActions";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
@@ -395,7 +395,7 @@ function UsersShellTable({
       />
       {showDiskUsageColumn && (
         <Table.Column<User>
-          title={t("users.col.disk_usage")}
+          title={t("users.col.usage")}
           dataIndex="disk_used_kb"
           key="disk_used_kb"
           // Server-side sort (same form as the other columns): the sweeper
@@ -434,19 +434,20 @@ function UsersShellTable({
         render={(_: unknown, r: User) => {
           const R = r.resources;
           if (!R) return <Typography.Text type="secondary">—</Typography.Text>;
-          const chips: Array<[string, string, number]> = [
-            [t("users.res.domains"), "Dom", R.domains],
-            [t("users.res.mailboxes"), "Mbx", R.mailboxes],
-            [t("users.res.databases"), "DB", R.databases],
-            [t("users.res.docker"), "Dkr", R.docker_apps],
-            [t("users.res.backups"), "Bkp", R.backups],
+          // GH #1242 (johnnyq): icons instead of short codes, tooltip kept.
+          const chips: Array<[string, React.ReactNode, number]> = [
+            [t("users.res.domains"), <GlobalOutlined />, R.domains],
+            [t("users.res.mailboxes"), <MailOutlined />, R.mailboxes],
+            [t("users.res.databases"), <DatabaseOutlined />, R.databases],
+            [t("users.res.docker"), <ContainerOutlined />, R.docker_apps],
+            [t("users.res.backups"), <SaveOutlined />, R.backups],
           ];
           return (
-            <Space size={8} wrap>
-              {chips.map(([full, abbr, n]) => (
-                <Tooltip key={abbr} title={full}>
+            <Space size={10} wrap>
+              {chips.map(([full, icon, n]) => (
+                <Tooltip key={full} title={full}>
                   <span style={{ fontSize: 12, whiteSpace: "nowrap" }}>
-                    <Typography.Text type="secondary">{abbr}</Typography.Text> {n}
+                    <Typography.Text type="secondary">{icon}</Typography.Text> {n}
                   </span>
                 </Tooltip>
               ))}

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -64,6 +64,8 @@ type User = {
     docker_apps: number;
     backups: number;
     bandwidth_bytes: number;
+    db_bytes: number;
+    mail_bytes: number;
   };
 };
 
@@ -403,10 +405,34 @@ function UsersShellTable({
           // per-row fetch was impossible — it only ever held the current
           // page's resolved rows.
           sorter
-          render={(_: unknown, r: User) => (
+          render={(_: unknown, r: User) => {
+            // GH #1242 (johnnyq): total storage = home files + databases + mail.
+            // Databases/mail live outside /home, so they're summed in from the
+            // swept resource stats; the home-vs-quota bar stays as the detail.
+            const homeBytes = (r.disk_used_kb ?? 0) * 1024;
+            const dbBytes = r.resources?.db_bytes ?? 0;
+            const mailBytes = r.resources?.mail_bytes ?? 0;
+            const total = homeBytes + dbBytes + mailBytes;
+            return (
             <div>
               {r.disk_checked_at ? (
-                <UserDiskUsageCell usedKB={r.disk_used_kb ?? 0} limitKB={r.disk_limit_kb ?? 0} />
+                <>
+                  <Tooltip
+                    title={
+                      <div style={{ whiteSpace: "pre" }}>
+                        {`Home files: ${fmtBytes(homeBytes)}\nDatabases: ${fmtBytes(dbBytes)}\nMail: ${fmtBytes(mailBytes)}`}
+                      </div>
+                    }
+                  >
+                    <Typography.Text
+                      strong
+                      style={{ fontSize: 12, whiteSpace: "nowrap", display: "block" }}
+                    >
+                      {fmtBytes(total)} total
+                    </Typography.Text>
+                  </Tooltip>
+                  <UserDiskUsageCell usedKB={r.disk_used_kb ?? 0} limitKB={r.disk_limit_kb ?? 0} />
+                </>
               ) : (
                 // Never swept (fresh upgrade, or the sweeper has not reached
                 // this row yet) — fall back to the live per-row fetch so the
@@ -424,7 +450,8 @@ function UsersShellTable({
                 </Tooltip>
               )}
             </div>
-          )}
+            );
+          }}
         />
       )}
       {showDiskUsageColumn && (


### PR DESCRIPTION
Follow-up after #1350, from @johnnyq's feedback. Three things:

## 1. Bug: Resources column showed all 0s

`databases` is a **MariaDB reserved word**, and the aggregator's raw query `… FROM databases …` was **unquoted → ERROR 1064**, which aborted the whole `Fetch` (returned `nil, err`) → the list handler fell back to zero resources for **every** user. (sqlmock matches patterns not real SQL, so unit tests missed it; the count repos use GORM which auto-backticks.)

- Backtick every table name in the aggregator.
- Each metric is now **independent**: a failing query records its error and continues; `Fetch` returns the **partial map + joined error** instead of nil, so one bad query can never zero the whole column again.

## 2. Polish

- Resources uses **icons** (globe / mail / database / container / save) with the tooltip kept, not `Dom/Mbx/DB/…`.
- The column is renamed **"Usage"**.

## 3. Feature: Usage = total storage (home + databases + mail)

The disk figure was the home-dir quota only — DBs (`/var/lib/mysql`), mail (Stalwart store), backups (restic) live outside `/home`. Backups are excluded (restic dedupes → per-user size meaningless); **home + DB + mail** are summed:

- **Migration 277** adds `databases.size_bytes`. The panel-api DB user can't read tenant sizes from information_schema, so a new **DB-usage sweeper** asks the root agent (`db.usage.by_schema`, one pass) every 15m and writes each schema's size back by name. Mail usage is already persisted (`mailboxes.last_usage_bytes`).
- The Users aggregator sums `SUM(databases.size_bytes)` + `SUM(mailboxes.last_usage_bytes)` per user (one grouped query each).
- The Usage cell headlines the **total** with a **breakdown tooltip** (Home / Databases / Mail); the home-vs-quota bar stays as the detail.

## Testing

- **Live DB (.60):** backticked `databases` query returns real counts (was 1064); migration 277 applied; the sweeper populated `size_bytes` (matches information_schema); per-user DB + mail SUM queries return real bytes.
- Aggregator tests (backticked matchers, partial-on-error, DB+mail sums); repository/api/app/reconciler suites; `tsc -b` + vite build — green.

Read-only new agent dependency (`db.usage.by_schema` already exists) — **no new agent verb**. Migration 277 → applies on update. GH #1242
