### PR TITLE
fix(php-ui): keep Extensions grid aligned when a label wraps (GH #1332)

### DIFF
--- a/panel-ui/src/shells/user/php-settings/PHPExtensionsCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/PHPExtensionsCard.tsx
@@ -122,8 +122,11 @@ export function PHPExtensionsCard() {
 
   const gridStyle = {
     display: "grid",
-    gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+    gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
     gap: 8,
+    // Top-align cells so a label that wraps to two lines (a long extension name)
+    // can't stretch its row and knock the neighbouring checkboxes out of line.
+    alignItems: "start",
   } as const;
 
   return (
@@ -154,16 +157,13 @@ export function PHPExtensionsCard() {
               <Typography.Text strong>Always on (server default)</Typography.Text>
               <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: "2px 0 8px" }}>
                 Enabled for every site on PHP {version}.
-                {xdebugOn ? " Xdebug is managed in the Xdebug control above." : ""}
+                {xdebugOn ? " Xdebug is managed in the Xdebug control." : ""}
               </Typography.Paragraph>
               <Checkbox.Group
                 value={alwaysOnRows}
                 disabled
                 style={gridStyle}
-                options={alwaysOnRows.map((name) => ({
-                  label: name === "xdebug" ? "xdebug (Xdebug control)" : name,
-                  value: name,
-                }))}
+                options={alwaysOnRows.map((name) => ({ label: name, value: name }))}
               />
             </div>
           )}


### PR DESCRIPTION
Follow-up to #1412. @lxsdevcode confirmed all three earlier fixes work, and flagged one small visual issue: after enabling Xdebug, its **Always on** label read `xdebug (Xdebug control)` — long enough to wrap to two lines, which stretched its grid row and knocked the neighbouring checkboxes out of alignment.

## Fix (UI-only)
- Drop the `(Xdebug control)` suffix — the group's caption already notes Xdebug is managed in the Xdebug control, so the row now just reads `xdebug`, like the others. Removes the immediate two-line wrap.
- Grid: `align-items: start` so a label that does wrap can never stretch its row and shift the sibling checkboxes — future-proofs any long extension name (the reporter's preferred, more robust option). Also widened the min column to `160px` for a little more room.

No backend / agent / migration change.

## Test plan
- `tsc -b` + vitest (`UserPHPPerformanceCard` suite) green.
- Not separately screenshotted (no interactive browser attached to this session); the change is a label + grid-alignment tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
