### PR TITLE
feat(domains): let tenants choose the reverse-proxy port, with an SSRF-safe validator (GH #1401)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1950,6 +1950,7 @@ jabali domain create [flags]
 - `--doc-root` — Document root (optional, auto-generated if not provided)
 - `--name` — Domain name (required)
 - `--reverse-proxy` — Make this a reverse-proxy domain: allocate a loopback port and proxy '/' to it (GH #1175)
+- `--reverse-proxy-port` — Reverse-proxy to this specific loopback port (GH #1401); 0 = auto-assign from the pool (default `0`)
 - `--user` — User email, username, or ULID (required)
 
 #### `jabali domain delete`

--- a/panel-api/cmd/server/cli_create.go
+++ b/panel-api/cmd/server/cli_create.go
@@ -213,6 +213,9 @@ type cliDomainInput struct {
 	// ReverseProxy (GH #1175): allocate a loopback port and make this a
 	// reverse-proxy domain (no docroot/PHP). Mirrors the HTTP create path.
 	ReverseProxy bool
+	// ReverseProxyPort (GH #1401): a specific loopback port to proxy to; 0 =
+	// auto-assign from the pool. Validated the same as the HTTP path.
+	ReverseProxyPort int
 }
 
 // createDomainDirect replicates the non-auth side of internal/api/domains.go
@@ -294,7 +297,16 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 	// as the HTTP create path (repository.AllocateReverseProxy).
 	ports := repository.NewPortAllocationRepository(sharedDB)
 	if in.ReverseProxy {
-		port, aerr := ports.AllocateReverseProxy(ctx, d.ID)
+		var port int
+		var aerr error
+		if in.ReverseProxyPort != 0 {
+			if verr := repository.ValidateReverseProxyPort(in.ReverseProxyPort); verr != nil {
+				return nil, nil, verr
+			}
+			port, aerr = ports.AllocateReverseProxySpecific(ctx, d.ID, in.ReverseProxyPort)
+		} else {
+			port, aerr = ports.AllocateReverseProxy(ctx, d.ID)
+		}
 		if aerr != nil {
 			return nil, nil, fmt.Errorf("allocate reverse-proxy port: %w", aerr)
 		}

--- a/panel-api/cmd/server/domain_cmd.go
+++ b/panel-api/cmd/server/domain_cmd.go
@@ -93,6 +93,7 @@ func newDomainListCmd() *cobra.Command {
 func newDomainCreateCmd() *cobra.Command {
 	var name, userID, docRoot string
 	var reverseProxy bool
+	var reverseProxyPort int
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -115,10 +116,11 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 			defer cancel()
 
 			d, warnings, err := createDomainDirect(ctx, cliDomainInput{
-				Name:         name,
-				UserID:       userID,
-				DocRoot:      docRoot,
-				ReverseProxy: reverseProxy,
+				Name:             name,
+				UserID:           userID,
+				DocRoot:          docRoot,
+				ReverseProxy:     reverseProxy,
+				ReverseProxyPort: reverseProxyPort,
 			})
 			if err != nil {
 				return err
@@ -154,6 +156,7 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 	cmd.Flags().StringVar(&userID, "user", "", "User email, username, or ULID (required)")
 	cmd.Flags().StringVar(&docRoot, "doc-root", "", "Document root (optional, auto-generated if not provided)")
 	cmd.Flags().BoolVar(&reverseProxy, "reverse-proxy", false, "Make this a reverse-proxy domain: allocate a loopback port and proxy '/' to it (GH #1175)")
+	cmd.Flags().IntVar(&reverseProxyPort, "reverse-proxy-port", 0, "Reverse-proxy to this specific loopback port (GH #1401); 0 = auto-assign from the pool")
 	return cmd
 }
 

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // domain_create_op.go — JAB-233. The domain-creation orchestration extracted
@@ -42,6 +44,9 @@ type createDomainInput struct {
 	// ReverseProxy (GH #1175): make this a reverse-proxy domain — the panel
 	// allocates a loopback port and the vhost proxies `/` to it. No DocRoot/PHP.
 	ReverseProxy bool
+	// ReverseProxyPort (GH #1401): the tenant's chosen loopback port. 0 = the
+	// panel auto-assigns from its pool (the #1175 default).
+	ReverseProxyPort uint32
 	// SkipInlineSSL omits the 30s inline ACME/self-signed attempt (JAB-233):
 	// the automation path lets the first reconciler tick bootstrap the cert,
 	// exactly like the `jabali domain create` CLI. GUI create leaves it false.
@@ -181,7 +186,22 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		if h.cfg.PortAllocations == nil {
 			return nil, &createDomainError{http.StatusServiceUnavailable, "reverse_proxy_unavailable", "reverse-proxy domains are not enabled on this host"}
 		}
-		port, aerr := h.cfg.PortAllocations.AllocateReverseProxy(ctx, domain.ID)
+		var port int
+		var aerr error
+		if in.ReverseProxyPort != 0 {
+			// GH #1401: tenant chose a specific port — validate it can't target
+			// the panel, a system service, another tenant's allocated port, or a
+			// privileged/reserved range, then reserve that exact port.
+			if verr := repository.ValidateReverseProxyPort(int(in.ReverseProxyPort)); verr != nil {
+				return nil, &createDomainError{http.StatusBadRequest, "reverse_proxy_port_invalid", verr.Error()}
+			}
+			port, aerr = h.cfg.PortAllocations.AllocateReverseProxySpecific(ctx, domain.ID, int(in.ReverseProxyPort))
+			if errors.Is(aerr, repository.ErrPortInUse) {
+				return nil, &createDomainError{http.StatusConflict, "reverse_proxy_port_in_use", "that port is already assigned to another domain — choose another"}
+			}
+		} else {
+			port, aerr = h.cfg.PortAllocations.AllocateReverseProxy(ctx, domain.ID)
+		}
 		if aerr != nil {
 			return nil, &createDomainError{http.StatusServiceUnavailable, "reverse_proxy_port_unavailable", "no free reverse-proxy port available; contact the administrator"}
 		}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -106,6 +106,13 @@ type createDomainRequest struct {
 	// ReverseProxy (GH #1175): create a reverse-proxy domain (panel allocates a
 	// loopback port; the vhost proxies / to it). No docroot/PHP.
 	ReverseProxy bool `json:"reverse_proxy"`
+	// ReverseProxyPort (GH #1401): the specific loopback port the tenant wants
+	// the domain proxied to (e.g. their app already listens on 6875). 0/absent
+	// = the panel auto-assigns from its reverse-proxy pool (the #1175 default).
+	// Validated (range + jabali-infra denylist + not-already-allocated) before
+	// it is reserved — a tenant must not be able to point their public domain at
+	// the panel, a system service, or another tenant's allocated port.
+	ReverseProxyPort uint32 `json:"reverse_proxy_port,omitempty"`
 	// SSLMode (GH #246) — le|self|none at create. 'custom' is rejected here:
 	// it needs a cert upload, set via PUT /domains/:id/ssl/custom after create.
 	// Empty defaults to 'le'.
@@ -674,16 +681,17 @@ func (h *domainHandler) create(c *gin.Context) {
 	// JAB-233: the orchestration lives in createDomainOp so the automation
 	// account-create handler can reuse the exact GUI semantics.
 	dom, oerr := createDomainOp(c.Request.Context(), h, createDomainInput{
-		OwnerID:         targetUserID,
-		Name:            req.Name,
-		DocRoot:         req.DocRoot,
-		MailProvider:    req.MailProvider,
-		M365Onmicrosoft: req.M365Onmicrosoft,
-		GoogleDKIM:      req.GoogleDKIM,
-		SSLMode:         req.SSLMode,
-		CreateWWW:       req.CreateWWW,
-		TempURLEnabled:  req.TempURLEnabled,
-		ReverseProxy:    req.ReverseProxy,
+		OwnerID:          targetUserID,
+		Name:             req.Name,
+		DocRoot:          req.DocRoot,
+		MailProvider:     req.MailProvider,
+		M365Onmicrosoft:  req.M365Onmicrosoft,
+		GoogleDKIM:       req.GoogleDKIM,
+		SSLMode:          req.SSLMode,
+		CreateWWW:        req.CreateWWW,
+		TempURLEnabled:   req.TempURLEnabled,
+		ReverseProxy:     req.ReverseProxy,
+		ReverseProxyPort: req.ReverseProxyPort,
 	})
 	if oerr != nil {
 		body := gin.H{"error": oerr.Code}

--- a/panel-api/internal/repository/port_allocation_repository.go
+++ b/panel-api/internal/repository/port_allocation_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -15,6 +16,64 @@ import (
 // ErrPortPoolExhausted — no free port in the requested pool for this
 // (bind_interface, protocol). GH #1175.
 var ErrPortPoolExhausted = errors.New("no free port in the allocation pool")
+
+// ErrPortInUse — the specific port a tenant asked for (GH #1401) is already
+// reserved by another allocation.
+var ErrPortInUse = errors.New("requested port is already allocated")
+
+// jabaliInfraPorts are fixed loopback ports jabali/system services bind. A
+// tenant reverse-proxy target (GH #1401) must never point at these — else a
+// public domain could be pointed at the panel or a system service (SSRF). Ports
+// inside the allocator pools (10000-39999) and the FTP passive range
+// (40000-40100) are blocked by range in ValidateReverseProxyPort; this set is
+// the fixed service ports, listed EXPLICITLY so the denylist is complete on its
+// own (a port that also falls in a blocked range, e.g. stalwart 18181, is
+// listed here too — not left to range-coincidence).
+// SECURITY-LOAD-BEARING: extend when a new jabali service binds a loopback port.
+// (A follow-up adds an agent-side "is a non-tenant process bound here?" check
+// that closes drift + the down-service race — see the #1401 PR.)
+var jabaliInfraPorts = map[int]bool{
+	3306:  true, // MariaDB
+	4433:  true, // Kratos (legacy TCP listener)
+	4434:  true, // Kratos (legacy TCP listener)
+	5300:  true, // PowerDNS authoritative
+	5432:  true, // PostgreSQL
+	6060:  true, // CrowdSec metrics/pprof
+	6379:  true, // Redis (unix-socket-only today; defensive)
+	7422:  true, // CrowdSec AppSec
+	8022:  true, // SSH (alternate)
+	8080:  true, // Stalwart admin
+	8081:  true, // CrowdSec LAPI
+	8443:  true, // panel (nginx :8443)
+	8446:  true, // Stalwart
+	8462:  true, // jabali-mailhook
+	18181: true, // Stalwart (also inside the docker pool range — explicit anyway)
+}
+
+// ValidateReverseProxyPort gates a tenant-chosen reverse-proxy target (GH
+// #1401). Rejects privileged/out-of-range ports, the shared allocator pools
+// (docker 10000-19999 / python 20000-29999 / reverse-proxy 30000-39999), the
+// FTP passive range, and the fixed jabali-infra ports. Shared by the HTTP and
+// CLI create paths so the policy has one home. 0 (auto-assign) is NOT passed
+// here — the caller only validates an explicit tenant port.
+func ValidateReverseProxyPort(port int) error {
+	if port < 1024 || port > 65535 {
+		return errors.New("port must be between 1024 and 65535")
+	}
+	// Infra denylist BEFORE the range blocks so a fixed service port gets the
+	// accurate "system service" reason even when it also falls in a blocked
+	// range (stalwart 18181 is inside the docker pool range).
+	if jabaliInfraPorts[port] {
+		return fmt.Errorf("port %d is used by a system service and can't be a reverse-proxy target", port)
+	}
+	if port >= 10000 && port <= 39999 {
+		return errors.New("ports 10000-39999 are reserved for the panel's app allocator — pick a port outside that range")
+	}
+	if port >= 40000 && port <= 40100 {
+		return errors.New("ports 40000-40100 are reserved for FTP — pick another")
+	}
+	return nil
+}
 
 // GH #1175 reverse-proxy port pool — a dedicated slice of port_allocations,
 // disjoint from docker (10000-19999) + python (20000-29999) during the
@@ -41,6 +100,11 @@ type PortAllocationRepository interface {
 	// place and every create path draws from the same range. Idempotent per
 	// domainID.
 	AllocateReverseProxy(ctx context.Context, domainID string) (int, error)
+	// AllocateReverseProxySpecific reserves the EXACT port a tenant chose (GH
+	// #1401) for a reverse-proxy domain. Idempotent per domainID; returns
+	// ErrPortInUse when that port is already allocated to another owner. The
+	// caller validates the port is safe (validateReverseProxyPort) first.
+	AllocateReverseProxySpecific(ctx context.Context, domainID string, port int) (int, error)
 	// Release frees every port held by (ownerKind, ownerID). Safe to call when
 	// the owner holds none.
 	Release(ctx context.Context, ownerKind, ownerID string) error
@@ -126,6 +190,55 @@ func (r *portAllocationRepo) Allocate(ctx context.Context, ownerKind, ownerID, b
 func (r *portAllocationRepo) AllocateReverseProxy(ctx context.Context, domainID string) (int, error) {
 	return r.Allocate(ctx, models.PortOwnerReverseProxy, domainID,
 		ReverseProxyBindIface, ReverseProxyProto, ReverseProxyPoolMin, ReverseProxyPoolMax)
+}
+
+// AllocateReverseProxySpecific reserves the EXACT port (GH #1401). Idempotent
+// per owner (a re-provision returns the held port); ErrPortInUse when the port
+// belongs to another owner. Locks the (interface, protocol) rows so a
+// concurrent claim can't double-reserve; the UNIQUE(bind_interface, port,
+// protocol) index is the final backstop.
+func (r *portAllocationRepo) AllocateReverseProxySpecific(ctx context.Context, domainID string, port int) (int, error) {
+	var out int
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.PortAllocation
+		e := tx.Where("owner_kind = ? AND owner_id = ? AND bind_interface = ? AND protocol = ?",
+			models.PortOwnerReverseProxy, domainID, ReverseProxyBindIface, ReverseProxyProto).First(&existing).Error
+		if e == nil {
+			out = int(existing.Port)
+			return nil
+		}
+		if !errors.Is(e, gorm.ErrRecordNotFound) {
+			return e
+		}
+		var taken int64
+		if err := tx.Model(&models.PortAllocation{}).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("bind_interface = ? AND protocol = ? AND port = ?", ReverseProxyBindIface, ReverseProxyProto, port).
+			Count(&taken).Error; err != nil {
+			return err
+		}
+		if taken > 0 {
+			return ErrPortInUse
+		}
+		row := &models.PortAllocation{
+			ID:            ids.NewULID(),
+			Port:          uint32(port),
+			BindInterface: ReverseProxyBindIface,
+			Protocol:      ReverseProxyProto,
+			OwnerKind:     models.PortOwnerReverseProxy,
+			OwnerID:       domainID,
+			CreatedAt:     time.Now().UTC(),
+		}
+		if err := tx.Create(row).Error; err != nil {
+			return ErrPortInUse // UNIQUE backstop on a concurrent claim
+		}
+		out = port
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return out, nil
 }
 
 func (r *portAllocationRepo) Release(ctx context.Context, ownerKind, ownerID string) error {

--- a/panel-api/internal/repository/port_allocation_validate_test.go
+++ b/panel-api/internal/repository/port_allocation_validate_test.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #1401: a tenant-chosen reverse-proxy port must not target the panel, a
+// system service, the allocator pools, or a privileged/out-of-range port.
+func TestValidateReverseProxyPort(t *testing.T) {
+	for _, p := range []int{1024, 6875, 3000, 5000, 8000, 9000, 40200, 65535} {
+		if err := ValidateReverseProxyPort(p); err != nil {
+			t.Errorf("port %d should be allowed, got %v", p, err)
+		}
+	}
+
+	reject := map[int]string{
+		80:    "1024",           // privileged
+		443:   "1024",           // privileged
+		1023:  "1024",           // just under floor
+		70000: "65535",          // above range
+		8443:  "system service", // panel
+		5432:  "system service", // postgres
+		3306:  "system service", // mariadb
+		8080:  "system service", // stalwart admin
+		7422:  "system service", // crowdsec appsec
+		18181: "system service", // stalwart — explicit, not pool-coincidence
+		10000: "10000-39999",    // docker pool
+		20000: "10000-39999",    // python pool
+		30005: "10000-39999",    // reverse-proxy pool
+		39999: "10000-39999",    // pool top
+		40050: "40000-40100",    // ftp passive
+	}
+	for p, want := range reject {
+		err := ValidateReverseProxyPort(p)
+		if err == nil {
+			t.Errorf("port %d must be rejected", p)
+			continue
+		}
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("port %d error %q should mention %q", p, err.Error(), want)
+		}
+	}
+}

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -1,7 +1,7 @@
 // UserDomainDrawer — tenant Add-domain Drawer (replaces the
 // /jabali-panel/domains/create page route).
 import { useTranslation } from "react-i18next";
-import { Button, Checkbox, Drawer, Form, Grid, Input, Select, Space } from "antd";
+import { Button, Checkbox, Drawer, Form, Grid, Input, InputNumber, Select, Space } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
@@ -19,6 +19,9 @@ type UserDomainCreateInput = {
   // port and proxies the domain to it (no docroot/PHP). The assigned port
   // comes back on the create response.
   reverse_proxy?: boolean;
+  // GH #1401: optional — the specific local port to proxy to (e.g. your app
+  // already listens on 6875). Left blank, the panel auto-assigns a free port.
+  reverse_proxy_port?: number;
 };
 type DomainCreated = { id: string; reverse_proxy_port?: number };
 
@@ -31,6 +34,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
   const { t } = useTranslation();
   const [form] = Form.useForm<UserDomainCreateInput>();
   const mailProvider = Form.useWatch("mail_provider", form) ?? "jabali";
+  const reverseProxy = Form.useWatch("reverse_proxy", form) ?? false;
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
 
@@ -170,6 +174,31 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         >
           <Checkbox>Set up as a reverse proxy (run your own app on a local port)</Checkbox>
         </Form.Item>
+
+        {/* GH #1401: let the tenant type their app's port; blank = auto-assign.
+            Server validates it (range + system-port denylist + not-in-use). */}
+        {reverseProxy && (
+          <Form.Item
+            name="reverse_proxy_port"
+            label="Port (optional)"
+            tooltip="The local port your app listens on (e.g. 6875). Leave blank to let the panel pick a free port for you. Ports below 1024, the panel's own ports, and ports used by system services are not allowed."
+            rules={[
+              {
+                validator: (_, v) =>
+                  v == null || v === "" || (Number.isInteger(v) && v >= 1024 && v <= 65535)
+                    ? Promise.resolve()
+                    : Promise.reject(new Error("Enter a port between 1024 and 65535, or leave blank")),
+              },
+            ]}
+          >
+            <InputNumber
+              min={1024}
+              max={65535}
+              style={{ width: "100%" }}
+              placeholder="Auto-assign a free port"
+            />
+          </Form.Item>
+        )}
 
         <Form.Item>
           <Space>


### PR DESCRIPTION
## Request

@mrlp57 (#1401): when creating a reverse-proxy domain, let the tenant **type** the local port — their app already listens on e.g. `6875`. #1175 shipped panel-**assigned** ports (a free port from the 30000–39999 pool); this adds an optional typed port, defaulting to auto-assign.

## Security

A tenant-chosen `127.0.0.1:<port>` is an SSRF vector — a public domain could be pointed at the panel itself (`:8443`), jabali infra, or another tenant's app. The port is validated before it's reserved (`repository.ValidateReverseProxyPort`, shared by the HTTP + CLI paths):

- reject `< 1024` / `> 65535`;
- reject the **fixed jabali-infra ports** (panel 8443, postgres 5432, mariadb 3306, crowdsec 6060/7422/8081, stalwart 8080/8446/18181, pdns 5300, mailhook 8462, kratos 4433/4434, redis 6379) — listed explicitly so the denylist is complete standing alone (a port that also falls in a blocked range, e.g. stalwart 18181, is listed anyway);
- reject the **allocator pools 10000–39999** (docker / python / reverse-proxy) so a typed port can't collide with an auto-assignment or another tenant's managed app, and the **FTP passive range** 40000–40100;
- reserve the **exact** port via `AllocateReverseProxySpecific` (idempotent per domain; `ErrPortInUse` when another domain holds it — the `UNIQUE(interface, port, protocol)` index is the backstop). `Release` is owner-keyed, so the existing `userops.DeleteDomain` path frees a typed reservation.

**Create-only** — the port isn't in the domain Update Select-allowlist, so a tenant can't repoint an existing domain. `nginxrules.Compile` already synthesises the `proxy_pass` from the column → no compile/agent change.

## Known limitation / follow-up

The denylist is a panel-side constant and can **drift** as new jabali services bind loopback ports. A follow-up should add an **agent-side** check that refuses a `proxy_pass` to a port a **non-tenant-uid process is currently bound to** (drift-proof + closes the down-service race, without false-rejecting a tenant app that isn't started yet). Called out in the code; mrlp57's ask is satisfied without it.

## UI / CLI

- UI: an optional **Port** field under the reverse-proxy checkbox (blank = auto-assign).
- CLI parity: `jabali domain create --reverse-proxy --reverse-proxy-port <n>` (CLI reference golden regenerated).

## Test plan

- [x] `go build ./...` + `go vet` clean; unit test covers the validator matrix (allowed 6875/etc., privileged, infra, pools, ftp range); CLI-reference + OpenAPI-coverage goldens green; `npx tsc -b` clean.
- [x] **Box-drill on .60** (via the CLI flag): typed **6875** assigned → vhost renders `proxy_pass http://127.0.0.1:6875`; **8443** and **5432** rejected as system services (message names the reason); **30005** rejected as pool-reserved; **6875 twice** rejected as already-allocated; blank still auto-assigns from the pool (30000); **deleting** the domain releases 6875 so a recreate reuses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
