### PR TITLE
fix(updates): background update poll honors release channel + preserves last-known-good (JAB-311)

### DIFF
--- a/panel-api/internal/reconciler/update_poll_channel_test.go
+++ b/panel-api/internal/reconciler/update_poll_channel_test.go
@@ -1,0 +1,110 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeUpdateState records UpsertApt / UpsertJabali so tests can assert whether
+// last-known-good counts were (over)written.
+type fakeUpdateState struct {
+	repository.UpdateStateRepository
+	aptCalls     int
+	lastAptTotal int
+	lastAptSec   int
+}
+
+func (f *fakeUpdateState) Get(context.Context) (*models.UpdateState, error) {
+	return &models.UpdateState{}, nil
+}
+func (f *fakeUpdateState) UpsertJabali(context.Context, int, string, time.Time) error { return nil }
+func (f *fakeUpdateState) UpsertApt(_ context.Context, total, security int, _ time.Time) error {
+	f.aptCalls++
+	f.lastAptTotal, f.lastAptSec = total, security
+	return nil
+}
+func (f *fakeUpdateState) UpsertAptStatus(context.Context, *time.Time, bool) error { return nil }
+
+func pollReconciler(agent *fakeAgent, us *fakeUpdateState, channel string) *Reconciler {
+	return &Reconciler{
+		agent:          agent,
+		updateState:    us,
+		serverSettings: &fakeSettingsRepo{srv: &models.ServerSettings{ReleaseChannel: channel}},
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestUpdatePoll_ForwardsStableChannel(t *testing.T) {
+	fa := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"system.update_check": json.RawMessage(`{"current_sha":"abc","behind_count":0}`),
+		"system.apt_check":    json.RawMessage(`{"total":4,"security_total":1}`),
+	}}
+	us := &fakeUpdateState{}
+	r := pollReconciler(fa, us, "stable")
+
+	r.reconcileUpdatePoll(context.Background())
+
+	// system.update_check must carry channel=stable.
+	var chan_ string
+	fa.mu.Lock()
+	for _, c := range fa.calls {
+		if c.method == "system.update_check" {
+			if m, ok := c.params.(map[string]any); ok {
+				chan_, _ = m["channel"].(string)
+			}
+		}
+	}
+	fa.mu.Unlock()
+	if chan_ != "stable" {
+		t.Fatalf("update_check channel = %q, want stable", chan_)
+	}
+	if us.aptCalls != 1 || us.lastAptTotal != 4 || us.lastAptSec != 1 {
+		t.Fatalf("clean apt counts not persisted: calls=%d total=%d sec=%d", us.aptCalls, us.lastAptTotal, us.lastAptSec)
+	}
+}
+
+func TestUpdatePoll_DefaultsDevelopmentChannel(t *testing.T) {
+	fa := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"system.update_check": json.RawMessage(`{"current_sha":"abc","behind_count":0}`),
+		"system.apt_check":    json.RawMessage(`{"total":0,"security_total":0}`),
+	}}
+	r := pollReconciler(fa, &fakeUpdateState{}, "development")
+	r.reconcileUpdatePoll(context.Background())
+
+	var chan_ string
+	fa.mu.Lock()
+	for _, c := range fa.calls {
+		if c.method == "system.update_check" {
+			if m, ok := c.params.(map[string]any); ok {
+				chan_, _ = m["channel"].(string)
+			}
+		}
+	}
+	fa.mu.Unlock()
+	if chan_ != "development" {
+		t.Fatalf("update_check channel = %q, want development", chan_)
+	}
+}
+
+func TestUpdatePoll_StructuredAptFailurePreservesLastKnownGood(t *testing.T) {
+	fa := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"system.update_check": json.RawMessage(`{"current_sha":"abc","behind_count":0}`),
+		// Structured JAB-10 failure: zero counts + an error object.
+		"system.apt_check": json.RawMessage(`{"total":0,"security_total":0,"error":{"reason":"apt lock","command":"apt-get update","exit_code":100}}`),
+	}}
+	us := &fakeUpdateState{}
+	r := pollReconciler(fa, us, "stable")
+
+	r.reconcileUpdatePoll(context.Background())
+
+	if us.aptCalls != 0 {
+		t.Fatalf("UpsertApt was called on a structured failure (clobbers last-known-good) — calls=%d", us.aptCalls)
+	}
+}

