### PR TITLE
feat(domains): drift-proof reverse-proxy port picker with an agent-side bind check (GH #1401 follow-up)

### DIFF
--- a/panel-agent/internal/commands/net_loopback_owner.go
+++ b/panel-agent/internal/commands/net_loopback_owner.go
@@ -1,0 +1,161 @@
+// net.loopback_listener_uid (GH #1401 follow-up): report whether a TCP port is
+// already LISTENing on the loopback path and, if so, the lowest owning uid.
+//
+// The reverse-proxy feature lets a tenant point a public domain at
+// 127.0.0.1:<port>. A panel-side constant denylist blocks the KNOWN jabali
+// infra ports, but that list can drift as new services are added. This verb is
+// the drift-proof backstop: the panel refuses a tenant-chosen port that is
+// already held by a SYSTEM/SERVICE process (uid < 1000 = below the tenant uid
+// floor) before it writes the proxy_pass — so a domain can never be aimed at
+// the panel, a database, the mail stack, etc. even if the constant list misses
+// a new one. A port bound by the tenant's own app (uid >= 1000), or not bound
+// at all (the app simply isn't started yet), is allowed.
+//
+// A listener reachable via 127.0.0.1:<port> is one bound to the loopback
+// address, OR to the any-address (0.0.0.0 / ::) which also answers on loopback.
+// A listener bound only to a specific public IP is NOT reachable on 127.0.0.1
+// and is ignored.
+package commands
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type netLoopbackOwnerParams struct {
+	Port int `json:"port"`
+}
+
+type netLoopbackOwnerResult struct {
+	Bound bool `json:"bound"`
+	UID   int  `json:"uid"` // lowest owning uid when bound; -1 when not bound
+}
+
+// tcpStateListen is the /proc/net/tcp st value for LISTEN.
+const tcpStateListen = "0A"
+
+func netLoopbackOwnerHandler(_ context.Context, raw json.RawMessage) (any, error) {
+	var p netLoopbackOwnerParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "malformed JSON body"}
+	}
+	if p.Port < 1 || p.Port > 65535 {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "port must be 1-65535"}
+	}
+	uid, bound := lowestLoopbackListenerUID(p.Port)
+	if !bound {
+		return netLoopbackOwnerResult{Bound: false, UID: -1}, nil
+	}
+	return netLoopbackOwnerResult{Bound: true, UID: uid}, nil
+}
+
+// lowestLoopbackListenerUID scans /proc/net/tcp + tcp6 for a LISTEN socket on
+// `port` reachable via loopback and returns the lowest owning uid found.
+func lowestLoopbackListenerUID(port int) (int, bool) {
+	best := -1
+	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		if uid, ok := scanProcNetTCP(path, port); ok && (best == -1 || uid < best) {
+			best = uid
+		}
+	}
+	if best == -1 {
+		return 0, false
+	}
+	return best, true
+}
+
+// scanProcNetTCP returns the lowest uid of any LISTEN socket in `path` whose
+// local port == port and whose local address is loopback or the any-address.
+func scanProcNetTCP(path string, port int) (int, bool) {
+	f, err := os.Open(path) //nolint:gosec // fixed procfs path
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	best := -1
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	first := true
+	for sc.Scan() {
+		if first { // header row
+			first = false
+			continue
+		}
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 8 {
+			continue
+		}
+		if fields[3] != tcpStateListen {
+			continue
+		}
+		addr, lport, ok := splitHexAddrPort(fields[1])
+		if !ok || lport != port {
+			continue
+		}
+		if !isLoopbackOrAnyHex(addr) {
+			continue
+		}
+		uid, err := strconv.Atoi(fields[7])
+		if err != nil {
+			continue
+		}
+		if best == -1 || uid < best {
+			best = uid
+		}
+	}
+	if best == -1 {
+		return 0, false
+	}
+	return best, true
+}
+
+// splitHexAddrPort splits a /proc/net/tcp "HEXADDR:HEXPORT" local_address into
+// the hex address and the decimal port.
+func splitHexAddrPort(s string) (string, int, bool) {
+	i := strings.IndexByte(s, ':')
+	if i <= 0 || i == len(s)-1 {
+		return "", 0, false
+	}
+	port, err := strconv.ParseInt(s[i+1:], 16, 32)
+	if err != nil {
+		return "", 0, false
+	}
+	return s[:i], int(port), true
+}
+
+// isLoopbackOrAnyHex reports whether a /proc/net/tcp hex local address is a
+// loopback or any-address (both answer on 127.0.0.1/::1). IPv4 (8 hex chars):
+// 0100007F = 127.0.0.1, 00000000 = 0.0.0.0. IPv6 (32 hex chars): the ::1
+// loopback (…01000000) and :: any (all zero); mapped ::ffff:127.0.0.1 and
+// mapped-any are covered too.
+func isLoopbackOrAnyHex(addr string) bool {
+	switch len(addr) {
+	case 8: // IPv4
+		return addr == "0100007F" || addr == "00000000"
+	case 32: // IPv6
+		if addr == strings.Repeat("0", 32) { // ::
+			return true
+		}
+		if strings.EqualFold(addr, "00000000000000000000000001000000") { // ::1
+			return true
+		}
+		// ::ffff:127.0.0.1 (v4-mapped loopback) and ::ffff:0.0.0.0 (v4-mapped any)
+		if strings.EqualFold(addr, "0000000000000000FFFF00000100007F") {
+			return true
+		}
+		if strings.EqualFold(addr, "0000000000000000FFFF000000000000") {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	Default.Register("net.loopback_listener_uid", netLoopbackOwnerHandler)
+}

--- a/panel-agent/internal/commands/net_loopback_owner_test.go
+++ b/panel-agent/internal/commands/net_loopback_owner_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsLoopbackOrAnyHex(t *testing.T) {
+	yes := []string{
+		"0100007F", // 127.0.0.1
+		"00000000", // 0.0.0.0
+		"00000000000000000000000001000000", // ::1
+		"00000000000000000000000000000000", // ::
+		"0000000000000000FFFF00000100007F", // ::ffff:127.0.0.1
+	}
+	for _, a := range yes {
+		if !isLoopbackOrAnyHex(a) {
+			t.Errorf("%s should be loopback/any", a)
+		}
+	}
+	no := []string{
+		"0101A8C0",                         // 192.168.1.1 (public-ish, LE)
+		"3CEC36B6",                         // some public IPv4
+		"FE800000000000000000000000000001", // link-local v6
+	}
+	for _, a := range no {
+		if isLoopbackOrAnyHex(a) {
+			t.Errorf("%s must NOT count as loopback/any", a)
+		}
+	}
+}
+
+func TestScanProcNetTCP(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp")
+	// port 5432 = 0x1538, 6875 = 0x1ADB, 8443 = 0x20FB
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1538 00000000:0000 0A 00000000:00000000 00:00000000 00000000   106        0 111 1 x
+   1: 0100007F:1ADB 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 222 1 x
+   2: 0100007F:1ADB C0A80101:E4C2 01 00000000:00000000 00:00000000 00000000     0        0 333 1 x
+   3: 3CEC36B6:20FB 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 444 1 x
+   4: 00000000:2328 00000000:0000 0A 00000000:00000000 00:00000000 00000000    33        0 555 1 x
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// 5432 → postgres, uid 106 (system).
+	if uid, ok := scanProcNetTCP(path, 5432); !ok || uid != 106 {
+		t.Errorf("5432: got uid=%d ok=%v, want 106/true", uid, ok)
+	}
+	// 6875 → LISTEN uid 1000 (tenant); the ESTABLISHED (st=01) row on the same
+	// port must be ignored, so the result is the LISTEN uid.
+	if uid, ok := scanProcNetTCP(path, 6875); !ok || uid != 1000 {
+		t.Errorf("6875: got uid=%d ok=%v, want 1000/true", uid, ok)
+	}
+	// 8443 (0x20FB) is bound only on a public IP (3CEC36B6), not loopback/any →
+	// not reachable via 127.0.0.1 → not found.
+	if _, ok := scanProcNetTCP(path, 8443); ok {
+		t.Error("8443 bound on a public IP only must not count as loopback-reachable")
+	}
+	// 9000 (0x2328) on 0.0.0.0 → reachable on loopback, uid 33.
+	if uid, ok := scanProcNetTCP(path, 9000); !ok || uid != 33 {
+		t.Errorf("9000 (any-addr): got uid=%d ok=%v, want 33/true", uid, ok)
+	}
+	// unbound port.
+	if _, ok := scanProcNetTCP(path, 12345); ok {
+		t.Error("an unbound port must return not-found")
+	}
+}

--- a/panel-api/cmd/server/cli_create.go
+++ b/panel-api/cmd/server/cli_create.go
@@ -303,6 +303,21 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 			if verr := repository.ValidateReverseProxyPort(in.ReverseProxyPort); verr != nil {
 				return nil, nil, verr
 			}
+			// GH #1401 follow-up: same drift-proof bind check as the HTTP path —
+			// refuse a port already LISTENing on loopback under a system uid
+			// (< 1000). Fail-open on agent trouble (the constant denylist is the
+			// primary gate).
+			if initAgent() == nil && sharedAgent != nil {
+				if raw, cerr := sharedAgent.Call(ctx, "net.loopback_listener_uid", map[string]any{"port": in.ReverseProxyPort}); cerr == nil {
+					var st struct {
+						Bound bool `json:"bound"`
+						UID   int  `json:"uid"`
+					}
+					if json.Unmarshal(raw, &st) == nil && st.Bound && st.UID >= 0 && st.UID < 1000 {
+						return nil, nil, fmt.Errorf("port %d is already in use by a system service — choose another", in.ReverseProxyPort)
+					}
+				}
+			}
 			port, aerr = ports.AllocateReverseProxySpecific(ctx, d.ID, in.ReverseProxyPort)
 		} else {
 			port, aerr = ports.AllocateReverseProxy(ctx, d.ID)

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -25,6 +26,11 @@ import (
 // validateDocumentRoot, EnableDomainEmailInline, and the domainHandler methods
 // findCoveringSharedCert / previewSlugConflict — and the only new caller
 // (automation) also lives in this package. Reuse, not packaging, was the goal.
+
+// reverseProxyTenantUIDFloor mirrors the agent's minTenantUID (GH #1401): a
+// loopback listener owned by a uid below this is a system/service process, not
+// a tenant app, so a tenant's reverse-proxy target must not point at it.
+const reverseProxyTenantUIDFloor = 1000
 
 // createDomainInput is the pre-normalized, pre-validated-shape input to
 // createDomainOp. Name MUST already be normalized (normalizeDomainName) and
@@ -194,6 +200,25 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 			// privileged/reserved range, then reserve that exact port.
 			if verr := repository.ValidateReverseProxyPort(int(in.ReverseProxyPort)); verr != nil {
 				return nil, &createDomainError{http.StatusBadRequest, "reverse_proxy_port_invalid", verr.Error()}
+			}
+			// GH #1401 drift-proof backstop: the constant denylist above blocks
+			// KNOWN jabali infra ports; this refuses a port already LISTENing on
+			// loopback under a system/service uid (< 1000, below the tenant floor)
+			// even if the constant list missed it — so a new infra service can't
+			// be silently proxied. Fail OPEN on any agent trouble: the constant
+			// denylist stays the primary gate, and a create shouldn't hard-fail
+			// because the agent is momentarily unreachable. A port bound by the
+			// tenant's own app (uid >= 1000), or not yet bound, passes.
+			if h.cfg.Agent != nil {
+				if raw, cerr := h.cfg.Agent.Call(ctx, "net.loopback_listener_uid", map[string]any{"port": int(in.ReverseProxyPort)}); cerr == nil {
+					var st struct {
+						Bound bool `json:"bound"`
+						UID   int  `json:"uid"`
+					}
+					if json.Unmarshal(raw, &st) == nil && st.Bound && st.UID >= 0 && st.UID < reverseProxyTenantUIDFloor {
+						return nil, &createDomainError{http.StatusConflict, "reverse_proxy_port_system_bound", "that port is already in use by a system service — choose another"}
+					}
+				}
 			}
 			port, aerr = h.cfg.PortAllocations.AllocateReverseProxySpecific(ctx, domain.ID, int(in.ReverseProxyPort))
 			if errors.Is(aerr, repository.ErrPortInUse) {


### PR DESCRIPTION
## Follow-up to #1402

#1402 gates a tenant-chosen reverse-proxy port against a **panel-side constant denylist** of jabali infra ports. That list can drift as new services bind loopback ports. This adds the backstop the #1402 PR promised: at create time, after the constant validator passes, the panel asks the agent whether the chosen port is already **LISTENing on the loopback path under a system/service uid** (`< 1000`, below the tenant uid floor) and refuses it if so — so a new infra service can never be silently proxied even when the constant list misses it.

- **Agent verb `net.loopback_listener_uid`**: parses `/proc/net/tcp` + `tcp6` for a LISTEN socket on the port bound to loopback **or** the any-address (`0.0.0.0` / `::`, which also answer on `127.0.0.1`), returns the lowest owning uid. The uid comes straight from the `/proc/net/tcp` uid column — no `/proc/*/fd` walk.
- **Panel** (HTTP create op + CLI `createDomainDirect`): reject (`reverse_proxy_port_system_bound`) when `bound && uid < 1000`. **Fail-open** on any agent trouble — the constant denylist stays the primary gate; a create must not hard-fail because the agent is momentarily unreachable. A port bound by the tenant's own app (`uid >= 1000`), or not yet bound, passes.

Deliberate residual: a hand-run **root** process on the tenant's chosen port (e.g. `docker run -p 127.0.0.1:<port>` outside jabali's docker feature) is uid 0 and gets rejected — safe (reject > SSRF); use the managed docker feature (pool-denylisted ports) or pick another port.

## Test plan
- [x] `go build ./...` + `go vet`; `/proc/net/tcp` parser unit test (loopback/any vs public, LISTEN-only, IPv4/v6, `0.0.0.0`, v4-mapped); CLI-reference golden green.
- [x] **Box-drill on .60**: agent verb returns `uid:0` for a root-bound 6900, `uid:111` for postgres 5432, `bound:false` for an unbound 6901. End-to-end: `--reverse-proxy-port 6900` (root-bound, **passes** the constant denylist) → **rejected "in use by a system service"**; unbound 6901 → created.

Agent-side change → fleet agent redeploy on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
