### PR TITLE
feat(db): PostgreSQL restore accepts pgAdmin custom/tar dumps + surfaces the real error (GH #1045)

### DIFF
--- a/panel-agent/internal/commands/db_postgres_restore.go
+++ b/panel-agent/internal/commands/db_postgres_restore.go
@@ -8,8 +8,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -101,6 +103,45 @@ func pgRestoreTmpDB(db string) string {
 	return "jbrt_" + hex.EncodeToString(sum[:])[:16]
 }
 
+// pgDumpIsArchive reports whether the dump header is a pg_dump ARCHIVE (custom
+// or tar) rather than a plain-SQL dump. Custom archives start with the magic
+// "PGDMP"; tar archives carry the POSIX "ustar" magic at offset 257. Anything
+// else — SQL text, including a UTF-8 BOM or CRLF plain dump, or a short/empty
+// file — is treated as plain (psql surfaces the real error there). A bounded
+// header slice keeps a <262-byte plain dump from panicking the tar check.
+func pgDumpIsArchive(hdr []byte) bool {
+	if len(hdr) >= 5 && string(hdr[:5]) == "PGDMP" {
+		return true // custom format (pg_dump -Fc / pgAdmin default "Custom")
+	}
+	if len(hdr) >= 262 && string(hdr[257:262]) == "ustar" {
+		return true // tar format (pg_dump -Ft)
+	}
+	return false
+}
+
+// pgPathScrubRe strips agent-internal absolute paths from a loader error before
+// it reaches the tenant's screen (GH #1045 error surfacing).
+var pgPathScrubRe = regexp.MustCompile(`/var/lib/jabali[-/][^\s"']*`)
+
+// pgTrimLoaderError bounds a psql/pg_restore stderr for tenant display: strips
+// absolute staging paths, keeps only the first handful of lines (a garbage dump
+// cascades into pages of errors), and caps the length. The dump is the tenant's
+// own, so the psql/pg_restore diagnostic itself is theirs to see — this only
+// keeps agent internals + unbounded output out.
+func pgTrimLoaderError(s string) string {
+	s = strings.TrimSpace(pgPathScrubRe.ReplaceAllString(s, "<path>"))
+	if lines := strings.Split(s, "\n"); len(lines) > 6 {
+		s = strings.Join(lines[:6], "\n")
+	}
+	if len(s) > 500 {
+		s = strings.TrimSpace(s[:500]) + "…"
+	}
+	if s == "" {
+		s = "no error output from the loader"
+	}
+	return s
+}
+
 // pgSuperExecInDB runs one statement as the postgres superuser CONNECTED TO db
 // (REASSIGN OWNED / GRANT ON ALL TABLES / DROP OWNED are database-local). db is
 // a pgValidIdent-checked identifier passed as an exec arg (no shell).
@@ -150,6 +191,16 @@ func dbPgRestoreHandler(ctx context.Context, params json.RawMessage) (any, error
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "restore path invalid, outside an allowed directory, or not readable"}
 	}
 	defer f.Close()
+
+	// GH #1045: detect the dump format so pgAdmin's default CUSTOM (and TAR)
+	// archives restore via pg_restore, not just plain-SQL via psql. Read the
+	// header, then rewind so whichever loader gets a stream from offset 0.
+	hdr := make([]byte, 512)
+	nHdr, _ := io.ReadFull(f, hdr) // short read (small dump) is fine
+	if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "rewind dump: " + serr.Error()}
+	}
+	isArchive := pgDumpIsArchive(hdr[:nHdr])
 
 	shadow := pgShadowRole(p.DBName)
 	tmpDB := pgRestoreTmpDB(p.DBName)
