### PR TITLE
feat(ssl): View Certificate action in the SSL Manager (GH #1355)

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5122,6 +5122,14 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /domains/{id}/ssl/certificate:
+    get:
+      tags: [Ssl]
+      summary: View the issued certificate (parsed X.509 + PEM)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
   /domains/{id}/ssl/custom:
     put:
       tags: [Ssl]

--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -77,6 +77,7 @@ func RegisterSSLRoutes(g *gin.RouterGroup, cfg SSLHandlerConfig) {
 	domains := g.Group("/domains/:id")
 	{
 		domains.GET("/ssl", h.getSSL)
+		domains.GET("/ssl/certificate", h.inspectSSL) // GH #1355: view the issued cert
 		domains.POST("/ssl", h.enableSSL)
 		domains.DELETE("/ssl", h.disableSSL)
 		domains.POST("/ssl/renew", h.renewSSL)

--- a/panel-api/internal/api/ssl_inspect.go
+++ b/panel-api/internal/api/ssl_inspect.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// sslCertDetails is the parsed X.509 leaf shown by the SSL Manager's "View
+// certificate" action (GH #1355). Everything here is public certificate data —
+// no private key material is read or returned.
+type sslCertDetails struct {
+	Subject            string    `json:"subject"`
+	Issuer             string    `json:"issuer"`
+	SANs               []string  `json:"sans"`
+	NotBefore          time.Time `json:"not_before"`
+	NotAfter           time.Time `json:"not_after"`
+	SerialNumber       string    `json:"serial_number"`
+	SHA256Fingerprint  string    `json:"sha256_fingerprint"`
+	SignatureAlgorithm string    `json:"signature_algorithm"`
+	PublicKeyAlgorithm string    `json:"public_key_algorithm"`
+	IsCA               bool      `json:"is_ca"`
+	PEM                string    `json:"pem"`
+}
+
+// inspectSSL parses and returns the domain's issued certificate (GET
+// /domains/:id/ssl/certificate). Admin or the domain owner. Only meaningful for
+// a cert that exists on disk; a non-issued / fileless cert is a clean 409.
+func (h *sslHandler) inspectSSL(c *gin.Context) {
+	domainID := c.Param("id")
+	if h.loadDomainOwned(c, domainID) == nil {
+		return // loadDomainOwned already wrote the 401/403/404
+	}
+
+	cert, err := h.cfg.SSLCerts.FindByDomainID(c.Request.Context(), domainID)
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no_certificate"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if cert.Status != models.SSLStatusIssued || cert.CertPath == nil || *cert.CertPath == "" {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":  "no_certificate_on_disk",
+			"detail": "This domain has no issued certificate to view yet (status: " + cert.Status + ").",
+		})
+		return
+	}
+
+	details, err := parseSSLCertFile(*cert.CertPath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "parse_failed"})
+		return
+	}
+	c.JSON(http.StatusOK, details)
+}
+
+// parseSSLCertFile reads a PEM cert file and returns the leaf's public details
+// plus the file's PEM (the full chain, public). The first CERTIFICATE block is
+// the leaf (same convention as the reconciler's certDNSNames / certNotAfter).
+func parseSSLCertFile(path string) (*sslCertDetails, error) {
+	rawFile, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(rawFile)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, os.ErrInvalid
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(leaf.Raw)
+	return &sslCertDetails{
+		Subject:            leaf.Subject.String(),
+		Issuer:             leaf.Issuer.String(),
+		SANs:               leaf.DNSNames,
+		NotBefore:          leaf.NotBefore,
+		NotAfter:           leaf.NotAfter,
+		SerialNumber:       colonHex(leaf.SerialNumber.Bytes()),
+		SHA256Fingerprint:  colonHex(sum[:]),
+		SignatureAlgorithm: leaf.SignatureAlgorithm.String(),
+		PublicKeyAlgorithm: leaf.PublicKeyAlgorithm.String(),
+		IsCA:               leaf.IsCA,
+		PEM:                string(rawFile),
+	}, nil
+}
+
+// colonHex renders bytes as AA:BB:CC… (the conventional fingerprint form).
+func colonHex(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	parts := make([]string, len(b))
+	for i, x := range b {
+		parts[i] = hex.EncodeToString([]byte{x})
+	}
+	return strings.ToUpper(strings.Join(parts, ":"))
+}

