### PR TITLE
feat(php): per-user Composer version selector (GH #1332 item 13)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2219,40 +2219,72 @@ EARLYDNS
   # Install Composer from getcomposer.org using the configured PHP binary.
   # Do NOT use the Debian `composer` apt package — it depends on php-cli meta
   # which re-installs php8.4-cli and fights our update-alternatives settings.
-  if ! command -v composer >/dev/null 2>&1; then
-    _log "downloading composer installer from getcomposer.org"
+  #
+  # GH #1332 item 13: provide TWO selectable versions. composer-latest and
+  # composer-lts (2.2 LTS, for legacy/older-PHP apps) are installed side by side,
+  # and /usr/local/bin/composer becomes a small dispatcher that reads the tenant's
+  # chosen channel (/etc/jabali-panel/user-composer/<user>, written by the agent)
+  # and execs the matching phar — defaulting to latest for anyone (incl. root)
+  # with no choice. Idempotent: only (re)download when a version binary is missing.
+  local _need_composer=0
+  [[ -x /usr/local/bin/composer-latest ]] || _need_composer=1
+  [[ -x /usr/local/bin/composer-lts ]] || _need_composer=1
+  if [[ "$_need_composer" == 1 ]]; then
+    _log "installing Composer versions (latest + LTS 2.2) from getcomposer.org"
     local _composer_tmp
     _composer_tmp="$(mktemp)"
     if curl -fsSL -o "$_composer_tmp" https://getcomposer.org/installer; then
-      # Verify the installer's SHA-384 before executing it as root — this is
-      # Composer's own documented procedure, and without it a MITM or a
-      # compromise of getcomposer.org is immediate root code execution during
-      # install/update. The signature is served from composer.github.io, a
-      # DIFFERENT host than the installer, so an attacker has to compromise
-      # both for the check to pass. Not pinned in-repo on purpose: the
-      # installer is rebuilt upstream regularly and a stale pin would fail
-      # every install.
+      # Verify the installer's SHA-384 before executing it as root — Composer's
+      # own documented procedure. The signature is served from composer.github.io
+      # (a DIFFERENT host than the installer), so an attacker must compromise
+      # both. Not pinned in-repo: the installer is rebuilt upstream regularly.
       local _composer_sig _composer_sum
       _composer_sig="$(curl -fsSL --max-time 20 https://composer.github.io/installer.sig || true)"
       _composer_sum="$(sha384sum "$_composer_tmp" | awk '{print $1}')"
       if [[ -z "$_composer_sig" ]]; then
         rm -f "$_composer_tmp"
-        _warn "could not fetch composer installer signature — refusing to run an unverified installer as root; composer unavailable"
+        _warn "could not fetch composer installer signature — refusing to run an unverified installer; composer unchanged"
       elif [[ "$_composer_sig" != "$_composer_sum" ]]; then
         rm -f "$_composer_tmp"
         _err "composer installer checksum mismatch (expected $_composer_sig, got $_composer_sum) — NOT executing it"
       else
         "php${primary_version}" "$_composer_tmp" \
-          --install-dir=/usr/local/bin --filename=composer --quiet
+          --install-dir=/usr/local/bin --filename=composer-latest --quiet \
+          && _ok "composer-latest installed (installer signature verified)"
+        "php${primary_version}" "$_composer_tmp" \
+          --install-dir=/usr/local/bin --filename=composer-lts --2.2 --quiet \
+          && _ok "composer-lts (2.2) installed" \
+          || _warn "composer-lts install failed — LTS channel will fall back to latest"
         rm -f "$_composer_tmp"
-        _ok "composer installed at /usr/local/bin/composer (installer signature verified)"
       fi
     else
       rm -f "$_composer_tmp"
-      _warn "failed to download composer installer — composer will be unavailable"
+      _warn "failed to download composer installer — composer versions unchanged"
     fi
   else
-    _ok "composer already present"
+    _ok "composer versions already present"
+  fi
+
+  # Install (or refresh) the dispatcher at /usr/local/bin/composer. Idempotent.
+  if [[ -x /usr/local/bin/composer-latest ]]; then
+    install -d -m 0755 /etc/jabali-panel/user-composer
+    local _disp
+    _disp="$(mktemp)"
+    cat > "$_disp" <<'COMPOSER_DISPATCH'
+#!/bin/sh
+# jabali Composer version dispatcher (GH #1332 item 13). Reads the invoking
+# tenant's chosen channel and execs the matching phar; defaults to latest.
+_choice="/etc/jabali-panel/user-composer/$(id -un 2>/dev/null)"
+if [ -r "$_choice" ]; then
+  case "$(cat "$_choice" 2>/dev/null)" in
+    lts) [ -x /usr/local/bin/composer-lts ] && exec /usr/local/bin/composer-lts "$@" ;;
+  esac
+fi
+exec /usr/local/bin/composer-latest "$@"
+COMPOSER_DISPATCH
+    install -m 0755 "$_disp" /usr/local/bin/composer
+    rm -f "$_disp"
+    _ok "composer dispatcher installed (latest + LTS selectable per user)"
   fi
 
   _ok "base packages ready"

