### PR TITLE
fix(php): hide uninstalled PHP versions from PHP Settings cards (GH #1332)

### DIFF
--- a/panel-api/internal/api/php_pool_extensions.go
+++ b/panel-api/internal/api/php_pool_extensions.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/phpext"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
@@ -85,7 +87,17 @@ func (h *phpPoolExtensionsHandler) list(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
 		return
 	}
-	st := h.agentExtState(c, pool.PHPVersion)
+	st, err := h.agentExtState(c, pool.PHPVersion)
+	// If the agent reports the version isn't installed (an orphaned pool row whose
+	// PHP version was uninstalled), 404 instead of falling back to the static
+	// catalog — the fallback would present a togglable extension list for a
+	// phantom version (GH #1332). A transient agent error (no code / not
+	// FailedPrecondition) still falls back so the card degrades gracefully.
+	var ae *agentwire.AgentError
+	if errors.As(err, &ae) && ae.Code == agent.CodeFailedPrecondition {
+		c.JSON(http.StatusNotFound, gin.H{"error": "version_not_installed", "detail": "PHP " + pool.PHPVersion + " is not installed"})
+		return
+	}
 	// Additive response (a tenant Automation API script may already read
 	// available/enabled): keep those exact keys; add always_on = the version's
 	// real server-default-enabled modules (conf.d, built-ins included) and
@@ -140,7 +152,8 @@ func (h *phpPoolExtensionsHandler) set(c *gin.Context) {
 	//    php_admin_value[extension]= line is redundant. Best-effort via the agent;
 	//    fail-open (a redundant line is only a PHP startup warning).
 	locked := map[string]bool{"xdebug": true}
-	for _, n := range h.agentExtState(c, req.PHPVersion).alwaysOn {
+	st, _ := h.agentExtState(c, req.PHPVersion)
+	for _, n := range st.alwaysOn {
 		locked[n] = true
 	}
 	// Validate each against the known-extension catalog and drop built-ins
@@ -182,8 +195,10 @@ type extState struct {
 
 // agentExtState asks the agent (php.ext.list) for the version's extension state.
 // Best-effort: on any agent hiccup it falls back to the static catalog for the
-// togglable set and reports ok=false.
-func (h *phpPoolExtensionsHandler) agentExtState(c *gin.Context, version string) extState {
+// togglable set and reports ok=false. It also returns the raw agent error so
+// list() can distinguish a "version not installed" (FailedPrecondition → 404)
+// from a transient hiccup (fall back to the catalog); set() ignores the error.
+func (h *phpPoolExtensionsHandler) agentExtState(c *gin.Context, version string) (extState, error) {
 	raw, err := h.cfg.Agent.Call(c.Request.Context(), "php.ext.list", map[string]string{"version": version})
 	if err == nil {
 		var env struct {
@@ -205,7 +220,7 @@ func (h *phpPoolExtensionsHandler) agentExtState(c *gin.Context, version string)
 					always = append(always, e.Name)
 				}
 			}
-			return extState{available: avail, alwaysOn: always, ok: true}
+			return extState{available: avail, alwaysOn: always, ok: true}, nil
 		}
 	}
 	avail := []string{}
@@ -214,5 +229,5 @@ func (h *phpPoolExtensionsHandler) agentExtState(c *gin.Context, version string)
 			avail = append(avail, s.Name)
 		}
 	}
-	return extState{available: avail, ok: false}
+	return extState{available: avail, ok: false}, err
 }

--- a/panel-api/internal/api/php_pool_extensions_test.go
+++ b/panel-api/internal/api/php_pool_extensions_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -139,6 +141,28 @@ func TestPHPExtensionsList_AgentDownOmitsAlwaysOn(t *testing.T) {
 	}
 	if _, present := raw["available"]; !present {
 		t.Fatalf("available should still be present (static-catalog fallback)")
+	}
+}
+
+func TestPHPExtensionsList_VersionNotInstalled404(t *testing.T) {
+	// An orphaned pool whose PHP version was uninstalled: the agent reports
+	// FailedPrecondition, and list() must 404 rather than fall back to the static
+	// catalog (which would present togglable checkboxes for a phantom version).
+	pool := &models.PHPPool{ID: "p1", UserID: "u1", PHPVersion: "8.5"}
+	r, _ := setupExtRouter(t, pool, func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		if cmd == "php.ext.list" {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "PHP 8.5 is not installed"}
+		}
+		return json.RawMessage(`{}`), nil
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/php-extensions?php_version=8.5", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404 for uninstalled version, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "version_not_installed") {
+		t.Fatalf("want version_not_installed, got %s", w.Body.String())
 	}
 }
 

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -10,6 +12,28 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
+
+// installedPHPVersionSet asks the agent which PHP versions are installed
+// (php.version.list — the same source /php/versions serves). Returns (set, true)
+// on success; (nil, false) on ANY agent error so callers FAIL OPEN (show every
+// pool) rather than blank the card on a transient agent hiccup.
+func installedPHPVersionSet(ctx context.Context, ag agent.AgentInterface) (map[string]bool, bool) {
+	raw, err := ag.Call(ctx, "php.version.list", nil)
+	if err != nil {
+		return nil, false
+	}
+	var resp struct {
+		Versions []string `json:"versions"`
+	}
+	if json.Unmarshal(raw, &resp) != nil || len(resp.Versions) == 0 {
+		return nil, false
+	}
+	set := make(map[string]bool, len(resp.Versions))
+	for _, v := range resp.Versions {
+		set[v] = true
+	}
+	return set, true
+}
 
 // PHPUserTuningHandlerConfig wires the user-facing tiered FPM tuning (GH #339
 // phase 2, Steps 5+6). SEPARATE from the admin-only /php-pools routes (PR #34):
