### PR TITLE
feat(python-apps): serve a per-app media directory directly from nginx (GH #878)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -1445,7 +1445,7 @@ func validatePageRedirects(prs models.PageRedirects) error {
 
 func isValidNginxRuleType(s string) bool {
 	switch s {
-	case "custom_header", "rewrite", "proxy_pass", "ip_access", "php_setting", "max_upload_size", "static_alias":
+	case "custom_header", "rewrite", "proxy_pass", "ip_access", "php_setting", "max_upload_size", "static_alias", "media_alias":
 		return true
 	}
 	return false
@@ -1530,20 +1530,20 @@ func validateNginxRules(rules models.NginxRules) error {
 			if r.Size == "" {
 				return fmt.Errorf("rule %d: size required", i)
 			}
-		case "static_alias":
+		case "static_alias", "media_alias":
 			// Serves a filesystem dir (Path=location, Target=alias dir). Used by
-			// framework apps (Django STATIC_ROOT). Admin-only (not in the tenant
-			// safe set). Constrain the alias to under /home/ so it can never be
-			// pointed at /etc or another system path (file disclosure), even by
-			// an admin PATCH; static aliases are always a tenant app dir.
+			// framework apps (Django STATIC_ROOT / MEDIA_ROOT). Admin-only (not in
+			// the tenant safe set). Constrain the alias to under /home/ so it can
+			// never be pointed at /etc or another system path (file disclosure),
+			// even by an admin PATCH; these aliases are always a tenant app dir.
 			if r.Path == "" || r.Target == "" {
 				return fmt.Errorf("rule %d: path and target required", i)
 			}
 			if !strings.HasPrefix(r.Target, "/home/") || strings.Contains(r.Target, "..") {
-				return fmt.Errorf("rule %d: static_alias target must be an absolute path under /home/ with no ..", i)
+				return fmt.Errorf("rule %d: %s target must be an absolute path under /home/ with no ..", i, r.Type)
 			}
 			if strings.ContainsAny(r.Target, " \t\n\r;{}") {
-				return fmt.Errorf("rule %d: invalid chars in static_alias target", i)
+				return fmt.Errorf("rule %d: invalid chars in %s target", i, r.Type)
 			}
 		}
 		// Forbid control characters everywhere to prevent newline injection into vhost

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1592,12 +1592,12 @@ paths:
   /python-apps/{id}/static:
     put:
       tags: [Python Apps]
-      summary: Set or clear a Python app's static-asset split (GH #878)
-      description: nginx serves base_uri+static_url directly from app_root/static_root instead of proxying to the app — the Passenger public/ equivalent. Both fields empty clears the mapping.
+      summary: Set or clear a Python app's static + media asset splits (GH #878)
+      description: nginx serves base_uri+static_url from app_root/static_root and base_uri+media_url from app_root/media_root directly instead of proxying to the app — the Passenger public/ equivalent. static is long-cached (immutable assets); media (Django MEDIA_ROOT) is short-cached with revalidation since uploads can change. Both fields of a pair empty clears that mapping.
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string, format: ulid } } ]
-      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { static_url: { type: string, example: /static }, static_root: { type: string, example: public } } } } } }
-      responses: { "200": { description: Saved }, "400": { description: Invalid static split } }
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { static_url: { type: string, example: /static }, static_root: { type: string, example: public }, media_url: { type: string, example: /media }, media_root: { type: string, example: media } } } } } }
+      responses: { "200": { description: Saved }, "400": { description: Invalid static/media split } }
 
   /python-apps/{id}/control:
     post:

--- a/panel-api/internal/api/python_apps.go
+++ b/panel-api/internal/api/python_apps.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -78,24 +78,34 @@ var (
 	staticRootRe = regexp.MustCompile(`^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$`)
 )
 
