### PR TITLE
feat(php): per-pool FPM slow log (GH #1332 item 12)

### DIFF
--- a/install/php/jabali-php-pool.conf.tmpl
+++ b/install/php/jabali-php-pool.conf.tmpl
@@ -27,6 +27,13 @@ pm.max_requests = {{.PmMaxRequests}}
 ; Kill a request stuck longer than this (0 = no limit).
 request_terminate_timeout = {{.RequestTerminateTimeoutSeconds}}s
 {{- end }}
+{{- if gt .SlowlogTimeoutSeconds 0 }}
+; Slow log (GH #1332). Dump a PHP backtrace of any request slower than this to
+; the tenant-owned slow log. Path is agent-derived from the slug; the master
+; runs as the tenant so it can write under /home/<user>/logs.
+request_slowlog_timeout = {{.SlowlogTimeoutSeconds}}s
+slowlog = {{.SlowlogPath}}
+{{- end }}
 chdir = /home/{{.User}}
 security.limit_extensions = .php
 ; Jailbreak defense (ADR-0023 decision 12). open_basedir is hard-coded

--- a/panel-agent/internal/commands/php_pool_apply.go
+++ b/panel-agent/internal/commands/php_pool_apply.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -37,8 +39,13 @@ type phpPoolApplyParams struct {
 	PmMaxSpareServers              uint32 `json:"pm_max_spare_servers"`
 	PmMaxRequests                  uint32 `json:"pm_max_requests"`
 	RequestTerminateTimeoutSeconds uint32 `json:"request_terminate_timeout_seconds"`
-	AdminValues                    []KV   `json:"admin_values"`
-	AdminFlags                     []KV   `json:"admin_flags"`
+	// SlowlogTimeoutSeconds (GH #1332 item 12): >0 enables the pool slow log with
+	// this request threshold. The slowlog PATH is derived here from the slug —
+	// never accepted over the wire — and lands under the tenant-owned
+	// /home/<user>/logs so the tenant-run FPM master can write it.
+	SlowlogTimeoutSeconds uint32 `json:"slowlog_timeout_seconds,omitempty"`
+	AdminValues           []KV   `json:"admin_values"`
+	AdminFlags            []KV   `json:"admin_flags"`
 	// DisableFunctions (GH #402) overrides the php_admin_value[disable_functions]
 	// line. nil = caller did not specify -> the safe default (#401) is used;
 	// "" = explicit admin opt-out (emit no line); any other value is rendered
@@ -74,6 +81,8 @@ type phpPoolSpecTemplate struct {
 	PmMaxSpareServers              uint32
 	PmMaxRequests                  uint32
 	RequestTerminateTimeoutSeconds uint32
+	SlowlogTimeoutSeconds          uint32
+	SlowlogPath                    string
 	AdminValues                    []KV
 	AdminFlags                     []KV
 	DisableFunctions               string
@@ -314,6 +323,24 @@ func ensureVersionedFPMDropin(ctx context.Context, slug, username string) error 
 		_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 	}
 	return nil
+}
+
+// ensureUserLogsDir makes /home/<user>/logs (0750, tenant-owned) if missing and
+// returns it (GH #1332 item 12). The per-user FPM master runs AS the tenant, so
+// its slow log must live somewhere the tenant can write; this also sets up the
+// per-domain log shortcut. Chown is best-effort — the dir already being
+// tenant-owned (the common case) is fine.
+func ensureUserLogsDir(username string) (string, error) {
+	dir := filepath.Join("/home", username, "logs")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return "", err
+	}
+	if u, err := user.Lookup(username); err == nil {
+		uid, _ := strconv.Atoi(u.Uid)
+		gid, _ := strconv.Atoi(u.Gid)
+		_ = os.Chown(dir, uid, gid)
+	}
+	return dir, nil
 }
 
 // acquireLock acquires an exclusive flock on a per-user lock file with a 30-second timeout.
@@ -588,6 +615,29 @@ func phpPoolApplyHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
+	// GH #1332 item 12: derive the slow-log path from the slug (never over the
+	// wire) and ensure the tenant-owned logs dir exists so the tenant-run FPM
+	// master can write it. Clamp defensively — the panel validates 0..600.
+	var slowlogPath string
+	slowlogTimeout := p.SlowlogTimeoutSeconds
+	if slowlogTimeout > 600 {
+		slowlogTimeout = 600
+	}
+	if slowlogTimeout > 0 {
+		name := "php-slow.log"
+		if isVersioned {
+			name = "php-slow-" + slug + ".log"
+		}
+		logsDir, lerr := ensureUserLogsDir(p.Username)
+		if lerr != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("ensure logs dir: %v", lerr),
+			}
+		}
+		slowlogPath = filepath.Join(logsDir, name)
+	}
+
 	spec := phpPoolSpecTemplate{
 		PoolName:                       poolName,
 		User:                           p.Username,
@@ -601,6 +651,8 @@ func phpPoolApplyHandler(ctx context.Context, params json.RawMessage) (any, erro
 		PmMaxSpareServers:              p.PmMaxSpareServers,
 		PmMaxRequests:                  p.PmMaxRequests,
 		RequestTerminateTimeoutSeconds: p.RequestTerminateTimeoutSeconds,
+		SlowlogTimeoutSeconds:          slowlogTimeout,
+		SlowlogPath:                    slowlogPath,
 		AdminValues:                    p.AdminValues,
 		AdminFlags:                     p.AdminFlags,
 		DisableFunctions:               disableFunctions,

--- a/panel-agent/internal/commands/php_pool_template_repo_test.go
+++ b/panel-agent/internal/commands/php_pool_template_repo_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"text/template"
 )
 
 // Pins the load-bearing lines of the REPO pool template (the box copy at
@@ -55,5 +56,50 @@ func TestRepoPoolTemplatePinsJailAndOpcache(t *testing.T) {
 	// cannot repoint the exec path.
 	if !strings.Contains(s, "php_admin_value[sendmail_path] = /usr/local/libexec/jabali/jabali-sendmail -t -i") {
 		t.Error("sendmail_path must point at the jabali-sendmail shim (JAB-230)")
+	}
+}
+
+// TestPoolTemplateSlowlog renders the repo template and pins the GH #1332 item 12
+// slow-log block: emitted (with the agent-derived path) only when the threshold
+// is > 0, absent when disabled.
+func TestPoolTemplateSlowlog(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "install", "php", "jabali-php-pool.conf.tmpl")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read repo pool template: %v", err)
+	}
+	tmpl, err := template.New("pool").Parse(string(b))
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+	render := func(spec phpPoolSpecTemplate) string {
+		var sb strings.Builder
+		if err := tmpl.Execute(&sb, spec); err != nil {
+			t.Fatalf("execute template: %v", err)
+		}
+		return sb.String()
+	}
+
+	base := phpPoolSpecTemplate{
+		PoolName: "jabali-alice", User: "alice", Group: "alice",
+		SocketPath: "/run/php/jabali-alice/fpm.sock", PmMode: "static",
+		PmMaxChildren: 5, ProcessIdleTimeoutSeconds: 60,
+		DisableFunctions: "exec",
+	}
+
+	on := base
+	on.SlowlogTimeoutSeconds = 5
+	on.SlowlogPath = "/home/alice/logs/php-slow.log"
+	got := render(on)
+	if !strings.Contains(got, "request_slowlog_timeout = 5s") {
+		t.Errorf("enabled: missing request_slowlog_timeout:\n%s", got)
+	}
+	if !strings.Contains(got, "slowlog = /home/alice/logs/php-slow.log") {
+		t.Errorf("enabled: missing slowlog path:\n%s", got)
+	}
+
+	off := render(base) // SlowlogTimeoutSeconds == 0
+	if strings.Contains(off, "slowlog") || strings.Contains(off, "request_slowlog_timeout") {
+		t.Errorf("disabled: slow-log lines must be absent:\n%s", off)
 	}
 }

