### PR TITLE
feat(mail): Mail Domains summary — foundation slice (GH #1387)

### DIFF
--- a/panel-api/internal/api/me_mail_domains.go
+++ b/panel-api/internal/api/me_mail_domains.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// me_mail_domains.go — GH #1387 foundation slice: a tenant-facing per-domain
+// mail summary, the drill-down entry point (Mail → Mail Domains → accounts).
+//
+// Read-only, owner-scoped, pure DB (no agent call): domains via ListByUserID,
+// mailbox count/storage via ListByOwnerWithDomain (both owner-scoped), 30-day
+// sent/received via MailStatsRepository.DomainSeriesForUser (owner-scoped). The
+// current mail queue (a per-domain Stalwart query) and the account drill-down /
+// tab migration are the operator's mail restructure and are deliberately out of
+// this slice.
+
+type MeMailDomainsConfig struct {
+	Domains   repository.DomainRepository
+	Mailboxes repository.MailboxRepository
+	MailStats repository.MailStatsRepository
+}
+
+// RegisterMeMailDomainsRoutes mounts GET /me/mail-domains on an auth-only group.
+func RegisterMeMailDomainsRoutes(g *gin.RouterGroup, cfg MeMailDomainsConfig) {
+	h := &meMailDomainsHandler{cfg: cfg}
+	g.GET("/me/mail-domains", h.list)
+}
+
+type meMailDomainsHandler struct{ cfg MeMailDomainsConfig }
+
+type mailDomainRow struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	MailboxCount int64  `json:"mailbox_count"`
+	MailBytes    int64  `json:"mail_bytes"`
+	Sent30d      int64  `json:"sent_30d"`
+	Received30d  int64  `json:"received_30d"`
+}
+
+func (h *meMailDomainsHandler) list(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+	ctx := c.Request.Context()
+	userID := claims.UserID
+
+	domains, _, err := h.cfg.Domains.ListByUserID(ctx, userID, repository.ListOptions{})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	// Per-domain mailbox count + storage, EXCLUDING the hidden system relay
+	// (GH #1056 `system = 0`) so the numbers match the mailbox list the tenant
+	// drills into. Best-effort: a stats hiccup shows zeros, not a 500.
+	type agg struct{ count, bytes int64 }
+	byDomainID := map[string]agg{}
+	if rows, mErr := h.cfg.Mailboxes.ListByOwnerWithDomain(ctx, userID); mErr == nil {
+		for i := range rows {
+			m := &rows[i]
+			if m.System {
+				continue
+			}
+			a := byDomainID[m.DomainID]
+			a.count++
+			a.bytes += int64(m.LastUsageBytes)
+			byDomainID[m.DomainID] = a
+		}
+	}
+
+	// Sent/received over the last 30 days, owner-scoped, keyed by domain NAME
+	// (DomainStatSample.Domain is the name). Only sent + received are summed;
+	// delivered/failed are separate metrics carried in the same table.
+	type traffic struct{ sent, received int64 }
+	byName := map[string]traffic{}
+	since := time.Now().Add(-30 * 24 * time.Hour)
+	if samples, sErr := h.cfg.MailStats.DomainSeriesForUser(ctx, since, userID); sErr == nil {
+		for _, s := range samples {
+			t := byName[s.Domain]
+			switch s.Metric {
+			case "sent":
+				t.sent += s.Value
+			case "received":
+				t.received += s.Value
+			}
+			byName[s.Domain] = t
+		}
+	}
+
+	out := []mailDomainRow{}
+	for i := range domains {
+		d := &domains[i]
+		if !d.EmailEnabled {
+			continue
+		}
+		a := byDomainID[d.ID]
+		t := byName[d.Name]
+		out = append(out, mailDomainRow{
+			ID:           d.ID,
+			Name:         d.Name,
+			MailboxCount: a.count,
+			MailBytes:    a.bytes,
+			Sent30d:      t.sent,
+			Received30d:  t.received,
+		})
+	}
+
+	// House list envelope (docs/CONVENTIONS.md) so panel-ui useListQuery reads
+	// .data. A tenant has few mail domains, so this is unpaginated by design.
+	c.JSON(http.StatusOK, gin.H{
+		"data":      out,
+		"total":     len(out),
+		"page":      1,
+		"page_size": len(out),
+	})
+}

