### PR TITLE
feat(php): OPcache reset + per-domain log & cron shortcuts (GH #1332 items 10, 7, 15)

### DIFF
--- a/panel-agent/internal/commands/php_opcache_reset.go
+++ b/panel-agent/internal/commands/php_opcache_reset.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// php_opcache_reset.go — GH #1332 item 10. Reset a pool's OPcache.
+//
+// OPcache's SHM lives in the FPM master process, so the only clean, complete
+// reset is a RESTART of that master (a graceful USR2 reload keeps the SHM). The
+// blast radius is exactly one user's sites on one PHP version — the slug's own
+// jabali-fpm@<slug> master. A tenant can already call opcache_reset() from any
+// PHP file they host, so this is a convenience, not a privileged capability.
+
+type phpOpcacheResetParams struct {
+	Username string `json:"username"`
+	Slug     string `json:"slug"`
+}
+
+func phpOpcacheResetHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p phpOpcacheResetParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "malformed JSON body"}
+	}
+	if !phpPoolUsernameRegex.MatchString(p.Username) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid username format"}
+	}
+	// The slug becomes a systemd instance name — validate as a safe path/instance
+	// component (default pool: slug == username; versioned: "<user>-php<ver>").
+	if !phpPoolSlugRegex.MatchString(p.Slug) || strings.Contains(p.Slug, "..") {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid slug format"}
+	}
+	// Defense in depth: the slug must belong to this user, so a tenant can never
+	// restart another user's FPM master by crafting a slug.
+	if p.Slug != p.Username && !strings.HasPrefix(p.Slug, p.Username+"-php") {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "slug does not belong to username"}
+	}
+	service := fmt.Sprintf("jabali-fpm@%s.service", p.Slug)
+	// Same test escape hatch the pool-apply reload path uses.
+	if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") != "" {
+		return map[string]any{"restarted": service, "skipped": true}, nil
+	}
+	if err := execCommandContext(ctx, "systemctl", "restart", service).Run(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("failed to restart %s: %v", service, err)}
+	}
+	return map[string]any{"restarted": service}, nil
+}
+
+func init() {
+	Default.Register("php.opcache.reset", phpOpcacheResetHandler)
+}