@@ -212,43 +263,70 @@ END $$;`, shadow, shadow, pwd, shadow, pwd)
 	if uerr != nil || gerr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "parse nobody uid/gid"}
 	}
-	load := execCommandContext(ctx, "psql",
-		"-v", "ON_ERROR_STOP=1", "-X", "-q",
-		"-h", "127.0.0.1", "-p", "5432",
-		"-U", shadow, "-d", tmpDB)
-	load.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}}
-	load.Env = append(os.Environ(), "PGPASSWORD="+pwd)
+	cred := &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}}
+	if isArchive {
+		// pg_restore path (GH #1045) — a pgAdmin CUSTOM/TAR archive. The archive
+		// rides in on a SEEKABLE stdin: `nobody` inherits root's already-open file
+		// fd and reads+seeks it without ever opening the path — the same
+		// escape-proof property as the psql pipe (a symlink swap can't redirect an
+		// already-open fd). --no-owner --no-privileges is the archive-native
+		// equivalent of the plain-SQL sanitizer (skips OWNER/ACL the non-superuser
+		// shadow couldn't replay); --exit-on-error aborts the whole load on any
+		// failure so a bad/partial archive never reaches the swap. Trusted
+		// extensions (pgcrypto, uuid-ossp, …) the shadow can create as the staging
+		// db's owner still load; an UNtrusted extension or a newer-than-server
+		// archive fails here and its real message is surfaced (not swallowed).
+		rest := execCommandContext(ctx, "pg_restore",
+			"--no-owner", "--no-privileges", "--exit-on-error",
+			"-h", "127.0.0.1", "-p", "5432", "-U", shadow, "-d", tmpDB)
+		rest.SysProcAttr = cred
+		rest.Env = append(os.Environ(), "PGPASSWORD="+pwd)
+		rest.Stdin = f // root-opened, seekable; child never opens the path
+		var out bytes.Buffer
+		rest.Stdout = &out
+		rest.Stderr = &out
+		if err := rest.Run(); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "restore load failed: " + pgTrimLoaderError(out.String())}
+		}
+	} else {
+		load := execCommandContext(ctx, "psql",
+			"-v", "ON_ERROR_STOP=1", "-X", "-q",
+			"-h", "127.0.0.1", "-p", "5432",
+			"-U", shadow, "-d", tmpDB)
+		load.SysProcAttr = cred
+		load.Env = append(os.Environ(), "PGPASSWORD="+pwd)
 
-	// Stream the dump through the ownership/privilege sanitizer (GH #1044) into
-	// psql's stdin via a pipe: a stock `pg_dump` carries `ALTER ... OWNER TO` /
-	// GRANT / SET SESSION AUTHORIZATION that the unprivileged shadow role can't
-	// replay ("must be able to SET ROLE ..."), which ON_ERROR_STOP turns into a
-	// whole-restore abort. psql (as `nobody`) reads the inherited pipe fd, never
-	// the dump path — the same escape-proof property as handing it the file fd,
-	// and the raw file is still only ever opened by root. The post-pass below
-	// re-establishes tenant ownership + panel-tracked grants, so nothing dropped
-	// here is lost.
-	pr, pw, perr := os.Pipe()
-	if perr != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore pipe: " + perr.Error()}
-	}
-	load.Stdin = pr
-	var out bytes.Buffer
-	load.Stdout = &out
-	load.Stderr = &out
-	if err := load.Start(); err != nil {
-		_ = pr.Close()
-		_ = pw.Close()
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore start: " + err.Error()}
-	}
-	_ = pr.Close() // child holds its own copy; parent closes so psql sees EOF
-	sanErr := sanitizePgPlainDump(f, pw)
-	_ = pw.Close() // signal EOF to psql whatever the sanitize outcome
-	if waitErr := load.Wait(); waitErr != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "restore load failed (check the dump is a plain-SQL pg_dump): " + strings.TrimSpace(out.String())}
-	}
-	if sanErr != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore stream: " + sanErr.Error()}
+		// Stream the dump through the ownership/privilege sanitizer (GH #1044) into
+		// psql's stdin via a pipe: a stock `pg_dump` carries `ALTER ... OWNER TO` /
+		// GRANT / SET SESSION AUTHORIZATION that the unprivileged shadow role can't
+		// replay ("must be able to SET ROLE ..."), which ON_ERROR_STOP turns into a
+		// whole-restore abort. psql (as `nobody`) reads the inherited pipe fd, never
+		// the dump path — the same escape-proof property as handing it the file fd,
+		// and the raw file is still only ever opened by root. The post-pass below
+		// re-establishes tenant ownership + panel-tracked grants, so nothing dropped
+		// here is lost.
+		pr, pw, perr := os.Pipe()
+		if perr != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore pipe: " + perr.Error()}
+		}
+		load.Stdin = pr
+		var out bytes.Buffer
+		load.Stdout = &out
+		load.Stderr = &out
+		if err := load.Start(); err != nil {
+			_ = pr.Close()
+			_ = pw.Close()
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore start: " + err.Error()}
+		}
+		_ = pr.Close() // child holds its own copy; parent closes so psql sees EOF
+		sanErr := sanitizePgPlainDump(f, pw)
+		_ = pw.Close() // signal EOF to psql whatever the sanitize outcome
+		if waitErr := load.Wait(); waitErr != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "restore load failed (check the dump is a plain-SQL pg_dump): " + pgTrimLoaderError(out.String())}
+		}
+		if sanErr != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "restore stream: " + sanErr.Error()}
+		}
 	}
 
 	// (4) Superuser post-pass on the STAGING db — ownership + grants, none of it

--- a/panel-agent/internal/commands/db_postgres_restore_format_test.go
+++ b/panel-agent/internal/commands/db_postgres_restore_format_test.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPgDumpIsArchive(t *testing.T) {
+	// custom-format magic
+	if !pgDumpIsArchive([]byte("PGDMP\x01\x0e\x00")) {
+		t.Error("PGDMP magic must be detected as an archive (custom format)")
+	}
+	// tar: "ustar" at offset 257
+	tar := make([]byte, 300)
+	copy(tar[257:], "ustar")
+	if !pgDumpIsArchive(tar) {
+		t.Error("ustar magic at offset 257 must be detected as an archive (tar format)")
+	}
+	// plain SQL variants — NOT archives
+	for _, plain := range []string{
+		"--\n-- PostgreSQL database dump\n--\nSET statement_timeout = 0;\n",
+		"\xef\xbb\xbf-- BOM-prefixed plain dump\n", // UTF-8 BOM
+		"SET client_encoding = 'UTF8';\r\nCREATE TABLE t();\r\n", // CRLF
+		"",   // empty
+		"PGD", // too short to be PGDMP
+	} {
+		if pgDumpIsArchive([]byte(plain)) {
+			t.Errorf("plain/short input %q must NOT be detected as an archive", plain)
+		}
+	}
+	// a <262-byte plain dump must not panic the tar check
+	if pgDumpIsArchive([]byte("SELECT 1;")) {
+		t.Error("short plain dump misclassified as archive")
+	}
+}
+
+func TestPgTrimLoaderError(t *testing.T) {
+	// strips absolute staging paths
+	got := pgTrimLoaderError(`psql: error: /var/lib/jabali/restore/up-abc.sql:5: syntax error`)
+	if strings.Contains(got, "/var/lib/jabali") {
+		t.Errorf("absolute jabali path must be scrubbed: %q", got)
+	}
+	if !strings.Contains(got, "syntax error") {
+		t.Errorf("the real diagnostic must survive: %q", got)
+	}
+	// caps to the first handful of lines
+	many := strings.Repeat("ERROR: cascading failure\n", 50)
+	if n := strings.Count(pgTrimLoaderError(many), "\n"); n > 6 {
+		t.Errorf("must cap cascading output to a few lines, got %d newlines", n)
+	}
+	// caps length
+	long := strings.Repeat("x", 5000)
+	if len(pgTrimLoaderError(long)) > 520 {
+		t.Errorf("must cap length, got %d", len(pgTrimLoaderError(long)))
+	}
+	// empty → a non-empty placeholder (never a blank tenant-facing error)
+	if pgTrimLoaderError("   ") == "" {
+		t.Error("empty loader output must yield a placeholder, not an empty string")
+	}
+}

--- a/panel-api/internal/api/databases_restore_chunk.go
+++ b/panel-api/internal/api/databases_restore_chunk.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -105,10 +106,36 @@ func evictStaleRestoreStaging(userID string) {
 type restoreOutcome struct {
 	Status string `json:"status"` // "restoring" | "done" | "failed"
 	TS     int64  `json:"ts"`
+	// Error is the tenant-facing failure detail on "failed" (GH #1045): the
+	// loader's own psql/pg_restore diagnostic (already path-scrubbed +
+	// length-bounded agent-side), so the UI can show WHY a restore failed
+	// instead of a bare "restore_failed". Empty on restoring/done.
+	Error string `json:"error,omitempty"`
 }
 
-func writeRestoreOutcome(path, status string) {
-	b, _ := json.Marshal(restoreOutcome{Status: status, TS: time.Now().Unix()})
+func writeRestoreOutcome(path, status, detail string) {
+	// Defence in depth: cap the stored detail even though the agent already
+	// bounds it — the outcome file is read straight back into a tenant response.
+	if len(detail) > 600 {
+		detail = detail[:600] + "…"
+	}
+	b, _ := json.Marshal(restoreOutcome{Status: status, TS: time.Now().Unix(), Error: detail})
+	writeOutcomeFile(path, b)
+}
+
+// restoreFailureDetail extracts a tenant-safe failure message from a restore
+// error. An agent AgentError carries a human-facing Message that the agent has
+// already path-scrubbed + length-bounded (GH #1045); anything else falls back to
+// a generic string so a raw internal error never reaches the tenant.
+func restoreFailureDetail(err error) string {
+	var ae *agentwire.AgentError
+	if errors.As(err, &ae) && ae.Message != "" {
+		return ae.Message
+	}
+	return "the restore failed — check that the uploaded file is a valid PostgreSQL dump"
+}
+
+func writeOutcomeFile(path string, b []byte) {
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, b, 0o600); err == nil {
 		_ = os.Rename(tmp, path) // atomic swap so a poll never sees a torn write
@@ -203,8 +230,12 @@ func (h *databaseHandler) restoreStatus(c *gin.Context) {
 	// (panel restart) — report failed so the client stops polling forever.
 	if o.Status == "restoring" && time.Since(time.Unix(o.TS, 0)) > restoreAgentTimeout {
 		o.Status = "failed"
+		if o.Error == "" {
+			o.Error = "the restore did not finish in time and was abandoned"
+		}
 	}
-	c.JSON(http.StatusOK, gin.H{"status": o.Status})
+	// GH #1045: return the failure detail so the UI shows WHY, not "restore_failed".
+	c.JSON(http.StatusOK, gin.H{"status": o.Status, "error": o.Error})
 }
 
 // restoreChunk handles POST /databases/:id/restore-chunk?upload_id=…&offset=…[&final=1].
@@ -346,16 +377,20 @@ func (h *databaseHandler) restoreChunk(c *gin.Context) {
 	// multi-minute restore). The client polls restore-status. Snapshot everything
 	// the goroutine needs — the request is done once we respond.
 	outcomePath := restoreOutcomePath(claims.UserID, uploadID)
-	writeRestoreOutcome(outcomePath, "restoring")
+	writeRestoreOutcome(outcomePath, "restoring", "")
 	go func() {
 		// context.Background(): fully detached; doDatabaseRestore applies its own
 		// restoreAgentTimeout ceiling.
 		if err := h.doDatabaseRestore(context.Background(), d, restorePath); err != nil {
 			slog.Error("chunked restore failed", "db_id", d.ID, "err", err)
-			writeRestoreOutcome(outcomePath, "failed")
+			// GH #1045: surface the loader's real reason (an agent AgentError
+			// carries a human-facing, already-sanitised Message) so the tenant
+			// sees e.g. "restore load failed: <psql/pg_restore error>" instead of
+			// a bare "restore_failed". Non-agent errors fall back to generic.
+			writeRestoreOutcome(outcomePath, "failed", restoreFailureDetail(err))
 			return
 		}
-		writeRestoreOutcome(outcomePath, "done")
+		writeRestoreOutcome(outcomePath, "done", "")
 	}()
 	c.JSON(http.StatusAccepted, gin.H{"upload_id": uploadID, "status": "restoring"})
 }

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -425,17 +425,21 @@ export async function restoreDatabaseUploadChunked(
   for (;;) {
     await new Promise((res) => setTimeout(res, 2000));
     let status = "restoring";
+    let failDetail = "";
     try {
-      const s = await apiClient.get<{ status: string }>(
+      const s = await apiClient.get<{ status: string; error?: string }>(
         `/databases/${databaseId}/restore-status`,
         { params: { upload_id: uploadId } },
       );
       status = s.data.status;
+      failDetail = s.data.error ?? "";
     } catch {
       // Transient poll error — keep trying until the deadline.
     }
     if (status === "done") break;
-    if (status === "failed") throw new Error("restore_failed");
+    // GH #1045: surface the real reason the restore failed (the loader's own
+    // psql/pg_restore diagnostic) instead of a generic "restore_failed".
+    if (status === "failed") throw new Error(failDetail || "restore_failed");
     if (Date.now() > deadline) throw new Error("restore_timeout");
   }
   lsDel(resumeKey);


### PR DESCRIPTION
## Bug

@lxsdevcode's per-database **Restore from file** failed on a **pgAdmin** dump with only a generic `Restore failed: restore_failed`. Two causes:

1. **Format.** pgAdmin's *default* export is the **Custom** format (`pg_dump -Fc` — a binary archive starting with the `PGDMP` magic); **Tar** is another option. The loader only ran `psql`, which reads plain SQL — so a custom/tar archive could never restore.
2. **Invisible error.** The async chunked-restore worker logged the agent's detailed error but stored only `{status}`; `/restore-status` returned only `{status}`; the UI poller threw a hardcoded `"restore_failed"`.

## Fix

### Format detection + pg_restore path (agent)
Sniff the dump header: `PGDMP` → custom, `ustar`@257 → tar, else plain (incl. BOM/CRLF/short). Plain keeps the existing `psql`-through-sanitizer path; **custom/tar** load via `pg_restore --no-owner --no-privileges --exit-on-error`.

Same security model as the psql path:
- archive rides in on a **seekable stdin** — the root-opened file fd handed to the `nobody` child, which reads+seeks it **without ever opening the path** (escape-proof; a symlink swap can't redirect an already-open fd);
- `pg_restore` runs as `nobody`, connecting as the per-db **NON-superuser shadow role** over scram TCP, into the **throwaway staging db**, renamed onto the real name only on success (**load-then-swap** — a bad/partial archive never touches the tenant's real db);
- `--no-owner --no-privileges` is the archive-native equivalent of the plain-SQL sanitizer; `--exit-on-error` fails the whole load on any error. Trusted extensions (pgcrypto, uuid-ossp, …) the shadow can create as the staging-db owner still load; an untrusted extension or a newer-than-server archive fails with a legible message.

### Surface the real error (API + UI)
The restore outcome now carries a tenant-facing `error`, filled from the agent's `AgentError.Message` (already path-scrubbed + line/length-bounded agent-side by `pgTrimLoaderError`); `/restore-status` returns `{status, error}`; the UI throws that instead of the generic string. Bounded again API-side; a non-agent error falls back to a generic string so a raw internal error never reaches the tenant — the **JAB-114 leak gate stays green**.

## Test plan

- [x] `go build ./...` + `go vet` clean; unit tests: `pgDumpIsArchive` (custom/tar/plain/BOM/CRLF/short) + `pgTrimLoaderError` (path-scrub, line/length caps); `NoAgentErrorLeak` still green; `npx tsc -b` clean.
- [x] **Box-drill on .60 (PG 16.15)** via the agent socket:
  - custom / tar / plain → restore OK (120 rows, objects reassigned to the tenant role, **no `jbrt_`/`jbsr_` leftovers**); the right loader ran each (garbage→psql, truncated-custom→pg_restore).
  - trusted-extension custom dump → restores as the non-superuser shadow.
  - **garbage** + **truncated** dumps → `ok:false` with the real psql/pg_restore error, and the tenant's **real database left untouched** (sentinel intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