--- a/panel-api/internal/api/me_mail_domains_test.go
+++ b/panel-api/internal/api/me_mail_domains_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Embedded-interface mocks: only the method the handler calls is implemented;
+// everything else would panic if touched (it isn't).
+type mdDomainRepo struct {
+	repository.DomainRepository
+	ds []models.Domain
+}
+
+func (m mdDomainRepo) ListByUserID(_ context.Context, userID string, _ repository.ListOptions) ([]models.Domain, int64, error) {
+	out := []models.Domain{}
+	for _, d := range m.ds {
+		if d.UserID == userID {
+			out = append(out, d)
+		}
+	}
+	return out, int64(len(out)), nil
+}
+
+type mdMailboxRepo struct {
+	repository.MailboxRepository
+	mbs []repository.MailboxWithDomain
+}
+
+func (m mdMailboxRepo) ListByOwnerWithDomain(_ context.Context, userID string) ([]repository.MailboxWithDomain, error) {
+	out := []repository.MailboxWithDomain{}
+	for _, r := range m.mbs {
+		if r.OwnerUserID == userID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+type mdStatsRepo struct {
+	repository.MailStatsRepository
+	byUser map[string][]repository.DomainStatSample
+}
+
+func (m mdStatsRepo) DomainSeriesForUser(_ context.Context, _ time.Time, userID string) ([]repository.DomainStatSample, error) {
+	return m.byUser[userID], nil
+}
+
+func mb(domainID, owner string, system bool, bytes uint64) repository.MailboxWithDomain {
+	var r repository.MailboxWithDomain
+	r.DomainID = domainID
+	r.System = system
+	r.LastUsageBytes = bytes
+	r.OwnerUserID = owner
+	return r
+}
+
+func setupMailDomainsRouter(t *testing.T, userID string, cfg MeMailDomainsConfig) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID})
+		c.Next()
+	})
+	RegisterMeMailDomainsRoutes(r.Group("/api/v1"), cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/mail-domains", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestMailDomains_AggregatesAndScopes(t *testing.T) {
+	// u1 owns a.test (mail on) + b.test (mail OFF). u2 owns c.test (mail on).
+	cfg := MeMailDomainsConfig{
+		Domains: mdDomainRepo{ds: []models.Domain{
+			{ID: "da", UserID: "u1", Name: "a.test", EmailEnabled: true},
+			{ID: "db", UserID: "u1", Name: "b.test", EmailEnabled: false},
+			{ID: "dc", UserID: "u2", Name: "c.test", EmailEnabled: true},
+		}},
+		Mailboxes: mdMailboxRepo{mbs: []repository.MailboxWithDomain{
+			mb("da", "u1", false, 1000), // real
+			mb("da", "u1", false, 500),  // real
+			mb("da", "u1", true, 999),   // system relay → excluded
+			mb("db", "u1", false, 42),   // b.test mail off → domain filtered out
+			mb("dc", "u2", false, 7),    // u2's — must not appear for u1
+		}},
+		MailStats: mdStatsRepo{byUser: map[string][]repository.DomainStatSample{
+			"u1": {
+				{Domain: "a.test", Metric: "sent", Value: 5},
+				{Domain: "a.test", Metric: "sent", Value: 2},
+				{Domain: "a.test", Metric: "received", Value: 3},
+				{Domain: "a.test", Metric: "delivered", Value: 99}, // not folded in
+			},
+		}},
+	}
+
+	w := setupMailDomainsRouter(t, "u1", cfg)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data  []mailDomainRow `json:"data"`
+		Total int             `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Total != 1 {
+		t.Fatalf("want exactly a.test (b.test mail-off filtered), got %+v", resp.Data)
+	}
+	row := resp.Data[0]
+	if row.Name != "a.test" {
+		t.Fatalf("want a.test, got %q", row.Name)
+	}
+	if row.MailboxCount != 2 {
+		t.Fatalf("mailbox_count = %d, want 2 (system relay excluded)", row.MailboxCount)
+	}
+	if row.MailBytes != 1500 {
+		t.Fatalf("mail_bytes = %d, want 1500 (system relay's 999 excluded)", row.MailBytes)
+	}
+	if row.Sent30d != 7 {
+		t.Fatalf("sent_30d = %d, want 7 (5+2)", row.Sent30d)
+	}
+	if row.Received30d != 3 {
+		t.Fatalf("received_30d = %d, want 3", row.Received30d)
+	}
+}
+
+func TestMailDomains_CrossTenantIsolation(t *testing.T) {
+	// The same config viewed as u2 shows only u2's domain, never u1's.
+	cfg := MeMailDomainsConfig{
+		Domains: mdDomainRepo{ds: []models.Domain{
+			{ID: "da", UserID: "u1", Name: "a.test", EmailEnabled: true},
+			{ID: "dc", UserID: "u2", Name: "c.test", EmailEnabled: true},
+		}},
+		Mailboxes: mdMailboxRepo{mbs: []repository.MailboxWithDomain{
+			mb("da", "u1", false, 1000),
+			mb("dc", "u2", false, 7),
+		}},
+		MailStats: mdStatsRepo{byUser: map[string][]repository.DomainStatSample{}},
+	}
+	w := setupMailDomainsRouter(t, "u2", cfg)
+	var resp struct {
+		Data []mailDomainRow `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 || resp.Data[0].Name != "c.test" {
+		t.Fatalf("u2 must see only c.test, got %+v", resp.Data)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3722,6 +3722,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/mail-domains:
+    get:
+      tags: [Me]
+      summary: List the caller's mail-enabled domains with a per-domain mail summary
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/disk-usage/files:
     get:
       tags: [Me]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -590,6 +590,12 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			QuotaMount: deps.QuotaMount,
 			Snapshots:  repository.NewDiskUsageSnapshotRepository(deps.DB),
 		})