-// validateStaticSplit checks the optional static-asset mapping (GH #878).
-// Both fields come together. The rendered location is base_uri+static_url and
-// the alias app_root/static_root/ — the whitelists guarantee neither can
-// escape the app tree or break the vhost.
-func validateStaticSplit(staticURL, staticRoot string) error {
-	if staticURL == "" && staticRoot == "" {
+// validateAssetSplit checks an optional URL->dir asset mapping (GH #878). Both
+// fields come together. The rendered location is base_uri+url and the alias
+// app_root/root/ — the whitelists guarantee neither can escape the app tree or
+// break the vhost. urlField/rootField name the fields for the error messages.
+func validateAssetSplit(url, root, urlField, rootField string) error {
+	if url == "" && root == "" {
 		return nil
 	}
-	if staticURL == "" || staticRoot == "" {
-		return errors.New("static_url and static_root must be set together")
+	if url == "" || root == "" {
+		return fmt.Errorf("%s and %s must be set together", urlField, rootField)
 	}
-	if !staticURLRe.MatchString(staticURL) || strings.Contains(staticURL, "..") {
-		return errors.New("static_url must be a URL path like /static (letters, digits, . _ -)")
+	if !staticURLRe.MatchString(url) || strings.Contains(url, "..") {
+		return fmt.Errorf("%s must be a URL path like /static (letters, digits, . _ -)", urlField)
 	}
-	if !staticRootRe.MatchString(staticRoot) || strings.Contains(staticRoot, "..") {
-		return errors.New("static_root must be a relative directory like public (letters, digits, . _ -)")
+	if !staticRootRe.MatchString(root) || strings.Contains(root, "..") {
+		return fmt.Errorf("%s must be a relative directory like public (letters, digits, . _ -)", rootField)
 	}
 	return nil
+}
+
+// validateStaticSplit / validateMediaSplit are the GH #878 static + media
+// (Django MEDIA_ROOT) mappings; both use the same rules.
+func validateStaticSplit(staticURL, staticRoot string) error {
+	return validateAssetSplit(staticURL, staticRoot, "static_url", "static_root")
+}
+
+func validateMediaSplit(mediaURL, mediaRoot string) error {
+	return validateAssetSplit(mediaURL, mediaRoot, "media_url", "media_root")
 }
 
 // loadOwned fetches the app and enforces owner/admin scope.
@@ -172,6 +182,9 @@ type createPythonAppRequest struct {
 	// proxying. Ignored when Framework is set (the catalog provides them).
 	StaticURL  string `json:"static_url,omitempty"`
 	StaticRoot string `json:"static_root,omitempty"`
+	// MediaURL/MediaRoot: same for user-uploaded media (Django MEDIA_ROOT).
+	MediaURL  string `json:"media_url,omitempty"`
+	MediaRoot string `json:"media_root,omitempty"`
 }
 
 func (h *pythonAppHandler) create(c *gin.Context) {
@@ -205,9 +218,14 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		req.AppType = spec.AppType
 		req.Entrypoint = spec.Entrypoint
 		req.StaticURL, req.StaticRoot = spec.StaticURL, spec.StaticRoot
+		req.MediaURL, req.MediaRoot = spec.MediaURL, spec.MediaRoot
 	}
 	if err := validateStaticSplit(req.StaticURL, req.StaticRoot); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_static", "detail": err.Error()})
+		return
+	}
+	if err := validateMediaSplit(req.MediaURL, req.MediaRoot); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_media", "detail": err.Error()})
 		return
 	}
 	if req.AppType == "" {
@@ -332,6 +350,8 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		BaseURI:       req.BaseURI,
 		StaticURL:     req.StaticURL,
 		StaticRoot:    req.StaticRoot,
+		MediaURL:      req.MediaURL,
+		MediaRoot:     req.MediaRoot,
 		LoopbackPort:  &port,
 		Framework:     req.Framework,
 		Status:        models.PythonAppStatusPending,
@@ -446,6 +466,8 @@ func (h *pythonAppHandler) putStatic(c *gin.Context) {
 	var req struct {
 		StaticURL  string `json:"static_url"`
 		StaticRoot string `json:"static_root"`
+		MediaURL   string `json:"media_url"`
+		MediaRoot  string `json:"media_root"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
@@ -455,6 +477,10 @@ func (h *pythonAppHandler) putStatic(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_static", "detail": err.Error()})
 		return
 	}
+	if err := validateMediaSplit(req.MediaURL, req.MediaRoot); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_media", "detail": err.Error()})
+		return
+	}
 	ctx := c.Request.Context()
 	domain, err := h.cfg.Domains.FindByID(ctx, app.DomainID)
 	if err != nil {
@@ -462,6 +488,7 @@ func (h *pythonAppHandler) putStatic(c *gin.Context) {
 		return
 	}
 	app.StaticURL, app.StaticRoot = req.StaticURL, req.StaticRoot
+	app.MediaURL, app.MediaRoot = req.MediaURL, req.MediaRoot
 	if err := h.cfg.Apps.Update(ctx, app); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
@@ -500,6 +527,13 @@ func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.D
 		alias := strings.TrimSuffix(app.AppRoot, "/") + "/" + strings.Trim(app.StaticRoot, "/") + "/"
 		upsert(models.NginxRule{Type: "static_alias", Path: loc, Target: alias})
 	}
+	// Media split (GH #878): same, but rendered as media_alias (short cache —
+	// user uploads can change at a URL, unlike immutable static assets).
+	if app.MediaURL != "" && app.MediaRoot != "" {
+		loc := strings.TrimSuffix(app.BaseURI, "/") + app.MediaURL
+		alias := strings.TrimSuffix(app.AppRoot, "/") + "/" + strings.Trim(app.MediaRoot, "/") + "/"
+		upsert(models.NginxRule{Type: "media_alias", Path: loc, Target: alias})
+	}
 	domain.NginxRules = rules
 	_ = h.cfg.Domains.Update(ctx, domain)
 }
@@ -511,7 +545,7 @@ func dropStaticRules(domain *models.Domain, app *models.PythonApp) {
 	aliasPrefix := strings.TrimSuffix(app.AppRoot, "/") + "/"
 	var kept models.NginxRules
 	for _, r := range domain.NginxRules {
-		if r.Type == "static_alias" && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
+		if (r.Type == "static_alias" || r.Type == "media_alias") && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
 			continue
 		}
 		kept = append(kept, r)
@@ -559,7 +593,7 @@ func (h *pythonAppHandler) detachProxyRule(ctx context.Context, domain *models.D
 			continue
 		}
 		// Drop the framework static_alias that points into this app's tree.
-		if r.Type == "static_alias" && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
+		if (r.Type == "static_alias" || r.Type == "media_alias") && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
 			continue
 		}
 		kept = append(kept, r)

--- a/panel-api/internal/db/migrations/000284_python_app_media_split.down.sql
+++ b/panel-api/internal/db/migrations/000284_python_app_media_split.down.sql
@@ -1,0 +1,4 @@
+-- Reverse GH #878 python app media split.
+ALTER TABLE python_apps
+  DROP COLUMN media_url,
+  DROP COLUMN media_root;

--- a/panel-api/internal/db/migrations/000284_python_app_media_split.up.sql
+++ b/panel-api/internal/db/migrations/000284_python_app_media_split.up.sql
@@ -1,0 +1,6 @@
+-- GH #878: per-app media mapping for Python apps (Django MEDIA_URL/MEDIA_ROOT).
+-- nginx serves <base_uri><media_url> from <app_root>/<media_root> directly,
+-- alongside the existing static split. NOT NULL DEFAULT '' matches static_*.
+ALTER TABLE python_apps
+  ADD COLUMN media_url VARCHAR(255) NOT NULL DEFAULT '',
+  ADD COLUMN media_root VARCHAR(512) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/python_app.go
+++ b/panel-api/internal/models/python_app.go
@@ -31,6 +31,12 @@ type PythonApp struct {
 	// catalog entry.
 	StaticURL  string `gorm:"column:static_url;type:varchar(255);not null" json:"static_url,omitempty"`
 	StaticRoot string `gorm:"column:static_root;type:varchar(512);not null" json:"static_root,omitempty"`
+	// MediaURL/MediaRoot are the same split for USER-UPLOADED media (GH #878,
+	// Django MEDIA_URL/MEDIA_ROOT): nginx serves <base_uri><media_url> from
+	// <app_root>/<media_root>. Rendered as a media_alias rule, which — unlike
+	// static_alias — uses a short cache, since uploads can change at a URL.
+	MediaURL  string `gorm:"column:media_url;type:varchar(255);not null" json:"media_url,omitempty"`
+	MediaRoot string `gorm:"column:media_root;type:varchar(512);not null" json:"media_root,omitempty"`
 	// LoopbackPort is the 127.0.0.1 port gunicorn/uvicorn binds; nginx
 	// proxy_passes to it. Allocated by the API on create (nil until then).
 	LoopbackPort *int `gorm:"column:loopback_port;type:int;null" json:"loopback_port,omitempty"`

--- a/panel-api/internal/nginxrules/compile.go
+++ b/panel-api/internal/nginxrules/compile.go
@@ -129,6 +129,21 @@ func Compile(d *models.Domain) string {
 					"    }\n",
 				quoteNginxLocation(r.Path), r.Target)
 
+		case "media_alias":
+			// Serve user-uploaded media (Django MEDIA_ROOT) directly from nginx
+			// (GH #878). Same constraints as static_alias, but a SHORT cache with
+			// revalidation: unlike hashed/immutable static assets, an upload can
+			// be replaced at the same URL, so a 30-day immutable cache would serve
+			// stale files.
+			fmt.Fprintf(&b,
+				"    location ^~ %s {\n"+
+					"        alias %s;\n"+
+					"        access_log off;\n"+
+					"        expires 1h;\n"+
+					"        add_header Cache-Control \"public, must-revalidate\";\n"+
+					"    }\n",
+				quoteNginxLocation(r.Path), r.Target)
+
 		case "max_upload_size":
 			fmt.Fprintf(&b, "    client_max_body_size %s;\n", r.Size)
 		}

--- a/panel-api/internal/pyframeworks/catalog.go
+++ b/panel-api/internal/pyframeworks/catalog.go
@@ -81,6 +81,9 @@ type Entry struct {
 	// from StaticRoot (a location alongside the proxy). Empty = no static split.
 	StaticURL  string `yaml:"static_url,omitempty"`
 	StaticRoot string `yaml:"static_root,omitempty"`
+	// MediaURL/MediaRoot: same split for user-uploaded media (Django MEDIA_ROOT).
+	MediaURL  string `yaml:"media_url,omitempty"`
+	MediaRoot string `yaml:"media_root,omitempty"`
 	// PostInstall are ordered steps run after pip install (e.g. migrate,
 	// collectstatic). Free-form tokens the scaffolder maps to framework actions.
 	PostInstall []string `yaml:"post_install,omitempty"`
@@ -162,9 +165,12 @@ func (e Entry) validate() error {
 	if !needsDBSet[e.NeedsDB] {
 		return fmt.Errorf("needs_db %q: must be none, sqlite, mariadb, or postgres", e.NeedsDB)
 	}
-	// Static split is all-or-nothing.
+	// Static + media splits are each all-or-nothing.
 	if (e.StaticURL == "") != (e.StaticRoot == "") {
 		return errors.New("static_url and static_root must be set together")
+	}
+	if (e.MediaURL == "") != (e.MediaRoot == "") {
+		return errors.New("media_url and media_root must be set together")
 	}
 	// Generated env vars must name a supported generator.
 	for _, v := range e.DefaultEnv {

--- a/panel-api/internal/pyframeworks/resolve.go
+++ b/panel-api/internal/pyframeworks/resolve.go
@@ -31,6 +31,8 @@ type CreateSpec struct {
 	NeedsDB     string
 	StaticURL   string
 	StaticRoot  string
+	MediaURL    string
+	MediaRoot   string
 	PostInstall []string
 	// GenerateEnv are the env vars the scaffolder must mint a value for (secret
 	// generators) — kept separate so the caller writes them to the app's env,
@@ -85,6 +87,8 @@ func (e Entry) ResolveCreate() (CreateSpec, error) {
 		NeedsDB:      e.NeedsDB,
 		StaticURL:    e.StaticURL,
 		StaticRoot:   e.StaticRoot,
+		MediaURL:     e.MediaURL,
+		MediaRoot:    e.MediaRoot,
 		PostInstall:  append([]string(nil), e.PostInstall...),
 	}
 	if e.Scaffold.Kind == "cmd" {

--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -114,14 +114,21 @@ export function PythonAppsPage() {
   const [logsApp, setLogsApp] = useState<PythonApp | null>(null);
   const [logsText, setLogsText] = useState("");
   const [envApp, setEnvApp] = useState<PythonApp | null>(null);
-  // GH #878: static-asset split editor (Passenger public/ equivalent).
+  // GH #878: static + media asset split editor (Passenger public/ equivalent).
   const [staticApp, setStaticApp] = useState<PythonApp | null>(null);
-  const [staticForm] = Form.useForm<{ static_url: string; static_root: string }>();
+  const [staticForm] = Form.useForm<{
+    static_url: string;
+    static_root: string;
+    media_url: string;
+    media_root: string;
+  }>();
   const setStatic = useSetPythonAppStatic();
   const openStatic = (app: PythonApp) => {
     staticForm.setFieldsValue({
       static_url: app.static_url ?? "",
       static_root: app.static_root ?? "",
+      media_url: app.media_url ?? "",
+      media_root: app.media_root ?? "",
     });
     setStaticApp(app);
   };
@@ -133,8 +140,10 @@ export function PythonAppsPage() {
         id: staticApp.id,
         static_url: v.static_url?.trim() ?? "",
         static_root: v.static_root?.trim() ?? "",
+        media_url: v.media_url?.trim() ?? "",
+        media_root: v.media_root?.trim() ?? "",
       });
-      message.success("Static file mapping saved");
+      message.success("Static & media mapping saved");
       setStaticApp(null);
     } catch (e) {
       message.error(e instanceof Error ? e.message : "Save failed");
@@ -250,7 +259,7 @@ export function PythonAppsPage() {
                 { key: "stop", label: "Stop", icon: <PauseCircleOutlined />, onClick: () => void doControl(r.id, "stop") },
                 { key: "logs", label: "Logs", icon: <FileTextOutlined />, onClick: () => void openLogs(r) },
                 { key: "env", label: "Environment", icon: <SettingOutlined />, onClick: () => setEnvApp(r) },
-                { key: "static", label: "Static files", icon: <FolderOpenOutlined />, onClick: () => openStatic(r) },
+                { key: "static", label: "Static & media", icon: <FolderOpenOutlined />, onClick: () => openStatic(r) },
                 {
                   key: "delete",
                   label: "Delete",
@@ -388,28 +397,46 @@ export function PythonAppsPage() {
             <Input placeholder="domains/example.com/app" />
           </Form.Item>
           {!installFw && (
-            <Space style={{ width: "100%" }} size="middle">
-              <Form.Item
-                name="static_url"
-                label="Static URL path"
-                tooltip="Optional. Requests under this path are served by nginx directly instead of your app — the Passenger public/ equivalent. Set both fields or neither."
-              >
-                <Input placeholder="/static" />
-              </Form.Item>
-              <Form.Item
-                name="static_root"
-                label="Static directory"
-                tooltip="Directory relative to the app directory that holds the static files, e.g. public or staticfiles."
-              >
-                <Input placeholder="public" />
-              </Form.Item>
-            </Space>
+            <>
+              <Space style={{ width: "100%" }} size="middle">
+                <Form.Item
+                  name="static_url"
+                  label="Static URL path"
+                  tooltip="Optional. Requests under this path are served by nginx directly instead of your app — the Passenger public/ equivalent. Set both fields or neither."
+                >
+                  <Input placeholder="/static" />
+                </Form.Item>
+                <Form.Item
+                  name="static_root"
+                  label="Static directory"
+                  tooltip="Directory relative to the app directory that holds the static files, e.g. public or staticfiles."
+                >
+                  <Input placeholder="public" />
+                </Form.Item>
+              </Space>
+              <Space style={{ width: "100%" }} size="middle">
+                <Form.Item
+                  name="media_url"
+                  label="Media URL path"
+                  tooltip="Optional. User-uploaded media (Django MEDIA_URL). Served by nginx directly from the media directory, with a short cache since uploads can change. Set both fields or neither."
+                >
+                  <Input placeholder="/media" />
+                </Form.Item>
+                <Form.Item
+                  name="media_root"
+                  label="Media directory"
+                  tooltip="Directory relative to the app directory that holds uploaded media (Django MEDIA_ROOT), e.g. media."
+                >
+                  <Input placeholder="media" />
+                </Form.Item>
+              </Space>
+            </>
           )}
         </Form>
       </Modal>
 
       <Modal
-        title={staticApp ? `Static files — ${staticApp.name}` : "Static files"}
+        title={staticApp ? `Static & media files — ${staticApp.name}` : "Static & media files"}
         open={staticApp !== null}
         onCancel={() => setStaticApp(null)}
         onOk={() => void submitStatic()}
@@ -417,10 +444,11 @@ export function PythonAppsPage() {
         confirmLoading={setStatic.isPending}
       >
         <Typography.Paragraph type="secondary">
-          nginx serves the URL path below directly from a directory inside your
+          nginx serves the URL paths below directly from directories inside your
           app — CSS/JS/images stop going through the Python process (what
-          Passenger did with public/). Clear both fields to proxy everything to
-          the app again.
+          Passenger did with public/). Media is user-uploaded content (Django
+          MEDIA_ROOT), cached briefly since uploads can change at the same URL.
+          Clear both fields of a pair to proxy those requests to the app again.
         </Typography.Paragraph>
         <Form form={staticForm} layout="vertical">
           <Form.Item
@@ -436,6 +464,20 @@ export function PythonAppsPage() {
             rules={[{ pattern: /^$|^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/, message: "Relative directory like public" }]}
           >
             <Input placeholder="public" />
+          </Form.Item>
+          <Form.Item
+            name="media_url"
+            label="Media URL path"
+            rules={[{ pattern: /^$|^\/[A-Za-z0-9._/-]+$/, message: "URL path like /media" }]}
+          >
+            <Input placeholder="/media" />
+          </Form.Item>
+          <Form.Item
+            name="media_root"
+            label="Media directory (relative to app directory)"
+            rules={[{ pattern: /^$|^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/, message: "Relative directory like media" }]}
+          >
+            <Input placeholder="media" />
           </Form.Item>
         </Form>
       </Modal>

--- a/panel-ui/src/shells/user/python-apps/usePythonApps.ts
+++ b/panel-ui/src/shells/user/python-apps/usePythonApps.ts
@@ -17,6 +17,9 @@ export type PythonApp = {
   // app_root/static_root (Passenger public/ equivalent). Empty = proxy all.
   static_url?: string;
   static_root?: string;
+  // GH #878: same split for user-uploaded media (Django MEDIA_ROOT).
+  media_url?: string;
+  media_root?: string;
   loopback_port?: number;
   status: string;
   last_error?: string;
@@ -37,6 +40,8 @@ export type CreatePythonAppInput = {
   framework?: string;
   static_url?: string;
   static_root?: string;
+  media_url?: string;
+  media_root?: string;
 };
 
 // Framework is a marketplace catalog entry (JAB-164), from GET
@@ -105,15 +110,27 @@ export function useDeletePythonApp() {
   });
 }
 
-// GH #878: set or clear the static-asset split on an existing app. Both
-// fields empty clears it (nginx goes back to proxying everything).
+// GH #878: set or clear the static + media asset splits on an existing app.
+// Both fields of a pair empty clears that split (nginx goes back to proxying
+// those paths).
 export function useSetPythonAppStatic() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (vars: { id: string; static_url: string; static_root: string }) => {
+    mutationFn: async (vars: {
+      id: string;
+      static_url: string;
+      static_root: string;
+      media_url: string;
+      media_root: string;
+    }) => {
       const { data } = await apiClient.put<{ app: PythonApp }>(
         `/python-apps/${vars.id}/static`,
-        { static_url: vars.static_url, static_root: vars.static_root },
+        {
+          static_url: vars.static_url,
+          static_root: vars.static_root,
+          media_url: vars.media_url,
+          media_root: vars.media_root,
+        },
       );
       return data.app;
     },


### PR DESCRIPTION
## What

Python apps already support a **static** split — `base_uri`+`static_url` served straight from `app_root`/`static_root` by nginx (the Passenger `public/` equivalent). GH #878's reporter asked for the same for **user-uploaded media** (Django `MEDIA_URL`/`MEDIA_ROOT`), which the WSGI/ASGI process shouldn't serve in production.

This adds a parallel **media** mapping.

## Changes

- **Model + migration 000284:** `media_url` / `media_root` columns on `python_apps`, mirroring `static_url`/`static_root` (`NOT NULL DEFAULT ''`).
- **API:** create and `PUT /python-apps/:id/static` accept `media_url`/`media_root`, validated by the same URL/relative-dir whitelists (refactored `validateStaticSplit` → shared `validateAssetSplit`, plus a `validateMediaSplit` wrapper).
- **Catalog + CreateSpec:** framework entries can declare a media split (all-or-nothing, like static).
- **New `media_alias` nginx rule type:** renders the location alias with a **short cache** (`expires 1h; Cache-Control "public, must-revalidate"`) instead of `static_alias`'s 30d immutable cache — an upload can change at the same URL. Target constrained to under `/home/` by the domains rule validator (JAB-65), same as `static_alias`; cleanup (`dropStaticRules`/`detachProxyRule`) drops both rule types.
- **UI:** the create dialog and the per-app editor (renamed **"Static & media"**) expose *Media URL path* / *Media directory* alongside the static fields.

No agent/reconciler change — media reuses the existing `NginxRule` storage and `compile.go` path.

## Test plan

- [x] `go build ./panel-api/...` + `go vet` clean
- [x] `go test ./panel-api/internal/{db,pyframeworks,nginxrules,api}/...` + `internal/app` OpenAPI/coverage — green
- [x] `npx tsc -b` + `npm run build` (panel-ui) — green
- [x] **Box-drill on .60 (real vhost, `jabali.site`):** deployed the panel binary + migrated 277→284; injected static_alias + media_alias rules; converge re-rendered both locations in the HTTP + HTTPS server blocks; `nginx -t` clean. Live `curl`:
  - `/media/hello.txt` → **200**, `cache-control: max-age=3600, public, must-revalidate` (served direct by nginx, not proxied); missing media → **404** (no listing/traversal).
  - `/static/index.html` → **200**, `cache-control: max-age=2592000, public` (30d) — confirms the static-vs-media cache contrast.
  - Reverted rules + removed the drill dir; vhost re-rendered clean, `nginx -t` ok, site root 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
