### PR TITLE
fix(mail): disable Stalwart outbound DANE against the dnssec-off resolver chain (JAB-391)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4724,9 +4724,15 @@ forward-zones-file=/etc/powerdns/recursor.forwards
 # and is only consulted by the stub, not by the recursor.
 forward-zones-recurse=.=${_rec_recurse_upstream}
 
-# DNSSEC: off. systemd-resolved validates DNSSEC upstream already.
-# Doubling up costs CPU per query for no security benefit on a
-# single-host panel.
+# DNSSEC: off. This recursor does NOT validate — and NEITHER does the
+# systemd-resolved stub in front of it (DNSSEC=no); both strip RRSIGs.
+# (The earlier claim here that "systemd-resolved validates upstream" was
+# wrong and directly caused JAB-391.) Leaving it off is intentional on a
+# single-host panel with no validating upstream, but it means DANE cannot
+# work: Stalwart's outbound DANE is shipped DISABLED for exactly this reason
+# (a signed zone with stripped sigs reads as "Bogus" and hard-defers mail to
+# gmail / Google Workspace). Do NOT re-enable DANE, or assume validation
+# happens, without first giving the resolver chain a DNSSEC-capable path.
 dnssec=off
 
 # Conservative defaults for a single-tenant panel. max-cache-entries

--- a/panel-agent/internal/commands/mail_outbound_tls.go
+++ b/panel-agent/internal/commands/mail_outbound_tls.go
@@ -1,0 +1,136 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// mail.outbound_tls.ensure converges the outbound TLS strategies Stalwart ships
+// so DANE is DISABLED on the ones jabali's outbound delivery uses (JAB-391).
+//
+// Why: Stalwart's shipped outbound TLS strategies carry dane="optional", so a
+// send to a DNSSEC-signed destination (gmail.com, Google Workspace, …) must
+// DNSSEC-validate the MX lookup. But jabali runs a NON-validating resolver
+// chain — pdns-recursor dnssec=off + systemd-resolved DNSSEC=no — so the stub
+// strips RRSIGs. Stalwart's DANE validator then sees a signed zone with no
+// valid signatures, classifies it "Bogus", and hard-defers the message —
+// breaking outbound to every DNSSEC-signed domain (a large, growing slice of
+// the internet). Even dane="optional" fails a Bogus result, because Bogus means
+// suspected tampering, not merely "no TLSA".
+//
+// The operator's decision (JAB-391) is to ship with DANE off: outbound MITM
+// protection continues via MTA-STS (which is what actually protects the
+// Google/Microsoft paths — they publish MTA-STS policies, not TLSA records) and
+// opportunistic STARTTLS, exactly what Gmail/Outlook and almost every MTA do.
+// The path *back* to DANE is a DNSSEC-capable resolver, NOT re-enabling it
+// against this chain.
+//
+// jabali owns exactly ONE knob here: the `dane` field on the two SHIPPED
+// strategies ("default" + "invalid-tls"). It never writes name / startTls /
+// mtaSts / allowInvalidCerts (operator tuning of those is never fought), and
+// never touches an operator-created custom strategy (a deliberate dane=require
+// there means they gave that route a validating resolver). RFC-8620 PatchObject
+// semantics — verified live on the Stalwart 0.16 wire — apply only the named
+// field, leaving the rest intact.
+//
+// This is deliberately NOT wired into install/stalwart/apply-plan.json.tmpl:
+// the strategies carry Stalwart-generated ids a static template cannot address,
+// so this ensure verb is the SINGLE mechanism for fresh installs AND retrofits.
+// The ≤1-tick fresh-install window at dane="optional" holds no tenant mail. Do
+// not "fix" the missing apply-plan entry — the template cannot express this.
+
+// jabaliOutboundDANEStrategies are the SHIPPED Stalwart TLS strategy names whose
+// `dane` knob jabali owns. Matched by name; a missing one is skipped, an
+// operator-created one is never touched.
+var jabaliOutboundDANEStrategies = map[string]bool{
+	"default":     true,
+	"invalid-tls": true,
+}
+
+type mtaTLSStrategyRow struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Dane string `json:"dane"`
+}
+
+type mailOutboundTLSResponse struct {
+	Changed []string `json:"changed"`           // strategy names patched to dane=disable
+	Skipped bool     `json:"skipped,omitempty"` // Stalwart unreachable → clean skip (retry later)
+}
+
+func mailOutboundTLSEnsureHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	var qr jmapQueryResult
+	if err := jmapCall(ctx, "x:MtaTlsStrategy/query", map[string]any{}, &qr); err != nil {
+		if isStalwartUnavailable(err) {
+			return mailOutboundTLSResponse{Skipped: true}, nil
+		}
+		return nil, err
+	}
+	if len(qr.IDs) == 0 {
+		return mailOutboundTLSResponse{}, nil
+	}
+
+	var gr jmapGetResult
+	if err := jmapCall(ctx, "x:MtaTlsStrategy/get", map[string]any{"ids": qr.IDs}, &gr); err != nil {
+		if isStalwartUnavailable(err) {
+			return mailOutboundTLSResponse{Skipped: true}, nil
+		}
+		return nil, err
+	}
+
+	update := map[string]any{}
+	var changed []string
+	for _, raw := range gr.List {
+		var row mtaTLSStrategyRow
+		if json.Unmarshal(raw, &row) != nil {
+			continue
+		}
+		if !jabaliOutboundDANEStrategies[row.Name] {
+			continue // operator-created strategy — deliberate config, never touched
+		}
+		if row.Dane == "disable" {
+			continue // already converged
+		}
+		update[row.ID] = map[string]any{"dane": "disable"}
+		changed = append(changed, row.Name)
+	}
+
+	if len(update) == 0 {
+		return mailOutboundTLSResponse{}, nil // no drift
+	}
+
+	var sr jmapSetResult
+	if err := jmapCall(ctx, "x:MtaTlsStrategy/set", map[string]any{"update": update}, &sr); err != nil {
+		return nil, err
+	}
+	for id, reason := range sr.NotUpdated {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("stalwart refused dane update for %s: %s", id, string(reason)),
+		}
+	}
+
+	// Reload so the patched strategies take effect on the next delivery attempt.
+	if err := reloadStalwartSettings(ctx); err != nil {
+		return nil, err
+	}
+	return mailOutboundTLSResponse{Changed: changed}, nil
+}
+
+// isStalwartUnavailable reports whether err is the "stalwart JMAP unreachable"
+// signal (Stalwart not running on this box) — a clean skip, not a failure.
+func isStalwartUnavailable(err error) bool {
+	var ae *agentwire.AgentError
+	if errors.As(err, &ae) {
+		return ae.Code == agentwire.CodeUnavailable
+	}
+	return false
+}
+
+func init() {
+	Default.Register("mail.outbound_tls.ensure", mailOutboundTLSEnsureHandler)
+}

