### PR TITLE
feat(domains): per-domain environment variables (GH #1332 item 14)

### DIFF
--- a/internal/phpenv/phpenv.go
+++ b/internal/phpenv/phpenv.go
@@ -1,0 +1,101 @@
+// Package phpenv validates and renders per-domain environment variables
+// (GH #1332 item 14). These become nginx fastcgi_param directives in the PHP
+// location, so key validation is a SECURITY boundary: a fastcgi_param named
+// PHP_ADMIN_VALUE overrides the FPM pool's php_admin_value and can clear
+// disable_functions / open_basedir (box-drilled). Both panel-api (request
+// validation) and panel-agent (defense-in-depth + rendering) use this package
+// so the denylist has a single source of truth.
+package phpenv
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// MaxVars caps the number of env vars per domain; MaxValueLen caps a value's
+// length. Generous but bounded so the vhost can't be blown up.
+const (
+	MaxVars     = 100
+	MaxValueLen = 4096
+)
+
+// keyRE bounds a key to a conventional env-var identifier.
+var keyRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
+
+// denyKeys are keys that must never be delivered as fastcgi_param. The first
+// three are the sandbox-escape vector (they override php_admin_value); the rest
+// are CGI/meta variables that route the request or PHP relies on — letting a
+// tenant set them breaks the app or worse.
+var denyKeys = map[string]bool{
+	"PHP_VALUE":            true,
+	"PHP_ADMIN_VALUE":      true,
+	"PHP_ADMIN_FLAG":       true,
+	"SCRIPT_FILENAME":      true,
+	"SCRIPT_NAME":          true,
+	"DOCUMENT_ROOT":        true,
+	"DOCUMENT_URI":         true,
+	"REQUEST_URI":          true,
+	"REQUEST_METHOD":       true,
+	"REQUEST_SCHEME":       true,
+	"QUERY_STRING":         true,
+	"CONTENT_TYPE":         true,
+	"CONTENT_LENGTH":       true,
+	"PATH_INFO":            true,
+	"PATH_TRANSLATED":      true,
+	"GATEWAY_INTERFACE":    true,
+	"SERVER_PROTOCOL":      true,
+	"SERVER_SOFTWARE":      true,
+	"SERVER_NAME":          true,
+	"SERVER_ADDR":          true,
+	"SERVER_PORT":          true,
+	"REMOTE_ADDR":          true,
+	"REMOTE_PORT":          true,
+	"REMOTE_USER":          true,
+	"HTTPS":                true,
+	"REDIRECT_STATUS":      true,
+	"FCGI_ROLE":            true,
+	"ORIG_SCRIPT_FILENAME": true,
+	"ORIG_SCRIPT_NAME":     true,
+	"ORIG_PATH_INFO":       true,
+	"ORIG_PATH_TRANSLATED": true,
+}
+
+// ValidKey reports whether key is a safe env-var name to deliver as a
+// fastcgi_param. Case-insensitive against the denylist; HTTP_-prefixed keys are
+// rejected (they masquerade as client request headers).
+func ValidKey(key string) error {
+	if !keyRE.MatchString(key) {
+		return fmt.Errorf("invalid env var name %q (must match [A-Za-z_][A-Za-z0-9_]*, <=64 chars)", key)
+	}
+	up := strings.ToUpper(key)
+	if denyKeys[up] {
+		return fmt.Errorf("env var name %q is reserved and cannot be set", key)
+	}
+	if strings.HasPrefix(up, "HTTP_") {
+		return fmt.Errorf("env var name %q may not start with HTTP_ (collides with request headers)", key)
+	}
+	return nil
+}
+
+// ValidValue reports whether value is safe to render into the double-quoted
+// nginx fastcgi_param string. Control characters could break out of the line;
+// the caller must still Escape() the value when rendering.
+func ValidValue(value string) error {
+	if len(value) > MaxValueLen {
+		return fmt.Errorf("env var value too long (max %d bytes)", MaxValueLen)
+	}
+	if strings.ContainsAny(value, "\n\r\x00") {
+		return fmt.Errorf("env var value contains control characters")
+	}
+	return nil
+}
+
+// Escape renders value safe inside an nginx double-quoted string: backslash and
+// double-quote are escaped. Callers must have already run ValidValue (which
+// rejects newlines) — this is the second layer.
+func Escape(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}

--- a/internal/phpenv/phpenv_test.go
+++ b/internal/phpenv/phpenv_test.go
@@ -1,0 +1,50 @@
+package phpenv
+
+import "testing"
+
+func TestValidKey(t *testing.T) {
+	ok := []string{"APP_ENV", "DB_HOST", "_X", "A1_B2", "REDIS_URL"}
+	for _, k := range ok {
+		if err := ValidKey(k); err != nil {
+			t.Errorf("ValidKey(%q) = %v, want nil", k, err)
+		}
+	}
+	// The jailbreak set + CGI meta + HTTP_ prefix + bad shapes must all be rejected.
+	bad := []string{
+		"PHP_ADMIN_VALUE", "php_admin_value", "PHP_VALUE", "PHP_ADMIN_FLAG",
+		"SCRIPT_FILENAME", "DOCUMENT_ROOT", "PATH_INFO", "HTTPS", "REDIRECT_STATUS",
+		"HTTP_X_FORWARDED_FOR", "1BAD", "has space", "has-dash", "toooo" + longName(),
+		"",
+	}
+	for _, k := range bad {
+		if err := ValidKey(k); err == nil {
+			t.Errorf("ValidKey(%q) = nil, want error", k)
+		}
+	}
+}
+
+func longName() string {
+	b := make([]byte, 70)
+	for i := range b {
+		b[i] = 'a'
+	}
+	return string(b)
+}
+
+func TestValidValue(t *testing.T) {
+	if err := ValidValue("postgres://u:p@localhost/db"); err != nil {
+		t.Errorf("normal value rejected: %v", err)
+	}
+	if err := ValidValue("line1\nline2"); err == nil {
+		t.Error("newline value must be rejected")
+	}
+	if err := ValidValue(string(make([]byte, MaxValueLen+1))); err == nil {
+		t.Error("over-long value must be rejected")
+	}
+}
+
+func TestEscape(t *testing.T) {
+	if got := Escape(`a"b\c`); got != `a\"b\\c` {
+		t.Errorf("Escape = %q, want %q", got, `a\"b\\c`)
+	}
+}

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -17,6 +17,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/phpenv"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/skelpath"
 )
 