--- a/panel-agent/internal/commands/php_opcache_reset_test.go
+++ b/panel-agent/internal/commands/php_opcache_reset_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+func TestPHPOpcacheReset_Validation(t *testing.T) {
+	t.Setenv("JABALI_PHP_POOL_SKIP_RELOAD", "1") // no real systemctl in tests
+	cases := []struct {
+		name    string
+		params  phpOpcacheResetParams
+		wantErr bool
+	}{
+		{"default pool ok", phpOpcacheResetParams{Username: "alice", Slug: "alice"}, false},
+		{"versioned pool ok", phpOpcacheResetParams{Username: "alice", Slug: "alice-php8.4"}, false},
+		{"bad username", phpOpcacheResetParams{Username: "Alice", Slug: "alice"}, true},
+		{"slug traversal", phpOpcacheResetParams{Username: "alice", Slug: "../bob"}, true},
+		{"slug of another user", phpOpcacheResetParams{Username: "alice", Slug: "bob"}, true},
+		{"versioned slug of another user", phpOpcacheResetParams{Username: "alice", Slug: "bob-php8.4"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, _ := json.Marshal(tc.params)
+			_, err := phpOpcacheResetHandler(context.Background(), raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				var aerr *agentwire.AgentError
+				if !errors.As(err, &aerr) || aerr.Code != agentwire.CodeInvalidArgument {
+					t.Fatalf("expected InvalidArgument, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3788,6 +3788,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/php-opcache/reset:
+    post:
+      tags: [Me]
+      summary: Reset OPcache for a PHP version (restarts that pool's FPM master)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/server-capabilities:
     get:
       tags: [Me]

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -35,6 +35,8 @@ func RegisterPHPUserTuningRoutes(g *gin.RouterGroup, cfg PHPUserTuningHandlerCon
 	g.GET("/me/php-pool-tuning", h.tuning)
 	g.PUT("/me/php-performance-mode", h.setMode)
 	g.PUT("/me/php-pool-tuning", h.setTuning)
+	// GH #1332 item 10: reset a version's OPcache (restarts that pool's master).
+	g.POST("/me/php-opcache/reset", h.resetOpcache)
 }
 
 // poolTuningRow is one of the caller's PHP pools, with its current per-version
@@ -237,6 +239,49 @@ func (h *phpUserTuningHandler) setTuning(c *gin.Context) {
 	}
 	pool.SlowlogTimeoutSeconds = req.SlowlogTimeoutSeconds
 	h.applyToPool(c, pool, req.PmMode, mc, st, mn, mx, mr, tt, idle, "custom")
+}
+
+type opcacheResetRequest struct {
+	PHPVersion string `json:"php_version"`
+}
+
+// resetOpcache restarts the master of the caller's pool for a given PHP version,
+// dropping (and so resetting) its OPcache SHM (GH #1332 item 10). Version-scoped
+// because OPcache is per-pool (per-user, per-version): the reset affects every
+// site the caller runs on that version, which the UI states plainly.
+func (h *phpUserTuningHandler) resetOpcache(c *gin.Context) {
+	user, pkg := h.ownerPackage(c)
+	if user == nil || pkg == nil || !pkg.FpmUserCanEdit {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	var req opcacheResetRequest
+	_ = c.ShouldBindJSON(&req) // php_version optional; empty => default pool
+	pool, ok := h.userPool(c, user.ID, req.PHPVersion)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+	// Resolve the slug exactly as reconcilePHPPoolViaAgent does: the earliest
+	// pool (ListByUserID[0]) is the default, whose slug == username.
+	isDefault := true
+	if list, err := h.cfg.PHPPools.ListByUserID(c.Request.Context(), user.ID); err == nil && len(list) > 0 {
+		isDefault = list[0].ID == pool.ID
+	}
+	username := ""
+	if user.Username != nil {
+		username = *user.Username
+	}
+	slug := models.PoolSlug(username, pool.PHPVersion, isDefault)
+	c.Set("audit_target", "php_opcache:"+slug)
+	if _, err := h.cfg.Agent.Call(c.Request.Context(), "php.opcache.reset", map[string]any{
+		"username": username,
+		"slug":     slug,
+	}); err != nil {
+		respondAgentErr(c, "opcache_reset_failed", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"restarted": true, "php_version": pool.PHPVersion})
 }
 
 func (h *phpUserTuningHandler) applyToPool(c *gin.Context, pool *models.PHPPool, pmMode string, mc, st, mn, mx, mr, tt, idle uint32, mode string) {

--- a/panel-ui/src/shells/user/logs/UserLogsPage.tsx
+++ b/panel-ui/src/shells/user/logs/UserLogsPage.tsx
@@ -55,6 +55,18 @@ export const UserLogsPage = () => {
 
   const domains: Domain[] = domainsData?.data || [];
 
+  // GH #1332 item 7: the per-domain PHP Settings page links here with
+  // ?domain=<id> to jump straight to that site's logs. Filter to it (and offer
+  // a one-click "show all") when present; unknown/foreign ids just fall through
+  // to the full list since the table is already scoped to the caller's domains.
+  const focusDomainId = searchParams.get("domain");
+  const shownDomains =
+    focusDomainId && domains.some((d) => d.id === focusDomainId)
+      ? domains.filter((d) => d.id === focusDomainId)
+      : domains;
+  const isFilteredToDomain =
+    !!focusDomainId && shownDomains.length < domains.length;
+
   const openStream = async (logType: LogType, domainId: string) => {
     try {
       const response = await apiClient.post("/logs/access", {
@@ -119,6 +131,11 @@ export const UserLogsPage = () => {
   const domainLogsTab = (
     <>
       <Space style={{ marginBottom: 16, width: "100%", justifyContent: "flex-end" }}>
+        {isFilteredToDomain && (
+          <Button onClick={() => setSearchParams({}, { replace: true })}>
+            Show all domains
+          </Button>
+        )}
         <Button
           type="primary"
           icon={<ReloadOutlined />}
@@ -130,7 +147,7 @@ export const UserLogsPage = () => {
       <Card>
         <Table
           columns={columns}
-          dataSource={domains}
+          dataSource={shownDomains}
           rowKey="id"
           loading={isLoading}
           pagination={false}

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Tabs, Alert, Button, Card, Form, Row, Col, Select, Space, Spin, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
@@ -151,7 +152,9 @@ const TIMEZONE_OPTIONS = [
 
 export function UserPHPSettingsPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const qc = useQueryClient();
+  const [opcacheResetting, setOpcacheResetting] = useState(false);
   const [, setMe] = useState<Identity | null>(null);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
@@ -357,6 +360,26 @@ export function UserPHPSettingsPage() {
     </Space>
   );
 
+  // GH #1332 item 10: reset OPcache for the selected domain's PHP version.
+  // OPcache is shared per FPM pool (per version), so this affects every site
+  // the account runs on that version — stated in the confirm copy.
+  const onResetOpcache = async () => {
+    setOpcacheResetting(true);
+    try {
+      await apiClient.post("/me/php-opcache/reset", {
+        php_version: phpSettings?.php_version ?? undefined,
+      });
+      feedback.message.success("OPcache reset (FPM restarted for this PHP version)");
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(
+        e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to reset OPcache",
+      );
+    } finally {
+      setOpcacheResetting(false);
+    }
+  };
+
   return (
     // GH #1332 item 1: the page was clamped to 800px and centred, unlike every
     // other settings page. Use the shell's full responsive width like its peers.
@@ -452,6 +475,39 @@ export function UserPHPSettingsPage() {
                       ]}
                     />
                   </Form.Item>
+
+                  {/* GH #1332 items 7, 10, 15: quick actions for the selected domain. */}
+                  <Space wrap style={{ marginBottom: 8 }}>
+                    <Button
+                      loading={opcacheResetting}
+                      onClick={onResetOpcache}
+                    >
+                      Reset OPcache
+                    </Button>
+                    <Button
+                      type="link"
+                      style={{ paddingInline: 0 }}
+                      onClick={() =>
+                        navigate(`/jabali-panel/logs?domain=${selectedDomain}`)
+                      }
+                    >
+                      View error log
+                    </Button>
+                    <Button
+                      type="link"
+                      style={{ paddingInline: 0 }}
+                      onClick={() => navigate("/jabali-panel/cron")}
+                    >
+                      Scheduled tasks (Cron)
+                    </Button>
+                  </Space>
+                  <Typography.Paragraph
+                    type="secondary"
+                    style={{ fontSize: 12, marginTop: -4 }}
+                  >
+                    Resetting OPcache restarts PHP-FPM for this version and
+                    affects all your sites running it — handy after a deploy.
+                  </Typography.Paragraph>
 
                   <Typography.Title level={5} style={{ marginBottom: 0 }}>
                     Resource Limits


### PR DESCRIPTION
## Summary

Final PR for the GH #1332 per-domain PHP Settings wishlist batch — **items 10, 7, 15**.

### item 10 — Reset OPcache

OPcache's SHM lives in the FPM **master** and is shared **per pool** (per-user, per-version). A per-domain enable/disable can't be done safely on a shared pool (disabling via `PHP_VALUE` sticks on the worker and can't be re-enabled at runtime — it would bleed onto sibling domains), but a **reset can**: restarting the master drops the SHM. The button on the PHP Settings page resets OPcache for the selected domain's PHP version; the copy states it affects every site on that version. A tenant can already call `opcache_reset()` from any PHP file they host, so this is a convenience, not a new privilege.

- **agent** — new `php.opcache.reset` verb: restarts `jabali-fpm@<slug>` (the same production-proven `systemctl` path `php.pool.apply` already uses). Validates username + slug and refuses a slug that doesn't belong to the caller.
- **panel-api** — `POST /me/php-opcache/reset {php_version}` resolves the caller's pool slug exactly as the reconciler does and calls the agent; agent errors go through `respondAgentErr` (no raw leak; caught by the agent-error-leak guard test). Documented in `openapi.yaml`.

### item 7 — Quick PHP error-log shortcut

A **"View error log"** link on the PHP Settings page jumps to Logs & Statistics pre-filtered to that domain (`/jabali-panel/logs?domain=<id>`, with a one-click **"Show all domains"**).

### item 15 — Domain cron shortcut

A **"Scheduled tasks (Cron)"** link to the tenant cron page.

## Verification

- ✅ **Box-drilled `php.opcache.reset` on the test host**: invoked over the agent socket for a live pool — the FPM master restarted (PID `1065 → 226284`), agent returned `{"ok":true,"restarted":"jabali-fpm@testing44.service"}`, the unit stayed active. Agent binary restored afterward.
- ✅ Unit: verb param-validation table (bad username, slug traversal, another user's slug → `InvalidArgument`); agent + panel-api + openapi-coverage suites; UI `tsc` + performance-card test.

## Release / deploy note

New **`php.opcache.reset` agent verb** — fleet agents must be redeployed. No migration.

## Test plan

- [ ] Deploy; on the PHP Settings page pick a domain, click **Reset OPcache** → toast confirms, sites on that version keep serving.
- [ ] Click **View error log** → lands on Logs filtered to that domain; **Show all domains** clears it.
- [ ] Click **Scheduled tasks (Cron)** → lands on the cron page.