--- a/panel-api/internal/api/php_pool_reconcile.go
+++ b/panel-api/internal/api/php_pool_reconcile.go
@@ -81,6 +81,7 @@ func reconcilePHPPoolViaAgent(
 		"pm_max_spare_servers":              pool.PmMaxSpareServers,
 		"pm_max_requests":                   pool.PmMaxRequests,
 		"request_terminate_timeout_seconds": pool.RequestTerminateTimeoutSeconds,
+		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
 		"admin_values":                      adminValues,
 		"admin_flags":                       adminFlags,
 	})

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -50,6 +50,7 @@ type poolTuningRow struct {
 	PmMaxRequests                  uint32 `json:"pm_max_requests"`
 	RequestTerminateTimeoutSeconds uint32 `json:"request_terminate_timeout_seconds"`
 	ProcessIdleTimeoutSeconds      uint32 `json:"process_idle_timeout_seconds"`
+	SlowlogTimeoutSeconds          uint32 `json:"slowlog_timeout_seconds"`
 	PerformanceMode                string `json:"performance_mode"`
 	IsDefault                      bool   `json:"is_default"`
 }
@@ -83,6 +84,7 @@ func (h *phpUserTuningHandler) tuning(c *gin.Context) {
 					PmMaxRequests:                  p.PmMaxRequests,
 					RequestTerminateTimeoutSeconds: p.RequestTerminateTimeoutSeconds,
 					ProcessIdleTimeoutSeconds:      p.ProcessIdleTimeoutSeconds,
+					SlowlogTimeoutSeconds:          p.SlowlogTimeoutSeconds,
 					PerformanceMode:                p.PerformanceMode,
 					IsDefault:                      i == 0,
 				})
