### PR TITLE
fix(crowdsec): stop AppSec dropping large panel uploads — inspect-partial not drop (GH #1044)

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -326,6 +326,26 @@ func Render(o Opts) string {
 	b.WriteString("# jabali-countries: " + csv + "\n")
 	b.WriteString("name: crowdsecurity/jabali-appsec\n")
 	b.WriteString("default_remediation: ban\n")
+
+	// GH #1044: the CrowdSec AppSec engine drops any request whose body
+	// exceeds its max (default 10 MB) BEFORE rule evaluation — earlier than
+	// the /api/v1/ on_match allowlist below can cancel it, so a large chunked
+	// DB restore (or admin File-Manager upload) POST to the panel API returns
+	// an opaque "403 CrowdSec Access Forbidden". The 10 MB default surfaced
+	// once the DB-restore chunk size was bumped to 80 MB (#1394); it also bit
+	// every other big-body panel route. Switch the oversize behaviour from
+	// "drop" to "partial": the first 10 MB is still inspected (WAF attacks
+	// live in the first bytes, and the inspection cost stays bounded — we do
+	// NOT raise max_body_size), but an oversized body is then PASSED instead
+	// of blocked. This is engine-wide (the AppSec listener is shared by every
+	// vhost), which is the deliberate tradeoff: no vhost blocks purely on
+	// body size, all vhosts keep full inspection of the first 10 MB. Set via
+	// the on_load hook (the supported mechanism — max_body_size /
+	// body_size_exceeded_action are not plain AppsecConfig fields).
+	b.WriteString("on_load:\n")
+	b.WriteString(" - apply:\n")
+	b.WriteString("    - SetBodySizeExceededAction(\"partial\")\n")
+
 	b.WriteString("inband_rules:\n")
 	for _, r := range o.Inband {
 		b.WriteString(" - " + r + "\n")

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -36,6 +36,13 @@ func TestRender_HeaderAndInband(t *testing.T) {
 	mustContain(t, out, "# jabali-mode: off", "mode header line")
 	mustContain(t, out, "name: crowdsecurity/jabali-appsec", "config name")
 	mustContain(t, out, "default_remediation: ban", "default remediation")
+	// GH #1044: oversize request bodies inspect-partial-then-pass instead of
+	// being dropped (the 10 MB body-size drop blocked large DB-restore chunks).
+	mustContain(t, out, "on_load:\n - apply:\n    - SetBodySizeExceededAction(\"partial\")\n", "GH#1044 body-size partial hook")
+	// on_load must run before inband_rules (it's a startup hook).
+	if strings.Index(out, "on_load:") > strings.Index(out, "inband_rules:") {
+		t.Fatal("on_load must precede inband_rules")
+	}
 	mustContain(t, out, "inband_rules:\n - crowdsecurity/base-config\n - crowdsecurity/vpatch-*\n - crowdsecurity/generic-*\n", "inband list in order")
 	// ADR-0102: panel-API allowlist present.
 	mustContain(t, out, `on_match:


### PR DESCRIPTION
## Bug (regression from #1394)

After the DB-restore chunk size was bumped 10 MB → 80 MB (#1394), a chunked PostgreSQL/MySQL restore (reported by @lxsdevcode) fails at the first 80 MB chunk with an opaque **`403 CrowdSec Access Forbidden`** (the CrowdSec ban page), on `POST /api/v1/databases/:id/restore-chunk`.

## Root cause

The CrowdSec **AppSec engine drops any request whose body exceeds its maximum** (`DefaultMaxBodySize` = 10 MB) **before rule evaluation** — earlier than the `/api/v1/` `on_match` allowlist (`SetRemediation("allow")`) can cancel it, and earlier than the self-IP allowlist. So nothing downstream could save it. Confirmed live on a box:

```
request body exceeds limit 10485760 bytes, will drop request   (module=acquisition.appsec)
→ CrowdSec ban page, HTTP 403
```

The 10 MB default was latent while chunks were ≤10 MB; #1394's 80 MB bump exposed it. It also bit **every** big-body panel route (admin File Manager upload, etc.).

Diagnosis notes (all reproduced on a box, bouncer disabled → 401 reaches the panel, confirming the bouncer/AppSec is the blocker; `SecRequestBodyLimit`/`ProcessPartial` seclang did NOT help — this is CrowdSec's pre-coraza body reader, not coraza's limit).

## Fix

Render an **`on_load` hook** in the jabali AppSec config that switches the oversize behaviour from `drop` to **`partial`** (`SetBodySizeExceededAction`). With `partial`, the engine still inspects the **first 10 MB** of every body — WAF attack payloads live in the first bytes, and inspection cost stays bounded (we do **not** raise `max_body_size`) — but an oversized body is then **passed** instead of blocked.

`on_load` is the supported mechanism in CrowdSec 1.7.x: `max_body_size` / `body_size_exceeded_action` are **not** plain `AppsecConfig` YAML fields (verified against v1.7.8 source — `pkg/appsec/appsec.go`, `BodySettings` "Settable via on_load hooks"); the direct-field attempts fail config validation.

Engine-wide (the AppSec listener is shared by all vhosts) — the deliberate tradeoff: no vhost blocks purely on body size, all keep full inspection of the first 10 MB. Shared `internal/appseccfg.Render`, so the panel `appsec render-config` and the agent geoblock re-render stay in lockstep. Ships on the next `jabali update`.

## Scope

- Addresses **only** @lxsdevcode's follow-up (the 403 block). Their original items **2** (restore job shown as "Account Backup" type) and **3** (Restore-Home-Directory option shown for a DB-only backup) are UI concerns and remain open.
- Separate pre-existing CRS defect noted in the commit (rule 980099 `strconv.Atoi` on uninitialised anomaly-score vars, fires on every inspected request) — follow-up candidate, not this fix.

## Test plan

- [x] `go build ./...` + `go vet` clean; `internal/appseccfg` unit test asserts the `on_load` hook renders before `inband_rules`.
- [x] **Box-drill on .60** via the real render path (`jabali-panel appsec render-config --reconcile` → `crowdsec -t` → reload): `POST /api/v1/databases/:id/restore-chunk` with **5 / 15 / 80 / 150 MB** bodies returned **403 (CrowdSec ban)** before the fix (≥~11 MB), **401 (reaching the panel)** after — the AppSec body-size drop is gone. Small requests still fully inspected (WAF unchanged for the first 10 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