+		// GH #1387 foundation slice: per-domain mail summary (Mail Domains list).
+		api.RegisterMeMailDomainsRoutes(v1, api.MeMailDomainsConfig{
+			Domains:   deps.Domains,
+			Mailboxes: deps.Mailboxes,
+			MailStats: repository.NewMailStatsRepository(deps.DB),
+		})
 		// JAB-171 phase 3b — tenant-facing notification channels + routing.
 		// Gated behind ServerSettings.TenantNotificationsEnabled (default OFF,
 		// no admin toggle until phase 4 lands the SSRF guard + email-verify),

--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -107,6 +107,8 @@ const APIDocsPage = lazy(() => import("./shells/shared/APIDocsPage").then((m) =>
 const UserCronList = lazy(() => import("./shells/user/cron/UserCronList").then((m) => ({ default: m.UserCronList })));
 const AdminCronList = lazy(() => import("./shells/admin/cron/AdminCronList").then((m) => ({ default: m.AdminCronList })));
 const MailTabsPage = lazy(() => import("./shells/user/mail/MailTabsPage").then((m) => ({ default: m.MailTabsPage })));
+// GH #1387 foundation slice: per-domain Mail Domains summary list.
+const MailDomainsPage = lazy(() => import("./shells/user/mail/MailDomainsPage").then((m) => ({ default: m.MailDomainsPage })));
 const AdminApplicationList = lazy(() => import("./shells/admin/applications/AdminApplicationList").then((m) => ({ default: m.AdminApplicationList })));
 const AdminDockerAppsPage = lazy(() => import("./shells/admin/docker-apps/AdminDockerAppsPage").then((m) => ({ default: m.AdminDockerAppsPage })));
 const LogsPage = lazy(() => import("./shells/admin/logs/LogsPage").then((m) => ({ default: m.LogsPage })));
@@ -428,6 +430,16 @@ const ThemedApp = () => {
               element={
                 <CapabilityRoute cap="mail_enabled" fallback="/jabali-panel/dashboard">
                   <MailTabsPage />
+                </CapabilityRoute>
+              }
+            />
+            {/* GH #1387 foundation slice — reachable route; sidebar/menu wiring
+                is left to the operator's mail restructure (Mail → Mail Domains). */}
+            <Route
+              path="mail-domains"
+              element={
+                <CapabilityRoute cap="mail_enabled" fallback="/jabali-panel/dashboard">
+                  <MailDomainsPage />
                 </CapabilityRoute>
               }
             />

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -1,0 +1,76 @@
+// MailDomainsPage — GH #1387 foundation slice. A per-domain mail summary: the
+// tenant's mail-enabled domains at a glance (mailbox count, storage, 30-day
+// sent/received). The drill-down into a domain's accounts and the mailbox-tab
+// migration are the operator's mail restructure; this is only the entry list.
+import { Card, Empty, Spin, Table, Typography } from "antd";
+import { useListQuery } from "../../../hooks/useQueries";
+import { humanBytes } from "../../../utils/bytes";
+
+interface MailDomainRow {
+  id: string;
+  name: string;
+  mailbox_count: number;
+  mail_bytes: number;
+  sent_30d: number;
+  received_30d: number;
+}
+
+const num = (n: number | null | undefined): string => (n ?? 0).toLocaleString();
+
+export function MailDomainsPage() {
+  const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
+  const rows = query.items;
+
+  return (
+    <Card title="Mail Domains">
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+        Your mail-enabled domains at a glance.
+      </Typography.Paragraph>
+      {query.isLoading ? (
+        <Spin />
+      ) : rows.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No mail-enabled domains."
+        />
+      ) : (
+        <Table<MailDomainRow>
+          rowKey="id"
+          dataSource={rows}
+          pagination={false}
+          scroll={{ x: "max-content" }}
+        >
+          <Table.Column<MailDomainRow> title="Domain" dataIndex="name" key="name" />
+          <Table.Column<MailDomainRow>
+            title="Mailboxes"
+            dataIndex="mailbox_count"
+            key="mailbox_count"
+            align="right"
+            render={(n: number) => num(n)}
+          />
+          <Table.Column<MailDomainRow>
+            title="Mail storage"
+            dataIndex="mail_bytes"
+            key="mail_bytes"
+            align="right"
+            render={(n: number) => humanBytes(n)}
+          />
+          <Table.Column<MailDomainRow>
+            title="Sent (30d)"
+            dataIndex="sent_30d"
+            key="sent_30d"
+            align="right"
+            render={(n: number) => num(n)}
+          />
+          <Table.Column<MailDomainRow>
+            title="Received (30d)"
+            dataIndex="received_30d"
+            key="received_30d"
+            align="right"
+            render={(n: number) => num(n)}
+          />
+        </Table>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
Foundation slice for @johnnyq's Mail restructure (#1387) — the **Mail Domains** entry point (Mail → Mail Domains → accounts). This is only the summary list; the account drill-down, the mailbox-tab migration, and the sidebar placement are your larger restructure and are deliberately left out.

## What's here
- **API `GET /me/mail-domains`** (house list envelope `{data,total,page,page_size}`): per mail-enabled domain the caller owns — `mailbox_count`, `mail_bytes`, `sent_30d`, `received_30d`. Read-only, **owner-scoped**, pure DB (no agent).
  - Domains: `ListByUserID`. Count + storage: `ListByOwnerWithDomain`, **excluding the hidden system relay** (GH #1056 `system = 0`) so the numbers match the mailbox list a user drills into. 30-day traffic: `MailStatsRepository.DomainSeriesForUser` (owner-scoped), summing `sent`+`received` keyed by domain name.
  - openapi entry added.
- **UI `MailDomainsPage`**: read-only table (Domain / Mailboxes / Mail storage / Sent 30d / Received 30d). Route `/jabali-panel/mail-domains` gated on `mail_enabled`. **Not linked in the sidebar** — that menu wiring belongs to your restructure.

## Deferred (v2 / your restructure)
- Current **mail queue** (the only stat that needs a per-domain Stalwart agent query).
- The **account drill-down** navigation and the **tab migration** (Disclaimer/Logs/Statistics/Catchall → domain view; 9→5 tabs; drop the Domain column).

## Test plan
- Handler unit test: aggregation (system relay excluded → count/bytes match; `sent`+`received` summed by name, `delivered`/`failed` not folded in; mail-off domains filtered out) + **cross-tenant isolation** (u2 never sees u1's domains).
- `go test ./panel-api/internal/api ./panel-api/internal/app` + openapi coverage golden green; `tsc -b` green.
- **Box-drilled on .60**: two tenants each see only their own mail-enabled domains (never the third tenant's); house envelope confirmed. Zero counts on the drill box (no mailboxes/traffic there) — shape + scoping is what's proven.

No agent / migration change. Nothing posted to #1387 — that thread is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
