### PR TITLE
fix(mail): sort mailbox "Quota" column by space used, not the quota limit (GH #1358)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -263,7 +263,11 @@ export const DomainMailboxesSection = ({
               ),
             },
             {
-              title: "Quota",
+              // GH #1358: renamed to match the main mailbox lists (the column
+              // shows used / quota). No client sorter here — this table is
+              // server-paginated (pageSize 10), so a client sort would only
+              // reorder the visible page and mislead.
+              title: "Usage / Quota",
               dataIndex: "quota_bytes",
               width: 220,
               render: (_quota: number, row: Mailbox) => renderMailboxQuota(row),

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -221,10 +221,12 @@ export function AdminMailPage() {
                 ),
             },
             {
-              title: "Quota",
+              title: "Usage / Quota",
               dataIndex: "quota_bytes",
               width: 200,
-              sorter: (a, b) => (a.quota_bytes ?? 0) - (b.quota_bytes ?? 0),
+              // GH #1358: sort by space USED (what the column shows), not the
+              // quota limit — the old sorter made "sort by usage" a no-op.
+              sorter: (a, b) => (a.last_usage_bytes ?? 0) - (b.last_usage_bytes ?? 0),
               render: (_quota: number, row) => renderMailboxQuota(row),
             },
             {

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -344,9 +344,12 @@ export const MailboxesTab = () => {
             },
           },
           {
-            title: "Quota",
+            title: "Usage / Quota",
             dataIndex: "quota_bytes",
-            sorter: (a, b) => (a.quota_bytes ?? 0) - (b.quota_bytes ?? 0),
+            // GH #1358: the column shows space USED (used / quota + fill bar), so
+            // sort by used bytes — not the quota limit, which made the header
+            // arrow a no-op for "sort by usage".
+            sorter: (a, b) => (a.last_usage_bytes ?? 0) - (b.last_usage_bytes ?? 0),
             width: 220,
             render: (_quota: number, row) => renderMailboxQuota(row),
           },


### PR DESCRIPTION
## Summary

GH #1358 — the mailbox **"Quota"** column shows space **used** (a `used / quota` label + a fill bar), but its header sorter compared `quota_bytes` (the allocated **limit**), so clicking to sort by usage reordered by quota instead — i.e. it didn't sort by the metric shown.

Fix: sort by `last_usage_bytes` (the used bytes the column displays), and rename the header to **"Usage / Quota"** so the sort target is unambiguous.

## Changes

- **User Mailboxes tab** (`MailboxesTab`) and **admin Mail page** (`AdminMailPage`) — both are client-sorted (they load the full set, pageSize 200 / all), so their column sorters now compare `last_usage_bytes`.
- **`DomainMailboxesSection`** — same header rename for consistency, but **no** client sorter added: it's server-paginated (pageSize 10, fixed `sort=local_part`), so a client-side comparator would only reorder the visible page and mislead.

`MailStatsTab` already has separate **Usage** and **Quota** columns and is correct — left as is.

## Verification

- UI-only; `tsc` + the mail UI tests green.

## Test plan

- [ ] On Mail → Mailboxes (and admin Mail), click the **Usage / Quota** header — rows order by space used ascending/descending, not by the quota limit.