@@ -112,6 +113,10 @@ type domainCreateParams struct {
 	PHPDisplayErrors  bool   `json:"php_display_errors,omitempty"`
 	PHPErrorReporting *int   `json:"php_error_reporting,omitempty"`
 	PHPTimezone       string `json:"php_timezone,omitempty"`
+	// EnvVars are per-domain environment variables (GH #1332 item 14), rendered
+	// as fastcgi_param in the PHP location. Keys are re-validated against the
+	// shared phpenv denylist here (defense in depth) before rendering.
+	EnvVars []domainEnvVarParam `json:"env_vars,omitempty"`
 	// M18 per-domain HTTP limits. DomainID is required when either
 	// RateLimitRPS or ConnectionLimit is set so the zone-name tag
 	// matches the declaration in 00-jabali-ratelimits.conf. All three
@@ -300,6 +305,8 @@ const vhostTemplate = `{{define "servebody"}}{{ if .IsEnabled }}
 {{ end }}
 {{ if .PHPValueParam }}
         fastcgi_param PHP_VALUE "{{.PHPValueParam}}";
+{{ end }}{{ if .EnvParams }}
+{{.EnvParams}}
 {{ end }}
 {{ if .CacheEnabled }}
         # Fail-CLOSED page-cache gate (Gitea #416/#419): cache ONLY genuinely
@@ -404,6 +411,8 @@ const vhostTemplate = `{{define "servebody"}}{{ if .IsEnabled }}
 {{ end }}
 {{ if .PHPValueParam }}
         fastcgi_param PHP_VALUE "{{.PHPValueParam}}";
+{{ end }}{{ if .EnvParams }}
+{{.EnvParams}}
 {{ end }}
 {{ if .CacheEnabled }}
         # Fail-CLOSED page-cache gate (Gitea #416/#419): cache ONLY genuinely
@@ -502,6 +511,8 @@ const vhostTemplate = `{{define "servebody"}}{{ if .IsEnabled }}
         fastcgi_param SCRIPT_FILENAME $realpath_root$jabali_pi_script;
         fastcgi_param PATH_INFO $jabali_pi_suffix;
 {{ if .PHPValueParam }}        fastcgi_param PHP_VALUE "{{.PHPValueParam}}";
+{{ end }}{{ if .EnvParams }}
+{{.EnvParams}}
 {{ end }}    }
 {{ end }}{{ end }}
 
@@ -711,6 +722,7 @@ type vhostData struct {
 	PHPMaxExecutionTime  int
 	PHPMaxInputTime      int
 	PHPValueParam        string // fastcgi_param PHP_VALUE directive content
+	EnvParams            string // GH #1332 item 14: fastcgi_param env-var lines
 	// RateLimitDirectives is the fully-rendered per-vhost rate/conn
 	// limit block (may span 0–2 lines). Computed by the caller via
 	// BuildRateLimitDirectives; interpolated verbatim. Never contains
@@ -815,6 +827,38 @@ func pathsUnderHome(username, docRoot string) []string {
 // that isn't a plain tz identifier is dropped here rather than risk injecting a
 // directive. Covers "Area/City", "UTC", "Etc/GMT+5", etc.
 var phpTimezoneRE = regexp.MustCompile(`^[A-Za-z0-9_+/-]{1,64}$`)
+
+// domainEnvVarParam is one per-domain environment variable from the panel.
+type domainEnvVarParam struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// buildEnvParams renders per-domain env vars as nginx fastcgi_param lines (GH
+// #1332 item 14). Returns "" for a non-PHP domain or no vars. Each key is
+// re-validated against the shared phpenv denylist (a PHP_ADMIN_VALUE key would
+// escape the FPM sandbox) and each value is escaped for the double-quoted nginx
+// string — a bad entry is skipped, never rendered raw. One directive per line.
+func buildEnvParams(hasPHP bool, envVars []domainEnvVarParam) string {
+	if !hasPHP || len(envVars) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, kv := range envVars {
+		if err := phpenv.ValidKey(kv.Key); err != nil {
+			continue
+		}
+		if err := phpenv.ValidValue(kv.Value); err != nil {
+			continue
+		}
+		b.WriteString("        fastcgi_param ")
+		b.WriteString(kv.Key)
+		b.WriteString(` "`)
+		b.WriteString(phpenv.Escape(kv.Value))
+		b.WriteString("\";\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
 
 // buildPHPValueParam assembles a fastcgi_param PHP_VALUE directive from per-domain
 // INI overrides. Returns empty string for a non-PHP domain (no PHP_VALUE line).
@@ -1019,7 +1063,7 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, phpDisplayErrors bool, phpErrorReporting *int, phpTimezone string, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, phpDisplayErrors bool, phpErrorReporting *int, phpTimezone string, envVars []domainEnvVarParam, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool) (string, error) {
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
 	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
@@ -1137,6 +1181,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		PHPMaxExecutionTime:        phpMaxExecTime,
 		PHPMaxInputTime:            phpMaxInputTime,
 		PHPValueParam:              buildPHPValueParam(hasPHP, phpMemLimit, phpUploadMax, phpPostMax, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime, phpDisplayErrors, phpErrorReporting, phpTimezone),
+		EnvParams:                  buildEnvParams(hasPHP, envVars),
 		ListenIPv4:                 listenIPv4,
 		ListenIPv6:                 listenIPv6,
 		InterceptErrors:            interceptErrors,
@@ -1400,7 +1445,7 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// panel always sends the field; writeVhost still forces it false if the
 	// cert file turns out to be missing on disk (#213).
 	redirectHTTPS, serveHTTPS := resolveHTTPSFlags(&p)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.PHPDisplayErrors, p.PHPErrorReporting, p.PHPTimezone, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.PHPDisplayErrors, p.PHPErrorReporting, p.PHPTimezone, p.EnvVars, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create_test.go
+++ b/panel-agent/internal/commands/domain_create_test.go
@@ -793,3 +793,30 @@ func TestVhostBrandedErrorPages(t *testing.T) {
 		t.Errorf("RootOverridden vhost must not wire jabali error pages")
 	}
 }
+
+// TestBuildEnvParams covers GH #1332 item 14: env vars render as fastcgi_param
+// lines for a PHP domain, values are escaped for the nginx double-quoted string,
+// and a key on the security denylist (PHP_ADMIN_VALUE — the sandbox-escape
+// vector) is dropped even if the panel somehow sent it.
+func TestBuildEnvParams(t *testing.T) {
+	if got := buildEnvParams(false, []domainEnvVarParam{{Key: "APP_ENV", Value: "prod"}}); got != "" {
+		t.Errorf("non-PHP domain must emit nothing, got %q", got)
+	}
+	if got := buildEnvParams(true, nil); got != "" {
+		t.Errorf("no env vars must emit nothing, got %q", got)
+	}
+	got := buildEnvParams(true, []domainEnvVarParam{
+		{Key: "APP_ENV", Value: "staging"},
+		{Key: "DB_DSN", Value: `p"a\ss`},
+		{Key: "PHP_ADMIN_VALUE", Value: "disable_functions="}, // denied — must be dropped
+	})
+	if !strings.Contains(got, `fastcgi_param APP_ENV "staging";`) {
+		t.Errorf("missing APP_ENV line:\n%s", got)
+	}
+	if !strings.Contains(got, `fastcgi_param DB_DSN "p\"a\\ss";`) {
+		t.Errorf("value not escaped:\n%s", got)
+	}
+	if strings.Contains(got, "PHP_ADMIN_VALUE") {
+		t.Errorf("denylisted key must be dropped:\n%s", got)
+	}
+}

--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -114,6 +114,9 @@ func (*fakeDomainRepo) CountByPHPPoolID(context.Context, string) (int64, error) 
 	return 0, nil
 }
 func (*fakeDomainRepo) SetPHPPoolID(context.Context, string, *string) error { return nil }