--- a/panel-api/internal/reconciler/update_poll_reconciler.go
+++ b/panel-api/internal/reconciler/update_poll_reconciler.go
@@ -29,6 +29,14 @@ type aptCheckView struct {
 	SecurityTotal  int        `json:"security_total"`
 	RebootRequired bool       `json:"reboot_required"`
 	LastAppliedAt  *time.Time `json:"last_applied_at"`
+	// Error is the structured diagnostic (JAB-10) set when the check itself
+	// failed (apt lock, repo unreachable, …). When present, Total/SecurityTotal
+	// are meaningless and must not be persisted (JAB-311).
+	Error *struct {
+		Reason   string `json:"reason"`
+		Command  string `json:"command"`
+		ExitCode int    `json:"exit_code"`
+	} `json:"error"`
 }
 
 func (r *Reconciler) reconcileUpdatePoll(ctx context.Context) {
@@ -48,8 +56,18 @@ func (r *Reconciler) reconcileUpdatePoll(ctx context.Context) {
 		prevSecurity = st.AptSecurity
 	}
 
-	// Panel (git) check — cheap.
-	if raw, err := r.agent.Call(ctx, "system.update_check", nil); err == nil {
+	// Panel (git) check — cheap. Forward the configured release channel
+	// (GH #445) so a stable box's "behind" count compares against stable, not
+	// development — the agent's default for an empty channel. JAB-311: the
+	// background poll was sending nil here, silently checking every stable box
+	// against development; mirror the HTTP adapter (admin_updates.jabaliCheck).
+	channel := "development"
+	if r.serverSettings != nil {
+		if s, serr := r.serverSettings.Get(ctx); serr == nil && s != nil && s.ReleaseChannel == "stable" {
+			channel = "stable"
+		}
+	}
+	if raw, err := r.agent.Call(ctx, "system.update_check", map[string]any{"channel": channel}); err == nil {
 		var v updateCheckView
 		if json.Unmarshal(raw, &v) == nil {
 			_ = r.updateState.UpsertJabali(ctx, v.BehindCount, v.CurrentSHA, time.Now())
@@ -66,6 +84,16 @@ func (r *Reconciler) reconcileUpdatePoll(ctx context.Context) {
 	}
 	var av aptCheckView
 	if json.Unmarshal(raw, &av) != nil {
+		return
+	}
+	// JAB-311: on a structured check failure (JAB-10 — apt lock, repo
+	// unreachable, …) the counts are meaningless; persisting them would clobber
+	// the last-known-good total with a misleading 0 ("0 updates" as if healthy).
+	// Skip all persistence + the security-rise notification, as the HTTP
+	// aptCheck adapter does.
+	if av.Error != nil {
+		r.log.Debug("update poll: apt check structured failure — preserving last-known-good",
+			"reason", av.Error.Reason, "exit", av.Error.ExitCode)
 		return
 	}
 	_ = r.updateState.UpsertApt(ctx, av.Total, av.SecurityTotal, time.Now())


### PR DESCRIPTION
## JAB-311 (slice)

The background update poll (M53.1) diverged from the HTTP Updates adapter, misreporting stable boxes:

- **Channel:** called `system.update_check` with `nil` → the agent defaults an empty channel to "development", so every **stable** box's "behind" count was computed against main, not the promoted `stable` tag. Now resolves the configured channel from `server_settings` and forwards it (mirrors `admin_updates.jabaliCheck`).
- **Last-known-good:** persisted decoded apt counts unconditionally. A structured JAB-10 failure (apt lock / repo unreachable) returns zeros + an `error` object; `UpsertApt(0,0)` clobbered the last-known-good total ("0 updates" as if healthy). Now a structured failure preserves counts + skips the security-rise notification, matching the HTTP `aptCheck` adapter.

Slice of the JAB-311 Update Check module; full module extraction stays open.

### Test plan
- [x] channel forwarded (stable / development), structured apt failure preserves last-known-good
- [x] `go vet` + full `panel-api/internal/reconciler` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)