@@ -194,6 +196,7 @@ type setTuningRequest struct {
 	PmMaxRequests                  uint32 `json:"pm_max_requests"`
 	RequestTerminateTimeoutSeconds uint32 `json:"request_terminate_timeout_seconds"`
 	ProcessIdleTimeoutSeconds      uint32 `json:"process_idle_timeout_seconds"`
+	SlowlogTimeoutSeconds          uint32 `json:"slowlog_timeout_seconds"`
 }
 
 func (h *phpUserTuningHandler) setTuning(c *gin.Context) {
@@ -225,6 +228,14 @@ func (h *phpUserTuningHandler) setTuning(c *gin.Context) {
 	if idle == 0 {
 		idle = 60
 	}
+	// GH #1332 item 12: slow-log threshold. 0 = off; otherwise 1..600s. Set on
+	// the pool before applyToPool persists it — the preset path (setMode) leaves
+	// this field untouched, so a slow-log opt-in survives a preset change.
+	if req.SlowlogTimeoutSeconds > 600 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slowlog_timeout_invalid", "detail": "slow log timeout must be 0 (off) or between 1 and 600 seconds"})
+		return
+	}
+	pool.SlowlogTimeoutSeconds = req.SlowlogTimeoutSeconds
 	h.applyToPool(c, pool, req.PmMode, mc, st, mn, mx, mr, tt, idle, "custom")
 }
 

--- a/panel-api/internal/db/migrations/000279_php_pool_slowlog.down.sql
+++ b/panel-api/internal/db/migrations/000279_php_pool_slowlog.down.sql
@@ -1,0 +1,3 @@
+-- Reverse GH #1332 per-pool FPM slow log.
+ALTER TABLE php_pools
+  DROP COLUMN slowlog_timeout_seconds;