+func (*fakeDomainRepo) UpdateEnvVars(context.Context, string, models.DomainEnvVars) error {
+	return nil
+}
 func (*fakeDomainRepo) UpdatePHPSettings(context.Context, string, repository.DomainPHPSettings) error {
 	return nil
 }

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -109,6 +109,10 @@ func (m *mockDomainRepo) UpdatePHPSettings(ctx context.Context, id string, setti
 	return nil
 }
 
+func (m *mockDomainRepo) UpdateEnvVars(ctx context.Context, id string, envVars models.DomainEnvVars) error {
+	return nil
+}
+
 func (m *mockDomainRepo) UpdateMailProvider(_ context.Context, _ string, _ repository.DomainMailProvider) error {
 	return nil
 }

--- a/panel-api/internal/api/domain_env_vars.go
+++ b/panel-api/internal/api/domain_env_vars.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/phpenv"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// domain_env_vars.go — GH #1332 item 14. Per-domain environment variables,
+// delivered to PHP as nginx fastcgi_param (reach getenv() + $_SERVER). Key
+// validation is a security boundary (phpenv package): a fastcgi_param named
+// PHP_ADMIN_VALUE overrides the FPM sandbox.
+
+// DomainEnvVarsHandlerConfig wires the per-domain env-var routes.
+type DomainEnvVarsHandlerConfig struct {
+	Domains repository.DomainRepository
+}
+
+// RegisterDomainEnvVarsRoutes adds:
+//   - GET /domains/:id/env-vars
+//   - PUT /domains/:id/env-vars   (full replace)
+func RegisterDomainEnvVarsRoutes(g *gin.RouterGroup, cfg DomainEnvVarsHandlerConfig) {
+	h := &domainEnvVarsHandler{cfg: cfg}
+	g.GET("/domains/:id/env-vars", h.get)
+	g.PUT("/domains/:id/env-vars", h.put)
+}
+
+type domainEnvVarsHandler struct{ cfg DomainEnvVarsHandlerConfig }
+
+type envVarDTO struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type putEnvVarsRequest struct {
+	EnvVars []envVarDTO `json:"env_vars"`
+}
+
+func (h *domainEnvVarsHandler) loadOwned(c *gin.Context) (*models.Domain, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return nil, false
+	}
+	dom, err := h.cfg.Domains.FindByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return nil, false
+		}
+		slog.ErrorContext(c.Request.Context(), "env-vars: load domain", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return nil, false
+	}
+	if !claims.IsAdmin && dom.UserID != claims.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return nil, false
+	}
+	return dom, true
+}
+
+func (h *domainEnvVarsHandler) get(c *gin.Context) {
+	dom, ok := h.loadOwned(c)
+	if !ok {
+		return
+	}
+	out := dom.EnvVars
+	if out == nil {
+		out = models.DomainEnvVars{}
+	}
+	c.JSON(http.StatusOK, gin.H{"env_vars": out})
+}
+
+func (h *domainEnvVarsHandler) put(c *gin.Context) {
+	dom, ok := h.loadOwned(c)
+	if !ok {
+		return
+	}
+	var req putEnvVarsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	if len(req.EnvVars) > phpenv.MaxVars {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "too_many_env_vars", "detail": fmt.Sprintf("max %d", phpenv.MaxVars)})
+		return
+	}
+	seen := map[string]bool{}
+	out := make(models.DomainEnvVars, 0, len(req.EnvVars))
+	for _, kv := range req.EnvVars {
+		if err := phpenv.ValidKey(kv.Key); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_env_key", "detail": err.Error()})
+			return
+		}
+		if err := phpenv.ValidValue(kv.Value); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_env_value", "detail": err.Error()})
+			return
+		}
+		if seen[kv.Key] {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duplicate_env_key", "detail": kv.Key})
+			return
+		}
+		seen[kv.Key] = true
+		out = append(out, models.DomainEnvVar{Key: kv.Key, Value: kv.Value})
+	}
+	if err := h.cfg.Domains.UpdateEnvVars(c.Request.Context(), dom.ID, out); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return
+		}
+		slog.ErrorContext(c.Request.Context(), "env-vars: update", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.Set("audit_target", "domain_env_vars:"+dom.Name)
+	c.JSON(http.StatusOK, gin.H{"env_vars": out})
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4582,6 +4582,20 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /domains/{id}/env-vars:
+    get:
+      tags: [Php Settings]
+      summary: List a domain's environment variables
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Php Settings]
+      summary: Replace a domain's environment variables
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
 
   # --- Processes (auto) ---
 

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -211,6 +211,11 @@ func (m *MockDomainRepository) UpdatePHPSettings(ctx context.Context, id string,
 	return args.Error(0)
 }
 