--- a/panel-agent/internal/commands/mail_outbound_tls_test.go
+++ b/panel-agent/internal/commands/mail_outbound_tls_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// strategyRow is the minimal MtaTlsStrategy shape the fake server emits.
+func strategyGetRoute(rows []map[string]any) jmapHandler {
+	return func(json.RawMessage) (any, *jmapFakeError) {
+		return map[string]any{"list": rows, "notFound": []string{}}, nil
+	}
+}
+
+func strategyQueryRoute(ids []string) jmapHandler {
+	return func(json.RawMessage) (any, *jmapFakeError) {
+		return map[string]any{"ids": ids, "total": len(ids)}, nil
+	}
+}
+
+// captureSetRoute records the /set update payload and returns success for
+// every id it was asked to update.
+func captureSetRoute(captured *map[string]map[string]any) jmapHandler {
+	return func(args json.RawMessage) (any, *jmapFakeError) {
+		var p struct {
+			Update map[string]map[string]any `json:"update"`
+		}
+		_ = json.Unmarshal(args, &p)
+		*captured = p.Update
+		updated := map[string]any{}
+		for id := range p.Update {
+			updated[id] = nil
+		}
+		return map[string]any{"updated": updated}, nil
+	}
+}
+
+func callEnsure(t *testing.T) mailOutboundTLSResponse {
+	t.Helper()
+	out, err := mailOutboundTLSEnsureHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	b, _ := json.Marshal(out)
+	var resp mailOutboundTLSResponse
+	if e := json.Unmarshal(b, &resp); e != nil {
+		t.Fatalf("decode resp: %v", e)
+	}
+	return resp
+}
+
+func TestOutboundTLS_PatchesBothStrategies(t *testing.T) {
+	var setPayload map[string]map[string]any
+	var reloaded bool
+	srv := newJMAPServer(t, map[string]jmapHandler{
+		"x:MtaTlsStrategy/query": strategyQueryRoute([]string{"idDef", "idInv"}),
+		"x:MtaTlsStrategy/get": strategyGetRoute([]map[string]any{
+			{"id": "idDef", "name": "default", "dane": "optional"},
+			{"id": "idInv", "name": "invalid-tls", "dane": "optional"},
+		}),
+		"x:MtaTlsStrategy/set": captureSetRoute(&setPayload),
+		"x:Action/set": func(json.RawMessage) (any, *jmapFakeError) {
+			reloaded = true
+			return map[string]any{"created": map[string]any{"reload": nil}}, nil
+		},
+	})
+	wireJMAP(t, srv)
+
+	resp := callEnsure(t)
+	if len(resp.Changed) != 2 {
+		t.Fatalf("expected 2 changed, got %v", resp.Changed)
+	}
+	for _, id := range []string{"idDef", "idInv"} {
+		v, ok := setPayload[id]
+		if !ok {
+			t.Fatalf("id %s not in set payload %v", id, setPayload)
+		}
+		if v["dane"] != "disable" {
+			t.Fatalf("id %s dane=%v, want disable", id, v["dane"])
+		}
+		if len(v) != 1 {
+			t.Fatalf("id %s patch touched more than dane: %v", id, v)
+		}
+	}
+	if !reloaded {
+		t.Fatalf("expected a settings reload after the patch")
+	}
+}
+
+func TestOutboundTLS_NoDriftWhenDisabled(t *testing.T) {
+	// No /set or /Action route: if the handler tries to write or reload, the
+	// fake 400s and the handler errors — which is exactly what we want to catch.
+	srv := newJMAPServer(t, map[string]jmapHandler{
+		"x:MtaTlsStrategy/query": strategyQueryRoute([]string{"idDef", "idInv"}),
+		"x:MtaTlsStrategy/get": strategyGetRoute([]map[string]any{
+			{"id": "idDef", "name": "default", "dane": "disable"},
+			{"id": "idInv", "name": "invalid-tls", "dane": "disable"},
+		}),
+	})
+	wireJMAP(t, srv)
+
+	resp := callEnsure(t)
+	if len(resp.Changed) != 0 {
+		t.Fatalf("expected no change, got %v", resp.Changed)
+	}
+}
+
+func TestOutboundTLS_SkipsOperatorCustomStrategy(t *testing.T) {
+	var setPayload map[string]map[string]any
+	srv := newJMAPServer(t, map[string]jmapHandler{
+		"x:MtaTlsStrategy/query": strategyQueryRoute([]string{"idDef", "idInv", "idCustom"}),
+		"x:MtaTlsStrategy/get": strategyGetRoute([]map[string]any{
+			{"id": "idDef", "name": "default", "dane": "optional"},
+			{"id": "idInv", "name": "invalid-tls", "dane": "optional"},
+			{"id": "idCustom", "name": "my-strict-route", "dane": "require"},
+		}),
+		"x:MtaTlsStrategy/set": captureSetRoute(&setPayload),
+		"x:Action/set":         func(json.RawMessage) (any, *jmapFakeError) { return map[string]any{}, nil },
+	})
+	wireJMAP(t, srv)
+
+	resp := callEnsure(t)
+	if len(resp.Changed) != 2 {
+		t.Fatalf("expected 2 changed (default+invalid-tls), got %v", resp.Changed)
+	}
+	if _, touched := setPayload["idCustom"]; touched {
+		t.Fatalf("operator custom strategy was clobbered: %v", setPayload)
+	}
+}
+
+func TestOutboundTLS_MissingStrategyPatchesWhatExists(t *testing.T) {
+	var setPayload map[string]map[string]any
+	srv := newJMAPServer(t, map[string]jmapHandler{
+		"x:MtaTlsStrategy/query": strategyQueryRoute([]string{"idDef"}),
+		"x:MtaTlsStrategy/get": strategyGetRoute([]map[string]any{
+			{"id": "idDef", "name": "default", "dane": "optional"},
+		}),
+		"x:MtaTlsStrategy/set": captureSetRoute(&setPayload),
+		"x:Action/set":         func(json.RawMessage) (any, *jmapFakeError) { return map[string]any{}, nil },
+	})
+	wireJMAP(t, srv)
+
+	resp := callEnsure(t)
+	if len(resp.Changed) != 1 || resp.Changed[0] != "default" {
+		t.Fatalf("expected only default patched, got %v", resp.Changed)
+	}
+}
+
+func TestOutboundTLS_StalwartUnavailableSkips(t *testing.T) {
+	// Point the URL at a closed port so jmapCall's HTTP Do() fails →
+	// CodeUnavailable → the verb returns skipped, not an error.
+	origURL, origTok, origClient := stalwartAdminURLFunc, stalwartAdminTokenFunc, stalwartHTTPClientFunc
+	stalwartAdminURLFunc = func() string { return "http://127.0.0.1:1" }
+	stalwartAdminTokenFunc = func() (string, error) { return "t", nil }
+	t.Cleanup(func() {
+		stalwartAdminURLFunc, stalwartAdminTokenFunc, stalwartHTTPClientFunc = origURL, origTok, origClient
+	})
+
+	resp := callEnsure(t)
+	if !resp.Skipped {
+		t.Fatalf("expected skipped=true when Stalwart unreachable, got %+v", resp)
+	}
+	if len(resp.Changed) != 0 {
+		t.Fatalf("expected no changes on skip, got %v", resp.Changed)
+	}
+}

