### PR TITLE
feat(domains): opt-in "also delete files" on domain delete (GH #1382)

### DIFF
--- a/panel-agent/internal/commands/domain_docroot_delete.go
+++ b/panel-agent/internal/commands/domain_docroot_delete.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// domain.docroot.delete — opt-in removal of a domain's document root, used only
+// when a tenant explicitly ticks "also delete the files" on domain delete
+// (GH #1382). Two deliberate safety properties:
+//
+//   - It is a SEPARATE verb, never folded into domain.delete, so the implicit
+//     teardown paths (user-delete cascade, billing-cancel) can NEVER delete a
+//     customer's files. Only the explicit human-approved HTTP delete calls it.
+//   - The removal runs AS THE TENANT UID (runFSAsUser → setuid child), so the
+//     kernel confines it to files the tenant already owns. A tenant who wins a
+//     TOCTOU race by swapping a parent dir for a symlink still can't make the
+//     agent delete anything they couldn't delete themselves over SSH.
+
+type domainDocrootDeleteParams struct {
+	Username string `json:"username"`
+	Docroot  string `json:"docroot"`
+}
+
+type domainDocrootDeleteResponse struct {
+	Docroot string `json:"docroot"`
+	Deleted bool   `json:"deleted"`
+	Skipped string `json:"skipped,omitempty"`
+}
+
+func domainDocrootDeleteHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p domainDocrootDeleteParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	uid, gid, err := resolveTenantDocroot(p.Username, p.Docroot)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: err.Error()}
+	}
+
+	fi, lerr := os.Lstat(p.Docroot)
+	if errors.Is(lerr, os.ErrNotExist) {
+		return domainDocrootDeleteResponse{Docroot: p.Docroot, Deleted: false, Skipped: "not present"}, nil
+	}
+	// A docroot that is itself a symlink: remove ONLY the link, never its target.
+	if lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+		if out, rerr := runFSAsUser(uid, gid, "rm", "-f", "--", p.Docroot); rerr != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove docroot symlink: %v: %s", rerr, string(out))}
+		}
+		return domainDocrootDeleteResponse{Docroot: p.Docroot, Deleted: true}, nil
+	}
+	// Recursive delete AS THE TENANT — coreutils rm does not descend into
+	// symlinked directories, and the setuid child means the kernel enforces the
+	// tenant's own permissions on every unlink.
+	if out, rerr := runFSAsUser(uid, gid, "rm", "-rf", "--", p.Docroot); rerr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove docroot: %v: %s", rerr, string(out))}
+	}
+	return domainDocrootDeleteResponse{Docroot: p.Docroot, Deleted: true}, nil
+}
+
+// docrootUnderHome is the pure path guard: the docroot must be a clean absolute
+// path at least two levels below home. Two-levels-deep excludes home itself, a
+// bare ~/public_html and a bare ~/domains (no denylist to keep in sync), and the
+// Rel escape check rejects anything outside home — including the /home/aliceXXX
+// prefix-sibling trick, since Rel("/home/alice", "/home/alicexx/y") starts "..".
+func docrootUnderHome(home, docroot string) error {
+	if !filepath.IsAbs(docroot) || filepath.Clean(docroot) != docroot {
+		return errors.New("docroot must be an absolute, clean path")
+	}
+	rel, err := filepath.Rel(home, docroot)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return errors.New("docroot must be inside the tenant's home directory")
+	}
+	if len(strings.Split(rel, string(os.PathSeparator))) < 2 {
+		return errors.New("refusing to delete a shared top-level directory")
+	}
+	return nil
+}
+
+// resolveTenantDocroot validates username + docroot and returns the tenant's
+// uid/gid. It REFUSES anything that isn't a clean absolute path at least two
+// levels below the tenant's own home — which excludes the home itself, a bare
+// ~/public_html, and a bare ~/domains, as well as any path outside the home or
+// carrying dot-segments. A uid of 0 is refused outright.
+func resolveTenantDocroot(username, docroot string) (uid, gid uint32, err error) {
+	if username == "" {
+		return 0, 0, errors.New("username required")
+	}
+	u, err := user.Lookup(username)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unknown user %q", username)
+	}
+	if u.HomeDir == "" || !filepath.IsAbs(u.HomeDir) {
+		return 0, 0, fmt.Errorf("user %q has no home directory", username)
+	}
+	if err := docrootUnderHome(u.HomeDir, docroot); err != nil {
+		return 0, 0, err
+	}
+	uid64, uerr := strconv.ParseUint(u.Uid, 10, 32)
+	gid64, gerr := strconv.ParseUint(u.Gid, 10, 32)
+	if uerr != nil || gerr != nil {
+		return 0, 0, fmt.Errorf("resolve uid/gid for %q", username)
+	}
+	if uid64 == 0 {
+		return 0, 0, errors.New("refusing to delete as root")
+	}
+	return uint32(uid64), uint32(gid64), nil
+}
+
+func init() {
+	Default.Register("domain.docroot.delete", domainDocrootDeleteHandler)
+}