--- a/panel-api/internal/api/ssl_inspect_test.go
+++ b/panel-api/internal/api/ssl_inspect_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// GH #1355: parseSSLCertFile must surface the leaf's public details + PEM.
+func TestParseSSLCertFile(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(0x0123456789),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		DNSNames:     []string{"example.com", "www.example.com", "mail.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "fullchain.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := parseSSLCertFile(path)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !strings.Contains(d.Subject, "example.com") {
+		t.Errorf("subject = %q", d.Subject)
+	}
+	// Self-signed → issuer == subject.
+	if !strings.Contains(d.Issuer, "example.com") {
+		t.Errorf("issuer = %q", d.Issuer)
+	}
+	if len(d.SANs) != 3 || d.SANs[0] != "example.com" {
+		t.Errorf("sans = %v", d.SANs)
+	}
+	if d.SHA256Fingerprint == "" || !strings.Contains(d.SHA256Fingerprint, ":") {
+		t.Errorf("fingerprint = %q (want colon-hex)", d.SHA256Fingerprint)
+	}
+	if d.SerialNumber == "" {
+		t.Error("serial empty")
+	}
+	if !strings.Contains(d.PEM, "BEGIN CERTIFICATE") {
+		t.Error("PEM missing")
+	}
+}
+
+func TestParseSSLCertFile_BadPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "junk.pem")
+	if err := os.WriteFile(path, []byte("not a certificate"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseSSLCertFile(path); err == nil {
+		t.Fatal("expected error on non-PEM input")
+	}
+}

--- a/panel-ui/src/components/ssl/SSLCertViewModal.tsx
+++ b/panel-ui/src/components/ssl/SSLCertViewModal.tsx
@@ -1,0 +1,117 @@
+// SSLCertViewModal — GH #1355: view the actual issued certificate for a domain.
+// Fetches the parsed X.509 leaf (public data only) + the PEM from
+// GET /domains/:id/ssl/certificate and shows it read-only, PEM copyable.
+import { Alert, Button, Descriptions, Modal, Spin, Typography } from "antd";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+
+type CertDetails = {
+  subject: string;
+  issuer: string;
+  sans: string[];
+  not_before: string;
+  not_after: string;
+  serial_number: string;
+  sha256_fingerprint: string;
+  signature_algorithm: string;
+  public_key_algorithm: string;
+  is_ca: boolean;
+  pem: string;
+};
+
+export function SSLCertViewModal({
+  domainId,
+  domainName,
+  onClose,
+}: {
+  domainId: string | null;
+  domainName?: string;
+  onClose: () => void;
+}) {
+  const open = !!domainId;
+  const { data, isLoading, error } = useQuery<CertDetails>({
+    queryKey: ["ssl-cert-view", domainId],
+    queryFn: async () =>
+      (await apiClient.get<CertDetails>(`/domains/${domainId}/ssl/certificate`))
+        .data,
+    enabled: open,
+  });
+
+  const detail = (error as { response?: { data?: { detail?: string } } })
+    ?.response?.data?.detail;
+
+  return (
+    <Modal
+      open={open}
+      title={`Certificate${domainName ? ` — ${domainName}` : ""}`}
+      onCancel={onClose}
+      footer={[
+        <Button key="close" onClick={onClose}>
+          Close
+        </Button>,
+      ]}
+      width={760}
+    >
+      {isLoading ? (
+        <div style={{ textAlign: "center", padding: 24 }}>
+          <Spin />
+        </div>
+      ) : error ? (
+        <Alert
+          type="error"
+          showIcon
+          message="Couldn't load the certificate"
+          description={detail ?? "The certificate may not be issued yet."}
+        />
+      ) : data ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Descriptions column={1} size="small" bordered>
+            <Descriptions.Item label="Subject">{data.subject || "—"}</Descriptions.Item>
+            <Descriptions.Item label="Issuer">{data.issuer || "—"}</Descriptions.Item>
+            <Descriptions.Item label="Subject Alternative Names">
+              {data.sans?.length ? data.sans.join(", ") : "—"}
+            </Descriptions.Item>
+            <Descriptions.Item label="Valid from">
+              {new Date(data.not_before).toLocaleString()}
+            </Descriptions.Item>
+            <Descriptions.Item label="Valid to">
+              {new Date(data.not_after).toLocaleString()}
+            </Descriptions.Item>
+            <Descriptions.Item label="Serial">
+              <Typography.Text style={{ fontFamily: "monospace", fontSize: 12, wordBreak: "break-all" }}>
+                {data.serial_number}
+              </Typography.Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="SHA-256 fingerprint">
+              <Typography.Text style={{ fontFamily: "monospace", fontSize: 12, wordBreak: "break-all" }}>
+                {data.sha256_fingerprint}
+              </Typography.Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="Signature">{data.signature_algorithm}</Descriptions.Item>
+            <Descriptions.Item label="Public key">{data.public_key_algorithm}</Descriptions.Item>
+          </Descriptions>
+          <div>
+            <Typography.Text strong copyable={{ text: data.pem, tooltips: ["Copy PEM", "Copied"] }}>
+              PEM
+            </Typography.Text>
+            <pre
+              style={{
+                maxHeight: 240,
+                overflow: "auto",
+                background: "var(--ant-color-fill-quaternary, rgba(0,0,0,0.04))",
+                padding: 8,
+                marginTop: 4,
+                fontSize: 11,
+                borderRadius: 4,
+                whiteSpace: "pre",
+              }}
+            >
+              {data.pem}
+            </pre>
+          </div>
+        </div>
+      ) : null}
+    </Modal>
+  );
+}

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -11,7 +11,9 @@ import {
   RedoOutlined,
   ExclamationCircleOutlined,
   MoreOutlined,
+  SafetyCertificateOutlined,
 } from "@icons";
