### PR TITLE
feat(php): per-version opt-in extra PHP extensions (GH #1332 item 16)

### DIFF
--- a/panel-agent/internal/commands/php_pool_apply.go
+++ b/panel-agent/internal/commands/php_pool_apply.go
@@ -53,7 +53,18 @@ type phpPoolApplyParams struct {
 	// forbiddenDirectives guard (which still rejects disable_functions in
 	// admin_values), so a tenant can never shorten their own blocklist.
 	DisableFunctions *string `json:"disable_functions"`
+	// ExtraExtensions are opt-in PHP extensions to load for this pool only (GH
+	// #1332 item 16), rendered as php_admin_value[extension]=<name>.so. Names
+	// are validated here (regex + the .so must exist) — an unknown or missing
+	// one is skipped, never rendered raw. Panel-controlled channel: it bypasses
+	// the tenant admin_values allowlist (which has no "extension" entry) exactly
+	// like disable_functions does.
+	ExtraExtensions []string `json:"extra_extensions,omitempty"`
 }
+
+// phpExtNameRE bounds an extension name to a safe module identifier before it is
+// turned into "<name>.so" and rendered into the pool conf.
+var phpExtNameRE = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$`)
 
 // KV represents a key-value pair for ini directives.
 type KV struct {
@@ -656,6 +667,30 @@ func phpPoolApplyHandler(ctx context.Context, params json.RawMessage) (any, erro
 		AdminValues:                    p.AdminValues,
 		AdminFlags:                     p.AdminFlags,
 		DisableFunctions:               disableFunctions,
+	}
+
+	// GH #1332 item 16: load opt-in extra extensions for THIS pool via
+	// php_admin_value[extension]=<name>.so (box-drilled: multiple such lines
+	// accumulate). Panel-controlled channel like disable_functions — validate
+	// the name and that the .so is actually installed; skip anything unknown so
+	// a bad entry can never break the pool. Copy first: don't mutate the caller's
+	// AdminValues backing array.
+	if len(p.ExtraExtensions) > 0 {
+		merged := make([]KV, 0, len(spec.AdminValues)+len(p.ExtraExtensions))
+		merged = append(merged, spec.AdminValues...)
+		seen := map[string]bool{}
+		for _, ext := range p.ExtraExtensions {
+			if !phpExtNameRE.MatchString(ext) || seen[ext] {
+				continue
+			}
+			so := ext + ".so"
+			if matches, _ := filepath.Glob("/usr/lib/php/*/" + so); len(matches) == 0 {
+				continue
+			}
+			seen[ext] = true
+			merged = append(merged, KV{Name: "extension", Value: so})
+		}
+		spec.AdminValues = merged
 	}
 
 	var buf strings.Builder

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3795,6 +3795,18 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/php-extensions:
+    get:
+      tags: [Me]
+      summary: List installable + enabled extra PHP extensions for a version
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Me]
+      summary: Set the pool's opt-in extra PHP extensions for a version
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/server-capabilities:
     get:
       tags: [Me]

--- a/panel-api/internal/api/php_pool_extensions.go
+++ b/panel-api/internal/api/php_pool_extensions.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/phpext"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// php_pool_extensions.go — GH #1332 item 16. Per-(user, PHP version) opt-in
+// extra PHP extensions. Extensions load once per FPM master (per pool), so this
+// is pool-scoped, not per-domain; a tenant can turn ON installed extras but not
+// turn OFF a base extension enabled server-wide.
+
+const maxExtraExtensions = 40
+
+// PHPPoolExtensionsHandlerConfig wires the per-pool extension routes.
+type PHPPoolExtensionsHandlerConfig struct {
+	Agent               agent.AgentInterface
+	Users               repository.UserRepository
+	Packages            repository.PackageRepository
+	PHPPools            repository.PHPPoolRepository
+	PHPPoolIniOverrides repository.PHPPoolIniOverrideRepository
+}
+
+func RegisterPHPPoolExtensionsRoutes(g *gin.RouterGroup, cfg PHPPoolExtensionsHandlerConfig) {
+	h := &phpPoolExtensionsHandler{cfg: cfg}
+	g.GET("/me/php-extensions", h.list)
+	g.PUT("/me/php-extensions", h.set)
+}
+
+type phpPoolExtensionsHandler struct {
+	cfg PHPPoolExtensionsHandlerConfig
+}
+
+// owner resolves the caller + their package; canEdit gates the whole feature on
+// the same FPM-editing package flag the tuning card uses.
+func (h *phpPoolExtensionsHandler) owner(c *gin.Context) (*models.User, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		return nil, false
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil || user == nil || user.PackageID == nil {
+		return user, false
+	}
+	pkg, err := h.cfg.Packages.FindByID(c.Request.Context(), *user.PackageID)
+	if err != nil || pkg == nil {
+		return user, false
+	}
+	return user, pkg.FpmUserCanEdit
+}
+
+func (h *phpPoolExtensionsHandler) pool(c *gin.Context, userID, version string) (*models.PHPPool, bool) {
+	ctx := c.Request.Context()
+	if version != "" {
+		if p, err := h.cfg.PHPPools.FindByUserAndVersion(ctx, userID, version); err == nil && p != nil {
+			return p, true
+		}
+		return nil, false
+	}
+	if p, err := h.cfg.PHPPools.FindByUserID(ctx, userID); err == nil && p != nil {
+		return p, true
+	}
+	return nil, false
+}
+
+// list returns the installed, non-built-in extensions the caller may toggle for
+// a version, plus the set currently enabled on that pool.
+func (h *phpPoolExtensionsHandler) list(c *gin.Context) {
+	user, canEdit := h.owner(c)
+	if user == nil || !canEdit {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	version := c.Query("php_version")
+	pool, ok := h.pool(c, user.ID, version)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+	available := h.installedExtensions(c, pool.PHPVersion)
+	c.JSON(http.StatusOK, gin.H{
+		"php_version": pool.PHPVersion,
+		"available":   available,
+		"enabled":     []string(pool.ExtraExtensions),
+	})
+}
+
+type setExtensionsRequest struct {
+	PHPVersion string   `json:"php_version"`
+	Extensions []string `json:"extensions"`
+}
+
+func (h *phpPoolExtensionsHandler) set(c *gin.Context) {
+	user, canEdit := h.owner(c)
+	if user == nil || !canEdit {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	var req setExtensionsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	if len(req.Extensions) > maxExtraExtensions {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "too_many_extensions"})
+		return
+	}
+	pool, ok := h.pool(c, user.ID, req.PHPVersion)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+	// Validate each against the known-extension catalog and drop built-ins
+	// (always present) + duplicates. The agent re-checks the .so is installed.
+	seen := map[string]bool{}
+	clean := make(models.StringList, 0, len(req.Extensions))
+	for _, name := range req.Extensions {
+		spec, known := phpext.Lookup(name)
+		if !known || spec.BuiltIn || seen[name] {
+			continue
+		}
+		seen[name] = true
+		clean = append(clean, name)
+	}
+	pool.ExtraExtensions = clean
+	pool.Status = "pending"
+	if err := h.cfg.PHPPools.Update(c.Request.Context(), pool); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.Set("audit_target", "php_extensions:"+pool.PHPVersion)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	c.JSON(http.StatusOK, gin.H{"enabled": []string(clean)})
+}
+
+// installedExtensions asks the agent which non-built-in extensions are installed
+// for the version. Best-effort: on any agent hiccup it falls back to the static
+// catalog so the UI still renders something to toggle.
+func (h *phpPoolExtensionsHandler) installedExtensions(c *gin.Context, version string) []string {
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "php.ext.list", map[string]string{"version": version})
+	if err == nil {
+		var env struct {
+			Extensions []struct {
+				Name      string `json:"name"`
+				Installed bool   `json:"installed"`
+				BuiltIn   bool   `json:"built_in"`
+			} `json:"extensions"`
+		}
+		if json.Unmarshal(raw, &env) == nil && len(env.Extensions) > 0 {
+			out := []string{}
+			for _, e := range env.Extensions {
+				if e.Installed && !e.BuiltIn {
+					out = append(out, e.Name)
+				}
+			}
+			return out
+		}
+	}
+	out := []string{}
+	for _, s := range phpext.All() {
+		if !s.BuiltIn {
+			out = append(out, s.Name)
+		}
+	}
+	return out
+}

--- a/panel-api/internal/api/php_pool_reconcile.go
+++ b/panel-api/internal/api/php_pool_reconcile.go
@@ -84,6 +84,7 @@ func reconcilePHPPoolViaAgent(
 		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
 		"admin_values":                      adminValues,
 		"admin_flags":                       adminFlags,
+		"extra_extensions":                  []string(pool.ExtraExtensions),
 	})
 	if err != nil {
 		pool.Status = "error"

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1234,6 +1234,14 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				PHPPoolIniOverrides: deps.PHPPoolIniOverrides,
 				Modes:               deps.PHPPerformanceModes,
 			})
+			// GH #1332 item 16: per-(user,version) opt-in extra extensions.
+			api.RegisterPHPPoolExtensionsRoutes(v1, api.PHPPoolExtensionsHandlerConfig{
+				Agent:               deps.Agent,
+				Users:               deps.Users,
+				Packages:            deps.Packages,
+				PHPPools:            deps.PHPPools,
+				PHPPoolIniOverrides: deps.PHPPoolIniOverrides,
+			})
 		}
 		if deps.Domains != nil && deps.PHPPools != nil {
 			api.RegisterDomainPHPPoolRoutes(v1, api.DomainPHPPoolHandlerConfig{

--- a/panel-api/internal/db/migrations/000281_php_pool_extra_extensions.down.sql
+++ b/panel-api/internal/db/migrations/000281_php_pool_extra_extensions.down.sql
@@ -1,0 +1,3 @@
+-- Reverse GH #1332 per-pool extra extensions.
+ALTER TABLE php_pools
+  DROP COLUMN extra_extensions;

--- a/panel-api/internal/db/migrations/000281_php_pool_extra_extensions.up.sql
+++ b/panel-api/internal/db/migrations/000281_php_pool_extra_extensions.up.sql
@@ -1,0 +1,4 @@
+-- GH #1332 (item 16): per-(user,version) pool opt-in extra PHP extensions,
+-- loaded via php_admin_value[extension] in the pool conf. JSON array of names.
+ALTER TABLE php_pools
+  ADD COLUMN extra_extensions JSON NULL DEFAULT NULL;

--- a/panel-api/internal/models/php_pool.go
+++ b/panel-api/internal/models/php_pool.go
@@ -1,6 +1,42 @@
 package models
 
-import "time"
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// StringList is a []string persisted to a JSON column (empty => SQL NULL).
+type StringList []string
+
+func (s StringList) Value() (driver.Value, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(s)
+}
+
+func (s *StringList) Scan(src any) error {
+	if src == nil {
+		*s = nil
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("StringList.Scan: unsupported type %T", src)
+	}
+	if len(b) == 0 {
+		*s = nil
+		return nil
+	}
+	return json.Unmarshal(b, s)
+}
 
 // PHPPool represents a PHP-FPM pool bound to a panel user.
 // Each panel user gets exactly one pool per MVP constraint.
@@ -19,12 +55,17 @@ type PHPPool struct {
 	// SlowlogTimeoutSeconds (GH #1332 item 12): when > 0, FPM logs a backtrace of
 	// any request slower than this to the pool's slow log. 0 = disabled. The
 	// slowlog path is derived agent-side from the slug (never sent over the wire).
-	SlowlogTimeoutSeconds uint32    `gorm:"column:slowlog_timeout_seconds;type:int unsigned;not null;default:0" json:"slowlog_timeout_seconds"`
-	PerformanceMode       string    `gorm:"column:performance_mode;type:varchar(24);not null;default:'balanced'" json:"performance_mode"`
-	Status                string    `gorm:"type:varchar(16);not null;default:'pending'" json:"status"`
-	LastError             *string   `gorm:"type:text" json:"last_error,omitempty"`
-	CreatedAt             time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt             time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+	SlowlogTimeoutSeconds uint32 `gorm:"column:slowlog_timeout_seconds;type:int unsigned;not null;default:0" json:"slowlog_timeout_seconds"`
+	PerformanceMode       string `gorm:"column:performance_mode;type:varchar(24);not null;default:'balanced'" json:"performance_mode"`
+	// ExtraExtensions are optional PHP extensions the tenant opted this pool into
+	// (GH #1332 item 16), loaded per-pool via php_admin_value[extension]. Names
+	// are validated against the installed-extension allowlist (phpext). Can add
+	// installed extras; cannot disable a base extension (loaded server-wide).
+	ExtraExtensions StringList `gorm:"column:extra_extensions;type:json" json:"extra_extensions,omitempty"`
+	Status          string     `gorm:"type:varchar(16);not null;default:'pending'" json:"status"`
+	LastError       *string    `gorm:"type:text" json:"last_error,omitempty"`
+	CreatedAt       time.Time  `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt       time.Time  `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (PHPPool) TableName() string { return "php_pools" }
@@ -50,6 +91,7 @@ func NewVersionedPHPPool(id, phpVersion string, def *PHPPool) *PHPPool {
 		RequestTerminateTimeoutSeconds: def.RequestTerminateTimeoutSeconds,
 		SlowlogTimeoutSeconds:          def.SlowlogTimeoutSeconds,
 		PerformanceMode:                def.PerformanceMode,
+		ExtraExtensions:                def.ExtraExtensions,
 		Status:                         "pending",
 	}
 }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1599,6 +1599,7 @@ func (r *Reconciler) applyPHPPool(ctx context.Context, user *models.User, pool *
 		"pm_max_requests":                   pool.PmMaxRequests,
 		"request_terminate_timeout_seconds": pool.RequestTerminateTimeoutSeconds,
 		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
+		"extra_extensions":                  []string(pool.ExtraExtensions),
 	}
 
 	// GH #402: if the user's package opts out of the #401 command-exec

--- a/panel-api/internal/repository/php_pool_repository_test.go
+++ b/panel-api/internal/repository/php_pool_repository_test.go
@@ -45,6 +45,7 @@ func TestPHPPoolRepository_Create(t *testing.T) {
 			sqlmock.AnyArg(), // request_terminate_timeout_seconds
 			sqlmock.AnyArg(), // slowlog_timeout_seconds (GH #1332 item 12)
 			sqlmock.AnyArg(), // performance_mode
+			sqlmock.AnyArg(), // extra_extensions (GH #1332 item 16)
 			pool.Status,
 			sqlmock.AnyArg(), // last_error
 			sqlmock.AnyArg(), // created_at
@@ -205,6 +206,7 @@ func TestPHPPoolRepository_Update(t *testing.T) {
 			sqlmock.AnyArg(), // request_terminate_timeout_seconds
 			sqlmock.AnyArg(), // slowlog_timeout_seconds (GH #1332 item 12)
 			sqlmock.AnyArg(), // performance_mode
+			sqlmock.AnyArg(), // extra_extensions (GH #1332 item 16)
 			sqlmock.AnyArg(), // status
 			sqlmock.AnyArg(), // last_error
 			sqlmock.AnyArg(), // created_at

--- a/panel-ui/src/shells/user/php-settings/PHPExtensionsCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/PHPExtensionsCard.tsx
@@ -1,0 +1,134 @@
+// PHPExtensionsCard — GH #1332 item 16. Per-(user, PHP version) opt-in extra
+// extensions. Extensions load once per FPM master (one per version), so this is
+// version-scoped: a tenant can turn ON installed extras for their pool; base
+// extensions stay enabled server-wide.
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Empty,
+  Select,
+  Space,
+  Spin,
+  Typography,
+} from "antd";
+import { feedback } from "../../../lib/feedback";
+import { apiClient } from "../../../apiClient";
+
+type PoolRow = { php_version: string; is_default: boolean };
+type ExtResp = { php_version: string; available: string[]; enabled: string[] };
+
+export function PHPExtensionsCard() {
+  const [versions, setVersions] = useState<PoolRow[]>([]);
+  const [version, setVersion] = useState<string>("");
+  const [available, setAvailable] = useState<string[]>([]);
+  const [enabled, setEnabled] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [notAllowed, setNotAllowed] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ pools: PoolRow[] }>("/me/php-pool-tuning");
+        const pools = resp.data?.pools ?? [];
+        setVersions(pools);
+        const def = pools.find((p) => p.is_default) ?? pools[0];
+        if (def) setVersion(def.php_version);
+      } catch {
+        /* no pools -> nothing to configure */
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!version) return;
+    setLoading(true);
+    apiClient
+      .get<ExtResp>("/me/php-extensions", { params: { php_version: version } })
+      .then((resp) => {
+        setAvailable(resp.data.available ?? []);
+        setEnabled(resp.data.enabled ?? []);
+        setNotAllowed(false);
+      })
+      .catch((err) => {
+        if (err?.response?.status === 403) setNotAllowed(true);
+        else feedback.message.error("Failed to load extensions");
+      })
+      .finally(() => setLoading(false));
+  }, [version]);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      await apiClient.put("/me/php-extensions", {
+        php_version: version,
+        extensions: enabled,
+      });
+      feedback.message.success(
+        "Extensions updated — PHP restarted for this version",
+      );
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(
+        e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to save",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (notAllowed) {
+    return (
+      <Alert
+        type="info"
+        showIcon
+        message="Extension management isn't enabled on your plan."
+      />
+    );
+  }
+
+  return (
+    <Card>
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Turn on additional PHP extensions for a version. This affects every
+          site you run on that PHP version (extensions load once per pool). You
+          can add installed extras; base extensions are always on.
+        </Typography.Paragraph>
+
+        {versions.length > 1 && (
+          <Select
+            style={{ minWidth: 220 }}
+            value={version}
+            onChange={setVersion}
+            options={versions.map((p) => ({
+              value: p.php_version,
+              label: `PHP ${p.php_version}${p.is_default ? " (default)" : ""}`,
+            }))}
+          />
+        )}
+
+        <Spin spinning={loading}>
+          {available.length === 0 ? (
+            <Empty description="No optional extensions available." />
+          ) : (
+            <Checkbox.Group
+              value={enabled}
+              onChange={(v) => setEnabled(v as string[])}
+              style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))", gap: 8 }}
+              options={available.map((name) => ({ label: name, value: name }))}
+            />
+          )}
+          <div style={{ marginTop: 16 }}>
+            <Button type="primary" loading={saving} disabled={!version} onClick={save}>
+              Save extensions
+            </Button>
+          </div>
+        </Spin>
+      </Space>
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
 import { DomainEnvVarsCard } from "./DomainEnvVarsCard";
+import { PHPExtensionsCard } from "./PHPExtensionsCard";
 import { apiClient } from "../../../apiClient";
 import { getIdentity, type Identity } from "../../../identity";
 import { isPHPEOL } from "../../../utils/phpEol";
@@ -723,6 +724,11 @@ export function UserPHPSettingsPage() {
               key: "env",
               label: "Environment",
               children: <DomainEnvVarsCard />,
+            },
+            {
+              key: "extensions",
+              label: "Extensions",
+              children: <PHPExtensionsCard />,
             },
           ]}
         />


### PR DESCRIPTION
## Summary

GH #1332 **item 16** — per-version opt-in **extra PHP extensions**. A tenant can turn **on** additional installed extensions for their own pool.

Extensions load once per FPM master, and a user gets one master per PHP version (GH #329), so this is **per-(user, PHP version)** — you can add installed extras, but you can't *disable* a base extension enabled server-wide (Debian `phpenmod`, an admin concern). That's the honest limit of a shared-hosting stack, and the UI says so.

**Mechanism (box-drilled):** multiple `php_admin_value[extension]=<name>.so` lines in the pool conf accumulate and load for that pool only — drilled with `redis` + `gd` both loading from a pool with a minimal baseline ini, no warnings.

## Changes

- **model/migration** — `php_pools.extra_extensions` JSON column (migration `000281`); `NewVersionedPHPPool` clones it.
- **agent (`php.pool.apply`)** — `extra_extensions` param → validated (name regex + the `.so` must exist under `/usr/lib/php/*/`) and injected as `php_admin_value[extension]` lines. Panel-controlled channel (bypasses the tenant `admin_values` allowlist like `disable_functions`); an unknown/missing name is skipped, never rendered raw.
- **panel-api** — `GET`/`PUT /me/php-extensions` (gated on the FPM-edit package flag). GET asks the agent `php.ext.list` for installed non-built-in extensions (falls back to the static `phpext` catalog); PUT validates against `phpext`, de-dupes, caps at 40, stores on the pool, reconciles.
- **panel-ui** — an **"Extensions"** tab on the PHP Settings page: a per-version checkbox grid.

## Verification

- ✅ Box-drilled multi-extension per-pool load (`php_admin_value[extension]`).
- ✅ agent + panel-api + reconciler + openapi-coverage suites; UI `tsc`.

## Release / deploy note

Touches the **`php.pool.apply` agent verb** (new `extra_extensions` param) — fleet agents must be redeployed. **Migration `000281`** — batch order `278` (#1383), `279` (#1384), `280` (#1386), `281` (here); **merge in number order**.

## Test plan

- [ ] Deploy; on the Extensions tab enable e.g. `redis` for a version.
- [ ] `php -m` (or `extension_loaded('redis')`) on a site running that version shows it; a site on another version doesn't.
