### PR TITLE
fix(php-ui): full IANA timezone list in per-domain PHP Settings (GH #1332)

### DIFF
--- a/panel-ui/src/data/timezones.ts
+++ b/panel-ui/src/data/timezones.ts
@@ -1,0 +1,13 @@
+// Shared IANA/PHP timezone list. Reused by the admin Server Settings selector and
+// the per-domain PHP Settings selector so the options are identical in both places
+// (GH #1332). `Intl.supportedValuesOf("timeZone")` is the full IANA tz database —
+// the same set PHP validates a `date.timezone` value against — so it includes
+// zones the old curated list missed (e.g. Europe/Bucharest). Guarded with a tiny
+// fallback for the rare engine without `supportedValuesOf`.
+export const IANA_TIMEZONES: string[] = (() => {
+  try {
+    return Array.from(Intl.supportedValuesOf("timeZone"));
+  } catch {
+    return ["UTC"];
+  }
+})();

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
+import { IANA_TIMEZONES } from "../../../data/timezones";
 import {
   BgColorsOutlined,
   CheckOutlined,
@@ -315,7 +316,7 @@ const GeneralSettingsTab = () => {
             filterOption={(input, option) =>
               (option?.label ?? "").toLowerCase().includes(input.toLowerCase())
             }
-            options={Array.from(Intl.supportedValuesOf("timeZone")).map((tz) => ({
+            options={IANA_TIMEZONES.map((tz) => ({
               label: tz,
               value: tz,
             }))}

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -12,6 +12,7 @@ import { PHPXdebugCard } from "./PHPXdebugCard";
 import { apiClient } from "../../../apiClient";
 import { getIdentity, type Identity } from "../../../identity";
 import { isPHPEOL } from "../../../utils/phpEol";
+import { IANA_TIMEZONES } from "../../../data/timezones";
 
 type Domain = {
   id: string;
@@ -124,33 +125,11 @@ const ERROR_REPORTING_OPTIONS = [
   { label: "All (development)", value: 32767 },
 ];
 
-// A curated set of common IANA zones. The server validates any value against
-// the tz database, so this is a convenience list, not the limit.
-const COMMON_TIMEZONES = [
-  "UTC",
-  "Africa/Johannesburg",
-  "America/Chicago",
-  "America/Los_Angeles",
-  "America/New_York",
-  "America/Sao_Paulo",
-  "Asia/Dubai",
-  "Asia/Jerusalem",
-  "Asia/Kolkata",
-  "Asia/Shanghai",
-  "Asia/Singapore",
-  "Asia/Tokyo",
-  "Australia/Sydney",
-  "Europe/Berlin",
-  "Europe/Istanbul",
-  "Europe/London",
-  "Europe/Madrid",
-  "Europe/Moscow",
-  "Europe/Paris",
-  "Pacific/Auckland",
-];
+// The full IANA/PHP timezone list, shared with admin Server Settings so both
+// selectors offer the same zones (GH #1332). Searchable in the Select below.
 const TIMEZONE_OPTIONS = [
   { label: "Use pool default", value: null as string | null },
-  ...COMMON_TIMEZONES.map((z) => ({ label: z, value: z as string | null })),
+  ...IANA_TIMEZONES.map((z) => ({ label: z, value: z as string | null })),
 ];
 
 export function UserPHPSettingsPage() {


### PR DESCRIPTION
@lxsdevcode found that the per-domain PHP Settings **timezone** selector was missing zones (e.g. `Europe/Bucharest`), while the admin **Server Settings** selector had the full list.

## Cause
The per-domain selector used a ~20-entry curated `COMMON_TIMEZONES` array. Admin Server Settings already used the complete `Intl.supportedValuesOf("timeZone")` set (the full IANA tz database — the same zones PHP validates against).

## Fix (UI-only)
- Extract the full IANA list into a shared `src/data/timezones.ts` and use it in **both** selectors, so options are identical across the panel (the reporter's ask).
- The per-domain Select keeps `showSearch` + `allowClear`: typing (e.g. "Bucharest") filters the full list, and clearing falls back to the pool default. That also covers "manually enter a timezone" — you type to find any IANA zone.

No backend change — the server already validates a `date.timezone` value against the tz database, so the wider list surfaces valid zones that were simply hidden before.

## Test plan
- `tsc -b` + vitest green (php-settings, admin settings, data).
- Not separately screenshotted (no interactive browser attached to this session); the change swaps the option source both selectors feed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
