### PR TITLE
fix(db): raise chunked DB-restore chunk size 10 MB -> 80 MB (GH #1044)

### DIFF
--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -301,10 +301,18 @@ export async function restoreDatabaseUpload(
 
 // GH #1323: chunked restore upload. Cloudflare's Free plan rejects any single
 // request body over 100 MB, so a large dump 413s at the edge regardless of the
-// panel's own cap. Above this threshold we upload the dump as sequential 10 MB
+// panel's own cap. Above the threshold we upload the dump as sequential
 // octet-stream chunks (like the File Manager), reassembled server-side, so no
-// single request approaches 100 MB. Small dumps keep the one-shot multipart path.
-const RESTORE_CHUNK_SIZE = 10 * 1024 * 1024;
+// single request reaches 100 MB. Small dumps keep the one-shot multipart path.
+//
+// GH #1044: chunks are raw octet-stream bodies (no base64/multipart inflation),
+// the panel nginx allows 10 GB, and the server streams each chunk straight to
+// disk — so the only ceiling is Cloudflare's 100 MB. 80 MB keeps a comfortable
+// ~20 MB margin under that while cutting the request count ~8x vs the old 10 MB
+// (a 2.7 GB dump drops from ~270 requests to ~34), which matters a lot on fast
+// links where per-request latency dominated. Note it stays below the 90 MB
+// single-shot threshold, which already sends bigger single requests via CF.
+const RESTORE_CHUNK_SIZE = 80 * 1024 * 1024;
 const RESTORE_CHUNK_THRESHOLD = 90 * 1024 * 1024;
 
 function lsGet(k: string): string | null {


### PR DESCRIPTION
## Summary

@lxsdevcode's follow-up on GH #1044: the chunked **Restore from file** upload used **10 MB** chunks, which means hundreds of sequential requests for a multi-GB dump — a 2.7 GB restore is ~270 requests, and on a fast link the per-request latency dominated.

This raises `RESTORE_CHUNK_SIZE` to **80 MB**.

## Why 80 MB is safe

- Chunks are **raw `application/octet-stream` bodies** — no base64/multipart inflation, so an 80 MB chunk = an ~80 MB request.
- The panel's nginx allows `client_max_body_size 10240m` (10 GB), so nginx isn't the limit.
- The `/restore-chunk` handler **streams each chunk straight to disk** (`io.Copy` + `io.LimitReader` bounded by the *whole-file* budget, not a per-chunk 10 MB cap), so a bigger chunk needs no backend change.
- The only real ceiling is **Cloudflare's 100 MB** request-body limit. 80 MB keeps a ~20 MB margin — and it's below the existing **90 MB single-shot threshold**, which already sends bigger single requests through Cloudflare.

Net: **~8× fewer requests** for large dumps (2.7 GB drops from ~270 to ~34), with the same safety behind Cloudflare.

## Verification

- UI-only constant change; the backend already accepts + streams chunks of this size.
- `tsc` + the `UserDatabaseList` restore test green.

## Test plan

- [ ] Restore a >90 MB PostgreSQL/MySQL dump behind Cloudflare Free — confirms it still goes through the chunked path (now 80 MB chunks) without a 413, and completes faster than before.
