### PR TITLE
fix(ssl): hide the stale last-error affordance on an issued cert (GH #1356)

### DIFF
--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -352,7 +352,9 @@ export const SSLManagerTable = ({
         } else if (status === "pending_acme_retry") {
           tooltip = `ACME failed — retrying at ${formatDate(record.next_retry_at)}`;
         }
-        const hasError = !!record.last_error;
+        // GH #1356: a cert that failed then succeeded keeps its stale last_error;
+        // don't surface the error affordance once it's issued.
+        const hasError = !!record.last_error && record.status !== "issued";
         return (
           <Space size={4}>
             <Tooltip title={tooltip}>
@@ -517,7 +519,7 @@ export const SSLManagerTable = ({
           ...(record.status === "pending_acme_retry" && !isRetryable
             ? [{ key: "retry", icon: <RedoOutlined />, label: "Force retry now" }]
             : []),
-          ...(record.last_error
+          ...(record.last_error && record.status !== "issued"
             ? [{ key: "error", icon: <ExclamationCircleOutlined />, label: t("sslmanagertable.show_last_error") }]
             : []),
         ];


### PR DESCRIPTION
## What

GH #1356 — @johnnyq: hide the little error icon in the SSL Manager once the cert is issued.

A cert that failed ACME then succeeded keeps its `last_error` populated, so the SSL Manager kept showing the error icon **and** the "Show last error" ⋯-menu item on a now-issued cert.

## Fix

Gate both surfacings on `status !== "issued"` — the error only shows while the cert is actually failed/retrying.

## Testing

`tsc -b` + vite build green. UI-only. GH #1356