### PR TITLE
fix(backup): cover admin docker apps + stop restore dropping fanned-out stages (GH #1360)

### DIFF
--- a/internal/backup/metadata.go
+++ b/internal/backup/metadata.go
@@ -316,6 +316,13 @@ type MetadataDockerApp struct {
 	MemoryLimit    *string `json:"memory_limit,omitempty"`
 	PIDsLimit      *int    `json:"pids_limit,omitempty"`
 	CreatedAt      string  `json:"created_at,omitempty"`
+	// ServerLevel marks an admin / server-level app (models.DockerApp.UserID
+	// NULL, M48). These have no tenant account, so account backups omitted
+	// them (GH #1360); an admin's account backup now carries them, and Apply
+	// must rebuild the row with UserID left NULL to keep it server-level
+	// rather than re-owning it to the admin. Absent on tenant apps and on
+	// pre-#1360 snapshots (defaults false → tenant).
+	ServerLevel bool `json:"server_level,omitempty"`
 	// Ports are the published-port rows (host_port pins the reverse-proxy
 	// target the migrated domain's proxy_pass points at).
 	Ports []MetadataDockerAppPort `json:"ports,omitempty"`

--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -249,6 +249,24 @@ func backupRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 //
 // stageResults carries the per-stage materialization outcome from the
 // caller; we only apply stages that materialized OK.
+// materializedStages reports, per manifest-stage index, whether that stage's
+// snapshot materialized OK and is therefore safe to apply. stageResults is
+// built one-per-manifest-stage in manifest order by the stage walk, so it
+// aligns by index with manifestStages. Indexing (rather than keying by
+// stage Name) is deliberate: docker/db fan out multiple stages sharing one
+// Name, and a name-keyed lookup would collapse them and drop good stages on a
+// single same-named failure (GH #1360). A short/misaligned stageResults slice
+// leaves the trailing stages false (not applied) — fail closed.
+func materializedStages(manifestStages []backup.ManifestStage, stageResults []backupRestoreStage) []bool {
+	ok := make([]bool, len(manifestStages))
+	for i := range manifestStages {
+		if i < len(stageResults) && stageResults[i].Status == backup.StageStatusOK {
+			ok[i] = true
+		}
+	}
+	return ok
+}
+
 func applyAccountRestore(
 	ctx context.Context,
 	stagingRoot, username string,
@@ -256,10 +274,17 @@ func applyAccountRestore(
 	manifestStages []backup.ManifestStage,
 	stageResults []backupRestoreStage,
 ) ([]string, []string) {
-	statusOf := map[string]string{}
-	for _, sr := range stageResults {
-		statusOf[sr.Name] = sr.Status
-	}
+	// Per-stage materialization gate, indexed — NOT keyed by stage Name.
+	// Docker and DB fan out one ManifestStage per app / per database, and
+	// EVERY one of them carries the same Name ("docker" / "db") — see
+	// backup_create.go runDockerStage / the db stage. A name-keyed map
+	// collapses those N statuses to whichever same-named stage happened to
+	// land last, so a single later failure (or "source missing") would skip
+	// EVERY docker app or database, including the ones that materialized
+	// fine — the account comes back with its data silently dropped (GH
+	// #1360). out.Stages is appended one-per-manifest-stage in manifest
+	// order by the caller's stage-walk, so index i aligns exactly.
+	applicable := materializedStages(manifestStages, stageResults)
 	var applied, warnings []string
 	if username == "" {
 		warnings = append(warnings,
@@ -322,8 +347,8 @@ func applyAccountRestore(
 	uid, _ := strconv.Atoi(u.Uid)
 	gid, _ := strconv.Atoi(u.Gid)
 
-	for _, st := range manifestStages {
-		if statusOf[st.Name] != backup.StageStatusOK {
+	for i, st := range manifestStages {
+		if !applicable[i] {
 			continue
 		}
 		switch st.Name {

--- a/panel-agent/internal/commands/backup_restore_collapse_test.go
+++ b/panel-agent/internal/commands/backup_restore_collapse_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+// GH #1360: docker and db fan out one ManifestStage per app / per database,
+// all sharing the same Name ("docker" / "db"). The apply gate must decide
+// per-stage (by index), NOT by a name-keyed map that collapses N same-named
+// statuses to the last one — that dropped every good app on a single later
+// failure.
+func TestMaterializedStages_PerStageNotCollapsedByName(t *testing.T) {
+	// Two docker apps: the first materialized fine, the second failed. The
+	// old name-keyed logic recorded statusOf["docker"] = the *last* status
+	// (failed) and skipped BOTH; index alignment keeps the first.
+	manifest := []backup.ManifestStage{
+		{Name: backup.StageHome},
+		{Name: backup.StageDocker, Items: []string{"nextcloud"}},
+		{Name: backup.StageDocker, Items: []string{"gitea"}},
+	}
+	results := []backupRestoreStage{
+		{Name: backup.StageHome, Status: backup.StageStatusOK},
+		{Name: backup.StageDocker, Status: backup.StageStatusOK},
+		{Name: backup.StageDocker, Status: backup.StageStatusFailed},
+	}
+	got := materializedStages(manifest, results)
+	want := []bool{true, true, false}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("stage %d (%s) applicable=%v, want %v", i, manifest[i].Name, got[i], want[i])
+		}
+	}
+}
+
+// The reverse ordering — first docker app failed, second OK — must apply the
+// second (a name-keyed map keyed on the last status would have kept both by
+// luck; the point is the decision is genuinely per-index).
+func TestMaterializedStages_FirstFailedSecondApplies(t *testing.T) {
+	manifest := []backup.ManifestStage{
+		{Name: backup.StageDocker, Items: []string{"a"}},
+		{Name: backup.StageDocker, Items: []string{"b"}},
+	}
+	results := []backupRestoreStage{
+		{Name: backup.StageDocker, Status: backup.StageStatusFailed},
+		{Name: backup.StageDocker, Status: backup.StageStatusOK},
+	}
+	got := materializedStages(manifest, results)
+	if got[0] || !got[1] {
+		t.Fatalf("want [false true], got %v", got)
+	}
+}
+
+// Fail closed: a short/misaligned results slice must not apply the stages it
+// can't vouch for (no out-of-range read, trailing stages stay false).
+func TestMaterializedStages_ShortResultsFailClosed(t *testing.T) {
+	manifest := []backup.ManifestStage{
+		{Name: backup.StageHome},
+		{Name: backup.StageDB, Items: []string{"db1"}},
+	}
+	results := []backupRestoreStage{
+		{Name: backup.StageHome, Status: backup.StageStatusOK},
+	}
+	got := materializedStages(manifest, results)
+	if !got[0] || got[1] {
+		t.Fatalf("want [true false] on a short results slice, got %v", got)
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -501,7 +501,7 @@ func (h *backupHandler) createForUser(c *gin.Context) {
 			"databases":          dbs,
 			"databases_postgres": pgDbs,
 			"mailboxes":          mbs,
-			"docker_apps":        h.cfg.allUserDockerApps(c.Request.Context(), user.ID),
+			"docker_apps":        h.cfg.allUserDockerApps(c.Request.Context(), user.ID, user.IsAdmin),
 			"content":            req.Content,
 			"folders":            req.Folders,
 			"compression":        req.Compression,
@@ -1281,7 +1281,7 @@ func (cfg BackupHandlerConfig) allUserDatabasesByEngine(ctx context.Context, use
 // Nil repo (older wiring, or a deployment without the docker surface)
 // yields no slugs and the stage records "no docker apps", which is the
 // same outcome as an account that has none.
-func (cfg BackupHandlerConfig) allUserDockerApps(ctx context.Context, userID string) []string {
+func (cfg BackupHandlerConfig) allUserDockerApps(ctx context.Context, userID string, isAdmin bool) []string {
 	if cfg.DockerApps == nil {
 		return nil
 	}
@@ -1306,7 +1306,36 @@ func (cfg BackupHandlerConfig) allUserDockerApps(ctx context.Context, userID str
 		}
 		out = append(out, slug)
 	}
+	// GH #1360: an admin account also carries the server-level docker apps
+	// (UserID NULL) so their data trees ride the stage=docker snapshot.
+	if isAdmin {
+		if extra, serr := serverLevelDockerSlugs(ctx, cfg.DockerApps); serr != nil {
+			cfg.logErr("list server-level docker apps for backup", serr)
+		} else {
+			out = append(out, extra...)
+		}
+	}
 	return out
+}
+
+// serverLevelDockerSlugs returns the EffectiveSlug of every live admin /
+// server-level docker app (models.DockerApp.UserID NULL, M48). Derived from
+// ListAll + filter so the repo interface (and its mocks) stays put.
+func serverLevelDockerSlugs(ctx context.Context, repo repository.DockerAppRepository) ([]string, error) {
+	all, err := repo.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0)
+	for _, r := range all {
+		if r == nil || r.UserID != nil || r.Status == models.DockerAppStatusDeleted {
+			continue
+		}
+		if slug := r.EffectiveSlug(); slug != "" {
+			out = append(out, slug)
+		}
+	}
+	return out, nil
 }
 
 // allUserMailboxes returns every mailbox EmailCached for a user, by
@@ -1405,7 +1434,7 @@ type MeBackupsHandlerConfig struct {
 
 // allUserDockerApps mirrors BackupHandlerConfig.allUserDockerApps for the
 // tenant's own backup path.
-func (cfg MeBackupsHandlerConfig) allUserDockerApps(ctx context.Context, userID string) []string {
+func (cfg MeBackupsHandlerConfig) allUserDockerApps(ctx context.Context, userID string, isAdmin bool) []string {
 	if cfg.DockerApps == nil {
 		return nil
 	}
@@ -1429,6 +1458,15 @@ func (cfg MeBackupsHandlerConfig) allUserDockerApps(ctx context.Context, userID 
 			continue
 		}
 		out = append(out, slug)
+	}
+	// GH #1360: an admin using the self-backup path also carries the
+	// server-level docker apps (UserID NULL) — see BackupHandlerConfig.
+	if isAdmin {
+		if extra, serr := serverLevelDockerSlugs(ctx, cfg.DockerApps); serr != nil {
+			cfg.logErr("list server-level docker apps for backup", serr)
+		} else {
+			out = append(out, extra...)
+		}
 	}
 	return out
 }
@@ -1870,7 +1908,7 @@ func (h *meBackupHandler) create(c *gin.Context) {
 			"databases":          dbs,
 			"databases_postgres": pgDbs,
 			"mailboxes":          mbs,
-			"docker_apps":        h.cfg.allUserDockerApps(c.Request.Context(), user.ID),
+			"docker_apps":        h.cfg.allUserDockerApps(c.Request.Context(), user.ID, user.IsAdmin),
 			"content":            req.Content,
 			"folders":            req.Folders,
 			"compression":        req.Compression,

--- a/panel-api/internal/api/backups_docker_apps_test.go
+++ b/panel-api/internal/api/backups_docker_apps_test.go
@@ -16,12 +16,17 @@ import (
 
 type stubDockerAppRepo struct {
 	repository.DockerAppRepository
-	rows []*models.DockerApp
-	err  error
+	rows    []*models.DockerApp // ListByUserID result (a tenant's apps)
+	allRows []*models.DockerApp // ListAll result (used for server-level resolution)
+	err     error
 }
 
 func (r *stubDockerAppRepo) ListByUserID(_ context.Context, _ string) ([]*models.DockerApp, error) {
 	return r.rows, r.err
+}
+
+func (r *stubDockerAppRepo) ListAll(_ context.Context) ([]*models.DockerApp, error) {
+	return r.allRows, r.err
 }
 
 func TestAllUserDockerApps_ReturnsSlugs(t *testing.T) {
@@ -29,7 +34,7 @@ func TestAllUserDockerApps_ReturnsSlugs(t *testing.T) {
 		{ID: "app-1", Slug: "nextcloud"},
 		{ID: "app-2", Slug: "uptime-kuma"},
 	}}}
-	got := cfg.allUserDockerApps(context.Background(), "user-1")
+	got := cfg.allUserDockerApps(context.Background(), "user-1", false)
 	if len(got) != 2 || got[0] != "nextcloud" || got[1] != "uptime-kuma" {
 		t.Fatalf("slugs not resolved for the backup call: %#v", got)
 	}
@@ -39,14 +44,14 @@ func TestAllUserDockerApps_ReturnsSlugs(t *testing.T) {
 // surface); it must degrade to "no apps", not panic mid-backup.
 func TestAllUserDockerApps_NilRepo(t *testing.T) {
 	cfg := BackupHandlerConfig{}
-	if got := cfg.allUserDockerApps(context.Background(), "user-1"); len(got) != 0 {
+	if got := cfg.allUserDockerApps(context.Background(), "user-1", false); len(got) != 0 {
 		t.Fatalf("nil repo should yield no slugs, got %#v", got)
 	}
 }
 
 func TestAllUserDockerApps_ErrorDoesNotPanic(t *testing.T) {
 	cfg := BackupHandlerConfig{DockerApps: &stubDockerAppRepo{err: errors.New("db down")}}
-	if got := cfg.allUserDockerApps(context.Background(), "user-1"); len(got) != 0 {
+	if got := cfg.allUserDockerApps(context.Background(), "user-1", false); len(got) != 0 {
 		t.Fatalf("a repo error should yield no slugs, got %#v", got)
 	}
 }
@@ -63,7 +68,7 @@ func TestAllUserDockerApps_UsesEffectiveSlug(t *testing.T) {
 		{ID: "app-1", Slug: "uptime-kuma", InstanceSlug: "uptime-kuma-2"},
 		{ID: "app-2", Slug: "gitea"},
 	}}}
-	got := cfg.allUserDockerApps(context.Background(), "user-1")
+	got := cfg.allUserDockerApps(context.Background(), "user-1", false)
 	if len(got) != 2 || got[0] != "uptime-kuma-2" {
 		t.Fatalf("second instance must resolve to its InstanceSlug, got %#v", got)
 	}
@@ -79,7 +84,7 @@ func TestAllUserDockerApps_SkipsEmptySlug(t *testing.T) {
 		{ID: "app-1", Slug: ""},
 		{ID: "app-2", Slug: "nextcloud"},
 	}}}
-	got := cfg.allUserDockerApps(context.Background(), "user-1")
+	got := cfg.allUserDockerApps(context.Background(), "user-1", false)
 	if len(got) != 1 || got[0] != "nextcloud" {
 		t.Fatalf("empty slug must be dropped, got %#v", got)
 	}
@@ -91,8 +96,53 @@ func TestMeAllUserDockerApps_ReturnsSlugs(t *testing.T) {
 	cfg := MeBackupsHandlerConfig{DockerApps: &stubDockerAppRepo{rows: []*models.DockerApp{
 		{ID: "app-1", Slug: "nextcloud"},
 	}}}
-	got := cfg.allUserDockerApps(context.Background(), "user-1")
+	got := cfg.allUserDockerApps(context.Background(), "user-1", false)
 	if len(got) != 1 || got[0] != "nextcloud" {
 		t.Fatalf("tenant path did not resolve docker apps: %#v", got)
+	}
+}
+
+func strp(s string) *string { return &s }
+
+// GH #1360: admin/server-level docker apps (UserID NULL) have no tenant
+// account, so account backups never carried them — the app's data came back
+// missing on restore. An ADMIN account backup now folds in the live
+// server-level apps (from ListAll), while tenant-owned rows in ListAll and
+// deleted tombstones are excluded.
+func TestAllUserDockerApps_AdminIncludesServerLevel(t *testing.T) {
+	repo := &stubDockerAppRepo{
+		rows: []*models.DockerApp{{ID: "own-1", Slug: "gitea"}}, // the admin's own tenant apps (usually none)
+		allRows: []*models.DockerApp{
+			{ID: "srv-1", Slug: "jabali-sounder", InstanceSlug: "jabali-sounder-test", UserID: nil},
+			{ID: "srv-2", Slug: "vaultwarden", UserID: nil},
+			{ID: "ten-1", Slug: "nextcloud", UserID: strp("someone")},                                 // tenant-owned — not server-level
+			{ID: "del-1", Slug: "ghost", UserID: nil, Status: models.DockerAppStatusDeleted},          // deleted tombstone
+		},
+	}
+	cfg := BackupHandlerConfig{DockerApps: repo}
+	got := cfg.allUserDockerApps(context.Background(), "admin-1", true)
+	want := map[string]bool{"gitea": true, "jabali-sounder-test": true, "vaultwarden": true}
+	if len(got) != len(want) {
+		t.Fatalf("admin backup slug set = %#v, want %v", got, want)
+	}
+	for _, s := range got {
+		if !want[s] {
+			t.Errorf("unexpected slug %q (tenant-owned or deleted apps must not be included)", s)
+		}
+	}
+}
+
+// A NON-admin account never carries server-level apps, even if some exist:
+// they are not the tenant's, and ListAll must not even be consulted for the
+// slug set beyond the tenant's own rows.
+func TestAllUserDockerApps_NonAdminExcludesServerLevel(t *testing.T) {
+	repo := &stubDockerAppRepo{
+		rows:    []*models.DockerApp{{ID: "own-1", Slug: "nextcloud"}},
+		allRows: []*models.DockerApp{{ID: "srv-1", Slug: "jabali-sounder", UserID: nil}},
+	}
+	cfg := BackupHandlerConfig{DockerApps: repo}
+	got := cfg.allUserDockerApps(context.Background(), "user-1", false)
+	if len(got) != 1 || got[0] != "nextcloud" {
+		t.Fatalf("non-admin must see only its own apps, got %#v", got)
 	}
 }

--- a/panel-api/internal/backupmetadata/apply.go
+++ b/panel-api/internal/backupmetadata/apply.go
@@ -406,9 +406,18 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 	// stage=docker restore (#1017); without this row the app is orphaned on disk.
 	if d.DockerApps != nil {
 		for _, a := range m.DockerApps {
-			uid := m.User.ID
+			// Server-level apps (GH #1360) restore with UserID NULL so they
+			// stay admin/server-level; tenant apps are (re)owned by the
+			// account being restored. Re-owning a server-level app to the
+			// admin would wrongly subject it to tenant validation + slice
+			// scoping on the next reconcile.
+			var owner *string
+			if !a.ServerLevel {
+				uid := m.User.ID
+				owner = &uid
+			}
 			row := &models.DockerApp{
-				ID: a.ID, UserID: &uid, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
+				ID: a.ID, UserID: owner, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
 				Name: a.Name, CatalogVersion: a.CatalogVersion, ImageSHA: a.ImageSHA,
 				Status: a.Status, UpdateMode: a.UpdateMode,
 				CPULimit: a.CPULimit, MemoryLimit: a.MemoryLimit, PIDsLimit: a.PIDsLimit,

--- a/panel-api/internal/backupmetadata/apply_docker_serverlevel_test.go
+++ b/panel-api/internal/backupmetadata/apply_docker_serverlevel_test.go
@@ -1,0 +1,67 @@
+package backupmetadata
+
+import (
+	"context"
+	"testing"
+
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// existingUsersRepo makes applyUser a no-op (user already present) so Apply
+// proceeds to the docker block without needing the rest of the user path.
+type existingUsersRepo struct {
+	repository.UserRepository
+}
+
+func (existingUsersRepo) FindByID(_ context.Context, id string) (*models.User, error) {
+	return &models.User{ID: id}, nil
+}
+
+// captureDockerRepo records the rows Apply tries to Create.
+type captureDockerRepo struct {
+	repository.DockerAppRepository
+	created []*models.DockerApp
+}
+
+func (c *captureDockerRepo) Create(_ context.Context, app *models.DockerApp) error {
+	c.created = append(c.created, app)
+	return nil
+}
+func (c *captureDockerRepo) CreatePort(context.Context, *models.DockerAppPublishedPort) error {
+	return nil
+}
+
+// GH #1360: a restored server-level app (ServerLevel=true) must keep UserID
+// NULL — re-owning it to the restoring admin would subject it to tenant
+// validation + cgroup scoping on the next reconcile. A tenant app is owned by
+// the account being restored.
+func TestApply_ServerLevelDockerAppKeepsNullOwner(t *testing.T) {
+	dockers := &captureDockerRepo{}
+	meta := &internalbackup.AccountMetadata{
+		User: internalbackup.MetadataUser{ID: "admin-1"},
+		DockerApps: []internalbackup.MetadataDockerApp{
+			{ID: "srv-1", Slug: "jabali-sounder", ServerLevel: true},
+			{ID: "ten-1", Slug: "nextcloud", ServerLevel: false},
+		},
+	}
+	r := Apply(context.Background(), meta, Deps{Users: existingUsersRepo{}, DockerApps: dockers})
+	if len(r.Errors) != 0 {
+		t.Fatalf("apply errors: %v", r.Errors)
+	}
+	owner := map[string]*string{}
+	for _, a := range dockers.created {
+		owner[a.ID] = a.UserID
+	}
+	if got, ok := owner["srv-1"]; !ok || got != nil {
+		t.Errorf("server-level app must restore with UserID=nil, got ok=%v ptr=%v", ok, got)
+	}
+	if got, ok := owner["ten-1"]; !ok || got == nil || *got != "admin-1" {
+		gotVal := "<nil>"
+		if got != nil {
+			gotVal = *got
+		}
+		t.Errorf("tenant app must be owned by the restored account, got ok=%v owner=%s", ok, gotVal)
+	}
+}

--- a/panel-api/internal/backupmetadata/builder.go
+++ b/panel-api/internal/backupmetadata/builder.go
@@ -75,6 +75,52 @@ func timeRFC(t interface{ Format(string) string }) string {
 	return t.Format("2006-01-02T15:04:05Z")
 }
 
+// metadataDockerRow maps a docker_apps row (+ its published ports) to the
+// backup metadata shape. serverLevel is threaded from the caller — it is
+// NOT derivable from the row here (a.UserID) alone in a way Apply can trust,
+// so we record it explicitly.
+func (d Deps) metadataDockerRow(ctx context.Context, a *models.DockerApp, serverLevel bool) internalbackup.MetadataDockerApp {
+	row := internalbackup.MetadataDockerApp{
+		ID: a.ID, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
+		Name: a.Name, CatalogVersion: a.CatalogVersion,
+		ImageSHA: a.ImageSHA, Status: a.Status, UpdateMode: a.UpdateMode,
+		CPULimit: a.CPULimit, MemoryLimit: a.MemoryLimit, PIDsLimit: a.PIDsLimit,
+		CreatedAt: timeRFC(a.CreatedAt), ServerLevel: serverLevel,
+	}
+	if ports, perr := d.DockerApps.ListPortsForApp(ctx, a.ID); perr == nil {
+		for _, p := range ports {
+			row.Ports = append(row.Ports, internalbackup.MetadataDockerAppPort{
+				ID: p.ID, PortName: p.PortName, ContainerPort: p.ContainerPort,
+				BindInterface: p.BindInterface, HostPort: p.HostPort,
+				Protocol: p.Protocol, ReverseProxy: p.ReverseProxy, Enabled: p.Enabled,
+			})
+		}
+	} else {
+		d.warn("metadata: list docker app ports", perr, "app_id", a.ID)
+	}
+	return row
+}
+
+// serverLevelDockerApps returns the live (non-deleted) admin / server-level
+// docker apps — UserID NULL (M48). Derived from ListAll + filter rather than
+// a new repo method so the DockerAppRepository interface (and its mocks)
+// stays put. Errors warn + yield nothing, matching the tenant path.
+func (d Deps) serverLevelDockerApps(ctx context.Context) []*models.DockerApp {
+	all, err := d.DockerApps.ListAll(ctx)
+	if err != nil {
+		d.warn("metadata: list all docker apps (server-level)", err)
+		return nil
+	}
+	out := make([]*models.DockerApp, 0, len(all))
+	for _, a := range all {
+		if a == nil || a.UserID != nil || a.Status == models.DockerAppStatusDeleted {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
 // Build returns the populated AccountMetadata bundle for the given
 // user. Non-nil result even on partial failures.
 func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.AccountMetadata {
@@ -342,25 +388,17 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 			d.warn("metadata: list docker apps", err, "user_id", user.ID)
 		}
 		for _, a := range apps {
-			row := internalbackup.MetadataDockerApp{
-				ID: a.ID, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
-				Name: a.Name, CatalogVersion: a.CatalogVersion,
-				ImageSHA: a.ImageSHA, Status: a.Status, UpdateMode: a.UpdateMode,
-				CPULimit: a.CPULimit, MemoryLimit: a.MemoryLimit, PIDsLimit: a.PIDsLimit,
-				CreatedAt: timeRFC(a.CreatedAt),
+			m.DockerApps = append(m.DockerApps, d.metadataDockerRow(ctx, a, false))
+		}
+		// Admin / server-level apps (models.DockerApp.UserID NULL, M48) have
+		// no tenant account, so account backups never carried them (GH #1360)
+		// — the only cover was a full system backup. Fold them into an admin
+		// account's backup so the ordinary per-account restore rebuilds them
+		// too. serverLevel=true keeps Apply from re-owning them to the admin.
+		if user.IsAdmin {
+			for _, a := range d.serverLevelDockerApps(ctx) {
+				m.DockerApps = append(m.DockerApps, d.metadataDockerRow(ctx, a, true))
 			}
-			if ports, perr := d.DockerApps.ListPortsForApp(ctx, a.ID); perr == nil {
-				for _, p := range ports {
-					row.Ports = append(row.Ports, internalbackup.MetadataDockerAppPort{
-						ID: p.ID, PortName: p.PortName, ContainerPort: p.ContainerPort,
-						BindInterface: p.BindInterface, HostPort: p.HostPort,
-						Protocol: p.Protocol, ReverseProxy: p.ReverseProxy, Enabled: p.Enabled,
-					})
-				}
-			} else {
-				d.warn("metadata: list docker app ports", perr, "app_id", a.ID)
-			}
-			m.DockerApps = append(m.DockerApps, row)
 		}
 	}
 

--- a/panel-api/internal/backupmetadata/builder_docker_serverlevel_test.go
+++ b/panel-api/internal/backupmetadata/builder_docker_serverlevel_test.go
@@ -1,0 +1,76 @@
+package backupmetadata
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// stubDockerRepo implements just the three methods Build touches; the rest of
+// the interface is embedded (nil) and would panic if reached — a guard that
+// Build stays on the expected read path.
+type stubDockerRepo struct {
+	repository.DockerAppRepository
+	byUser []*models.DockerApp
+	all    []*models.DockerApp
+}
+
+func (s *stubDockerRepo) ListByUserID(context.Context, string) ([]*models.DockerApp, error) {
+	return s.byUser, nil
+}
+func (s *stubDockerRepo) ListAll(context.Context) ([]*models.DockerApp, error) { return s.all, nil }
+func (s *stubDockerRepo) ListPortsForApp(context.Context, string) ([]*models.DockerAppPublishedPort, error) {
+	return nil, nil
+}
+
+func ptr(s string) *string { return &s }
+
+// GH #1360: an admin account's metadata bundle folds in the live server-level
+// docker apps (UserID NULL) marked ServerLevel, so restore rebuilds their
+// rows. Tenant-owned rows in ListAll and deleted tombstones are excluded, and
+// the admin's own tenant apps stay ServerLevel=false.
+func TestBuild_AdminFoldsServerLevelDockerApps(t *testing.T) {
+	repo := &stubDockerRepo{
+		byUser: []*models.DockerApp{{ID: "own-1", Slug: "gitea"}},
+		all: []*models.DockerApp{
+			{ID: "srv-1", Slug: "jabali-sounder", UserID: nil},
+			{ID: "ten-1", Slug: "nextcloud", UserID: ptr("someone")},
+			{ID: "del-1", Slug: "ghost", UserID: nil, Status: models.DockerAppStatusDeleted},
+		},
+	}
+	m := Build(context.Background(), &models.User{ID: "admin-1", IsAdmin: true}, Deps{DockerApps: repo})
+
+	byID := map[string]bool{}
+	for _, a := range m.DockerApps {
+		byID[a.ID] = a.ServerLevel
+	}
+	if len(m.DockerApps) != 2 {
+		t.Fatalf("want 2 docker apps (own + one server-level), got %d: %#v", len(m.DockerApps), m.DockerApps)
+	}
+	if sl, ok := byID["own-1"]; !ok || sl {
+		t.Errorf("own-1 must be present with ServerLevel=false, got ok=%v serverLevel=%v", ok, sl)
+	}
+	if sl, ok := byID["srv-1"]; !ok || !sl {
+		t.Errorf("srv-1 must be present with ServerLevel=true, got ok=%v serverLevel=%v", ok, sl)
+	}
+	if _, ok := byID["ten-1"]; ok {
+		t.Error("a tenant-owned app from ListAll must NOT be folded into the admin backup")
+	}
+	if _, ok := byID["del-1"]; ok {
+		t.Error("a deleted server-level tombstone must NOT be folded in")
+	}
+}
+
+// A non-admin account never folds in server-level apps.
+func TestBuild_NonAdminOmitsServerLevelDockerApps(t *testing.T) {
+	repo := &stubDockerRepo{
+		byUser: []*models.DockerApp{{ID: "own-1", Slug: "nextcloud"}},
+		all:    []*models.DockerApp{{ID: "srv-1", Slug: "jabali-sounder", UserID: nil}},
+	}
+	m := Build(context.Background(), &models.User{ID: "user-1", IsAdmin: false}, Deps{DockerApps: repo})
+	if len(m.DockerApps) != 1 || m.DockerApps[0].ID != "own-1" || m.DockerApps[0].ServerLevel {
+		t.Fatalf("non-admin must carry only its own tenant apps, got %#v", m.DockerApps)
+	}
+}

--- a/panel-api/internal/backupscheduler/resolve_targets_test.go
+++ b/panel-api/internal/backupscheduler/resolve_targets_test.go
@@ -1,0 +1,76 @@
+package backupscheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type stubUsers struct {
+	repository.UserRepository
+	byID    map[string]*models.User
+	listOut []models.User
+	lastOpt repository.ListOptions
+}
+
+func (s *stubUsers) List(_ context.Context, opts repository.ListOptions) ([]models.User, int64, error) {
+	s.lastOpt = opts
+	return s.listOut, int64(len(s.listOut)), nil
+}
+func (s *stubUsers) FindByID(_ context.Context, id string) (*models.User, error) {
+	if u, ok := s.byID[id]; ok {
+		return u, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// No explicit users → the default sweep lists tenants only (IsAdmin=false),
+// admins are never touched by a blanket schedule.
+func TestResolveAccountTargets_DefaultSweepExcludesAdmins(t *testing.T) {
+	repo := &stubUsers{listOut: []models.User{{ID: "t1"}, {ID: "t2"}}}
+	got, err := resolveAccountTargets(context.Background(), repo, "sched-1", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.lastOpt.IsAdmin == nil || *repo.lastOpt.IsAdmin != false {
+		t.Fatalf("default sweep must filter IsAdmin=false, got %#v", repo.lastOpt.IsAdmin)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want the two tenants, got %#v", got)
+	}
+}
+
+// GH #1360: an explicitly named admin IS honored (so their server-level docker
+// apps get a scheduled account backup); a normal tenant too.
+func TestResolveAccountTargets_ExplicitAdminHonored(t *testing.T) {
+	repo := &stubUsers{byID: map[string]*models.User{
+		"admin-1": {ID: "admin-1", IsAdmin: true},
+		"ten-1":   {ID: "ten-1", IsAdmin: false},
+	}}
+	got, err := resolveAccountTargets(context.Background(), repo, "sched-1", []string{"admin-1", "ten-1"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("both the named admin and tenant must be honored, got %#v", got)
+	}
+	seen := map[string]bool{got[0].ID: true, got[1].ID: true}
+	if !seen["admin-1"] || !seen["ten-1"] {
+		t.Errorf("expected admin-1 + ten-1, got %#v", got)
+	}
+}
+
+// A named user that no longer exists is warn-skipped, not fatal.
+func TestResolveAccountTargets_MissingUserSkipped(t *testing.T) {
+	repo := &stubUsers{byID: map[string]*models.User{"ten-1": {ID: "ten-1"}}}
+	got, err := resolveAccountTargets(context.Background(), repo, "sched-1", []string{"gone", "ten-1"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "ten-1" {
+		t.Fatalf("missing user must be skipped, leaving only ten-1, got %#v", got)
+	}
+}

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -769,7 +769,7 @@ func (s *Scheduler) dispatchAccount(ctx context.Context, j models.BackupJob) {
 		"databases":          dbs,
 		"databases_postgres": pgDbs,
 		"mailboxes":          mbs,
-		"docker_apps":        userDockerApps(callCtx, s.deps, user.ID, logger),
+		"docker_apps":        userDockerApps(callCtx, s.deps, user.ID, user.IsAdmin, logger),
 		"content":            content,
 		"metadata":           meta,
 		"schedule_id":        scheduleID,
@@ -935,7 +935,7 @@ func buildScheduleMetadata(ctx context.Context, deps Deps, user *models.User, lo
 // userDockerApps returns the slugs of the account's docker apps. Their
 // data trees live outside the home, so the agent has to be told about
 // them explicitly or the scheduled backup omits the app (GH #954).
-func userDockerApps(ctx context.Context, deps Deps, userID string, logger *slog.Logger) []string {
+func userDockerApps(ctx context.Context, deps Deps, userID string, isAdmin bool, logger *slog.Logger) []string {
 	if deps.DockerApps == nil {
 		return nil
 	}
@@ -959,6 +959,23 @@ func userDockerApps(ctx context.Context, deps Deps, userID string, logger *slog.
 			continue
 		}
 		out = append(out, slug)
+	}
+	// GH #1360: a scheduled admin account backup also covers server-level
+	// docker apps (UserID NULL), whose only prior cover was a system backup.
+	if isAdmin {
+		all, aerr := deps.DockerApps.ListAll(ctx)
+		if aerr != nil {
+			logger.Warn("list server-level docker apps for backup failed", "err", aerr)
+		} else {
+			for _, r := range all {
+				if r == nil || r.UserID != nil || r.Status == models.DockerAppStatusDeleted {
+					continue
+				}
+				if slug := r.EffectiveSlug(); slug != "" {
+					out = append(out, slug)
+				}
+			}
+		}
 	}
 	return out
 }

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -447,32 +447,9 @@ func (s *Scheduler) enqueueBackup(ctx context.Context, sched models.BackupSchedu
 		if err != nil {
 			return false, fmt.Errorf("load schedule users: %w", err)
 		}
-		var targets []models.User
-		if len(explicitIDs) == 0 {
-			notAdmin := false
-			users, _, err := s.deps.Users.List(ctx, repository.ListOptions{
-				Limit:   10000,
-				IsAdmin: &notAdmin,
-			})
-			if err != nil {
-				return false, fmt.Errorf("list users: %w", err)
-			}
-			targets = users
-		} else {
-			for _, uid := range explicitIDs {
-				u, err := s.deps.Users.FindByID(ctx, uid)
-				if err != nil || u == nil {
-					s.deps.Log.Warn("schedule references missing user; skipping",
-						"schedule_id", sched.ID, "user_id", uid)
-					continue
-				}
-				if u.IsAdmin {
-					s.deps.Log.Warn("schedule references admin; skipping",
-						"schedule_id", sched.ID, "user_id", uid)
-					continue
-				}
-				targets = append(targets, *u)
-			}
+		targets, err := resolveAccountTargets(ctx, s.deps.Users, sched.ID, explicitIDs, s.deps.Log)
+		if err != nil {
+			return false, err
 		}
 		for i := range targets {
 			u := &targets[i]
@@ -932,6 +909,37 @@ func buildScheduleMetadata(ctx context.Context, deps Deps, user *models.User, lo
 // userMailboxes returns the email addresses of every mailbox under
 // every domain owned by the user. Two-step: domain.list_by_user →
 // mailbox.list_by_domain. Errors per-domain are tolerated.
+// resolveAccountTargets resolves the users an account-backup schedule fans out
+// to. An empty explicit set = the default sweep of every TENANT (admins are
+// not hosting accounts, so a blanket schedule never touches them). An
+// explicitly named user is honored even when admin (GH #1360): server-level
+// docker apps (UserID NULL) have no tenant account, so an admin's own account
+// backup is the per-account path that covers them on a schedule. Missing users
+// are warn-skipped, not fatal.
+func resolveAccountTargets(ctx context.Context, users repository.UserRepository, scheduleID string, explicitIDs []string, log *slog.Logger) ([]models.User, error) {
+	if len(explicitIDs) == 0 {
+		notAdmin := false
+		list, _, err := users.List(ctx, repository.ListOptions{Limit: 10000, IsAdmin: &notAdmin})
+		if err != nil {
+			return nil, fmt.Errorf("list users: %w", err)
+		}
+		return list, nil
+	}
+	var targets []models.User
+	for _, uid := range explicitIDs {
+		u, err := users.FindByID(ctx, uid)
+		if err != nil || u == nil {
+			if log != nil {
+				log.Warn("schedule references missing user; skipping",
+					"schedule_id", scheduleID, "user_id", uid)
+			}
+			continue
+		}
+		targets = append(targets, *u)
+	}
+	return targets, nil
+}
+
 // userDockerApps returns the slugs of the account's docker apps. Their
 // data trees live outside the home, so the agent has to be told about
 // them explicitly or the scheduled backup omits the app (GH #954).


### PR DESCRIPTION
## Bug

GH #1360: "restore a docker app and its data is missing from restore." Investigation found **two** independent ways docker-app data goes missing on restore. This is a real, reproducible gap **consistent with** the report — not a confirmed reproduction of the reporter's exact case (see "Reporter follow-up" below).

### 1. Admin / server-level docker apps had no per-account backup path

Docker apps with `models.DockerApp.UserID == NULL` are **admin / server-level** (M48). They belong to no tenant account, so account backups never carried them; their only cover was a full **system** backup. Since docker apps are **admin-gated by default**, most real installs are server-level — so the prominent per-account backup silently omitted them.

Two things blocked coverage, both fixed:
- **Resolution + rebuild.** An **admin** account backup now folds in the live server-level apps: data trees ride the `stage=docker` snapshot (slug resolution in `api/backups.go` both variants + `backupscheduler`), rows ride the metadata bundle (`backupmetadata` builder). `Apply` rebuilds a server-level app with `UserID` left **NULL** (new `MetadataDockerApp.ServerLevel` flag) so it stays server-level rather than being re-owned to the restoring admin (which would wrongly subject it to tenant validation + cgroup scoping). Tenant-owned rows and deleted tombstones are excluded; non-admin accounts are unaffected.
- **Scheduler.** The scheduler dropped admins from *every* `account_backup` schedule (an m30.1 fan-out guard, "admins aren't hosting accounts"), so the nightly path never fired for them. Now the default sweep stays tenant-only, but a user an operator **explicitly names** (`--user admin@…`) is honored even when admin. Target resolution pulled into a pure, unit-tested `resolveAccountTargets`.

### 2. Restore dropped every fanned-out docker/db stage on one failure

`applyAccountRestore` gated each manifest stage on a **name-keyed** status map. Docker and db fan out **one stage per app / per database, all sharing the same `Name`** (`"docker"` / `"db"`). The map collapsed N statuses to whichever same-named stage landed last — so a single later failure (`source missing`, one bad app) skipped **every** docker app or database, including the ones that materialized fine. Now gated **per-stage by index** via a pure `materializedStages` helper.

## Notes

- Server-level resolution reuses `DockerAppRepository.ListAll` + a `UserID==nil` filter — the repo interface (and its mocks) is untouched.
- **No migration**: `MetadataDockerApp.ServerLevel` is a JSON metadata field; absent on pre-#1360 snapshots → defaults false → tenant (old behaviour).
- Coverage half is panel-api-only; the collapse fix is agent-side.

## Reporter follow-up

The exact #1360 cause depends on info only the reporter has (which restore surface — account / system / per-app; is the app admin- or tenant-owned; backup date re #1017). The eventual reply should ask that. This PR closes a real gap the report points at.

## Test plan

- [x] `go build ./...` + `go vet` clean.
- [x] Unit: `materializedStages` per-stage + fail-closed; admin folds server-level (non-admin does not) in the slug resolver + the metadata builder; `Apply` keeps NULL owner for server-level and account-owner for tenant apps; `resolveAccountTargets` (default excludes admins / explicit admin honored / missing skipped). All green.
- [x] **Box-drill on .60** (reporter's scenario — server-level app `jabali-sounder-test`):
  - `account_backup` schedule naming the admin now **enqueues an admin job** (no "references admin; skipping").
  - its manifest carries `stage=docker done item=[jabali-sounder-test] status=ok` (255 KB, incl. a planted marker).
  - a recon restore (`--apply=false`) **materializes the app data** (marker round-trips) and the metadata carries `server_level=true` for the NULL-owner rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
