### PR TITLE
feat(mail-ui): sortable Mail Logs columns (GH #1365)

### DIFF
--- a/panel-ui/src/shells/user/mail/tabs/LogsTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/LogsTab.tsx
@@ -97,6 +97,9 @@ export const LogsTab = () => {
         />
       )}
 
+      <Typography.Text type="secondary" style={{ display: "block", fontSize: 12, marginBottom: 8 }}>
+        Click a column header to sort the loaded page.
+      </Typography.Text>
       <Table
         rowKey={(r) => `${r.timestamp}-${r.from}-${r.to}`}
         dataSource={entries}
@@ -114,11 +117,15 @@ export const LogsTab = () => {
             title: "Timestamp",
             dataIndex: "timestamp",
             width: 200,
+            // GH #1365: client-side column sort (sorts the current page).
+            sorter: (a, b) => a.timestamp.localeCompare(b.timestamp),
+            defaultSortOrder: "descend" as const,
             render: (v: string) => new Date(v).toLocaleString(),
           },
           {
             title: "From",
             dataIndex: "from",
+            sorter: (a, b) => (a.from ?? "").localeCompare(b.from ?? ""),
             render: (v: string) => (
               <Typography.Text style={{ fontFamily: "monospace" }}>{v}</Typography.Text>
             ),
@@ -126,6 +133,7 @@ export const LogsTab = () => {
           {
             title: "To",
             dataIndex: "to",
+            sorter: (a, b) => (a.to ?? "").localeCompare(b.to ?? ""),
             render: (v: string) => (
               <Typography.Text style={{ fontFamily: "monospace" }}>{v}</Typography.Text>
             ),
@@ -134,6 +142,7 @@ export const LogsTab = () => {
             title: "Size",
             dataIndex: "size",
             width: 100,
+            sorter: (a, b) => (a.size ?? 0) - (b.size ?? 0),
             render: (n: number) => `${(n / 1024).toFixed(1)} KB`,
           },
           {
@@ -142,6 +151,7 @@ export const LogsTab = () => {
             title: "Status",
             dataIndex: "status",
             width: 110,
+            sorter: (a, b) => (a.status ?? "").localeCompare(b.status ?? ""),
             render: (v: string | undefined) => {
               const map: Record<string, { color: string; label: string }> = {
                 delivered: { color: "green", label: "Delivered" },


### PR DESCRIPTION
@johnnyq asked for the Mail Logs table to be sortable on column click.

## Change (UI-only)
Added AntD column sorters to the tenant Mail Logs table — **Timestamp, From, To, Size, Status** — so clicking a header sorts on that field. Timestamp defaults to descending (newest first), matching the server's default order.

The table is server-paginated, so a click sorts the **loaded page** (a small caption says so). A true cross-page / server-side sort would require an agent change to the Stalwart file-tracer log query (collect the full filtered set, then sort — with a perf cost on busy logs), so it's kept as a separate, larger change; this delivers the requested click-to-sort without touching the backend.

## Test plan
- `tsc -b` green.
- Not separately screenshotted (no interactive browser attached to this session); the change adds `sorter` functions to existing columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
