### PR TITLE
feat(backups): restore a single domain's document root from a backup (GH #1359)

### DIFF
--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -22,6 +22,11 @@ var ulidRE = regexp.MustCompile(`^[0-9A-HJKMNP-TV-Z]{26}$`)
 // username constraint, used to build /home/<u> paths.
 var backupUsernameRE = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,31}$`)
 
+// backupDomainNameRE constrains a domain name that flows into a restic --include
+// path + rsync destination (GH #1359 per-domain docroot restore): lowercase DNS
+// labels only, so no '/', '..', or leading '-' can escape ~/domains/<domain>.
+var backupDomainNameRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$`)
+
 // dbNameRE matches MariaDB database names: alpha + digits + underscore,
 // up to 64 chars.
 var dbNameRE = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]{0,63}$`)

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -46,7 +46,11 @@ type backupRestoreSelectiveParams struct {
 	Databases          []string `json:"databases"`
 	Mailboxes          []string `json:"mailboxes"`
 	RestoreHome        bool     `json:"home"`
-	Overwrite          bool     `json:"overwrite"`
+	// Domains restores only the named domains' docroots (~/domains/<domain>)
+	// from the home stage, additively — the per-domain alternative to a full
+	// home restore (GH #1359). The panel validates ownership + format.
+	Domains   []string `json:"domains"`
+	Overwrite bool     `json:"overwrite"`
 	// Restic dest (optional; empty = default local repo, like materialize).
 	RepoURL        string            `json:"repo_url,omitempty"`
 	CredentialsRef string            `json:"credentials_ref,omitempty"`
@@ -80,8 +84,16 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 	if !backupUsernameRE.MatchString(p.TargetUsername) {
 		return nil, bkInvalidArg("target_username must match ^[a-z][a-z0-9_-]{0,31}$")
 	}
-	if len(p.Databases) == 0 && !p.RestoreHome && len(p.Mailboxes) == 0 {
-		return nil, bkInvalidArg("select at least one database, mailbox, and/or home")
+	if len(p.Databases) == 0 && !p.RestoreHome && len(p.Mailboxes) == 0 && len(p.Domains) == 0 {
+		return nil, bkInvalidArg("select at least one database, mailbox, domain, and/or home")
+	}
+	// Defence-in-depth: domain names flow into a restic --include path and an
+	// rsync destination, so refuse anything with path/traversal characters even
+	// though the panel already checks ownership. (Same posture as target_username.)
+	for _, d := range p.Domains {
+		if !backupDomainNameRE.MatchString(d) {
+			return nil, bkInvalidArg("invalid domain name: " + d)
+		}
 	}
 
 	out := backupRestoreSelectiveResult{JobID: p.JobID}
@@ -165,8 +177,10 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 		}
 	}
 
+	// The home stage holds both the whole home (RestoreHome) and the per-domain
+	// docroots (~/domains/<domain>, GH #1359) — resolve it for either.
 	var homeStage *backup.ManifestStage
-	if p.RestoreHome {
+	if p.RestoreHome || len(p.Domains) > 0 {
 		for i := range manifest.Stages {
 			st := manifest.Stages[i]
 			if st.Name == backup.StageHome && st.Status == backup.StageStatusOK && st.SnapshotID != "" {
@@ -175,7 +189,7 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 			}
 		}
 		if homeStage == nil {
-			out.Warnings = append(out.Warnings, "home directory is not in this backup — skipped")
+			out.Warnings = append(out.Warnings, "the home stage (which holds domain files) is not in this backup — skipped")
 		}
 	}
 
@@ -189,8 +203,13 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 		for _, st := range dbStages {
 			out.Skipped = append(out.Skipped, st.Items[0])
 		}
-		if homeStage != nil {
+		if homeStage != nil && p.RestoreHome {
 			out.Skipped = append(out.Skipped, "home")
+		}
+		if homeStage != nil {
+			for _, d := range p.Domains {
+				out.Skipped = append(out.Skipped, "domain:"+d)
+			}
 		}
 		if mailStage != nil {
 			for _, mb := range p.Mailboxes {
@@ -234,12 +253,20 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 	// Home — ADDITIVE rsync (NO --delete): restores backup files over the live
 	// home but never removes files created since the backup (unlike the admin
 	// whole-account restore, which mirrors with --delete). overwrite-gated above.
-	if homeStage != nil {
+	if homeStage != nil && p.RestoreHome {
 		if hwarn := applySelectiveHome(ctx, stagingRoot, p.TargetUsername, homeStage, c); hwarn != "" {
 			out.Warnings = append(out.Warnings, hwarn)
 		} else {
 			out.Applied = append(out.Applied, "home → /home/"+p.TargetUsername+" (additive, no delete)")
 		}
+	}
+
+	// Per-domain docroots (GH #1359): restore only ~/domains/<domain> from the
+	// home stage, additively — the granular alternative to a full home restore.
+	if homeStage != nil && len(p.Domains) > 0 && !p.RestoreHome {
+		applied, warnings := applySelectiveDomains(ctx, stagingRoot, p.TargetUsername, p.Domains, homeStage, c)
+		out.Applied = append(out.Applied, applied...)
+		out.Warnings = append(out.Warnings, warnings...)
 	}
 
 	// Mail — ADDITIVE + idempotent: restic-restore the mail stage's Maildir
@@ -343,6 +370,62 @@ func applySelectiveHome(ctx context.Context, stagingRoot, username string, st *b
 		return "home: docroot group: " + err.Error()
 	}
 	return ""
+}
+
+// applySelectiveDomains restores ONLY the named domains' docroots
+// (~/domains/<domain>) from the home stage, additively (GH #1359). Restic
+// --include limits the extract to those paths; the rsync then writes over the
+// live docroot without --delete (never removes files created since the backup),
+// re-owns to the tenant, and re-applies the docroot setgid group. Per-domain
+// failures are collected as warnings so one bad domain doesn't sink the rest.
+func applySelectiveDomains(ctx context.Context, stagingRoot, username string, domains []string, st *backup.ManifestStage, c *backup.Client) (applied, warnings []string) {
+	target := filepath.Join(stagingRoot, "domains")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		return nil, []string{"domains: mkdir staging: " + err.Error()}
+	}
+	includes := make([]string, 0, len(domains))
+	for _, d := range domains {
+		includes = append(includes, "/home/"+username+"/domains/"+d)
+	}
+	if err := c.Restore(ctx, backup.RestoreOpts{SnapshotID: st.SnapshotID, Target: target, Include: includes}); err != nil {
+		return nil, []string{"domains: restic restore: " + err.Error()}
+	}
+	u, uerr := user.Lookup(username)
+	if uerr != nil {
+		return nil, []string{"domains: user lookup: " + uerr.Error()}
+	}
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(u.Gid)
+
+	for _, d := range domains {
+		// Restic preserves the absolute path: staged at target/home/<user>/domains/<d>.
+		src := filepath.Join(target, "home", username, "domains", d) + "/"
+		if _, err := os.Stat(filepath.Clean(src)); err != nil {
+			warnings = append(warnings, "domain "+d+": not in this backup — skipped")
+			continue
+		}
+		dst := "/home/" + username + "/domains/" + d + "/"
+		if err := os.MkdirAll(dst, 0o750); err != nil {
+			warnings = append(warnings, "domain "+d+": mkdir target: "+err.Error())
+			continue
+		}
+		// -aH not -aHAX: skip untrusted ACL/xattr from the repo; owner/mode are
+		// re-normalized below (same posture as applySelectiveHome).
+		if err := execCommandContext(ctx, "rsync", "-aH", src, dst).Run(); err != nil {
+			warnings = append(warnings, "domain "+d+": rsync: "+err.Error())
+			continue
+		}
+		if err := chownTreeRecursive(dst, uid, gid); err != nil {
+			warnings = append(warnings, "domain "+d+": chown: "+err.Error())
+			continue
+		}
+		applied = append(applied, "domain "+d+" → /home/"+username+"/domains/"+d+" (additive, no delete)")
+	}
+	// Re-apply the docroot setgid/www-data group across the user's docroots.
+	if err := restoreDocrootGroup(username); err != nil {
+		warnings = append(warnings, "domains: docroot group: "+err.Error())
+	}
+	return applied, warnings
 }
 
 func init() {

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -2544,7 +2544,10 @@ type meRestoreSelectiveRequest struct {
 	Home       bool     `json:"home"`
 	Mailboxes  []string `json:"mailboxes"`
 	DNSDomains []string `json:"dns_domains"`
-	Overwrite  bool     `json:"overwrite"`
+	// Domains restores only these domains' docroots (~/domains/<domain>) from the
+	// home stage — the per-domain alternative to a full home restore (GH #1359).
+	Domains   []string `json:"domains"`
+	Overwrite bool     `json:"overwrite"`
 }
 
 // restoreSelective restores a chosen subset of the caller's OWN backup
@@ -2581,9 +2584,9 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"status": "error", "error": "validation_failed", "detail": err.Error()})
 		return
 	}
-	if len(req.Databases) == 0 && !req.Home && len(req.DNSDomains) == 0 && len(req.Mailboxes) == 0 {
+	if len(req.Databases) == 0 && !req.Home && len(req.DNSDomains) == 0 && len(req.Mailboxes) == 0 && len(req.Domains) == 0 {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"status": "error", "error": "nothing_selected",
-			"detail": "select at least one database, mailbox, home, and/or dns domain"})
+			"detail": "select at least one database, mailbox, home, domain, and/or dns domain"})
 		return
 	}
 
@@ -2615,9 +2618,10 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 		}
 	}
 
-	// DNS domains must also be currently owned by the caller (name -> id map).
+	// DNS domains + domain docroots + mailboxes must all be currently owned by
+	// the caller (name -> id map). Fail-closed.
 	ownedDomains := map[string]string{}
-	if (len(req.DNSDomains) > 0 || len(req.Mailboxes) > 0) && h.cfg.Domains != nil {
+	if (len(req.DNSDomains) > 0 || len(req.Mailboxes) > 0 || len(req.Domains) > 0) && h.cfg.Domains != nil {
 		doms, _, derr := h.cfg.Domains.ListByUserID(c.Request.Context(), claims.UserID, repository.ListOptions{Limit: 10000})
 		if derr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "domain_list_failed"})
@@ -2627,6 +2631,13 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 			ownedDomains[d.Name] = d.ID
 		}
 		for _, n := range req.DNSDomains {
+			if _, ok := ownedDomains[n]; !ok {
+				c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "domain_not_owned",
+					"detail": "you do not own a domain named " + n})
+				return
+			}
+		}
+		for _, n := range req.Domains {
 			if _, ok := ownedDomains[n]; !ok {
 				c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "domain_not_owned",
 					"detail": "you do not own a domain named " + n})
@@ -2654,7 +2665,7 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 		Kind:   models.BackupJobKindAccountRestore,
 		// GH #1044: record what this restore actually touches so the list reads
 		// "Database Restore" (etc.) rather than the generic "Account Restore".
-		Content:   restoreContentFromSelective(req.Databases, req.Mailboxes, req.DNSDomains, req.Home),
+		Content:   restoreContentFromSelective(req.Databases, req.Mailboxes, req.DNSDomains, req.Domains, req.Home),
 		CreatedAt: time.Now().UTC(),
 		Status:    models.BackupJobStatusQueued,
 	}
@@ -2716,7 +2727,7 @@ func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username s
 
 	// Databases + home go to the agent (host-side). Only dispatch when one is
 	// requested — the agent rejects an empty db+home set.
-	if len(req.Databases) > 0 || req.Home || len(req.Mailboxes) > 0 {
+	if len(req.Databases) > 0 || req.Home || len(req.Mailboxes) > 0 || len(req.Domains) > 0 {
 		params := map[string]any{
 			"job_id":               jobID,
 			"manifest_snapshot_id": manifestSnap,
@@ -2724,6 +2735,7 @@ func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username s
 			"databases":            req.Databases,
 			"mailboxes":            req.Mailboxes,
 			"home":                 req.Home,
+			"domains":              req.Domains,
 			"overwrite":            req.Overwrite,
 		}
 		// Point the agent at the repo the snapshot actually lives in, and

--- a/panel-api/internal/api/restore_view.go
+++ b/panel-api/internal/api/restore_view.go
@@ -27,13 +27,14 @@ func isRestoreKind(kind string) bool {
 // same Content vocabulary a backup uses, so the shared label logic can describe
 // it. databases-only -> "database", home-only -> "files", anything mixed (or
 // mailbox/DNS-only, which have no dedicated content bucket) -> "full".
-func restoreContentFromSelective(databases, mailboxes, dnsDomains []string, home bool) string {
-	onlyDatabases := len(databases) > 0 && !home && len(mailboxes) == 0 && len(dnsDomains) == 0
+func restoreContentFromSelective(databases, mailboxes, dnsDomains, domains []string, home bool) string {
+	onlyDatabases := len(databases) > 0 && !home && len(mailboxes) == 0 && len(dnsDomains) == 0 && len(domains) == 0
 	if onlyDatabases {
 		return models.BackupContentDatabase
 	}
-	onlyHome := home && len(databases) == 0 && len(mailboxes) == 0 && len(dnsDomains) == 0
-	if onlyHome {
+	// Home and per-domain docroots (GH #1359) are both file restores.
+	onlyFiles := (home || len(domains) > 0) && len(databases) == 0 && len(mailboxes) == 0 && len(dnsDomains) == 0
+	if onlyFiles {
 		return models.BackupContentFiles
 	}
 	return models.BackupContentFull

--- a/panel-api/internal/api/restore_view_test.go
+++ b/panel-api/internal/api/restore_view_test.go
@@ -14,20 +14,23 @@ func TestRestoreContentFromSelective(t *testing.T) {
 		databases  []string
 		mailboxes  []string
 		dnsDomains []string
+		domains    []string
 		home       bool
 		want       string
 	}{
-		{"databases only", []string{"db1"}, nil, nil, false, models.BackupContentDatabase},
-		{"multiple databases only", []string{"db1", "db2"}, nil, nil, false, models.BackupContentDatabase},
-		{"home only", nil, nil, nil, true, models.BackupContentFiles},
-		{"db + home -> full", []string{"db1"}, nil, nil, true, models.BackupContentFull},
-		{"mailboxes only -> full", nil, []string{"a@x.com"}, nil, false, models.BackupContentFull},
-		{"dns only -> full", nil, nil, []string{"x.com"}, false, models.BackupContentFull},
-		{"empty -> full", nil, nil, nil, false, models.BackupContentFull},
+		{"databases only", []string{"db1"}, nil, nil, nil, false, models.BackupContentDatabase},
+		{"multiple databases only", []string{"db1", "db2"}, nil, nil, nil, false, models.BackupContentDatabase},
+		{"home only", nil, nil, nil, nil, true, models.BackupContentFiles},
+		{"domains only -> files", nil, nil, nil, []string{"x.com"}, false, models.BackupContentFiles},
+		{"db + home -> full", []string{"db1"}, nil, nil, nil, true, models.BackupContentFull},
+		{"db + domains -> full", []string{"db1"}, nil, nil, []string{"x.com"}, false, models.BackupContentFull},
+		{"mailboxes only -> full", nil, []string{"a@x.com"}, nil, nil, false, models.BackupContentFull},
+		{"dns only -> full", nil, nil, []string{"x.com"}, nil, false, models.BackupContentFull},
+		{"empty -> full", nil, nil, nil, nil, false, models.BackupContentFull},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := restoreContentFromSelective(tc.databases, tc.mailboxes, tc.dnsDomains, tc.home); got != tc.want {
+			if got := restoreContentFromSelective(tc.databases, tc.mailboxes, tc.dnsDomains, tc.domains, tc.home); got != tc.want {
 				t.Errorf("restoreContentFromSelective = %q, want %q", got, tc.want)
 			}
 		})

--- a/panel-ui/src/shells/user/RestoreDrawer.tsx
+++ b/panel-ui/src/shells/user/RestoreDrawer.tsx
@@ -53,6 +53,9 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
   const [selectedMb, setSelectedMb] = useState<string[]>([]);
   const [dnsDomains, setDnsDomains] = useState<string[]>([]);
   const [selectedDns, setSelectedDns] = useState<string[]>([]);
+  // GH #1359: restore only specific domains' docroots (~/domains/<domain>)
+  // instead of the whole home. Offered when the backup has a home stage.
+  const [selectedDomainFiles, setSelectedDomainFiles] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<RestoreResult | null>(null);
 
@@ -68,6 +71,7 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
     setSelectedMb([]);
     setDnsDomains([]);
     setSelectedDns([]);
+    setSelectedDomainFiles([]);
     setResult(null);
     apiClient
       .get<ManifestResponse>(`/me/backups/${backupId}/manifest`)
@@ -101,13 +105,28 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
   // server finished the work anyway). Poll the job row until it seals and
   // render the outcome it recorded.
   const handleRestore = async () => {
-    if (!backupId || (selected.length === 0 && !restoreHome && selectedDns.length === 0 && selectedMb.length === 0)) return;
+    if (
+      !backupId ||
+      (selected.length === 0 &&
+        !restoreHome &&
+        selectedDns.length === 0 &&
+        selectedMb.length === 0 &&
+        selectedDomainFiles.length === 0)
+    )
+      return;
     setSubmitting(true);
     setResult(null);
     try {
       const resp = await apiClient.post<{ job_id: string }>(
         `/me/backups/${backupId}/restore`,
-        { databases: selected, home: restoreHome, mailboxes: selectedMb, dns_domains: selectedDns, overwrite: true },
+        {
+          databases: selected,
+          home: restoreHome,
+          mailboxes: selectedMb,
+          dns_domains: selectedDns,
+          domains: selectedDomainFiles,
+          overwrite: true,
+        },
       );
       const jobId = resp.data.job_id;
       feedback.message.info("Restore started — this can take a while for large backups");
@@ -228,7 +247,26 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
             </>
           )}
 
-          {(selected.length > 0 || restoreHome || selectedDns.length > 0 || selectedMb.length > 0) && (
+          {/* GH #1359: restore one site's document root instead of the whole home. */}
+          {hasHome && dnsDomains.length > 0 && (
+            <>
+              <Typography.Text strong>Domain files</Typography.Text>
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Restores just these domains&apos; files (
+                <code>~/domains/&lt;domain&gt;</code>) from the backup, over the
+                live files — nothing is deleted. Use this to recover one site&apos;s
+                document root without restoring the whole home directory.
+              </Typography.Text>
+              <Checkbox.Group
+                value={selectedDomainFiles}
+                onChange={(v) => setSelectedDomainFiles(v as string[])}
+                style={{ display: "flex", flexDirection: "column", gap: 8 }}
+                options={dnsDomains.map((d) => ({ label: d, value: d }))}
+              />
+            </>
+          )}
+
+          {(selected.length > 0 || restoreHome || selectedDns.length > 0 || selectedMb.length > 0 || selectedDomainFiles.length > 0) && (
             <Alert
               type="warning"
               showIcon
@@ -237,7 +275,7 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
             />
           )}
 
-          {(selected.length > 0 || restoreHome || selectedDns.length > 0 || selectedMb.length > 0) && (
+          {(selected.length > 0 || restoreHome || selectedDns.length > 0 || selectedMb.length > 0 || selectedDomainFiles.length > 0) && (
             <>
               <Checkbox
                 checked={confirmOverwrite}


### PR DESCRIPTION
## Summary

GH #1359 — the account-backup restore dialog offered Home / Databases / Mailboxes / DNS, but **no way to restore a single domain's document root**. Recovering one broken site meant restoring the whole home directory (every domain + dotfiles) — far more blast radius than the problem needs.

This adds a per-domain **"Domain files"** option that restores only `~/domains/<domain>` from the backup, additively.

## What changed

**Agent** (`backup.restore_selective`)
- New `domains []string` param. Resolves the home stage (which holds the docroots) and, via new `applySelectiveDomains`, uses restic `--include /home/<user>/domains/<domain>` to extract ONLY the named domains, then `rsync -aH` (**no `--delete`** — never removes files created since the backup) over the live docroot, re-owns to the tenant, and re-applies the docroot setgid/www-data group.
- Per-domain failures collect as warnings so one bad domain doesn't sink the rest.
- Defense-in-depth: each domain name is validated against a DNS-label regex (`backupDomainNameRE`) before it reaches the restic `--include` path / rsync destination — same posture as `target_username`.

**panel-api**
- `domains` flows through the selective-restore request with the same **ownership check** the DNS/mailbox scopes already use (`domain_not_owned`), is dispatched to the agent, and folds into the restore job's Content (domains-only → "files"; mixed with a DB → "full").

**panel-ui** (`RestoreDrawer`)
- A "Domain files" checkbox group, shown when the backup has a home stage and the account has domains, alongside the existing controls. Shares the destructive-overwrite warning + confirm gate.

The whole-home restore is unchanged and still available — this is the granular alternative.

## Verification

- ✅ agent `go build` + `go vet`
- ✅ panel-api `go build` + `go test ./internal/api/ -run TestRestore` (incl. new `restoreContentFromSelective` cases: "domains only → files", "db + domains → full")
- ✅ panel-ui `npx tsc -b`
- ✅ **Box-drilled the restic `--include` mechanic** on a test host: restoring `--include /home/<user>/domains/example.com` staged ONLY that domain at `Target/home/<user>/domains/example.com` and excluded the account's other domain + mail — confirming `applySelectiveDomains`' src path.

## Release / deploy note

Changes an **agent verb** (`backup.restore_selective`) — fleet agents must be **redeployed** for the per-domain option to work end-to-end. **No migration.**

## Test plan

- [ ] Deploy panel-api + agent to a box with an account that has ≥2 domains and a backup containing a home stage.
- [ ] In the restore drawer, select one domain under "Domain files", confirm, restore.
- [ ] Verify only that domain's `~/domains/<domain>` files were written; the other domain + home dotfiles untouched; files owned by the tenant with the docroot group.