--- a/panel-agent/internal/commands/php_composer_default.go
+++ b/panel-agent/internal/commands/php_composer_default.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// php.composer_default_set — set or clear a user's chosen Composer channel
+// (GH #1332 item 13). The host's /usr/local/bin/composer is a dispatcher that
+// reads /etc/jabali-panel/user-composer/<user> and execs the matching phar
+// (composer-latest / composer-lts). The choice file is root-owned + world-
+// readable (the dispatcher runs as the invoking tenant). An empty/"latest"
+// channel clears the file → the default latest Composer.
+
+type composerDefaultParams struct {
+	Username string `json:"username"`
+	Channel  string `json:"channel"` // "" or "latest" = default; "lts"
+}
+
+func composerChoiceRoot() string {
+	if r := os.Getenv("JABALI_COMPOSER_CHOICE_ROOT"); r != "" {
+		return r
+	}
+	return "/etc/jabali-panel/user-composer"
+}
+
+// validComposerChannel bounds the channel to the set the dispatcher understands.
+func validComposerChannel(ch string) bool {
+	switch ch {
+	case "", "latest", "lts":
+		return true
+	}
+	return false
+}
+
+func composerDefaultSetHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p composerDefaultParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse: %v", err)}
+	}
+	if !phpPoolUsernameRegex.MatchString(p.Username) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid username %q", p.Username)}
+	}
+	if !validComposerChannel(p.Channel) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid composer channel %q", p.Channel)}
+	}
+	choicePath := filepath.Join(composerChoiceRoot(), p.Username)
+	if p.Channel == "" || p.Channel == "latest" {
+		if err := os.Remove(choicePath); err != nil && !os.IsNotExist(err) {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("clear choice: %v", err)}
+		}
+		return map[string]any{"username": p.Username, "channel": "latest"}, nil
+	}
+	if err := os.MkdirAll(composerChoiceRoot(), 0o755); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir choice root: %v", err)}
+	}
+	// 0644: the dispatcher runs as the tenant and only needs to read it.
+	if err := os.WriteFile(choicePath, []byte(p.Channel+"\n"), 0o644); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write choice: %v", err)}
+	}
+	return map[string]any{"username": p.Username, "channel": p.Channel}, nil
+}
+
+func init() {
+	Default.Register("php.composer_default_set", composerDefaultSetHandler)
+}