--- a/panel-api/internal/db/migrations/000279_php_pool_slowlog.up.sql
+++ b/panel-api/internal/db/migrations/000279_php_pool_slowlog.up.sql
@@ -1,0 +1,5 @@
+-- GH #1332 (item 12): per-pool FPM slow log. When > 0, FPM logs a backtrace of
+-- any request slower than this many seconds to the pool's slow log (path derived
+-- agent-side from the slug). 0 = disabled.
+ALTER TABLE php_pools
+  ADD COLUMN slowlog_timeout_seconds INT UNSIGNED NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/php_pool.go
+++ b/panel-api/internal/models/php_pool.go
@@ -5,22 +5,26 @@ import "time"
 // PHPPool represents a PHP-FPM pool bound to a panel user.
 // Each panel user gets exactly one pool per MVP constraint.
 type PHPPool struct {
-	ID                             string    `gorm:"type:char(26);primaryKey" json:"id"`
-	UserID                         string    `gorm:"type:char(26);not null" json:"user_id"`
-	PHPVersion                     string    `gorm:"type:varchar(8);not null" json:"php_version"`
-	PmMode                         string    `gorm:"type:varchar(16);not null;default:'ondemand'" json:"pm_mode"`
-	PmMaxChildren                  uint32    `gorm:"type:int unsigned;not null;default:20" json:"pm_max_children"`
-	ProcessIdleTimeoutSeconds      uint32    `gorm:"type:int unsigned;not null;default:60" json:"process_idle_timeout_seconds"`
-	PmStartServers                 uint32    `gorm:"column:pm_start_servers;type:int unsigned;not null;default:2" json:"pm_start_servers"`
-	PmMinSpareServers              uint32    `gorm:"column:pm_min_spare_servers;type:int unsigned;not null;default:1" json:"pm_min_spare_servers"`
-	PmMaxSpareServers              uint32    `gorm:"column:pm_max_spare_servers;type:int unsigned;not null;default:3" json:"pm_max_spare_servers"`
-	PmMaxRequests                  uint32    `gorm:"column:pm_max_requests;type:int unsigned;not null;default:0" json:"pm_max_requests"`
-	RequestTerminateTimeoutSeconds uint32    `gorm:"column:request_terminate_timeout_seconds;type:int unsigned;not null;default:0" json:"request_terminate_timeout_seconds"`
-	PerformanceMode                string    `gorm:"column:performance_mode;type:varchar(24);not null;default:'balanced'" json:"performance_mode"`
-	Status                         string    `gorm:"type:varchar(16);not null;default:'pending'" json:"status"`
-	LastError                      *string   `gorm:"type:text" json:"last_error,omitempty"`
-	CreatedAt                      time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt                      time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+	ID                             string `gorm:"type:char(26);primaryKey" json:"id"`
+	UserID                         string `gorm:"type:char(26);not null" json:"user_id"`
+	PHPVersion                     string `gorm:"type:varchar(8);not null" json:"php_version"`
+	PmMode                         string `gorm:"type:varchar(16);not null;default:'ondemand'" json:"pm_mode"`
+	PmMaxChildren                  uint32 `gorm:"type:int unsigned;not null;default:20" json:"pm_max_children"`
+	ProcessIdleTimeoutSeconds      uint32 `gorm:"type:int unsigned;not null;default:60" json:"process_idle_timeout_seconds"`
+	PmStartServers                 uint32 `gorm:"column:pm_start_servers;type:int unsigned;not null;default:2" json:"pm_start_servers"`
+	PmMinSpareServers              uint32 `gorm:"column:pm_min_spare_servers;type:int unsigned;not null;default:1" json:"pm_min_spare_servers"`
+	PmMaxSpareServers              uint32 `gorm:"column:pm_max_spare_servers;type:int unsigned;not null;default:3" json:"pm_max_spare_servers"`
+	PmMaxRequests                  uint32 `gorm:"column:pm_max_requests;type:int unsigned;not null;default:0" json:"pm_max_requests"`
+	RequestTerminateTimeoutSeconds uint32 `gorm:"column:request_terminate_timeout_seconds;type:int unsigned;not null;default:0" json:"request_terminate_timeout_seconds"`
+	// SlowlogTimeoutSeconds (GH #1332 item 12): when > 0, FPM logs a backtrace of
+	// any request slower than this to the pool's slow log. 0 = disabled. The
+	// slowlog path is derived agent-side from the slug (never sent over the wire).
+	SlowlogTimeoutSeconds uint32    `gorm:"column:slowlog_timeout_seconds;type:int unsigned;not null;default:0" json:"slowlog_timeout_seconds"`
+	PerformanceMode       string    `gorm:"column:performance_mode;type:varchar(24);not null;default:'balanced'" json:"performance_mode"`
+	Status                string    `gorm:"type:varchar(16);not null;default:'pending'" json:"status"`
+	LastError             *string   `gorm:"type:text" json:"last_error,omitempty"`
+	CreatedAt             time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt             time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (PHPPool) TableName() string { return "php_pools" }
@@ -44,6 +48,7 @@ func NewVersionedPHPPool(id, phpVersion string, def *PHPPool) *PHPPool {
 		PmMaxSpareServers:              def.PmMaxSpareServers,
 		PmMaxRequests:                  def.PmMaxRequests,
 		RequestTerminateTimeoutSeconds: def.RequestTerminateTimeoutSeconds,
+		SlowlogTimeoutSeconds:          def.SlowlogTimeoutSeconds,
 		PerformanceMode:                def.PerformanceMode,
 		Status:                         "pending",
 	}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1598,6 +1598,7 @@ func (r *Reconciler) applyPHPPool(ctx context.Context, user *models.User, pool *
 		"pm_max_spare_servers":              pool.PmMaxSpareServers,
 		"pm_max_requests":                   pool.PmMaxRequests,
 		"request_terminate_timeout_seconds": pool.RequestTerminateTimeoutSeconds,
+		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
 	}
 
 	// GH #402: if the user's package opts out of the #401 command-exec

--- a/panel-api/internal/repository/php_pool_repository_test.go
+++ b/panel-api/internal/repository/php_pool_repository_test.go
@@ -43,6 +43,7 @@ func TestPHPPoolRepository_Create(t *testing.T) {
 			sqlmock.AnyArg(), // pm_max_spare_servers
 			sqlmock.AnyArg(), // pm_max_requests
 			sqlmock.AnyArg(), // request_terminate_timeout_seconds
+			sqlmock.AnyArg(), // slowlog_timeout_seconds (GH #1332 item 12)
 			sqlmock.AnyArg(), // performance_mode
 			pool.Status,
 			sqlmock.AnyArg(), // last_error
@@ -202,6 +203,7 @@ func TestPHPPoolRepository_Update(t *testing.T) {
 			sqlmock.AnyArg(), // pm_max_spare_servers
 			sqlmock.AnyArg(), // pm_max_requests
 			sqlmock.AnyArg(), // request_terminate_timeout_seconds
+			sqlmock.AnyArg(), // slowlog_timeout_seconds (GH #1332 item 12)
 			sqlmock.AnyArg(), // performance_mode
 			sqlmock.AnyArg(), // status
 			sqlmock.AnyArg(), // last_error

--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
@@ -36,6 +36,7 @@ type PoolRow = {
   pm_max_requests: number;
   request_terminate_timeout_seconds: number;
   process_idle_timeout_seconds: number;
+  slowlog_timeout_seconds: number;
   performance_mode: string;
   is_default: boolean;
 };
@@ -88,6 +89,7 @@ export const UserPHPPerformanceCard = () => {
       pm_min_spare_servers: selectedPool.pm_min_spare_servers,
       pm_max_spare_servers: selectedPool.pm_max_spare_servers,
       pm_max_requests: selectedPool.pm_max_requests,
+      slowlog_timeout_seconds: selectedPool.slowlog_timeout_seconds,
     });
     // selectedPool identity changes with version/data; fields depend only on it.
   }, [selectedPool, advForm]);