+func (m *MockDomainRepository) UpdateEnvVars(ctx context.Context, id string, envVars models.DomainEnvVars) error {
+	args := m.Called(ctx, id, envVars)
+	return args.Error(0)
+}
+
 func (m *MockDomainRepository) UpdateMailProvider(_ context.Context, _ string, _ repository.DomainMailProvider) error {
 	return nil
 }

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1249,6 +1249,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Domains:  deps.Domains,
 				PHPPools: deps.PHPPools,
 			})
+			// GH #1332 item 14: per-domain env vars.
+			api.RegisterDomainEnvVarsRoutes(v1, api.DomainEnvVarsHandlerConfig{
+				Domains: deps.Domains,
+			})
 		}
 		if deps.Domains != nil {
 			api.RegisterDomainHtaccessRoutes(v1, api.DomainHtaccessHandlerConfig{

--- a/panel-api/internal/db/migrations/000280_domain_env_vars.down.sql
+++ b/panel-api/internal/db/migrations/000280_domain_env_vars.down.sql
@@ -1,0 +1,3 @@
+-- Reverse GH #1332 per-domain environment variables.
+ALTER TABLE domains
+  DROP COLUMN env_vars;

--- a/panel-api/internal/db/migrations/000280_domain_env_vars.up.sql
+++ b/panel-api/internal/db/migrations/000280_domain_env_vars.up.sql
@@ -1,0 +1,6 @@
+-- GH #1332 (item 14): per-domain environment variables, delivered to PHP as
+-- nginx fastcgi_param (reach getenv() + $_SERVER). Stored as a JSON array of
+-- {key,value}. Keys are validated against a security denylist in the API/agent
+-- (a fastcgi_param named PHP_ADMIN_VALUE would override the FPM sandbox).
+ALTER TABLE domains
+  ADD COLUMN env_vars JSON NULL DEFAULT NULL;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -130,6 +130,45 @@ func (n *NginxRules) Scan(src any) error {
 	return json.Unmarshal(b, n)
 }
 
+// DomainEnvVar is one per-domain environment variable (GH #1332 item 14),
+// delivered to PHP as an nginx fastcgi_param (reaches getenv() + $_SERVER).
+type DomainEnvVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// DomainEnvVars persists to a JSON column. An empty slice round-trips as SQL
+// NULL (same pattern as PageRedirects / NginxRules).
+type DomainEnvVars []DomainEnvVar
+
+func (e DomainEnvVars) Value() (driver.Value, error) {
+	if len(e) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(e)
+}
+
+func (e *DomainEnvVars) Scan(src any) error {
+	if src == nil {
+		*e = nil
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("DomainEnvVars.Scan: unsupported type %T", src)
+	}
+	if len(b) == 0 {
+		*e = nil
+		return nil
+	}
+	return json.Unmarshal(b, e)
+}
+
 // Domain represents a hosted domain bound to a user account. Each domain
 // gets an nginx vhost config managed by the agent and a document root
 // under the user's home directory.
@@ -215,6 +254,11 @@ type Domain struct {
 	// Separate from NginxCustomDirectives (which holds raw user snippets)
 	// and from PageRedirects (which has its own dedicated UI).
 	NginxRules NginxRules `gorm:"type:json" json:"nginx_rules,omitempty"`
+
+	// EnvVars are per-domain environment variables (GH #1332 item 14), rendered
+	// as nginx fastcgi_param in the PHP location. Keys are validated against a
+	// security denylist (PHP_ADMIN_VALUE etc. would escape the FPM sandbox).
+	EnvVars DomainEnvVars `gorm:"column:env_vars;type:json" json:"env_vars,omitempty"`
 
 	// NginxSafeOptions is a curated, owner-settable set of vetted nginx options
 	// (GH #307) — rendered to fixed safe directives by the panel. Gated by

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1931,6 +1931,15 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 	if domain.PHPTimezone != nil {
 		params["php_timezone"] = *domain.PHPTimezone
 	}
+	// GH #1332 item 14: per-domain env vars -> nginx fastcgi_param. The agent
+	// re-validates keys against the security denylist before rendering.
+	if len(domain.EnvVars) > 0 {
+		ev := make([]map[string]string, 0, len(domain.EnvVars))
+		for _, kv := range domain.EnvVars {
+			ev = append(ev, map[string]string{"key": kv.Key, "value": kv.Value})
+		}
+		params["env_vars"] = ev
+	}
 
 	cust := ""
 	if domain.NginxCustomDirectives != nil {

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -190,6 +190,16 @@ func (f *fakeDomainRepo) UpdatePHPSettings(ctx context.Context, id string, setti
 	return &notFoundErr{}
 }
 
+func (f *fakeDomainRepo) UpdateEnvVars(ctx context.Context, id string, envVars models.DomainEnvVars) error {
+	for i, d := range f.domains {
+		if d.ID == id {
+			f.domains[i].EnvVars = envVars
+			return nil
+		}
+	}
+	return &notFoundErr{}
+}
+
 func (f *fakeDomainRepo) UpdateMailProvider(_ context.Context, _ string, _ repository.DomainMailProvider) error {
 	return nil
 }

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -63,6 +63,10 @@ type DomainRepository interface {
 	// explicitly clear the override. This is a dedicated method because the
 	// columns are not in Update()'s allowlist.
 	UpdatePHPSettings(ctx context.Context, id string, settings DomainPHPSettings) error
+	// UpdateEnvVars replaces a domain's per-domain environment variables (GH
+	// #1332 item 14). Dedicated method (not in Update()'s allowlist); an empty
+	// slice clears them (JSON column round-trips to NULL).
+	UpdateEnvVars(ctx context.Context, id string, envVars models.DomainEnvVars) error
 	// UpdateEmailState writes the four M6 email columns (email_enabled,
 	// dkim_selector, dkim_public_key, email_enabled_at) in one go. Dedicated
 	// method because none of these are in Update()'s allowlist and because
@@ -517,6 +521,21 @@ func (r *domainRepo) UpdatePHPSettings(ctx context.Context, id string, settings 
 			"php_error_reporting": settings.ErrorReporting,
 			"php_timezone":        settings.Timezone,
 		})
+	if res.Error != nil {
+		return translate(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *domainRepo) UpdateEnvVars(ctx context.Context, id string, envVars models.DomainEnvVars) error {
+	// Use Updates(map) so a nil/empty slice writes NULL (clears). The column is
+	// not in Update()'s Select allowlist on purpose.
+	res := r.db.WithContext(ctx).Model(&models.Domain{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{"env_vars": envVars})
 	if res.Error != nil {
 		return translate(res.Error)
 	}

--- a/panel-ui/src/shells/user/php-settings/DomainEnvVarsCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/DomainEnvVarsCard.tsx
@@ -1,0 +1,205 @@
+// DomainEnvVarsCard — GH #1332 item 14. Per-domain environment variables,
+// delivered to PHP as fastcgi_param (reach getenv() + $_SERVER). Self-contained
+// (its own domain picker) so it drops into the PHP Settings tabs cleanly.
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  Input,
+  Select,
+  Space,
+  Spin,
+  Typography,
+} from "antd";
+import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
+import { feedback } from "../../../lib/feedback";
+import { apiClient } from "../../../apiClient";
+
+type Domain = { id: string; name: string };
+type EnvVar = { key: string; value: string };
+
+// Mirrors the server denylist (phpenv) so the user gets an inline hint before
+// submitting; the API + agent are the real enforcement.
+const RESERVED = new Set([
+  "PHP_VALUE",
+  "PHP_ADMIN_VALUE",
+  "PHP_ADMIN_FLAG",
+  "SCRIPT_FILENAME",
+  "DOCUMENT_ROOT",
+  "PATH_INFO",
+  "PATH_TRANSLATED",
+  "QUERY_STRING",
+  "HTTPS",
+  "REDIRECT_STATUS",
+]);
+const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+function keyError(key: string): string | null {
+  if (key === "") return null;
+  if (!KEY_RE.test(key)) return "Letters, digits, underscore; can't start with a digit";
+  if (RESERVED.has(key.toUpperCase()) || key.toUpperCase().startsWith("HTTP_"))
+    return "Reserved name";
+  return null;
+}
+
+export function DomainEnvVarsCard() {
+  const [domains, setDomains] = useState<Domain[]>([]);
+  const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
+  const [rows, setRows] = useState<EnvVar[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ data: Domain[] }>("/domains");
+        setDomains(resp.data?.data ?? []);
+      } catch {
+        feedback.message.error("Failed to load domains");
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedDomain) {
+      setRows([]);
+      return;
+    }
+    setLoading(true);
+    apiClient
+      .get<{ env_vars: EnvVar[] }>(`/domains/${selectedDomain}/env-vars`)
+      .then((resp) => setRows(resp.data.env_vars ?? []))
+      .catch(() => feedback.message.error("Failed to load environment variables"))
+      .finally(() => setLoading(false));
+  }, [selectedDomain]);
+
+  const setRow = (i: number, patch: Partial<EnvVar>) =>
+    setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+  const addRow = () => setRows((prev) => [...prev, { key: "", value: "" }]);
+  const removeRow = (i: number) =>
+    setRows((prev) => prev.filter((_, idx) => idx !== i));
+
+  const dupKeys = (() => {
+    const seen = new Set<string>();
+    const dups = new Set<string>();
+    for (const r of rows) {
+      if (r.key && seen.has(r.key)) dups.add(r.key);
+      seen.add(r.key);
+    }
+    return dups;
+  })();
+
+  const hasErrors =
+    rows.some((r) => r.key.trim() === "" || keyError(r.key) !== null) ||
+    dupKeys.size > 0;
+
+  const save = async () => {
+    if (!selectedDomain) return;
+    setSaving(true);
+    try {
+      await apiClient.put(`/domains/${selectedDomain}/env-vars`, {
+        env_vars: rows.map((r) => ({ key: r.key, value: r.value })),
+      });
+      feedback.message.success("Environment variables saved");
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(
+        e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to save",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Per-domain environment variables for PHP apps. They're delivered to
+          PHP&nbsp;via <code>getenv()</code> and <code>$_SERVER</code> (works for
+          Laravel/Symfony <code>env()</code>). They apply only to this
+          domain&apos;s PHP requests.
+        </Typography.Paragraph>
+
+        <Select
+          style={{ minWidth: 280 }}
+          placeholder="Select a domain"
+          value={selectedDomain}
+          onChange={setSelectedDomain}
+          options={domains.map((d) => ({ label: d.name, value: d.id }))}
+        />
+
+        {selectedDomain && (
+          <Spin spinning={loading}>
+            <Space direction="vertical" size="small" style={{ width: "100%" }}>
+              {rows.length === 0 && (
+                <Typography.Text type="secondary">
+                  No variables yet.
+                </Typography.Text>
+              )}
+              {rows.map((r, i) => {
+                const err = keyError(r.key) ?? (dupKeys.has(r.key) ? "Duplicate" : null);
+                return (
+                  <Space
+                    key={i}
+                    align="start"
+                    style={{ width: "100%" }}
+                    wrap
+                  >
+                    <div>
+                      <Input
+                        placeholder="KEY"
+                        value={r.key}
+                        status={err ? "error" : undefined}
+                        style={{ width: 200 }}
+                        onChange={(e) => setRow(i, { key: e.target.value })}
+                      />
+                      {err && (
+                        <Typography.Text
+                          type="danger"
+                          style={{ fontSize: 11, display: "block" }}
+                        >
+                          {err}
+                        </Typography.Text>
+                      )}
+                    </div>
+                    <Input
+                      placeholder="value"
+                      value={r.value}
+                      style={{ width: 320 }}
+                      onChange={(e) => setRow(i, { value: e.target.value })}
+                    />
+                    <Button
+                      icon={<DeleteOutlined />}
+                      onClick={() => removeRow(i)}
+                      aria-label="Remove variable"
+                    />
+                  </Space>
+                );
+              })}
+              <Button icon={<PlusOutlined />} onClick={addRow}>
+                Add variable
+              </Button>
+              {hasErrors && (
+                <Alert
+                  type="warning"
+                  showIcon
+                  message="Fix the highlighted keys before saving (no empty, reserved, or duplicate names)."
+                />
+              )}
+              <Button
+                type="primary"
+                loading={saving}
+                disabled={hasErrors}
+                onClick={save}
+              >
+                Save environment variables
+              </Button>
+            </Space>
+          </Spin>
+        )}
+      </Space>
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
+import { DomainEnvVarsCard } from "./DomainEnvVarsCard";
 import { apiClient } from "../../../apiClient";
 import { getIdentity, type Identity } from "../../../identity";
 import { isPHPEOL } from "../../../utils/phpEol";
@@ -717,6 +718,11 @@ export function UserPHPSettingsPage() {
               key: "perf",
               label: "Performance",
               children: <UserPHPPerformanceCard />,
+            },
+            {
+              key: "env",
+              label: "Environment",
+              children: <DomainEnvVarsCard />,
             },
           ]}
         />


### PR DESCRIPTION
## Summary

GH #1332 **item 14** — per-domain **environment variables** for PHP apps (Laravel/Symfony et al). Delivered to PHP as nginx `fastcgi_param` in the PHP location, so they're readable via `getenv()` **and** `$_SERVER`.

Box-drilled: `fastcgi_param APP_ENV=staging` → `getenv("APP_ENV") == "staging"` (and `$_SERVER`).

## Security — the key list is a sandbox boundary

Box-drilled on the test host: a `fastcgi_param` named **`PHP_ADMIN_VALUE`** *overrides* the FPM pool's `php_admin_value`:

```
pool: php_admin_value[disable_functions] = exec,system
request PHP_ADMIN_VALUE="disable_functions="  ->  ini_get('disable_functions') == []
```

That clears the #401 command-exec lockdown (and `open_basedir` the same way) — full sandbox escape. So a shared **`internal/phpenv`** package (used by **both** panel-api and the agent) denies `PHP_VALUE` / `PHP_ADMIN_VALUE` / `PHP_ADMIN_FLAG` and the CGI routing/meta vars (`SCRIPT_FILENAME`, `DOCUMENT_ROOT`, `PATH_INFO`, `SERVER_*`, `REMOTE_*`, `HTTPS`, …) and any `HTTP_` prefix; values reject control chars and are backslash/quote-escaped for the nginx double-quoted string.

## Changes

- **model/migration** — `domains.env_vars` JSON column (migration `000280`); dedicated `UpdateEnvVars` repo method (not in the Update allowlist).
- **panel-api** — `GET`/`PUT /domains/:id/env-vars` (owner/admin scoped, full replace, validated + de-duped, capped at 100). In `openapi.yaml`.
- **agent (`domain.create`)** — `env_vars` param → `buildEnvParams` renders one `fastcgi_param KEY "VALUE";` per var in every PHP location, re-validating each key against the same denylist (defense in depth) and dropping a bad entry rather than rendering it. Non-PHP domains emit nothing; the empty case is **byte-identical** to the pre-feature vhost (guard test).
- **panel-ui** — an **"Environment"** tab on the PHP Settings page: a key/value editor with inline validation mirroring the server denylist.

## Verification

- ✅ Box-drilled `fastcgi_param`→`getenv`/`$_SERVER` and the `PHP_ADMIN_VALUE` override vector (justifying the denylist).
- ✅ Unit: `phpenv` key/value/escape table (full deny set); `buildEnvParams` render/escape/denylist-drop; vhost byte-identical guard; widened `DomainRepository` stubbed in affected mocks; UI `tsc`.

## Release / deploy note

Touches the **`domain.create` agent verb** (new `fastcgi_param` env lines) — fleet agents must be redeployed. **Migration `000280`.** This batch also carries `278` (#1383) and `279` (#1384); **merge in number order** so the sequence stays contiguous — the isolated-branch migration-contiguity check only sees this branch's own migrations until the siblings land.

## Test plan

- [ ] Deploy; on a PHP domain, add `APP_ENV=staging` under the Environment tab.
- [ ] In a PHP file: `echo getenv('APP_ENV');` → `staging`; confirm a sibling domain doesn't see it.
- [ ] Confirm the API rejects a var named `PHP_ADMIN_VALUE`.