--- a/panel-api/internal/reconciler/outbound_mail_tls_reconcile.go
+++ b/panel-api/internal/reconciler/outbound_mail_tls_reconcile.go
@@ -1,0 +1,59 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// reconcileOutboundMailTLS dispatches the JAB-391 DANE-disable ensure to the
+// agent once per process, on a mail-enabled box, until it succeeds.
+//
+// Background: Stalwart's shipped outbound TLS strategies default to
+// dane="optional", which hard-defers mail to DNSSEC-signed destinations
+// (gmail.com, Google Workspace, …) because jabali runs a non-validating
+// resolver chain that strips the RRSIGs DANE needs — Stalwart reads the signed
+// zone as "Bogus". The agent verb mail.outbound_tls.ensure patches the shipped
+// strategies to dane="disable" (see its doc comment for the full rationale and
+// why this lives in a verb, not the apply-plan).
+//
+// Gating: MailEnabled (a no-mail box has no outbound to fix) and
+// once-per-process-until-success. A transient Stalwart-unreachable reply
+// ("skipped") is NOT success — it retries next tick; a real failure logs and
+// retries. Only a genuine converge (or a no-drift no-op) flips the latch. The
+// verb is idempotent, so re-running after a spurious extra tick is harmless.
+func (r *Reconciler) reconcileOutboundMailTLS(ctx context.Context) {
+	if r.agent == nil || r.serverSettings == nil || r.outboundTLSConverged {
+		return
+	}
+	settings, err := r.serverSettings.Get(ctx)
+	if err != nil {
+		r.log.Debug("outbound-mail-TLS reconcile skipped: server_settings unavailable", "error", err)
+		return
+	}
+	if !settings.MailEnabled {
+		return
+	}
+
+	raw, err := r.agent.Call(ctx, "mail.outbound_tls.ensure", map[string]any{})
+	if err != nil {
+		r.log.Warn("outbound-mail-TLS DANE ensure failed (JAB-391), will retry next tick", "error", err)
+		return
+	}
+
+	// A "skipped" reply means Stalwart was not reachable this tick (not yet up
+	// on a freshly-provisioned box) — don't latch, so the next tick retries.
+	var resp struct {
+		Changed []string `json:"changed"`
+		Skipped bool     `json:"skipped"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	if resp.Skipped {
+		r.log.Debug("outbound-mail-TLS ensure skipped: Stalwart not reachable yet, retrying next tick")
+		return
+	}
+
+	r.outboundTLSConverged = true
+	if len(resp.Changed) > 0 {
+		r.log.Info("outbound-mail-TLS DANE disabled on shipped strategies (JAB-391)", "strategies", resp.Changed)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -123,6 +123,12 @@ type Reconciler struct {
 	wordPressInstalls repository.WordPressInstallRepository
 	// sshKeys holds reference to the SSH keys repository
 	sshKeys repository.SSHKeyRepository
+	// outboundTLSConverged gates the JAB-391 one-shot: once the DANE-disable
+	// ensure succeeds this process, stop re-dispatching (the agent verb is
+	// idempotent, but there is no value re-querying Stalwart every tick). A
+	// panel restart — which every jabali update performs — clears it, so the
+	// desired state is re-asserted exactly when a new build arrives.
+	outboundTLSConverged bool
 	// ftpAccounts holds the FTP/SFTP subaccount repository (GH #1053).
 	ftpAccounts repository.FtpAccountRepository
 	// cronJobs holds reference to the cron jobs repository
@@ -765,6 +771,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// before the rest of the loop touches the agent. Cheap noop when
 	// use_le=0 or routability gate fails.
 	r.reconcilePanelCertificate(ctx)
+	// JAB-391: converge Stalwart outbound TLS strategies to dane=disable.
+	r.reconcileOutboundMailTLS(ctx)
 	r.reconcileUpdateRuns(ctx)
 	r.reconcileAutoupdate(ctx)
 


### PR DESCRIPTION
## JAB-391 — outbound mail hard-defers to DNSSEC-signed domains (Stalwart DANE vs jabali's dnssec-off resolver)

### Problem
On newzaps (production, `mx.zaps.co.il`), outbound mail to gmail.com / Google
Workspace is stuck in the Stalwart queue:
`DANE failed to authenticate: Bogus MX records were found` (also blocks webmail
sends). A client (Ofek) reported it.

**Root cause:** Stalwart's shipped outbound TLS strategies carry `dane="optional"`,
so a send must DNSSEC-validate the destination MX. But jabali runs a
non-validating resolver chain — pdns-recursor `dnssec=off` **and**
systemd-resolved `DNSSEC=no` — so the stub strips RRSIGs. Stalwart's DANE
validator sees a signed zone with no valid signatures → classifies **Bogus** →
hard-defers. (Even `optional` fails Bogus: Bogus = suspected tampering, not "no
TLSA".) This breaks outbound to **every** DNSSEC-signed domain.

### Decision (operator, JAB-391)
Ship with **DANE disabled**. Outbound MITM protection continues via **MTA-STS**
— which is what actually covers the Google/Microsoft paths (they publish
MTA-STS policies, not TLSA records) — plus opportunistic STARTTLS, exactly what
Gmail/Outlook and almost every MTA do. The path *back* to DANE is a
DNSSEC-capable resolver (ticket option 2), **not** re-enabling it against this
chain. This is removing a check that was delivering zero protection while
blocking delivery — not relaxing hardening.

### Fix
- **panel-agent** — new `mail.outbound_tls.ensure` verb. Patches **only** the
  `dane` field to `"disable"` on the two SHIPPED strategies (`default`,
  `invalid-tls`), by name. Never writes other fields (operator tuning of
  startTls/mtaSts/etc. is never fought), never touches an operator-created
  custom strategy (a deliberate `dane=require` there means they gave that route
  a validating resolver), no-ops when already disabled, reloads only on change,
  and cleanly skips when Stalwart is unreachable. RFC-8620 PatchObject
  semantics — only the named field changes.
- **panel-api reconciler** — dispatches the verb once-per-process-until-success,
  gated on `MailEnabled`. The panel restarts on every `jabali update`, so the
  desired state re-asserts when a new build lands (the fleet-retrofit path).
- **Not in `apply-plan.json.tmpl`** — the strategies carry Stalwart-generated
  ids a static template can't address, so the verb is the single mechanism for
  fresh installs **and** retrofits (a ≤1-tick fresh-install window at
  `optional` holds no tenant mail). This is a conscious deviation from the
  "template AND converger" pattern; the template *cannot* express this.
- **install.sh** — correct the false recursor comment ("systemd-resolved
  validates DNSSEC upstream already") that caused this: it does not; both
  layers strip. New comment cites JAB-391 so nobody re-enables DANE against
  this chain.

The newzaps web-admin workaround (DANE: Disabled + requeue) produces the exact
state this converges to → the fix **no-ops** there when it ships.

### Verification
- [x] Verb unit tests: patches both strategies, no-drift when already disabled,
  skips an operator custom strategy, patches only what exists when one is
  missing, cleanly skips when Stalwart is unreachable. `go vet` + full
  `panel-agent/internal/commands` and `panel-api/internal/reconciler` suites green.
- [x] **Live wire verification on .60 (jabalitest, Stalwart 0.16):** all four
  JMAP calls the verb makes confirmed against real Stalwart — `MtaTlsStrategy/query`,
  `/get`, `/set update {dane:"disable"}` (GET-confirmed only `dane` changed, all
  other fields preserved), and `Action/set` `ReloadSettings`. The broken chain
  reproduced there too (`dig +dnssec gmail.com MX @127.0.0.53` → no RRSIG, no `ad`).
  .60 restored to `dane=optional` afterward.
- **Behavioral link** (dane=disable clears the Bogus defer) is **operator-confirmed
  on newzaps itself** — the ticket's web-admin workaround fixed the stuck
  messages, and this verb converges to that exact state. A synthetic send on .60
  was blocked by Stalwart's (correct) relay policy for unauthenticated localhost.
- Note: with the apply-plan change dropped, there is **no install-time failure
  surface** — an ensure failure is a next-tick retry, never a bricked install.

### Ofek's relief is separate from this PR
The code fix reaches newzaps on its next `jabali update`. The **now**-fix is the
operator action on newzaps: Stalwart web admin → Settings → MTA → Outbound → TLS
Strategies → `default` (and `invalid-tls`) → **DANE: Disabled** → Save → requeue
the stuck messages. (I can't touch production.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