@@ -250,6 +252,13 @@ export const UserPHPPerformanceCard = () => {
                     </Form.Item>
                     <Form.Item name="pm_max_requests" label={t("userphpperformancecard.max_requests_per_worker_0_never")}>
                       <InputNumber min={0} max={100000} style={{ width: 160 }} />
+                    </Form.Item>
+                    <Form.Item
+                      name="slowlog_timeout_seconds"
+                      label="Slow-log threshold (seconds, 0 = off)"
+                      extra="Logs a PHP backtrace of any request slower than this to ~/logs/php-slow*.log. Applies to every site on this PHP version."
+                    >
+                      <InputNumber min={0} max={600} style={{ width: 160 }} />
                     </Form.Item>
                     <Button loading={saving} onClick={applyAdvanced}>
                       Apply advanced


### PR DESCRIPTION
## Summary

GH #1332 **item 12** — a **Slow Log** toggle + configurable threshold for the PHP-FPM pool. When enabled, FPM logs a PHP backtrace of any request slower than the threshold to the tenant's slow log — the performance-debugging tool the reporter asked for, no shell access needed. Second of three PRs for the wishlist batch.

Slow log is a **pool** property (per-user, per-version — GH #329), so it sits with the other `pm_*` tuning in **Performance → Advanced**, not on the per-domain page.

## Changes

- **model / migration** — `php_pools.slowlog_timeout_seconds` (0 = off), migration `000279`; `NewVersionedPHPPool` clones it so a new per-version pool inherits the setting.
- **panel-api** — the L2 advanced PUT (`/me/php-pool-tuning`) accepts `slowlog_timeout_seconds` (validated `0..600`); GET returns it per pool so the card shows each version's own value. Preset changes (`setMode`) leave it untouched. Both reconcile paths (immediate + ticker) forward it.
- **agent (`php.pool.apply`)** — renders `request_slowlog_timeout` + `slowlog` into the pool conf. The slowlog **path is derived agent-side from the slug** (never over the wire) and lands under `/home/<user>/logs` — the per-user FPM master runs **as the tenant** (`User=<tenant>` in the `jabali-fpm@` unit), so the log must be tenant-writable; the agent ensures that dir exists + is tenant-owned. (Also sets up the per-domain log shortcut, item 7, in the next PR.)
- **panel-ui** — a "Slow-log threshold (seconds, 0 = off)" field in the Advanced panel of the Performance card.

## Verification

- ✅ **Box-drilled FPM slow log** on the test host (`pm=static`, `cgi-fcgi`, a 2.5s request): the slow log captured the backtrace —

  ```
  [pool slowpool] pid ...
  script_filename = .../slow.php
  [0x...] usleep() .../slow.php:1
  ```

  confirming ptrace-of-workers works under this box's kernel; the `jabali-fpm@` unit carries no `SystemCallFilter`/capability restriction that would block it. Master-runs-as-tenant confirmed on the box.
- ✅ Unit: template-render test (slow-log block present with the derived path when `>0`, absent at `0`); pool + tuning + reconciler suites; UI `tsc` + performance-card test.

## Release / deploy note

Touches the **`php.pool.apply` agent verb** AND the **pool template** (`install/php/jabali-php-pool.conf.tmpl`, installed on `jabali update`) — fleet agents + template must be redeployed; `install.sh` already flags active pools pending on a template change so they re-render. Migration `000279` (follows `000278` from the sibling directives PR #1383).

## Test plan

- [ ] Deploy; in Performance → Advanced set a slow-log threshold (e.g. 2s) for a version.
- [ ] Hit a deliberately slow PHP page on a domain running that version.
- [ ] Confirm `~/logs/php-slow*.log` gets a backtrace and 0 disables it.