--- a/panel-agent/internal/commands/domain_docroot_delete_test.go
+++ b/panel-agent/internal/commands/domain_docroot_delete_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+func TestDocrootUnderHome(t *testing.T) {
+	const home = "/home/alice"
+	tests := []struct {
+		name    string
+		docroot string
+		wantErr bool
+	}{
+		{"depth-2 public_html/domain", "/home/alice/public_html/example.com", false},
+		{"depth-3 domains/domain/public_html", "/home/alice/domains/example.com/public_html", false},
+		{"home itself", "/home/alice", true},
+		{"bare public_html", "/home/alice/public_html", true},
+		{"bare domains", "/home/alice/domains", true},
+		{"outside home", "/etc/passwd", true},
+		{"root path", "/", true},
+		{"prefix sibling", "/home/alicexx/public_html/x", true},
+		{"unclean dotdot", "/home/alice/../bob/public_html/x", true},
+		{"relative", "public_html/x", true},
+		{"trailing dotdot escape", "/home/alice/domains/../../etc", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := docrootUnderHome(home, tt.docroot)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("docrootUnderHome(%q) err=%v, wantErr=%v", tt.docroot, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveTenantDocroot_Refusals(t *testing.T) {
+	// Unknown user is refused before any path work.
+	if _, _, err := resolveTenantDocroot("no_such_user_zzz_1382", "/home/x/public_html/y"); err == nil {
+		t.Fatal("unknown user must be refused")
+	}
+	// root (uid 0) is refused outright even with an otherwise-valid path.
+	if u, err := user.Lookup("root"); err == nil {
+		if _, _, rerr := resolveTenantDocroot("root", filepath.Join(u.HomeDir, "a", "b")); rerr == nil {
+			t.Fatal("root (uid 0) must be refused")
+		}
+	}
+	// empty username refused.
+	if _, _, err := resolveTenantDocroot("", "/home/x/public_html/y"); err == nil {
+		t.Fatal("empty username must be refused")
+	}
+}

--- a/panel-api/internal/api/domain_php_pool_test.go
+++ b/panel-api/internal/api/domain_php_pool_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -18,21 +20,55 @@ import (
 
 // mockPHPPoolRepo is a minimal in-memory PHPPoolRepository used by the
 // domain↔pool binding tests. It implements only the methods the bind
-// handler touches; unused methods return zero values.
+// handler touches; unused methods return zero values. The mutex guards the
+// map: the extensions/tuning handlers fire an async reconcile goroutine
+// (reconcilePHPPoolViaAgent) that reads the pools concurrently with the test,
+// which the -race detector flags without it.
 type mockPHPPoolRepo struct {
+	mu    sync.Mutex
 	pools map[string]*models.PHPPool
+	// updated carries each Update's resulting Status so a test can wait for the
+	// async reconcile goroutine's terminal Update ("ready"/"error") before it
+	// reads the pool — the goroutine mutates pool.Status directly, so reading
+	// mid-flight is a -race.
+	updated chan string
 }
 
 func newMockPHPPoolRepo() *mockPHPPoolRepo {
-	return &mockPHPPoolRepo{pools: make(map[string]*models.PHPPool)}
+	return &mockPHPPoolRepo{
+		pools:   make(map[string]*models.PHPPool),
+		updated: make(chan string, 16),
+	}
+}
+
+// settleReconcile blocks until the async reconcile goroutine posts its terminal
+// (non-"pending") Update, so the caller can read the pool without racing the
+// goroutine's pool.Status write.
+func (m *mockPHPPoolRepo) settleReconcile(t *testing.T) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case st := <-m.updated:
+			if st != "pending" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("reconcile did not settle in time")
+		}
+	}
 }
 
 func (m *mockPHPPoolRepo) Create(ctx context.Context, p *models.PHPPool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.pools[p.ID] = p
 	return nil
 }
 
 func (m *mockPHPPoolRepo) FindByID(ctx context.Context, id string) (*models.PHPPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if p, ok := m.pools[id]; ok {
 		return p, nil
 	}
@@ -40,6 +76,8 @@ func (m *mockPHPPoolRepo) FindByID(ctx context.Context, id string) (*models.PHPP
 }
 
 func (m *mockPHPPoolRepo) FindByUserID(ctx context.Context, userID string) (*models.PHPPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for _, p := range m.pools {
 		if p.UserID == userID {
 			return p, nil
@@ -49,6 +87,8 @@ func (m *mockPHPPoolRepo) FindByUserID(ctx context.Context, userID string) (*mod
 }
 
 func (m *mockPHPPoolRepo) FindByUserAndVersion(ctx context.Context, userID, phpVersion string) (*models.PHPPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for _, p := range m.pools {
 		if p.UserID == userID && p.PHPVersion == phpVersion {
 			return p, nil
@@ -58,6 +98,8 @@ func (m *mockPHPPoolRepo) FindByUserAndVersion(ctx context.Context, userID, phpV
 }
 
 func (m *mockPHPPoolRepo) ListByUserID(ctx context.Context, userID string) ([]models.PHPPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	var result []models.PHPPool
 	for _, p := range m.pools {
 		if p.UserID == userID {
@@ -72,20 +114,43 @@ func (m *mockPHPPoolRepo) ListAll(ctx context.Context, opts repository.ListOptio
 }
 
 func (m *mockPHPPoolRepo) Update(ctx context.Context, p *models.PHPPool) error {
+	m.mu.Lock()
 	m.pools[p.ID] = p
+	st := p.Status
+	m.mu.Unlock()
+	select {
+	case m.updated <- st:
+	default:
+	}
 	return nil
 }
 
 func (m *mockPHPPoolRepo) Delete(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	delete(m.pools, id)
 	return nil
 }
 
 func (m *mockPHPPoolRepo) SetStatus(ctx context.Context, id, status string, lastErr *string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if p, ok := m.pools[id]; ok {
 		p.Status = status
 	}
 	return nil
+}
+
+// get returns a value copy of a pool under the lock, for test assertions that
+// would otherwise read the map unguarded while the async reconcile goroutine is
+// still touching it (-race).
+func (m *mockPHPPoolRepo) get(id string) (models.PHPPool, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.pools[id]; ok {
+		return *p, true
+	}
+	return models.PHPPool{}, false
 }
 
 func setupBindRouter(t *testing.T, claims auth.AccessClaims) (*gin.Engine, *mockDomainRepo, *mockPHPPoolRepo) {
@@ -163,8 +228,8 @@ func TestBindDomainPHPPool_ByPHPVersion_NonDefault_CreatesVersionedPool(t *testi
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
 	// The default pool must be untouched.
-	if got := pools.pools["p1"].PHPVersion; got != "8.3" {
-		t.Fatalf("default pool version must not change, got %q", got)
+	if p, _ := pools.get("p1"); p.PHPVersion != "8.3" {
+		t.Fatalf("default pool version must not change, got %q", p.PHPVersion)
 	}
 	// A new 8.1 pool must exist (pending) and the domain bound to it.
 	newPool, err := pools.FindByUserAndVersion(context.Background(), "u1", "8.1")

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -1181,6 +1182,33 @@ func (h *domainHandler) delete(c *gin.Context) {
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
+	}
+
+	// GH #1382: opt-in "also delete the domain's files". Runs ONLY on this
+	// explicit, human-approved HTTP delete — never inside userops.DeleteDomain,
+	// so the user-delete cascade and billing-cancel teardown paths can't destroy
+	// a customer's site implicitly. Best-effort AFTER a successful delete: done
+	// ONCE here (not tombstone-retried, so a retry can never delete files a
+	// re-added domain recreated), fired async so a large docroot can't stall the
+	// response past a proxy timeout, and on any failure the files simply remain
+	// (the pre-#1382 behavior). The agent removes the docroot AS THE TENANT UID.
+	if c.Query("delete_files") == "true" && domain.DocRoot != "" {
+		if owner, uerr := h.cfg.Users.FindByID(ctx, domain.UserID); uerr == nil &&
+			owner != nil && owner.Username != nil && *owner.Username != "" {
+			username, docroot, dname := *owner.Username, domain.DocRoot, domain.Name
+			ag := h.cfg.Agent
+			go func() {
+				dctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer cancel()
+				if _, aerr := ag.Call(dctx, "domain.docroot.delete", map[string]string{
+					"username": username,
+					"docroot":  docroot,
+				}); aerr != nil {
+					slog.Warn("domain delete: docroot cleanup failed; files left in place",
+						"domain", dname, "error", aerr)
+				}
+			}()
+		}
 	}
 
 	c.Status(http.StatusNoContent)

--- a/panel-api/internal/api/php_pool_extensions_test.go
+++ b/panel-api/internal/api/php_pool_extensions_test.go
@@ -188,7 +188,9 @@ func TestPHPExtensionsSet_StripsXdebugAndServerDefaults(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if got := []string(pools.pools["p1"].ExtraExtensions); !equalSet(got, []string{"imagick"}) {
+	pools.settleReconcile(t)
+	pool1, _ := pools.get("p1")
+	if got := []string(pool1.ExtraExtensions); !equalSet(got, []string{"imagick"}) {
 		t.Fatalf("ExtraExtensions = %v, want [imagick] (xdebug/redis/bogus stripped)", got)
 	}
 }
@@ -212,7 +214,9 @@ func TestPHPExtensionsSet_StripsXdebugEvenWhenAgentDown(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if got := []string(pools.pools["p1"].ExtraExtensions); !equalSet(got, []string{"imagick"}) {
+	pools.settleReconcile(t)
+	pool1, _ := pools.get("p1")
+	if got := []string(pool1.ExtraExtensions); !equalSet(got, []string{"imagick"}) {
 		t.Fatalf("ExtraExtensions = %v, want [imagick] (xdebug stripped statically)", got)
 	}
 }

--- a/panel-ui/src/hooks/useQueries.ts
+++ b/panel-ui/src/hooks/useQueries.ts
@@ -189,11 +189,13 @@ export function useDeleteMutation({
   resource,
 }: {
   resource: string;
-}): UseMutationResult<void, unknown, { id: string }> {
+}): UseMutationResult<void, unknown, { id: string; query?: Record<string, string> }> {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id }) => {
-      await apiClient.delete(`/${resource}/${id}`);
+    mutationFn: async ({ id, query }) => {
+      // Optional query string (e.g. domains: ?delete_files=true, GH #1382).
+      const qs = query ? `?${new URLSearchParams(query).toString()}` : "";
+      await apiClient.delete(`/${resource}/${id}${qs}`);
     },
     onSuccess: async (_data, { id }) => {
       await Promise.all([

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -3,7 +3,7 @@
 // "..." overflow with Info/Redirects/Index/Settings/Caching/Toggle/Delete.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import { Button, Card, Dropdown, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { Button, Card, Checkbox, Dropdown, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   DeleteOutlined,
@@ -440,15 +440,30 @@ export const DomainList = () => {
                               icon: <DeleteOutlined />,
                               label: "Delete",
                               danger: true,
-                              onClick: () =>
+                              onClick: () => {
+                                // GH #1382: opt-in "also delete the files"
+                                // (removed as the domain's owner). Default off.
+                                let deleteFiles = false;
                                 feedback.modal.confirm({
                                   title: `Delete domain "${r.name}"?`,
+                                  content: (
+                                    <div>
+                                      <p>This removes the domain, its DNS and its web config. This cannot be undone.</p>
+                                      <Checkbox onChange={(e) => { deleteFiles = e.target.checked; }}>
+                                        Also permanently delete the owner&apos;s files for this domain (document root). This cannot be undone.
+                                      </Checkbox>
+                                    </div>
+                                  ),
                                   okText: "Delete",
                                   okButtonProps: { danger: true },
                                   onOk: async () => {
-                                    await deleteMutation.mutateAsync({ id: r.id });
+                                    await deleteMutation.mutateAsync({
+                                      id: r.id,
+                                      query: deleteFiles ? { delete_files: "true" } : undefined,
+                                    });
                                   },
-                                }),
+                                });
+                              },
                             },
                           ]),
                     ],

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -18,7 +18,7 @@ import {
   ToolOutlined,
   FolderOutlined,
 } from "@icons";
-import { Button, Card, Dropdown, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { Button, Card, Checkbox, Dropdown, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 import { useNavigate } from "react-router";
@@ -429,16 +429,30 @@ export const UserDomainList = () => {
                         label: "Delete",
                         icon: <DeleteOutlined />,
                         danger: true,
-                        onClick: () =>
+                        onClick: () => {
+                          // GH #1382: opt-in "also delete the files". Uncontrolled
+                          // checkbox → closure flag read in onOk (default off).
+                          let deleteFiles = false;
                           feedback.modal.confirm({
                             title: `Delete domain "${r.name}"?`,
-                            content: "This cannot be undone.",
+                            content: (
+                              <div>
+                                <p>This removes the domain, its DNS and its web config. This cannot be undone.</p>
+                                <Checkbox onChange={(e) => { deleteFiles = e.target.checked; }}>
+                                  Also permanently delete the domain&apos;s files (document root). This cannot be undone.
+                                </Checkbox>
+                              </div>
+                            ),
                             okText: "Delete",
                             okType: "danger",
                             onOk: async () => {
-                              await deleteMutation.mutateAsync({ id: r.id });
+                              await deleteMutation.mutateAsync({
+                                id: r.id,
+                                query: deleteFiles ? { delete_files: "true" } : undefined,
+                              });
                             },
-                          }),
+                          });
+                        },
                       },
                     ],
                   }}


### PR DESCRIPTION
@johnnyq reported that deleting a domain leaves its document root on disk. That's correct — delete reaps the vhost, DNS and logs, but not the files. This adds an **opt-in** way to also delete them.

Files stay by default deliberately: auto-deleting a tenant's website on domain removal is irreversible data loss (a mistaken delete, or a delete-then-re-add, would destroy the site). So the removal is behind an explicit, off-by-default checkbox.

## Change
- **UI** (tenant + admin domain lists): the delete confirmation gains a checkbox **"Also permanently delete the domain's files (document root)"**, default off. `useDeleteMutation` gained an optional query param to pass `?delete_files=true`.
- **Panel**: on this explicit human delete **only** — never inside `userops.DeleteDomain`, so the user-delete cascade and billing-cancel teardown can't destroy a customer's site implicitly — the handler fires a **best-effort, once, async** call to a new agent verb **after a successful delete**. It's not tombstone-retried (a retry could otherwise delete files a re-added domain recreated), and on any failure the files simply remain (today's behavior).
- **Agent** `domain.docroot.delete`: removes the docroot **as the tenant uid** (`runFSAsUser` setuid child), so a won TOCTOU symlink race can only touch files the tenant already owns. The guard refuses anything not ≥2 levels below the tenant's own home (excludes the home, a bare `~/public_html`, a bare `~/domains`, and any escape), refuses uid 0, and if the docroot itself is a symlink removes only the link, never its target. It deletes exactly `DocRoot`, not the parent (so `~/domains/<d>` survives when the docroot is `~/domains/<d>/public_html` — say the word if you'd rather it took the whole `~/domains/<d>` shell).

**New agent verb → fleet agent redeploy on release.** The panel tolerates an older agent (unknown-command is logged; files just remain).

## Test plan
- Unit: agent path-guard table (depth-2 accept; home / bare public_html / bare domains / outside-home / prefix-sibling / unclean / relative refused) + uid-0 & unknown-user refusals. `go test ./panel-agent/... ./panel-api/internal/api` green; `tsc -b` + vitest (48) green.
- **Box-drilled on .60** (both binaries, real agent, throwaway tenant + 2 domains):
  - delete **without** the flag → docroot stays;
  - delete **with** `?delete_files=true` → docroot gone, `/home/<user>` intact;
  - adversarial agent-direct: `/etc`, home, bare `public_html` all refused;
  - symlink docroot → link removed, target intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
