### PR TITLE
fix(webmail): set SESSION_SECRET so Login via Webmail (impersonate) works (GH #1354)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14174,16 +14174,29 @@ _install_bulwark_impersonate_secrets() {
     _die "Stalwart admin token missing at $stalwart_token_file — install_stalwart must run first"
   fi
 
-  local jwt_secret master_pw
+  local jwt_secret master_pw session_secret
   jwt_secret=$(cat "$jwt_secret_file")
   master_pw=$(cat "$stalwart_token_file")
+
+  # GH #1354: Bulwark's newer build reads SESSION_SECRET from the environment
+  # directly (it no longer resolves SESSION_SECRET_FILE on the session /
+  # impersonate path), so a webmail version bump broke "Login via Webmail"
+  # (GET /api/auth/impersonate → HTTP 500 "SESSION_SECRET not configured")
+  # even though bulwark-session.key was present and referenced. Publish the
+  # value into bulwark.env alongside the file ref so both old and new builds
+  # resolve it. The key is generated once (install_bulwark) and preserved.
+  local session_key_file=/etc/jabali-panel/bulwark-session.key
+  if [[ ! -s "$session_key_file" ]]; then
+    _die "Bulwark session key missing at $session_key_file — install_bulwark must run first"
+  fi
+  session_secret=$(cat "$session_key_file")
 
   # Rebuild bulwark.env in tmp: strip any prior M6.6 lines, append fresh.
   # Diff via sha256; restart only on real change to avoid 60s reconciler
   # spam when nothing changed (memory: feedback_per_tick_idempotent_loops).
   local tmp
   tmp=$(mktemp)
-  grep -v -E '^(BULWARK_JWT_AUTH_SECRET|BULWARK_STALWART_MASTER_USER|BULWARK_STALWART_MASTER_PASSWORD|BULWARK_JWT_AUTH_ISSUER)=' "$bulwark_env" > "$tmp" || true
+  grep -v -E '^(BULWARK_JWT_AUTH_SECRET|BULWARK_STALWART_MASTER_USER|BULWARK_STALWART_MASTER_PASSWORD|BULWARK_JWT_AUTH_ISSUER|SESSION_SECRET)=' "$bulwark_env" > "$tmp" || true
   # Trim trailing blank lines off the PRESERVED portion before appending. The
   # heredoc below opens with a blank separator and `grep -v` strips only the
   # managed KEYS, never blanks -- so every run left one more blank line sitting
@@ -14207,6 +14220,9 @@ BULWARK_JWT_AUTH_SECRET=${jwt_secret}
 BULWARK_STALWART_MASTER_USER=admin
 BULWARK_STALWART_MASTER_PASSWORD=${master_pw}
 BULWARK_JWT_AUTH_ISSUER=jabali-panel/webmail-sso
+# GH #1354: value form of the session secret (kept in lockstep with
+# SESSION_SECRET_FILE=/etc/jabali-panel/bulwark-session.key from the template).
+SESSION_SECRET=${session_secret}
 EOF
 
   # Login-form flags (Bulwark >=1.7.8, bulwarkmail/webmail#520). Unlike the


### PR DESCRIPTION
## What

GH #1354 — @johnnyq: after a stable update, **Login via Webmail (Impersonate)** started returning **HTTP 500**, while manual login at `mail.<domain>` stayed fine.

## Root cause

The Bulwark webmail build now reads **`SESSION_SECRET` from the environment directly** on the session / impersonate path — it no longer resolves the `SESSION_SECRET_FILE` indirection jabali writes into `bulwark.env`. So `GET /api/auth/impersonate` failed with **`Error: SESSION_SECRET not configured`** even though `/etc/jabali-panel/bulwark-session.key` existed and was referenced.

The **panel side is unaffected** — it mints the SSO token + JWT and 303-redirects to the mail vhost correctly (verified). That's why manual login worked and only the impersonate hop broke.

## Fix

`_install_bulwark_impersonate_secrets` now also publishes **`SESSION_SECRET`** (the value from `bulwark-session.key`) into `bulwark.env`, alongside the template's `SESSION_SECRET_FILE`, so **both old and new Bulwark builds** resolve it. Added to the managed-key strip list so re-runs replace it cleanly; the key is still generated once and preserved. install.sh re-runs this on every `jabali update`, so **existing boxes self-heal on their next update**.

## Testing

- `bash -n` clean.
- **Live box (.60), behavior not deploy:**
  - Reproduced the 500: webmail log `Error: SESSION_SECRET not configured`, `GET /api/auth/impersonate` → **500** (panel land handler itself returns a clean 303 to the mail vhost).
  - After the fixed function ran: `SESSION_SECRET` written (`SESSION_SECRET_FILE` preserved, no duplicate), `jabali-webmail` restarted → `GET /api/auth/impersonate` → **303** (success).

install.sh-only; no panel/agent binary change. GH #1354