### PR TITLE
feat(php): per-version Xdebug toggle, safe modes (GH #1332 item 9)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2770,6 +2770,19 @@ PLACEHOLDER_EOF
   chmod 0644 "/etc/php/${version}/fpm/pool.d/_jabali-placeholder.conf"
   _ok "installed placeholder pool for PHP ${version}"
 
+  # GH #1332 item 9: Xdebug is opt-in PER POOL via a per-slug PHP_INI_SCAN_DIR
+  # (fpm-exec adds /etc/php/<v>/jabali-ext/<slug>). Install the .so but keep it
+  # GLOBALLY DISABLED — enabled globally it would tax every request on every
+  # site fleet-wide. The base scan-dir parent is pre-created so the agent can
+  # drop per-slug ini files into it.
+  install -d -m 0755 "/etc/php/${version}/jabali-ext"
+  if DEBIAN_FRONTEND=noninteractive apt-get install -y "php${version}-xdebug" >/dev/null 2>&1; then
+    phpdismod -v "${version}" xdebug 2>/dev/null || true
+    _ok "PHP ${version} Xdebug installed (globally off; opt-in per pool)"
+  else
+    _warn "php${version}-xdebug unavailable — per-pool Xdebug will be off for ${version}"
+  fi
+
 
   # Mask the distro's global php<v>-fpm.service — per ADR-0025 we run
   # one FPM master per hosting user (jabali-fpm@<user>.service) inside

--- a/install/systemd/fpm-exec
+++ b/install/systemd/fpm-exec
@@ -16,6 +16,15 @@ verfile="/run/php/jabali-${user}/phpver"
 ver=$(cat "$verfile")
 [[ "$ver" =~ ^[0-9]+\.[0-9]+$ ]] || { echo "fpm-exec: malformed version '$ver' in $verfile" >&2; exit 1; }
 
+# GH #1332 item 9: give THIS master an additional per-slug ini scan dir so
+# opt-in Zend extensions (Xdebug) can be enabled for one user's pool only. The
+# leading colon keeps PHP's compiled-in default conf.d (every normal extension),
+# then also scans the per-slug dir. The dir usually does not exist (no opt-in) —
+# PHP silently skips a missing scan dir, so this is a no-op for every pool that
+# hasn't enabled anything. Path stays under /etc/php/** (already AppArmor-readable
+# + agent/root-writable); "$user" here is the systemd instance = the pool slug.
+export PHP_INI_SCAN_DIR=":/etc/php/${ver}/jabali-ext/${user}"
+
 # --nodaemonize (-F) keeps php-fpm in foreground so systemd supervises
 # it with Type=simple. --fpm-config points at the per-user FPM config
 # so only this user's pool is loaded (fixes the glob-includes-all-pools bug).

--- a/panel-agent/internal/commands/php_pool_apply.go
+++ b/panel-agent/internal/commands/php_pool_apply.go
@@ -60,6 +60,11 @@ type phpPoolApplyParams struct {
 	// the tenant admin_values allowlist (which has no "extension" entry) exactly
 	// like disable_functions does.
 	ExtraExtensions []string `json:"extra_extensions,omitempty"`
+	// XdebugEnabled (GH #1332 item 9) turns Xdebug on for THIS pool via a per-slug
+	// PHP_INI_SCAN_DIR ini (fpm-exec sets the scan dir). Safe modes only — no
+	// step-debug/remote-connect. Requires xdebug.so installed; the agent refuses
+	// to enable it otherwise so the master can't crash-loop on a missing .so.
+	XdebugEnabled bool `json:"xdebug_enabled,omitempty"`
 }
 
 // phpExtNameRE bounds an extension name to a safe module identifier before it is
@@ -749,6 +754,15 @@ func phpPoolApplyHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
+	// GH #1332 item 9: manage the per-slug Xdebug ini before the (re)start.
+	// fpm-exec adds /etc/php/<ver>/jabali-ext/<slug> to PHP_INI_SCAN_DIR, so an
+	// ini dropped there enables Xdebug for THIS pool only. Refuse to enable when
+	// xdebug.so is missing (a bad zend_extension line crash-loops the master).
+	xdebugChanged, xderr := applyPoolXdebug(p.PHPVersion, slug, p.Username, p.XdebugEnabled)
+	if xderr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: xderr.Error()}
+	}
+
 	// Restart or reload the slug's FPM service.
 	if err := restartOrReloadUserFPM(ctx, slug, oldVersion, p.PHPVersion); err != nil {
 		return nil, &agentwire.AgentError{
@@ -757,10 +771,67 @@ func phpPoolApplyHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
+	// A changed Xdebug state needs a FULL restart — a USR2 reload (which
+	// restartOrReloadUserFPM may have done for an unchanged version) never
+	// re-reads a zend_extension.
+	if xdebugChanged && os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
+		_ = execCommandContext(ctx, "systemctl", "restart", fmt.Sprintf("jabali-fpm@%s.service", slug)).Run()
+	}
+
 	return phpPoolApplyResponse{
 		SocketPath: socketPath,
 		PoolName:   poolName,
 	}, nil
+}
+
+// applyPoolXdebug writes or removes the per-slug Xdebug ini (GH #1332 item 9),
+// returning whether the on-disk state changed (so the caller can force a full
+// restart). Safe modes only — develop/coverage/profile, never remote
+// step-debug; profiler output goes to the tenant's ~/logs.
+func applyPoolXdebug(version, slug, username string, enabled bool) (bool, error) {
+	dir := filepath.Join("/etc/php", version, "jabali-ext", slug)
+	ini := filepath.Join(dir, "20-xdebug.ini")
+	_, statErr := os.Stat(ini)
+	isOn := statErr == nil
+
+	if !enabled {
+		if !isOn {
+			return false, nil
+		}
+		if err := os.Remove(ini); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("disable xdebug: %w", err)
+		}
+		return true, nil
+	}
+
+	// Enabling: xdebug.so must be installed or the master won't start.
+	if m, _ := filepath.Glob("/usr/lib/php/*/xdebug.so"); len(m) == 0 {
+		return false, fmt.Errorf("Xdebug is not installed on this server")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Errorf("create xdebug scan dir: %w", err)
+	}
+	logsDir := filepath.Join("/home", username, "logs")
+	_ = os.MkdirAll(logsDir, 0o750)
+	if u, e := user.Lookup(username); e == nil {
+		uid, _ := strconv.Atoi(u.Uid)
+		gid, _ := strconv.Atoi(u.Gid)
+		_ = os.Chown(logsDir, uid, gid)
+	}
+	content := "; Managed by jabali (GH #1332 item 9). Safe modes only — no remote step-debug.\n" +
+		"zend_extension=xdebug.so\n" +
+		"xdebug.mode=develop,coverage,profile\n" +
+		"xdebug.start_with_request=no\n" +
+		"xdebug.output_dir=" + logsDir + "\n"
+	if isOn {
+		if cur, _ := os.ReadFile(ini); string(cur) == content {
+			return false, nil // already in the desired state
+		}
+	}
+	if err := os.WriteFile(ini, []byte(content), 0o644); err != nil {
+		return false, fmt.Errorf("write xdebug ini: %w", err)
+	}
+	return true, nil
 }
 
 func init() {

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3807,6 +3807,18 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/php-xdebug:
+    get:
+      tags: [Me]
+      summary: Get the pool's Xdebug state for a PHP version
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Me]
+      summary: Toggle Xdebug (safe modes) for a PHP version's pool
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/server-capabilities:
     get:
       tags: [Me]