@@ -73,6 +97,21 @@ func (h *phpUserTuningHandler) tuning(c *gin.Context) {
 	rows := []poolTuningRow{}
 	if user != nil {
 		if pools, err := h.cfg.PHPPools.ListByUserID(c.Request.Context(), user.ID); err == nil {
+			// GH #1332: a pool row survives its PHP version being uninstalled, but
+			// the Performance/Xdebug/Extensions cards drive their version dropdown
+			// off these rows — so an orphaned version would keep showing (and be
+			// configurable). Hide pools whose version is no longer installed.
+			// Filter BEFORE the is_default loop so the earliest INSTALLED pool
+			// carries is_default; fail-open (agent unreachable → unfiltered).
+			if installed, ok := installedPHPVersionSet(c.Request.Context(), h.cfg.Agent); ok {
+				kept := make([]models.PHPPool, 0, len(pools))
+				for _, p := range pools {
+					if installed[p.PHPVersion] {
+						kept = append(kept, p)
+					}
+				}
+				pools = kept
+			}
 			// ListByUserID orders the default pool (earliest created) first.
 			for i := range pools {
 				p := &pools[i]

--- a/panel-api/internal/api/php_pool_user_tuning_test.go
+++ b/panel-api/internal/api/php_pool_user_tuning_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type mockModesRepo struct{}
+
+func (mockModesRepo) GetAll(context.Context) ([]models.PHPPerformanceMode, error) { return nil, nil }
+func (mockModesRepo) Get(context.Context, string) (*models.PHPPerformanceMode, error) {
+	return nil, repository.ErrNotFound
+}
+func (mockModesRepo) Update(context.Context, *models.PHPPerformanceMode) error { return nil }
+func (mockModesRepo) EnsureDefaults(context.Context) (int, error)              { return 0, nil }
+
+func setupTuningRouter(
+	t *testing.T,
+	pools []*models.PHPPool,
+	agentFn func(ctx context.Context, command string, params any) (json.RawMessage, error),
+) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"})
+		c.Next()
+	})
+	pkgID := "pkg1"
+	users := &mockUserRepo{users: map[string]*models.User{"u1": {ID: "u1", PackageID: &pkgID}}}
+	packages := &mockPackageRepo{packages: map[string]*models.HostingPackage{
+		"pkg1": {ID: "pkg1", FpmUserCanEdit: true},
+	}}
+	pr := newMockPHPPoolRepo()
+	for _, p := range pools {
+		pr.Create(context.Background(), p)
+	}
+	RegisterPHPUserTuningRoutes(r.Group("/api/v1"), PHPUserTuningHandlerConfig{
+		Agent:               &mockAgent{callFn: agentFn},
+		Users:               users,
+		Packages:            packages,
+		PHPPools:            pr,
+		PHPPoolIniOverrides: mockPHPPoolIniOverrideRepo{},
+		Modes:               mockModesRepo{},
+	})
+	return r
+}
+
+func tuningVersions(t *testing.T, r *gin.Engine) []struct {
+	PHPVersion string `json:"php_version"`
+	IsDefault  bool   `json:"is_default"`
+} {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/php-pool-tuning", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Pools []struct {
+			PHPVersion string `json:"php_version"`
+			IsDefault  bool   `json:"is_default"`
+		} `json:"pools"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Pools
+}
+
+func versionsInstalled(versions ...string) func(context.Context, string, any) (json.RawMessage, error) {
+	return func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		if cmd == "php.version.list" {
+			b, _ := json.Marshal(map[string][]string{"versions": versions})
+			return b, nil
+		}
+		return json.RawMessage(`{}`), nil
+	}
+}
+
+func TestTuning_HidesUninstalledVersionPools(t *testing.T) {
+	// A pool row survives its PHP version being uninstalled; the tuning list must
+	// not surface it. Only 8.4 is installed, so the orphaned 8.5 pool is dropped
+	// and 8.4 (the sole survivor) carries is_default.
+	pools := []*models.PHPPool{
+		{ID: "p84", UserID: "u1", PHPVersion: "8.4"},
+		{ID: "p85", UserID: "u1", PHPVersion: "8.5"},
+	}
+	got := tuningVersions(t, setupTuningRouter(t, pools, versionsInstalled("8.4")))
+	if len(got) != 1 || got[0].PHPVersion != "8.4" {
+		t.Fatalf("want only 8.4, got %+v", got)
+	}
+	if !got[0].IsDefault {
+		t.Fatalf("the sole surviving pool must be is_default, got %+v", got[0])
+	}
+}
+
+func TestTuning_AgentDownReturnsAllPools(t *testing.T) {
+	// Fail-open: an agent hiccup must not blank the card — every pool is returned.
+	pools := []*models.PHPPool{
+		{ID: "p84", UserID: "u1", PHPVersion: "8.4"},
+		{ID: "p85", UserID: "u1", PHPVersion: "8.5"},
+	}
+	agentFn := func(context.Context, string, any) (json.RawMessage, error) {
+		return nil, context.DeadlineExceeded
+	}
+	got := tuningVersions(t, setupTuningRouter(t, pools, agentFn))
+	seen := map[string]bool{}
+	defaults := 0
+	for _, p := range got {
+		seen[p.PHPVersion] = true
+		if p.IsDefault {
+			defaults++
+		}
+	}
+	if !seen["8.4"] || !seen["8.5"] || len(got) != 2 {
+		t.Fatalf("want both 8.4 and 8.5 (fail-open), got %+v", got)
+	}
+	if defaults != 1 {
+		t.Fatalf("exactly one pool must be is_default, got %d", defaults)
+	}
+}
+
+func TestTuning_NoInstalledVersionsLeaves_NoPanic(t *testing.T) {
+	// None of the user's pool versions are installed → empty list, no panic.
+	pools := []*models.PHPPool{{ID: "p85", UserID: "u1", PHPVersion: "8.5"}}
+	got := tuningVersions(t, setupTuningRouter(t, pools, versionsInstalled("9.9")))
+	if len(got) != 0 {
+		t.Fatalf("want no pools, got %+v", got)
+	}
+}


### PR DESCRIPTION
@lxsdevcode found that after uninstalling a PHP version (8.5), it disappeared from **CLI** and the **Domain** version selector, but stayed in **Performance**, **Xdebug**, and **Extensions** — and Extensions even let you toggle checkboxes for the removed version.

## Cause
A per-`(user, version)` PHP **pool row survives** the version being uninstalled. The Performance/Xdebug/Extensions cards drive their version dropdown off those pool rows (`GET /me/php-pool-tuning`), so an orphaned version kept showing. CLI + Domain were fine because they read `/php/versions` (installed versions from the agent).

## Fix (panel-api only — no agent / migration / UI change)
- **`GET /me/php-pool-tuning`** now filters pools to currently-installed versions (agent `php.version.list`, the same source `/php/versions` uses). Filtered **before** the `is_default` pass so the earliest *installed* pool carries `is_default`. **Fail-open** (agent unreachable → unfiltered) so a transient hiccup never blanks the card. One filter fixes all three cards.
- **`GET /me/php-extensions`** now returns **404 `version_not_installed`** when the agent reports the version isn't installed (`FailedPrecondition`), instead of falling back to the static catalog — which had presented togglable checkboxes for a phantom version. A transient agent error still falls back (degrades gracefully).

Pool rows are **kept** (not deleted), so a version's tuning returns intact if it's reinstalled. Note: the UI "(default)" can now differ from the DB default pool if the DB default's version was uninstalled — deliberate; the cards pick the first installed pool.

## Test plan
- Unit (`go test ./panel-api/internal/api`): tuning filter (installed-only; fail-open returns all; none-installed → empty, no panic) + extensions 404 guard. Green.
- **Box-drilled on .60** (deployed binary, real agent): inserted an orphaned `8.1` pool (8.1 not installed) for a tenant → `GET /me/php-pool-tuning` returned only `8.5` with `is_default` sane (8.1 hidden); `GET /me/php-extensions?php_version=8.1` → **404 version_not_installed**; `?php_version=8.5` (installed) → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