--- a/panel-agent/internal/commands/php_composer_default_test.go
+++ b/panel-agent/internal/commands/php_composer_default_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+func TestComposerDefaultSet(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("JABALI_COMPOSER_CHOICE_ROOT", dir)
+
+	call := func(username, channel string) error {
+		raw, _ := json.Marshal(composerDefaultParams{Username: username, Channel: channel})
+		_, err := composerDefaultSetHandler(context.Background(), raw)
+		return err
+	}
+
+	// lts writes the choice file.
+	if err := call("alice", "lts"); err != nil {
+		t.Fatalf("set lts: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "alice"))
+	if err != nil || string(b) != "lts\n" {
+		t.Fatalf("choice file = %q (%v), want \"lts\\n\"", b, err)
+	}
+
+	// latest clears it.
+	if err := call("alice", "latest"); err != nil {
+		t.Fatalf("set latest: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "alice")); !os.IsNotExist(err) {
+		t.Fatalf("choice file should be gone, stat err = %v", err)
+	}
+
+	// "" also clears (idempotent, no error when already absent).
+	if err := call("alice", ""); err != nil {
+		t.Fatalf("clear empty: %v", err)
+	}
+
+	// Invalid channel + username are rejected.
+	for _, tc := range []struct{ u, ch string }{{"alice", "beta"}, {"Alice", "lts"}, {"../etc", "lts"}} {
+		err := call(tc.u, tc.ch)
+		if err == nil {
+			t.Fatalf("expected error for username=%q channel=%q", tc.u, tc.ch)
+		}
+		var aerr *agentwire.AgentError
+		if !errors.As(err, &aerr) || aerr.Code != agentwire.CodeInvalidArgument {
+			t.Fatalf("want InvalidArgument, got %v", err)
+		}
+	}
+}

--- a/panel-api/cmd/server/kratos_rebuild_cmd_test.go
+++ b/panel-api/cmd/server/kratos_rebuild_cmd_test.go
@@ -56,6 +56,8 @@ func (*fakeRebuildUserRepo) List(context.Context, repository.ListOptions) ([]mod
 	return nil, 0, nil
 }
 func (*fakeRebuildUserRepo) Update(context.Context, *models.User) error { return nil }
+func (*fakeRebuildUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (*fakeRebuildUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error {
 	return nil
 }

--- a/panel-api/internal/api/cron_admin_list_test.go
+++ b/panel-api/internal/api/cron_admin_list_test.go
@@ -168,6 +168,8 @@ func (u *userRepoAdapterForCronAdminTest) LinkKratosIdentity(context.Context, st
 	return nil
 }
 
+func (u *userRepoAdapterForCronAdminTest) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (u *userRepoAdapterForCronAdminTest) UpdateCLIPHPVersion(context.Context, string, *string) error {
 	return nil
 }

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -188,6 +188,8 @@ func (m *mockUserRepo) Update(ctx context.Context, u *models.User) error {
 	return nil
 }
 
+func (m *mockUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (m *mockUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
 func (m *mockUserRepo) LinkKratosIdentity(ctx context.Context, userID, kratosID string) error {

--- a/panel-api/internal/api/me_composer.go
+++ b/panel-api/internal/api/me_composer.go
@@ -1,0 +1,117 @@
+// me_composer.go — per-user Composer version channel (GH #1332 item 13).
+//
+// The host `composer` is a dispatcher that picks a phar from the tenant's
+// chosen channel. These self-service routes let a user select it:
+//
+//	GET /api/v1/me/composer-channel          { channel }   ("latest" default)
+//	PUT /api/v1/me/composer-channel {channel}              ("" | "latest" | "lts")
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// MeComposerConfig carries the deps the composer-channel routes need.
+type MeComposerConfig struct {
+	Users repository.UserRepository
+	Agent agent.AgentInterface
+}
+
+func validComposerChannel(ch string) bool {
+	switch ch {
+	case "", "latest", "lts":
+		return true
+	}
+	return false
+}
+
+// RegisterMeComposerRoutes mounts the self-service Composer channel routes on a
+// group that already carries auth.
+func RegisterMeComposerRoutes(g *gin.RouterGroup, cfg MeComposerConfig) {
+	if cfg.Users == nil {
+		return
+	}
+	h := &meComposerHandler{cfg: cfg}
+	g.GET("/me/composer-channel", h.get)
+	g.PUT("/me/composer-channel", h.put)
+}
+
+type meComposerHandler struct{ cfg MeComposerConfig }
+
+func (h *meComposerHandler) get(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil || user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user_not_found"})
+		return
+	}
+	channel := "latest"
+	if user.ComposerChannel != nil && *user.ComposerChannel != "" {
+		channel = *user.ComposerChannel
+	}
+	c.JSON(http.StatusOK, gin.H{"channel": channel})
+}
+
+type putComposerReq struct {
+	Channel string `json:"channel"` // "" | "latest" | "lts"
+}
+
+func (h *meComposerHandler) put(c *gin.Context) {
+	ctx := c.Request.Context()
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	var req putComposerReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
+		return
+	}
+	if !validComposerChannel(req.Channel) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_channel", "detail": "channel must be latest or lts"})
+		return
+	}
+	user, err := h.cfg.Users.FindByID(ctx, claims.UserID)
+	if err != nil || user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user_not_found"})
+		return
+	}
+	username := ""
+	if user.Username != nil {
+		username = *user.Username
+	}
+	if username == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no_shell_user"})
+		return
+	}
+	// Normalise "" -> "latest" for storage as NULL (the default).
+	var stored *string
+	if req.Channel == "lts" {
+		lts := "lts"
+		stored = &lts
+	}
+	if err := h.cfg.Users.UpdateComposerChannel(ctx, claims.UserID, stored); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.Set("audit_target", "composer_channel:"+username)
+	if _, err := h.cfg.Agent.Call(ctx, "php.composer_default_set", map[string]string{
+		"username": username,
+		"channel":  req.Channel,
+	}); err != nil {
+		respondAgentErr(c, "composer_channel_failed", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"channel": req.Channel})
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3762,6 +3762,18 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/composer-channel:
+    get:
+      tags: [Me]
+      summary: Get the user's Composer version channel
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Me]
+      summary: Set the user's Composer version channel (latest | lts)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/php-fpm-policy:
     get:
       tags: [Me]

--- a/panel-api/internal/api/sso_phpmyadmin_validate_test.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate_test.go
@@ -307,6 +307,8 @@ func (m *mockUserRepoValidate) Update(ctx context.Context, u *models.User) error
 	return nil
 }
 
+func (m *mockUserRepoValidate) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (m *mockUserRepoValidate) UpdateCLIPHPVersion(context.Context, string, *string) error {
 	return nil
 }

--- a/panel-api/internal/api/users_test.go
+++ b/panel-api/internal/api/users_test.go
@@ -162,6 +162,8 @@ func (m *memUserRepo) Update(_ context.Context, u *models.User) error {
 	return nil
 }
 
+func (m *memUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (m *memUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
 func (m *memUserRepo) LinkKratosIdentity(_ context.Context, userID, kratosID string) error {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -575,6 +575,11 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			Users: deps.Users,
 			Agent: deps.Agent,
 		})
+		// GH #1332 item 13: per-user Composer version channel.
+		api.RegisterMeComposerRoutes(v1, api.MeComposerConfig{
+			Users: deps.Users,
+			Agent: deps.Agent,
+		})
 		// Per-user disk-usage breakdown (files + email + databases).
 		api.RegisterMeDiskUsageRoutes(v1, api.DiskUsageConfig{
 			Users:      deps.Users,

--- a/panel-api/internal/auth/testhelpers_test.go
+++ b/panel-api/internal/auth/testhelpers_test.go
@@ -96,6 +96,8 @@ func (f *fakeUserRepo) Update(_ context.Context, u *models.User) error {
 	return nil
 }
 
+func (f *fakeUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (f *fakeUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
 func (f *fakeUserRepo) LinkKratosIdentity(_ context.Context, userID, kratosID string) error {

--- a/panel-api/internal/db/migrations/000283_user_composer_channel.down.sql
+++ b/panel-api/internal/db/migrations/000283_user_composer_channel.down.sql
@@ -1,0 +1,3 @@
+-- Reverse GH #1332 per-user Composer channel.
+ALTER TABLE users
+  DROP COLUMN composer_channel;

--- a/panel-api/internal/db/migrations/000283_user_composer_channel.up.sql
+++ b/panel-api/internal/db/migrations/000283_user_composer_channel.up.sql
@@ -1,0 +1,4 @@
+-- GH #1332 (item 13): per-user Composer version channel for the shell `composer`.
+-- NULL = latest (default); "lts" = the 2.2 LTS. Applied by the host dispatcher.
+ALTER TABLE users
+  ADD COLUMN composer_channel VARCHAR(16) NULL DEFAULT NULL;

--- a/panel-api/internal/middleware/auth_kratos_test.go
+++ b/panel-api/internal/middleware/auth_kratos_test.go
@@ -59,6 +59,8 @@ func (f *fakeUsersRepo) Update(context.Context, *models.User) error {
 	panic("Update not expected from middleware")
 }
 
+func (f *fakeUsersRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (f *fakeUsersRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 func (f *fakeUsersRepo) LinkKratosIdentity(context.Context, string, string) error {
 	panic("LinkKratosIdentity not expected from middleware")

--- a/panel-api/internal/models/user.go
+++ b/panel-api/internal/models/user.go
@@ -26,6 +26,10 @@ type User struct {
 	// CLIPHPVersion is the user's chosen default PHP version for shell/CLI
 	// (bare `php`, composer, wp-cli). NULL = auto (follow the pool pin). GH #256.
 	CLIPHPVersion *string `gorm:"column:cli_php_version;type:varchar(8)" json:"cli_php_version,omitempty"`
+	// ComposerChannel is the user's chosen Composer version channel for the
+	// shell `composer` (GH #1332 item 13). NULL/"latest" = the latest Composer;
+	// "lts" = the 2.2 LTS. Applied by the host dispatcher via a choice file.
+	ComposerChannel *string `gorm:"column:composer_channel;type:varchar(16)" json:"composer_channel,omitempty"`
 
 	NameFirst    string `gorm:"type:varchar(100);not null;default:''"                 json:"name_first"`
 	NameLast     string `gorm:"type:varchar(100);not null;default:''"                 json:"name_last"`

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -576,6 +576,8 @@ func (f *fakeUserRepo) Update(ctx context.Context, u *models.User) error {
 	return nil
 }
 
+func (f *fakeUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (f *fakeUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
 func (f *fakeUserRepo) LinkKratosIdentity(ctx context.Context, userID, kratosID string) error {

--- a/panel-api/internal/repository/user_repository.go
+++ b/panel-api/internal/repository/user_repository.go
@@ -37,6 +37,9 @@ type UserRepository interface {
 	// Dedicated method: the Select-allowlist Update would silently drop it, and
 	// a *string lets NULL (auto) be written.
 	UpdateCLIPHPVersion(ctx context.Context, id string, version *string) error
+	// UpdateComposerChannel sets the per-user Composer version channel (GH #1332
+	// item 13). Dedicated method — Update()'s Select allowlist would drop it.
+	UpdateComposerChannel(ctx context.Context, id string, channel *string) error
 	// UpdateUsername renames the tenant's login/Linux username (GH #1238).
 	// Dedicated method: the Select-allowlist Update excludes username, so a
 	// full-model Update would silently drop the rename.
@@ -203,6 +206,11 @@ func (r *userRepo) UpdateShadowDBUsernames(ctx context.Context, id string, mysql
 func (r *userRepo) UpdateCLIPHPVersion(ctx context.Context, id string, version *string) error {
 	return translate(r.db.WithContext(ctx).Model(&models.User{}).
 		Where("id = ?", id).Update("cli_php_version", version).Error)
+}
+
+func (r *userRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error {
+	return translate(r.db.WithContext(ctx).Model(&models.User{}).
+		Where("id = ?", id).Update("composer_channel", channel).Error)
 }
 
 // UpdateDiskUsage writes the sweeper's snapshot. Dedicated method for the

--- a/panel-api/internal/repository/user_repository_test.go
+++ b/panel-api/internal/repository/user_repository_test.go
@@ -34,6 +34,7 @@ func TestUserRepository_Create(t *testing.T) {
 			u.Email,
 			nil, // username
 			nil, // cli_php_version (GH #256)
+			nil, // composer_channel (GH #1332 item 13)
 			"",  // name_first default
 			"",  // name_last default
 			u.PasswordHash,

--- a/panel-api/internal/sso/sso_test.go
+++ b/panel-api/internal/sso/sso_test.go
@@ -120,6 +120,8 @@ func (m *mockUsersForSSO) Update(ctx context.Context, u *models.User) error {
 	return nil
 }
 
+func (m *mockUsersForSSO) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+
 func (m *mockUsersForSSO) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
 func (m *mockUsersForSSO) LinkKratosIdentity(ctx context.Context, userID, kratosID string) error {

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -166,6 +166,8 @@ export function UserPHPSettingsPage() {
   const [versionSaving, setVersionSaving] = useState(false);
   const [cliVersion, setCliVersion] = useState<string>(""); // "" = auto
   const [cliSaving, setCliSaving] = useState(false);
+  const [composerChannel, setComposerChannel] = useState<string>("latest");
+  const [composerSaving, setComposerSaving] = useState(false);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [form] = Form.useForm<PHPSettingsFormData>();
@@ -202,8 +204,37 @@ export function UserPHPSettingsPage() {
       } catch {
         // Non-fatal: account may have no shell user.
       }
+
+      try {
+        const resp = await apiClient.get<{ channel: string }>(
+          "/me/composer-channel",
+        );
+        setComposerChannel(resp.data?.channel ?? "latest");
+      } catch {
+        // Non-fatal: account may have no shell user.
+      }
     })();
   }, []);
+
+  const onChangeComposer = async (channel: string) => {
+    setComposerSaving(true);
+    try {
+      await apiClient.put("/me/composer-channel", { channel });
+      setComposerChannel(channel);
+      feedback.message.success(
+        channel === "lts"
+          ? "Composer set to the 2.2 LTS channel"
+          : "Composer set to the latest channel",
+      );
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(
+        e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to set Composer version",
+      );
+    } finally {
+      setComposerSaving(false);
+    }
+  };
 
   const onChangeCliVersion = async (version: string) => {
     setCliSaving(true);
@@ -422,6 +453,23 @@ export function UserPHPSettingsPage() {
             options={[
               { value: "", label: "Automatic (follow domain pool)" },
               ...availableVersions.map((v) => ({ value: v, label: `PHP ${v}` })),
+            ]}
+          />
+          {/* GH #1332 item 13: Composer version channel. */}
+          <Typography.Paragraph
+            type="secondary"
+            style={{ marginTop: 16, marginBottom: 4 }}
+          >
+            Composer version for your shell <code>composer</code>.
+          </Typography.Paragraph>
+          <Select
+            style={{ minWidth: 280 }}
+            value={composerChannel}
+            loading={composerSaving}
+            onChange={onChangeComposer}
+            options={[
+              { value: "latest", label: "Composer (latest)" },
+              { value: "lts", label: "Composer 2.2 LTS (older PHP compatibility)" },
             ]}
           />
         </Card>


### PR DESCRIPTION
## Summary

GH #1332 **item 13** — per-user **Composer version selector**. A tenant picks which Composer their shell `composer` runs: the **latest**, or the **2.2 LTS** (legacy apps / older PHP). Mirrors the per-user CLI PHP version picker (GH #256).

## Changes

- **install.sh** — installs `composer-latest` **and** `composer-lts` (2.2) side by side via the signature-verified getcomposer.org installer, and replaces `/usr/local/bin/composer` with a small **dispatcher** that reads the tenant's chosen channel (`/etc/jabali-panel/user-composer/<user>`) and execs the matching phar — defaulting to latest for anyone (incl. root) with no choice. Idempotent.
- **agent** — new `php.composer_default_set` verb writes/clears the per-user choice file (root-owned, world-readable; the dispatcher runs as the tenant).
- **model/migration** — `users.composer_channel` (migration `000283`); dedicated `UpdateComposerChannel` repo method (Update()'s allowlist would drop it).
- **panel-api** — `GET`/`PUT /me/composer-channel` (`channel` = `latest` | `lts`).
- **panel-ui** — a Composer selector in the CLI/terminal card on the PHP Settings page, beside the CLI PHP version.

## Verification

- ✅ **Dispatcher logic box-drilled** on the test host: no choice → latest; `lts` → lts; cleared → latest.
- ✅ `php.composer_default_set` unit-tested (write/clear/validate; rejects bad channel + username); widened `UserRepository` stubbed across the affected mocks; agent + panel-api + openapi-coverage suites; UI `tsc`.

## Release / deploy note

Touches **install.sh** (new composer versions + dispatcher) + a new **`php.composer_default_set`** agent verb — fleet agents + install.sh must be redeployed. **Migration `000283`** (batch order `278`..`283` — merge in number order).

## Test plan

- [ ] Deploy (install.sh installs both composer versions + the dispatcher).
- [ ] On the PHP Settings CLI card pick "Composer 2.2 LTS"; in the shell `composer --version` shows 2.2.x; switch back to latest → newest.