--- a/panel-api/internal/api/php_pool_reconcile.go
+++ b/panel-api/internal/api/php_pool_reconcile.go
@@ -85,6 +85,7 @@ func reconcilePHPPoolViaAgent(
 		"admin_values":                      adminValues,
 		"admin_flags":                       adminFlags,
 		"extra_extensions":                  []string(pool.ExtraExtensions),
+		"xdebug_enabled":                    pool.XdebugEnabled,
 	})
 	if err != nil {
 		pool.Status = "error"

--- a/panel-api/internal/api/php_pool_xdebug.go
+++ b/panel-api/internal/api/php_pool_xdebug.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// php_pool_xdebug.go — GH #1332 item 9. Per-(user, PHP version) Xdebug toggle
+// (safe modes only: develop/coverage/profile — no remote step-debug). Xdebug is
+// a Zend extension loaded once per FPM master, so this is pool-scoped.
+
+// PHPXdebugHandlerConfig wires the per-pool Xdebug routes.
+type PHPXdebugHandlerConfig struct {
+	Agent               agent.AgentInterface
+	Users               repository.UserRepository
+	Packages            repository.PackageRepository
+	PHPPools            repository.PHPPoolRepository
+	PHPPoolIniOverrides repository.PHPPoolIniOverrideRepository
+}
+
+func RegisterPHPXdebugRoutes(g *gin.RouterGroup, cfg PHPXdebugHandlerConfig) {
+	h := &phpXdebugHandler{cfg: cfg}
+	g.GET("/me/php-xdebug", h.get)
+	g.PUT("/me/php-xdebug", h.set)
+}
+
+type phpXdebugHandler struct{ cfg PHPXdebugHandlerConfig }
+
+func (h *phpXdebugHandler) owner(c *gin.Context) (*models.User, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		return nil, false
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil || user == nil || user.PackageID == nil {
+		return user, false
+	}
+	pkg, err := h.cfg.Packages.FindByID(c.Request.Context(), *user.PackageID)
+	if err != nil || pkg == nil {
+		return user, false
+	}
+	return user, pkg.FpmUserCanEdit
+}
+
+func (h *phpXdebugHandler) pool(c *gin.Context, userID, version string) (*models.PHPPool, bool) {
+	ctx := c.Request.Context()
+	if version != "" {
+		if p, err := h.cfg.PHPPools.FindByUserAndVersion(ctx, userID, version); err == nil && p != nil {
+			return p, true
+		}
+		return nil, false
+	}
+	if p, err := h.cfg.PHPPools.FindByUserID(ctx, userID); err == nil && p != nil {
+		return p, true
+	}
+	return nil, false
+}
+
+func (h *phpXdebugHandler) get(c *gin.Context) {
+	user, canEdit := h.owner(c)
+	if user == nil || !canEdit {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	pool, ok := h.pool(c, user.ID, c.Query("php_version"))
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"php_version": pool.PHPVersion, "enabled": pool.XdebugEnabled})
+}
+
+type setXdebugRequest struct {
+	PHPVersion string `json:"php_version"`
+	Enabled    bool   `json:"enabled"`
+}
+
+func (h *phpXdebugHandler) set(c *gin.Context) {
+	user, canEdit := h.owner(c)
+	if user == nil || !canEdit {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	var req setXdebugRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	pool, ok := h.pool(c, user.ID, req.PHPVersion)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+	pool.XdebugEnabled = req.Enabled
+	pool.Status = "pending"
+	if err := h.cfg.PHPPools.Update(c.Request.Context(), pool); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.Set("audit_target", "php_xdebug:"+pool.PHPVersion)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	c.JSON(http.StatusOK, gin.H{"enabled": pool.XdebugEnabled})
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1242,6 +1242,14 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				PHPPools:            deps.PHPPools,
 				PHPPoolIniOverrides: deps.PHPPoolIniOverrides,
 			})