+import { SSLCertViewModal } from "./SSLCertViewModal";
 import { apiClient } from "../../apiClient";
 import { columnSearchProps } from "../columnSearch";
 import { RowActionButton } from "../RowActionButton";
@@ -143,6 +145,7 @@ export const SSLManagerTable = ({
   // diagnose pending_acme_retry / failed states without shelling into the
   // VPS to grep journalctl.
   const [errorRow, setErrorRow] = useState<SSLCertificate | null>(null);
+  const [viewRow, setViewRow] = useState<SSLCertificate | null>(null); // GH #1355
 
   // Fetch SSL certificates
   const { data, isLoading, error } = useQuery({
@@ -504,6 +507,10 @@ export const SSLManagerTable = ({
         // live in the ⋯ overflow (Certificate console). Renew stays primary
         // for issued rows, Retry now for retryable failures.
         const menuItems = [
+          // GH #1355: view the issued cert (only issued rows have one on disk).
+          ...(record.status === "issued"
+            ? [{ key: "view", icon: <SafetyCertificateOutlined />, label: "View certificate" }]
+            : []),
           ...(record.status === "issued"
             ? [{ key: "revoke", danger: true, icon: <DeleteOutlined />, label: t("sslmanagertable.revoke_certificate") }]
             : []),
@@ -516,6 +523,7 @@ export const SSLManagerTable = ({
         ];
         const onMenuClick = ({ key }: { key: string }) => {
           if (key === "retry") retryMutation.mutate(record.domain_id);
+          else if (key === "view") setViewRow(record);
           else if (key === "error") setErrorRow(record);
           else if (key === "revoke") {
             feedback.modal.confirm({
@@ -590,6 +598,11 @@ export const SSLManagerTable = ({
           />
         </Space>
       )}
+      <SSLCertViewModal
+        domainId={viewRow?.domain_id ?? null}
+        domainName={viewRow?.domain_name}
+        onClose={() => setViewRow(null)}
+      />
       <Modal
         open={!!errorRow}
         title={errorRow ? `Last error — ${errorRow.domain_name}` : "Last error"}


### PR DESCRIPTION
## What

GH #1355 — @johnnyq: add a way to **view the actual certificate** from the SSL Manager row menu.

## How

- New **`GET /domains/:id/ssl/certificate`** (admin or domain owner) parses the issued cert's leaf and returns its **public** details — subject, issuer, SANs, valid-from/to, serial, **SHA-256 fingerprint**, signature + public-key algorithm — plus the **PEM** (the cert file is the fullchain; public, no key material). A non-issued / fileless cert is a clean **409**.
- The SSL Manager row menu gains **"View certificate"** for issued rows → a read-only modal with the parsed details and a **copyable PEM**. Scoped to website-cert rows (the synthetic panel-/mail-cert rows keep their own menus).

## Testing

- `parseSSLCertFile` unit tests: a generated leaf (subject/issuer/SANs/serial/colon-hex fingerprint/PEM present) + a bad-PEM error case.
- openapi coverage + `internal/api`/`internal/app` suites green; `tsc -b` + vite build green.

Read-only — **no agent verb, no migration**. GH #1355