### PR TITLE
feat(php): per-domain display_errors, error_reporting, timezone + override badges (GH #1332)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -105,6 +105,13 @@ type domainCreateParams struct {
 	PHPMaxInputVars      int    `json:"php_max_input_vars,omitempty"`
 	PHPMaxExecutionTime  int    `json:"php_max_execution_time,omitempty"`
 	PHPMaxInputTime      int    `json:"php_max_input_time,omitempty"`
+	// GH #1332 per-domain runtime directives. PHPDisplayErrors is a plain bool:
+	// absent/false => the safe default (display_errors=Off, always pinned — see
+	// buildPHPValueParam). PHPErrorReporting is a *int bitmask (nil => not set;
+	// 0 is a meaningful "report nothing"). PHPTimezone "" => not set.
+	PHPDisplayErrors  bool   `json:"php_display_errors,omitempty"`
+	PHPErrorReporting *int   `json:"php_error_reporting,omitempty"`
+	PHPTimezone       string `json:"php_timezone,omitempty"`
 	// M18 per-domain HTTP limits. DomainID is required when either
 	// RateLimitRPS or ConnectionLimit is set so the zone-name tag
 	// matches the declaration in 00-jabali-ratelimits.conf. All three
@@ -802,10 +809,32 @@ func pathsUnderHome(username, docRoot string) []string {
 	return paths
 }
 
-// buildPHPValueParam assembles a fastcgi_param PHP_VALUE directive from per-domain INI overrides.
-// Returns empty string if all overrides are empty/zero. Format: key1=val1\nkey2=val2\n
-func buildPHPValueParam(memLimit, uploadMax, postMax string, maxInputVars, maxExecTime, maxInputTime int) string {
+// phpTimezoneRE is a defense-in-depth guard on the per-domain date.timezone
+// value before it is rendered into the PHP_VALUE line (which joins directives
+// with "\n"). panel-api already validates against the tz database, but a value
+// that isn't a plain tz identifier is dropped here rather than risk injecting a
+// directive. Covers "Area/City", "UTC", "Etc/GMT+5", etc.
+var phpTimezoneRE = regexp.MustCompile(`^[A-Za-z0-9_+/-]{1,64}$`)
+
+// buildPHPValueParam assembles a fastcgi_param PHP_VALUE directive from per-domain
+// INI overrides. Returns empty string for a non-PHP domain (no PHP_VALUE line).
+// For a PHP domain it ALWAYS emits display_errors (GH #1332): a value set via
+// PHP_VALUE sticks on the reused FPM worker and would otherwise bleed into a
+// sibling domain on the same per-user pool that sets none — display_errors
+// leaking is information disclosure (box-drilled on .60). Default Off pins it
+// safely and neutralizes any error_reporting/date.timezone bleed too.
+// Format: key1=val1\nkey2=val2.
+func buildPHPValueParam(hasPHP bool, memLimit, uploadMax, postMax string, maxInputVars, maxExecTime, maxInputTime int, displayErrors bool, errorReporting *int, timezone string) string {
+	if !hasPHP {
+		return ""
+	}
 	var parts []string
+	// Always pinned — see the function comment (GH #1332). Default Off.
+	if displayErrors {
+		parts = append(parts, "display_errors=On")
+	} else {
+		parts = append(parts, "display_errors=Off")
+	}
 	if memLimit != "" {
 		parts = append(parts, "memory_limit="+memLimit)
 	}
@@ -824,8 +853,13 @@ func buildPHPValueParam(memLimit, uploadMax, postMax string, maxInputVars, maxEx
 	if maxInputTime > 0 {
 		parts = append(parts, "max_input_time="+strconv.Itoa(maxInputTime))
 	}
-	if len(parts) == 0 {
-		return ""
+	// error_reporting is an int bitmask; 0 (report nothing) is meaningful, so a
+	// non-nil pointer is the emit gate, not >0. strconv.Itoa keeps it injection-free.
+	if errorReporting != nil {
+		parts = append(parts, "error_reporting="+strconv.Itoa(*errorReporting))
+	}
+	if timezone != "" && phpTimezoneRE.MatchString(timezone) {
+		parts = append(parts, "date.timezone="+timezone)
 	}
 	return strings.Join(parts, "\n")
 }
@@ -985,7 +1019,7 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, phpDisplayErrors bool, phpErrorReporting *int, phpTimezone string, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool) (string, error) {
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
 	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
@@ -1102,7 +1136,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		PHPMaxInputVars:            phpMaxInputVars,
 		PHPMaxExecutionTime:        phpMaxExecTime,
 		PHPMaxInputTime:            phpMaxInputTime,
-		PHPValueParam:              buildPHPValueParam(phpMemLimit, phpUploadMax, phpPostMax, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime),
+		PHPValueParam:              buildPHPValueParam(hasPHP, phpMemLimit, phpUploadMax, phpPostMax, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime, phpDisplayErrors, phpErrorReporting, phpTimezone),
 		ListenIPv4:                 listenIPv4,
 		ListenIPv6:                 listenIPv6,
 		InterceptErrors:            interceptErrors,
@@ -1366,7 +1400,7 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// panel always sends the field; writeVhost still forces it false if the
 	// cert file turns out to be missing on disk (#213).
 	redirectHTTPS, serveHTTPS := resolveHTTPSFlags(&p)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.PHPDisplayErrors, p.PHPErrorReporting, p.PHPTimezone, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create_test.go
+++ b/panel-agent/internal/commands/domain_create_test.go
@@ -551,71 +551,95 @@ func TestDomainCreateHandler_RuleDirectivesIntegration(t *testing.T) {
 // TestBuildPHPValueParam verifies the buildPHPValueParam helper correctly formats
 // INI overrides into fastcgi_param PHP_VALUE format.
 func TestBuildPHPValueParam(t *testing.T) {
+	er := func(n int) *int { return &n }
 	tests := []struct {
 		name           string
+		hasPHP         bool
 		memLimit       string
 		uploadMax      string
 		postMax        string
 		maxInputVars   int
 		maxExecTime    int
 		maxInputTime   int
+		displayErrors  bool
+		errorReporting *int
+		timezone       string
 		expectedOutput string
 	}{
 		{
-			name:           "no overrides",
-			memLimit:       "",
-			uploadMax:      "",
-			postMax:        "",
-			maxInputVars:   0,
-			maxExecTime:    0,
-			maxInputTime:   0,
+			// GH #1332: a PHP domain ALWAYS pins display_errors=Off (info-disclosure
+			// guard against PHP_VALUE bleeding between a user's domains on a reused
+			// FPM worker), even with no other overrides.
+			name:           "no overrides pins display_errors off",
+			hasPHP:         true,
+			expectedOutput: "display_errors=Off",
+		},
+		{
+			name:           "non-PHP domain emits nothing",
+			hasPHP:         false,
+			memLimit:       "256M",
+			displayErrors:  true,
 			expectedOutput: "",
 		},
 		{
 			name:           "single string override",
+			hasPHP:         true,
 			memLimit:       "256M",
-			uploadMax:      "",
-			postMax:        "",
-			maxInputVars:   0,
-			maxExecTime:    0,
-			maxInputTime:   0,
-			expectedOutput: "memory_limit=256M",
+			expectedOutput: "display_errors=Off\nmemory_limit=256M",
 		},
 		{
 			name:           "single int override",
-			memLimit:       "",
-			uploadMax:      "",
-			postMax:        "",
+			hasPHP:         true,
 			maxInputVars:   1000,
-			maxExecTime:    0,
-			maxInputTime:   0,
-			expectedOutput: "max_input_vars=1000",
+			expectedOutput: "display_errors=Off\nmax_input_vars=1000",
 		},
 		{
 			name:           "multiple overrides",
+			hasPHP:         true,
 			memLimit:       "512M",
 			uploadMax:      "100M",
 			postMax:        "100M",
 			maxInputVars:   5000,
 			maxExecTime:    300,
 			maxInputTime:   60,
-			expectedOutput: "memory_limit=512M\nupload_max_filesize=100M\npost_max_size=100M\nmax_input_vars=5000\nmax_execution_time=300\nmax_input_time=60",
+			expectedOutput: "display_errors=Off\nmemory_limit=512M\nupload_max_filesize=100M\npost_max_size=100M\nmax_input_vars=5000\nmax_execution_time=300\nmax_input_time=60",
 		},
 		{
 			name:           "zero int values are skipped",
+			hasPHP:         true,
 			memLimit:       "256M",
 			uploadMax:      "50M",
-			postMax:        "",
-			maxInputVars:   0,
-			maxExecTime:    0,
 			maxInputTime:   30,
-			expectedOutput: "memory_limit=256M\nupload_max_filesize=50M\nmax_input_time=30",
+			expectedOutput: "display_errors=Off\nmemory_limit=256M\nupload_max_filesize=50M\nmax_input_time=30",
+		},
+		{
+			name:           "display_errors on plus runtime directives",
+			hasPHP:         true,
+			displayErrors:  true,
+			errorReporting: er(22527),
+			timezone:       "Europe/Berlin",
+			expectedOutput: "display_errors=On\nerror_reporting=22527\ndate.timezone=Europe/Berlin",
+		},
+		{
+			// error_reporting=0 (report nothing) is meaningful; a non-nil pointer
+			// must emit even though the value is zero.
+			name:           "error_reporting zero still emits",
+			hasPHP:         true,
+			errorReporting: er(0),
+			expectedOutput: "display_errors=Off\nerror_reporting=0",
+		},
+		{
+			// A timezone that isn't a plain tz identifier is dropped agent-side.
+			name:           "malformed timezone dropped",
+			hasPHP:         true,
+			timezone:       "Europe/Berlin\ninjected=1",
+			expectedOutput: "display_errors=Off",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildPHPValueParam(tt.memLimit, tt.uploadMax, tt.postMax, tt.maxInputVars, tt.maxExecTime, tt.maxInputTime)
+			result := buildPHPValueParam(tt.hasPHP, tt.memLimit, tt.uploadMax, tt.postMax, tt.maxInputVars, tt.maxExecTime, tt.maxInputTime, tt.displayErrors, tt.errorReporting, tt.timezone)
 			assert.Equal(t, tt.expectedOutput, result)
 		})
 	}
@@ -718,7 +742,7 @@ func TestBuildPHPValueParam_InjectionAttempts(t *testing.T) {
 			// will emit it inside nginx double-quotes, which is safe.
 			// The API layer (panel-api) validates the input, so the agent
 			// can assume it's already safe.
-			result := buildPHPValueParam(tt.memLimit, "", "", 0, 0, 0)
+			result := buildPHPValueParam(true, tt.memLimit, "", "", 0, 0, 0, false, nil, "")
 			assert.NotEmpty(t, result)
 			// The agent doesn't sanitize; the API does.
 			// This test just verifies buildPHPValueParam passes through

--- a/panel-api/internal/api/domain_php_settings.go
+++ b/panel-api/internal/api/domain_php_settings.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -42,11 +43,16 @@ type getDomainPHPSettingsResponse struct {
 	PHPMaxInputVars      *int    `json:"php_max_input_vars,omitempty"`
 	PHPMaxExecutionTime  *int    `json:"php_max_execution_time,omitempty"`
 	PHPMaxInputTime      *int    `json:"php_max_input_time,omitempty"`
+	// GH #1332 per-domain runtime directives.
+	PHPDisplayErrors  *bool   `json:"php_display_errors,omitempty"`
+	PHPErrorReporting *int    `json:"php_error_reporting,omitempty"`
+	PHPTimezone       *string `json:"php_timezone,omitempty"`
 }
 
-// updateDomainPHPSettingsRequest mirrors the six overridable fields
-// plus an optional PHPVersion change. NULL values clear the override.
-// PHPVersion, if set, updates the DOMAIN OWNER's pool (one pool per
+// updateDomainPHPSettingsRequest mirrors the overridable fields plus an optional
+// PHPVersion change. NULL values clear the override. The client is expected to
+// send the full set on each PATCH (the UI does) — an omitted field is nil, which
+// clears it. PHPVersion, if set, updates the DOMAIN OWNER's pool (one pool per
 // user, per ADR-0023) — it applies to every domain that user owns.
 type updateDomainPHPSettingsRequest struct {
 	PHPVersion           *string `json:"php_version"`
@@ -56,12 +62,46 @@ type updateDomainPHPSettingsRequest struct {
 	PHPMaxInputVars      *int    `json:"php_max_input_vars"`
 	PHPMaxExecutionTime  *int    `json:"php_max_execution_time"`
 	PHPMaxInputTime      *int    `json:"php_max_input_time"`
+	// GH #1332 per-domain runtime directives.
+	PHPDisplayErrors  *bool   `json:"php_display_errors"`
+	PHPErrorReporting *int    `json:"php_error_reporting"`
+	PHPTimezone       *string `json:"php_timezone"`
 }
 
 // regexes for input validation
 var (
 	regexSizeParam = regexp.MustCompile(`^(\d{1,8})([KMG]?)$`)
+	// regexTimezone bounds a date.timezone identifier to plain tz-database
+	// characters before it is handed to time.LoadLocation — keeps anything
+	// with a newline/quote out of the fastcgi_param PHP_VALUE line the agent
+	// renders (GH #1332). Must stay in step with phpTimezoneRE in the agent.
+	regexTimezone = regexp.MustCompile(`^[A-Za-z0-9_+/-]{1,64}$`)
 )
+
+// phpErrorReportingMax is E_ALL in PHP 8. error_reporting is a bitmask, so any
+// value in [0, 32767] is a legal combination (0 = report nothing).
+const phpErrorReportingMax = 32767
+
+// validateErrorReporting bounds the error_reporting bitmask to [0, E_ALL].
+func validateErrorReporting(v int) error {
+	if v < 0 || v > phpErrorReportingMax {
+		return errInvalidPHPSetting("error_reporting out of range (0..32767)")
+	}
+	return nil
+}
+
+// validateTimezone accepts only a real tz-database identifier. Character-class
+// first (cheap + injection guard), then time.LoadLocation confirms PHP will
+// accept it (both read the same IANA tz data).
+func validateTimezone(s string) error {
+	if !regexTimezone.MatchString(s) {
+		return errInvalidPHPSetting("invalid timezone format")
+	}
+	if _, err := time.LoadLocation(s); err != nil {
+		return errInvalidPHPSetting("unknown timezone")
+	}
+	return nil
+}
 
 // validateSizeParam validates memory_limit, upload_max_filesize, post_max_size.
 // Regex: ^\d+[KMG]?$ (case-insensitive), max 8 chars total, no special characters.
@@ -125,6 +165,9 @@ func (h *domainPHPSettingsHandler) get(c *gin.Context) {
 		PHPMaxInputVars:      dom.PHPMaxInputVars,
 		PHPMaxExecutionTime:  dom.PHPMaxExecutionTime,
 		PHPMaxInputTime:      dom.PHPMaxInputTime,
+		PHPDisplayErrors:     dom.PHPDisplayErrors,
+		PHPErrorReporting:    dom.PHPErrorReporting,
+		PHPTimezone:          dom.PHPTimezone,
 	}
 
 	// Resolve the effective PHP version. If the domain is bound to a
@@ -194,6 +237,18 @@ func (h *domainPHPSettingsHandler) patch(c *gin.Context) {
 			return
 		}
 	}
+	if req.PHPErrorReporting != nil {
+		if err := validateErrorReporting(*req.PHPErrorReporting); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if req.PHPTimezone != nil {
+		if err := validateTimezone(*req.PHPTimezone); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
 	if req.PHPVersion != nil {
 		if !isVersionSupported(*req.PHPVersion) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported_php_version"})
@@ -229,6 +284,9 @@ func (h *domainPHPSettingsHandler) patch(c *gin.Context) {
 		MaxInputVars:      req.PHPMaxInputVars,
 		MaxExecutionTime:  req.PHPMaxExecutionTime,
 		MaxInputTime:      req.PHPMaxInputTime,
+		DisplayErrors:     req.PHPDisplayErrors,
+		ErrorReporting:    req.PHPErrorReporting,
+		Timezone:          req.PHPTimezone,
 	}
 
 	if err := h.cfg.Domains.UpdatePHPSettings(ctx, domainID, settings); err != nil {

--- a/panel-api/internal/api/domain_php_settings_test.go
+++ b/panel-api/internal/api/domain_php_settings_test.go
@@ -1,0 +1,60 @@
+package api
+
+import "testing"
+
+// GH #1332: the per-domain error_reporting bitmask and date.timezone are the two
+// new free-ish inputs; both feed a fastcgi_param PHP_VALUE line, so their
+// validators are the injection/typo boundary.
+
+func TestValidateErrorReporting(t *testing.T) {
+	cases := []struct {
+		name string
+		v    int
+		ok   bool
+	}{
+		{"zero reports nothing", 0, true},
+		{"production bitmask", 22527, true},
+		{"E_ALL", 32767, true},
+		{"above E_ALL", 32768, false},
+		{"negative", -1, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateErrorReporting(tc.v)
+			if tc.ok && err != nil {
+				t.Errorf("validateErrorReporting(%d) = %v, want nil", tc.v, err)
+			}
+			if !tc.ok && err == nil {
+				t.Errorf("validateErrorReporting(%d) = nil, want error", tc.v)
+			}
+		})
+	}
+}
+
+func TestValidateTimezone(t *testing.T) {
+	cases := []struct {
+		name string
+		v    string
+		ok   bool
+	}{
+		{"utc", "UTC", true},
+		{"area/city", "Europe/Berlin", true},
+		{"etc offset", "Etc/GMT+5", true},
+		{"empty", "", false},
+		{"unknown zone", "Mars/Olympus", false},
+		{"newline injection", "UTC\ndisplay_errors=On", false},
+		{"quote injection", "UTC\"", false},
+		{"too long", "A/" + string(make([]byte, 64)), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTimezone(tc.v)
+			if tc.ok && err != nil {
+				t.Errorf("validateTimezone(%q) = %v, want nil", tc.v, err)
+			}
+			if !tc.ok && err == nil {
+				t.Errorf("validateTimezone(%q) = nil, want error", tc.v)
+			}
+		})
+	}
+}

--- a/panel-api/internal/db/migrations/000278_domain_php_runtime_directives.down.sql
+++ b/panel-api/internal/db/migrations/000278_domain_php_runtime_directives.down.sql
@@ -1,0 +1,5 @@
+-- Reverse GH #1332 per-domain PHP runtime directives.
+ALTER TABLE domains
+  DROP COLUMN php_display_errors,
+  DROP COLUMN php_error_reporting,
+  DROP COLUMN php_timezone;

--- a/panel-api/internal/db/migrations/000278_domain_php_runtime_directives.up.sql
+++ b/panel-api/internal/db/migrations/000278_domain_php_runtime_directives.up.sql
@@ -1,0 +1,10 @@
+-- GH #1332 (items 8/11): per-domain PHP runtime directives, rendered as
+-- fastcgi_param PHP_VALUE alongside the existing resource-limit overrides.
+--   php_display_errors  — pinned on every PHP vhost by the agent (default Off).
+--   php_error_reporting — int bitmask (0 = report nothing; E_ALL = 32767).
+--   php_timezone        — date.timezone tz-database identifier.
+-- All NULL = use the pool default. The `domains` table is not a reserved word.
+ALTER TABLE domains
+  ADD COLUMN php_display_errors TINYINT(1) NULL DEFAULT NULL,
+  ADD COLUMN php_error_reporting INT NULL DEFAULT NULL,
+  ADD COLUMN php_timezone VARCHAR(64) NULL DEFAULT NULL;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -263,6 +263,15 @@ type Domain struct {
 	PHPMaxExecutionTime  *int    `gorm:"type:int unsigned" json:"php_max_execution_time,omitempty"`
 	PHPMaxInputTime      *int    `gorm:"type:int unsigned" json:"php_max_input_time,omitempty"`
 
+	// GH #1332: per-domain runtime directives, same PHP_VALUE mechanism, all
+	// NULL = use pool default. PHPDisplayErrors is pinned on every PHP vhost
+	// by the agent (default Off) so an "On" override on one domain can't bleed
+	// onto a sibling on the same per-user pool. PHPErrorReporting is an int
+	// bitmask (0 = report nothing). PHPTimezone is a tz-database identifier.
+	PHPDisplayErrors  *bool   `gorm:"type:tinyint(1)" json:"php_display_errors,omitempty"`
+	PHPErrorReporting *int    `gorm:"type:int" json:"php_error_reporting,omitempty"`
+	PHPTimezone       *string `gorm:"type:varchar(64)" json:"php_timezone,omitempty"`
+
 	// M18: per-domain HTTP rate/conn limits. Zero = unlimited (no
 	// nginx directive emitted). RateLimitRPS is requests-per-SECOND
 	// as seen by the reconciler; the vhost renderer converts to

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1918,6 +1918,18 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 	if domain.PHPMaxInputTime != nil {
 		params["php_max_input_time"] = *domain.PHPMaxInputTime
 	}
+	// GH #1332 per-domain runtime directives. display_errors is only sent when
+	// the owner opted in (true); the agent otherwise pins it Off on every PHP
+	// vhost, so a nil/false override needs no param.
+	if domain.PHPDisplayErrors != nil && *domain.PHPDisplayErrors {
+		params["php_display_errors"] = true
+	}
+	if domain.PHPErrorReporting != nil {
+		params["php_error_reporting"] = *domain.PHPErrorReporting
+	}
+	if domain.PHPTimezone != nil {
+		params["php_timezone"] = *domain.PHPTimezone
+	}
 
 	cust := ""
 	if domain.NginxCustomDirectives != nil {

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -57,9 +57,11 @@ type DomainRepository interface {
 	// mutations must only come from the dedicated bind/unbind handlers,
 	// not from generic domain PATCH.
 	SetPHPPoolID(ctx context.Context, id string, poolID *string) error
-	// UpdatePHPSettings atomically updates the six per-domain PHP INI override
-	// columns. NULL values explicitly clear the override. This is a dedicated
-	// method because the columns are not in Update()'s allowlist.
+	// UpdatePHPSettings atomically updates the per-domain PHP INI override
+	// columns (the six resource/execution limits plus the GH #1332 runtime
+	// directives display_errors/error_reporting/timezone). NULL values
+	// explicitly clear the override. This is a dedicated method because the
+	// columns are not in Update()'s allowlist.
 	UpdatePHPSettings(ctx context.Context, id string, settings DomainPHPSettings) error
 	// UpdateEmailState writes the four M6 email columns (email_enabled,
 	// dkim_selector, dkim_public_key, email_enabled_at) in one go. Dedicated
@@ -194,6 +196,10 @@ type DomainPHPSettings struct {
 	MaxInputVars      *int    `json:"php_max_input_vars,omitempty"`
 	MaxExecutionTime  *int    `json:"php_max_execution_time,omitempty"`
 	MaxInputTime      *int    `json:"php_max_input_time,omitempty"`
+	// GH #1332 per-domain runtime directives (same NULL = pool-default rule).
+	DisplayErrors  *bool   `json:"php_display_errors,omitempty"`
+	ErrorReporting *int    `json:"php_error_reporting,omitempty"`
+	Timezone       *string `json:"php_timezone,omitempty"`
 }
 
 type domainRepo struct{ db *gorm.DB }
@@ -506,6 +512,10 @@ func (r *domainRepo) UpdatePHPSettings(ctx context.Context, id string, settings 
 			"php_max_input_vars":      settings.MaxInputVars,
 			"php_max_execution_time":  settings.MaxExecutionTime,
 			"php_max_input_time":      settings.MaxInputTime,
+			// GH #1332 — a nil pointer writes NULL (clears the override).
+			"php_display_errors":  settings.DisplayErrors,
+			"php_error_reporting": settings.ErrorReporting,
+			"php_timezone":        settings.Timezone,
 		})
 	if res.Error != nil {
 		return translate(res.Error)

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Tabs, Alert, Button, Card, Form, Row, Col, Select, Space, Spin, Typography } from "antd";
+import { Tabs, Alert, Button, Card, Form, Row, Col, Select, Space, Spin, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -24,6 +24,10 @@ type DomainPHPSettings = {
   php_max_input_vars?: number | null;
   php_max_execution_time?: number | null;
   php_max_input_time?: number | null;
+  // GH #1332 per-domain runtime directives.
+  php_display_errors?: boolean | null;
+  php_error_reporting?: number | null;
+  php_timezone?: string | null;
 };
 
 type PHPSettingsFormData = {
@@ -34,6 +38,9 @@ type PHPSettingsFormData = {
   php_max_input_vars?: number | null;
   php_max_execution_time?: number | null;
   php_max_input_time?: number | null;
+  php_display_errors?: boolean | null;
+  php_error_reporting?: number | null;
+  php_timezone?: string | null;
 };
 
 const MEMORY_LIMIT_OPTIONS = [
@@ -93,6 +100,53 @@ const MAX_INPUT_TIME_OPTIONS = [
   { label: "60s", value: 60 },
   { label: "120s", value: 120 },
   { label: "300s", value: 300 },
+];
+
+// GH #1332 per-domain runtime directives. display_errors is pinned Off on every
+// PHP vhost by the agent, so "Use pool default" and "Off" are the same effect —
+// both keep errors hidden; "On" surfaces them for this domain only.
+const DISPLAY_ERRORS_OPTIONS = [
+  { label: "On (show errors)", value: true },
+  { label: "Off", value: false },
+];
+
+// error_reporting bitmask presets. Production (22527) = E_ALL minus notices,
+// deprecations and strict; matches the php.ini-production default. All (32767)
+// = E_ALL (php.ini-development).
+const ERROR_REPORTING_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "None (report nothing)", value: 0 },
+  { label: "Production (errors + warnings)", value: 22527 },
+  { label: "All (development)", value: 32767 },
+];
+
+// A curated set of common IANA zones. The server validates any value against
+// the tz database, so this is a convenience list, not the limit.
+const COMMON_TIMEZONES = [
+  "UTC",
+  "Africa/Johannesburg",
+  "America/Chicago",
+  "America/Los_Angeles",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Asia/Dubai",
+  "Asia/Jerusalem",
+  "Asia/Kolkata",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Europe/Berlin",
+  "Europe/Istanbul",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Moscow",
+  "Europe/Paris",
+  "Pacific/Auckland",
+];
+const TIMEZONE_OPTIONS = [
+  { label: "Use pool default", value: null as string | null },
+  ...COMMON_TIMEZONES.map((z) => ({ label: z, value: z as string | null })),
 ];
 
 export function UserPHPSettingsPage() {
@@ -225,6 +279,9 @@ export function UserPHPSettingsPage() {
           php_max_input_vars: resp.data.php_max_input_vars,
           php_max_execution_time: resp.data.php_max_execution_time,
           php_max_input_time: resp.data.php_max_input_time,
+          php_display_errors: resp.data.php_display_errors,
+          php_error_reporting: resp.data.php_error_reporting,
+          php_timezone: resp.data.php_timezone,
         });
       } catch (err) {
         feedback.message.error("Failed to load PHP settings");
@@ -246,6 +303,10 @@ export function UserPHPSettingsPage() {
         php_max_input_vars: values.php_max_input_vars,
         php_max_execution_time: values.php_max_execution_time,
         php_max_input_time: values.php_max_input_time,
+        // undefined (never set / cleared) -> null so the API clears the override.
+        php_display_errors: values.php_display_errors ?? null,
+        php_error_reporting: values.php_error_reporting ?? null,
+        php_timezone: values.php_timezone ?? null,
       });
       feedback.message.success("PHP settings updated successfully");
       // Reload settings to confirm
@@ -274,7 +335,27 @@ export function UserPHPSettingsPage() {
     "php_max_input_vars",
     "php_max_execution_time",
     "php_max_input_time",
+    "php_display_errors",
+    "php_error_reporting",
+    "php_timezone",
   ];
+
+  // GH #1332 item 6: a small tag on each field showing whether it is a custom
+  // override or falls back to the pool default. Reflects the last-saved state
+  // (phpSettings), refreshed after every save.
+  const fieldSet = (v: unknown) => v !== null && v !== undefined;
+  const overrideLabel = (text: string, overridden: boolean) => (
+    <Space size={6}>
+      {text}
+      {overridden ? (
+        <Tag color="blue" style={{ marginInlineEnd: 0 }}>
+          Custom
+        </Tag>
+      ) : (
+        <Tag style={{ marginInlineEnd: 0 }}>Pool default</Tag>
+      )}
+    </Space>
+  );
 
   return (
     // GH #1332 item 1: the page was clamped to 800px and centred, unlike every
@@ -385,7 +466,10 @@ export function UserPHPSettingsPage() {
                   <Row gutter={[16, 16]}>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label={t("userphpsettingspage.memory_limit")}
+                        label={overrideLabel(
+                          t("userphpsettingspage.memory_limit"),
+                          fieldSet(phpSettings?.php_memory_limit),
+                        )}
                         name="php_memory_limit"
                       >
                         <Select
@@ -397,7 +481,10 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label={t("userphpsettingspage.upload_max_file_size")}
+                        label={overrideLabel(
+                          t("userphpsettingspage.upload_max_file_size"),
+                          fieldSet(phpSettings?.php_upload_max_filesize),
+                        )}
                         name="php_upload_max_filesize"
                       >
                         <Select
@@ -409,7 +496,10 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label={t("userphpsettingspage.post_max_size")}
+                        label={overrideLabel(
+                          t("userphpsettingspage.post_max_size"),
+                          fieldSet(phpSettings?.php_post_max_size),
+                        )}
                         name="php_post_max_size"
                       >
                         <Select
@@ -421,7 +511,10 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label={t("userphpsettingspage.max_input_variables")}
+                        label={overrideLabel(
+                          t("userphpsettingspage.max_input_variables"),
+                          fieldSet(phpSettings?.php_max_input_vars),
+                        )}
                         name="php_max_input_vars"
                       >
                         <Select
@@ -437,7 +530,10 @@ export function UserPHPSettingsPage() {
                   <Row gutter={[16, 16]}>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label={t("userphpsettingspage.max_execution_time")}
+                        label={overrideLabel(
+                          t("userphpsettingspage.max_execution_time"),
+                          fieldSet(phpSettings?.php_max_execution_time),
+                        )}
                         name="php_max_execution_time"
                       >
                         <Select
@@ -449,13 +545,79 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label={t("userphpsettingspage.max_input_time")}
+                        label={overrideLabel(
+                          t("userphpsettingspage.max_input_time"),
+                          fieldSet(phpSettings?.php_max_input_time),
+                        )}
                         name="php_max_input_time"
                       >
                         <Select
                           placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={MAX_INPUT_TIME_OPTIONS}
+                        />
+                      </Form.Item>
+                    </Col>
+                  </Row>
+
+                  <Typography.Title level={5}>
+                    Error Handling &amp; Runtime
+                  </Typography.Title>
+                  <Typography.Paragraph
+                    type="secondary"
+                    style={{ marginTop: -4 }}
+                  >
+                    These apply to this domain across all its PHP versions.
+                    Turn <strong>Display errors</strong> on only for
+                    development — it prints PHP errors to visitors.
+                  </Typography.Paragraph>
+                  <Row gutter={[16, 16]}>
+                    <Col xs={24} sm={12}>
+                      <Form.Item
+                        label={overrideLabel(
+                          "Display errors",
+                          fieldSet(phpSettings?.php_display_errors),
+                        )}
+                        name="php_display_errors"
+                        extra="Shows PHP errors in the page output. Keep off on public/production sites."
+                      >
+                        <Select
+                          placeholder="Use pool default (off)"
+                          allowClear
+                          options={DISPLAY_ERRORS_OPTIONS}
+                        />
+                      </Form.Item>
+                    </Col>
+                    <Col xs={24} sm={12}>
+                      <Form.Item
+                        label={overrideLabel(
+                          "Error reporting",
+                          fieldSet(phpSettings?.php_error_reporting),
+                        )}
+                        name="php_error_reporting"
+                      >
+                        <Select
+                          placeholder={t("userphpsettingspage.use_pool_default")}
+                          allowClear
+                          options={ERROR_REPORTING_OPTIONS}
+                        />
+                      </Form.Item>
+                    </Col>
+                    <Col xs={24} sm={12}>
+                      <Form.Item
+                        label={overrideLabel(
+                          "Timezone",
+                          fieldSet(phpSettings?.php_timezone),
+                        )}
+                        name="php_timezone"
+                        extra="date.timezone for this domain's PHP."
+                      >
+                        <Select
+                          showSearch
+                          placeholder={t("userphpsettingspage.use_pool_default")}
+                          allowClear
+                          optionFilterProp="label"
+                          options={TIMEZONE_OPTIONS}
                         />
                       </Form.Item>
                     </Col>


### PR DESCRIPTION
## Summary

Wishlist items **6, 8, 11** from GH #1332 (per-domain PHP Settings). First of three PRs for the "bigger batch" agreed on the issue.

- **#8** — per-domain `display_errors` + `error_reporting`
- **#11** — per-domain `date.timezone`
- **#6** — a **Custom / Pool default** tag on each overridable field

All three new directives ride the same nginx `fastcgi_param PHP_VALUE` mechanism the existing six resource-limit overrides use; `NULL` = inherit the pool default.

## Security — why `display_errors` is *pinned*, not opt-in-emit

A value set via `PHP_VALUE` **sticks on the reused FPM worker** and bleeds into the next request that sets none. One pool serves all of a user's domains, so an `On` set on one domain would leak PHP error output onto a sibling domain — information disclosure.

Box-drilled on a test host (`pm=static`, `pm.max_children=1`, `cgi-fcgi`):

```
req1 (display_errors=On via PHP_VALUE): display_errors=1
req2 (NO PHP_VALUE)                   : display_errors=1   <-- leaked
req2 (explicit display_errors=Off)    : display_errors=    <-- mitigation works
```

So the agent now **always emits `display_errors` on every PHP vhost** — the domain's value if it opted in, else `Off`. Drilled: an explicit `Off` correctly overrides the sticky `On`. Pinning `display_errors=Off` everywhere also neutralizes any `error_reporting`/`date.timezone` bleed (nothing displays with errors off), so those stay opt-in-emit like the existing six.

## Changes

**agent (`domain.create`)** — `buildPHPValueParam` gains `hasPHP` + `displayErrors` + `errorReporting *int` (0 is a meaningful "report nothing") + `timezone`; non-PHP domains emit no `PHP_VALUE`. A defensive tz regex drops anything that isn't a plain tz identifier before it reaches the rendered line.

**panel-api** — three nullable `domains` columns (migration `000278`); GET/PATCH expose them; `error_reporting` validated to `[0, 32767]`, `timezone` validated against a char-class **and** `time.LoadLocation`; the reconciler forwards them (`display_errors` only when the owner opted in — the agent defaults `Off`).

**panel-ui** — an **Error Handling & Runtime** section (Display errors / Error-reporting presets / searchable timezone) plus the per-field override tags on all overridable fields.

## Verification

- ✅ Box-drilled the FPM `PHP_VALUE` sticky-bleed + explicit-`Off`-override on the test host (the novel, security-critical behavior).
- ✅ Unit: `buildPHPValueParam` table (always-pin, non-PHP, `error_reporting=0`, malformed-tz-drop cases), `validateErrorReporting`, `validateTimezone`.
- ✅ agent + panel-api + reconciler + repository suites; UI `tsc` + existing performance-card test.
- ✅ Wire contract checked end-to-end: reconciler keys ↔ agent JSON tags ↔ DB columns ↔ API/UI fields all match.
- The rendered `PHP_VALUE` line is the same multi-directive format the existing six overrides already ship in production.

## Release / deploy note

Touches the **`domain.create` agent verb** (new `PHP_VALUE` directives) — **fleet agents must be redeployed** for the new options to render. On the first reconcile after redeploy, every existing PHP vhost gains an explicit `display_errors=Off` line (idempotent, behavior-neutral, one-time nginx reload). Migration `000278`.

## Test plan

- [ ] Deploy panel-api + agent to a box; set **Display errors = On** on one of a user's domains, leave a sibling unset.
- [ ] Verify the target vhost renders `display_errors=On` and the sibling renders `display_errors=Off`.
- [ ] Set a timezone + error-reporting preset; confirm `date.timezone` / `error_reporting` appear in the target vhost only.