+			// GH #1332 item 9: per-(user,version) Xdebug toggle.
+			api.RegisterPHPXdebugRoutes(v1, api.PHPXdebugHandlerConfig{
+				Agent:               deps.Agent,
+				Users:               deps.Users,
+				Packages:            deps.Packages,
+				PHPPools:            deps.PHPPools,
+				PHPPoolIniOverrides: deps.PHPPoolIniOverrides,
+			})
 		}
 		if deps.Domains != nil && deps.PHPPools != nil {
 			api.RegisterDomainPHPPoolRoutes(v1, api.DomainPHPPoolHandlerConfig{

--- a/panel-api/internal/db/migrations/000282_php_pool_xdebug.down.sql
+++ b/panel-api/internal/db/migrations/000282_php_pool_xdebug.down.sql
@@ -1,0 +1,3 @@
+-- Reverse GH #1332 per-pool Xdebug toggle.
+ALTER TABLE php_pools
+  DROP COLUMN xdebug_enabled;

--- a/panel-api/internal/db/migrations/000282_php_pool_xdebug.up.sql
+++ b/panel-api/internal/db/migrations/000282_php_pool_xdebug.up.sql
@@ -1,0 +1,4 @@
+-- GH #1332 (item 9): per-(user,version) pool Xdebug toggle (safe modes only).
+-- Applied by the agent via a per-slug PHP_INI_SCAN_DIR ini.
+ALTER TABLE php_pools
+  ADD COLUMN xdebug_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/php_pool.go
+++ b/panel-api/internal/models/php_pool.go
@@ -62,10 +62,13 @@ type PHPPool struct {
 	// are validated against the installed-extension allowlist (phpext). Can add
 	// installed extras; cannot disable a base extension (loaded server-wide).
 	ExtraExtensions StringList `gorm:"column:extra_extensions;type:json" json:"extra_extensions,omitempty"`
-	Status          string     `gorm:"type:varchar(16);not null;default:'pending'" json:"status"`
-	LastError       *string    `gorm:"type:text" json:"last_error,omitempty"`
-	CreatedAt       time.Time  `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt       time.Time  `gorm:"type:datetime(6);not null" json:"updated_at"`
+	// XdebugEnabled (GH #1332 item 9): Xdebug on for this (user,version) pool,
+	// safe modes only. Applied via a per-slug PHP_INI_SCAN_DIR ini by the agent.
+	XdebugEnabled bool      `gorm:"column:xdebug_enabled;type:tinyint(1);not null;default:0" json:"xdebug_enabled"`
+	Status        string    `gorm:"type:varchar(16);not null;default:'pending'" json:"status"`
+	LastError     *string   `gorm:"type:text" json:"last_error,omitempty"`
+	CreatedAt     time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt     time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (PHPPool) TableName() string { return "php_pools" }
@@ -92,6 +95,7 @@ func NewVersionedPHPPool(id, phpVersion string, def *PHPPool) *PHPPool {
 		SlowlogTimeoutSeconds:          def.SlowlogTimeoutSeconds,
 		PerformanceMode:                def.PerformanceMode,
 		ExtraExtensions:                def.ExtraExtensions,
+		XdebugEnabled:                  def.XdebugEnabled,
 		Status:                         "pending",
 	}
 }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1600,6 +1600,7 @@ func (r *Reconciler) applyPHPPool(ctx context.Context, user *models.User, pool *
 		"request_terminate_timeout_seconds": pool.RequestTerminateTimeoutSeconds,
 		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
 		"extra_extensions":                  []string(pool.ExtraExtensions),
+		"xdebug_enabled":                    pool.XdebugEnabled,
 	}
 
 	// GH #402: if the user's package opts out of the #401 command-exec

--- a/panel-api/internal/repository/php_pool_repository_test.go
+++ b/panel-api/internal/repository/php_pool_repository_test.go
@@ -46,6 +46,7 @@ func TestPHPPoolRepository_Create(t *testing.T) {
 			sqlmock.AnyArg(), // slowlog_timeout_seconds (GH #1332 item 12)
 			sqlmock.AnyArg(), // performance_mode
 			sqlmock.AnyArg(), // extra_extensions (GH #1332 item 16)
+			sqlmock.AnyArg(), // xdebug_enabled (GH #1332 item 9)
 			pool.Status,
 			sqlmock.AnyArg(), // last_error
 			sqlmock.AnyArg(), // created_at
@@ -207,6 +208,7 @@ func TestPHPPoolRepository_Update(t *testing.T) {
 			sqlmock.AnyArg(), // slowlog_timeout_seconds (GH #1332 item 12)
 			sqlmock.AnyArg(), // performance_mode
 			sqlmock.AnyArg(), // extra_extensions (GH #1332 item 16)
+			sqlmock.AnyArg(), // xdebug_enabled (GH #1332 item 9)
 			sqlmock.AnyArg(), // status
 			sqlmock.AnyArg(), // last_error
 			sqlmock.AnyArg(), // created_at

--- a/panel-ui/src/shells/user/php-settings/PHPXdebugCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/PHPXdebugCard.tsx
@@ -1,0 +1,107 @@
+// PHPXdebugCard — GH #1332 item 9. Per-(user, PHP version) Xdebug toggle. Safe
+// modes only (develop/coverage/profile); no remote step-debugging. Xdebug loads
+// once per FPM master, so it's version-scoped, not per-domain.
+import { useEffect, useState } from "react";
+import { Alert, Button, Card, Select, Space, Spin, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback";
+import { apiClient } from "../../../apiClient";
+
+type PoolRow = { php_version: string; is_default: boolean };
+
+export function PHPXdebugCard() {
+  const [versions, setVersions] = useState<PoolRow[]>([]);
+  const [version, setVersion] = useState<string>("");
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [notAllowed, setNotAllowed] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ pools: PoolRow[] }>("/me/php-pool-tuning");
+        const pools = resp.data?.pools ?? [];
+        setVersions(pools);
+        const def = pools.find((p) => p.is_default) ?? pools[0];
+        if (def) setVersion(def.php_version);
+      } catch {
+        /* no pools */
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!version) return;
+    setLoading(true);
+    apiClient
+      .get<{ enabled: boolean }>("/me/php-xdebug", { params: { php_version: version } })
+      .then((resp) => {
+        setEnabled(!!resp.data.enabled);
+        setNotAllowed(false);
+      })
+      .catch((err) => {
+        if (err?.response?.status === 403) setNotAllowed(true);
+        else feedback.message.error("Failed to load Xdebug state");
+      })
+      .finally(() => setLoading(false));
+  }, [version]);
+
+  const save = async (next: boolean) => {
+    setSaving(true);
+    try {
+      await apiClient.put("/me/php-xdebug", { php_version: version, enabled: next });
+      setEnabled(next);
+      feedback.message.success(
+        next ? "Xdebug enabled — PHP restarted for this version" : "Xdebug disabled",
+      );
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(
+        e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to update Xdebug",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (notAllowed) {
+    return <Alert type="info" showIcon message="Xdebug isn't enabled on your plan." />;
+  }
+
+  return (
+    <Card>
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Turn on Xdebug for a PHP version — better error messages, stack traces,
+          code coverage and a profiler (output goes to <code>~/logs</code>).
+          Remote step-debugging is not enabled. Xdebug slows PHP down, so use it
+          on staging, not production. Affects every site on this PHP version.
+        </Typography.Paragraph>
+
+        {versions.length > 1 && (
+          <Select
+            style={{ minWidth: 220 }}
+            value={version}
+            onChange={setVersion}
+            options={versions.map((p) => ({
+              value: p.php_version,
+              label: `PHP ${p.php_version}${p.is_default ? " (default)" : ""}`,
+            }))}
+          />
+        )}
+
+        <Spin spinning={loading}>
+          <Space>
+            <Switch checked={enabled} loading={saving} onChange={save} disabled={!version} />
+            <Typography.Text>{enabled ? "Xdebug on" : "Xdebug off"}</Typography.Text>
+          </Space>
+        </Spin>
+        {enabled && (
+          <Button type="link" style={{ paddingInline: 0 }} disabled>
+            Mode: develop, coverage, profile
+          </Button>
+        )}
+      </Space>
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -8,6 +8,7 @@ import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
 import { DomainEnvVarsCard } from "./DomainEnvVarsCard";
 import { PHPExtensionsCard } from "./PHPExtensionsCard";
+import { PHPXdebugCard } from "./PHPXdebugCard";
 import { apiClient } from "../../../apiClient";
 import { getIdentity, type Identity } from "../../../identity";
 import { isPHPEOL } from "../../../utils/phpEol";
@@ -729,6 +730,11 @@ export function UserPHPSettingsPage() {
               key: "extensions",
               label: "Extensions",
               children: <PHPExtensionsCard />,
+            },
+            {
+              key: "xdebug",
+              label: "Xdebug",
+              children: <PHPXdebugCard />,
             },
           ]}
         />


### PR DESCRIPTION
## Summary

GH #1332 **item 9** — per-version **Xdebug** toggle. Enables Xdebug for a PHP version: better error messages, stack traces, code coverage and a profiler (output to `~/logs`).

**Safe modes only** (`develop, coverage, profile`) — remote step-debugging is deliberately **not** enabled, so a shared box never opens an outbound debug connection (the posture you picked). Xdebug is a Zend extension loaded once per FPM master, so this is **per-(user, PHP version)**, not per-domain.

## Mechanism (box-drilled on a real pool)

Zend extensions load at master startup, so `php_admin_value[zend_extension]` can't enable them per pool (drilled: doesn't work). Instead `fpm-exec` now exports `PHP_INI_SCAN_DIR=":/etc/php/<ver>/jabali-ext/<slug>"` for each master — the **leading colon keeps PHP's default conf.d** (every normal extension), then also scans a per-slug dir the agent writes a xdebug ini into.

Drilled on the **real `jabali-fpm@testing44` pool under AppArmor**:
```
pool active after restart: yes
probe: xdebug=Y ; redis=Y (global still loaded) ; mode=[develop,coverage]
... fully restored
```
The scan dir sits under `/etc/php/**`, which the existing fpm AppArmor profile already allows (`/etc/php/** r`, `/usr/lib/php/** mr` for `xdebug.so`) — **no AppArmor change**.

## Changes

- **install.sh** — installs `php<v>-xdebug` then `phpdismod`s it (globally **off**; enabled globally it would tax every request fleet-wide); pre-creates `/etc/php/<v>/jabali-ext`.
- **fpm-exec** — the per-slug `PHP_INI_SCAN_DIR` export (a no-op when the dir is empty, i.e. every pool that hasn't opted in).
- **agent (`php.pool.apply`)** — `xdebug_enabled` param → `applyPoolXdebug` writes/removes the per-slug ini. **Refuses to enable when `xdebug.so` isn't installed** (a bad `zend_extension` line would crash-loop the master), and **forces a full restart** on a state change (a USR2 reload never re-reads a zend_extension).
- **model/migration** — `php_pools.xdebug_enabled` (migration `000282`); cloned to new per-version pools; both reconcile paths forward it.
- **panel-api** — `GET`/`PUT /me/php-xdebug` (gated on the FPM-edit package flag).
- **panel-ui** — an **"Xdebug"** tab on the PHP Settings page: a per-version switch.

## Verification

- ✅ **Box-drilled** the fpm-exec + per-slug scan-dir + xdebug-load path on a **real pool under AppArmor** (reversible).
- ✅ agent + panel-api + reconciler + openapi-coverage suites; UI `tsc`.

## Release / deploy note

Touches **`fpm-exec`** (the fleet-wide FPM-master launcher) + the **`php.pool.apply`** agent verb + **install.sh** (xdebug packages). Fleet agents + install.sh must be redeployed and existing FPM masters restart to pick up the new launcher (the launcher change is a no-op until a pool opts in). **Migration `000282`** — batch order `278`/`279`/`280`/`281`/`282`; **merge in number order**.

## Test plan

- [ ] Deploy (install.sh + agent + fpm-exec); on the Xdebug tab enable it for a version.
- [ ] On a site running that version: `extension_loaded('xdebug')` true, `xdebug_info()` shows mode develop/coverage/profile, no debug/remote.
- [ ] Disable → off after restart; a version without it is unaffected.
