### PR TITLE
feat(mail): per-domain mail queue count on Mail Domains (GH #1387 v2)

### DIFF
--- a/panel-api/internal/api/me_mail_domains.go
+++ b/panel-api/internal/api/me_mail_domains.go
@@ -1,29 +1,38 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// me_mail_domains.go — GH #1387 foundation slice: a tenant-facing per-domain
-// mail summary, the drill-down entry point (Mail → Mail Domains → accounts).
+// me_mail_domains.go — GH #1387 Mail Domains summary (Mail → Mail Domains →
+// accounts entry point).
 //
-// Read-only, owner-scoped, pure DB (no agent call): domains via ListByUserID,
-// mailbox count/storage via ListByOwnerWithDomain (both owner-scoped), 30-day
-// sent/received via MailStatsRepository.DomainSeriesForUser (owner-scoped). The
-// current mail queue (a per-domain Stalwart query) and the account drill-down /
-// tab migration are the operator's mail restructure and are deliberately out of
-// this slice.
+// Read-only, owner-scoped. The DB stats (domains via ListByUserID, mailbox
+// count/storage via ListByOwnerWithDomain, 30-day sent/received via
+// MailStatsRepository.DomainSeriesForUser) are always present. The current mail
+// queue (v2) is a best-effort per-domain count derived from the server queue
+// (agent mail.queue.list, filtered to the caller's own domains — only counts
+// leave); on any agent hiccup the `queue` field is OMITTED so the UI shows
+// "unknown" rather than a false 0. The account drill-down + mailbox-tab
+// migration remain the operator's mail restructure and are out of scope here.
 
 type MeMailDomainsConfig struct {
 	Domains   repository.DomainRepository
 	Mailboxes repository.MailboxRepository
 	MailStats repository.MailStatsRepository
+	// Agent backs the best-effort per-domain queue count. Optional: nil (or an
+	// error) simply omits the queue field.
+	Agent agent.AgentInterface
 }
 
 // RegisterMeMailDomainsRoutes mounts GET /me/mail-domains on an auth-only group.
@@ -41,6 +50,10 @@ type mailDomainRow struct {
 	MailBytes    int64  `json:"mail_bytes"`
 	Sent30d      int64  `json:"sent_30d"`
 	Received30d  int64  `json:"received_30d"`
+	// Queue is the count of queued messages touching this domain (as sender or
+	// recipient). nil = unknown (agent unavailable) — omitted from JSON so the
+	// UI shows "—" instead of a misleading 0.
+	Queue *int64 `json:"queue,omitempty"`
 }
 
 func (h *meMailDomainsHandler) list(c *gin.Context) {
@@ -113,6 +126,10 @@ func (h *meMailDomainsHandler) list(c *gin.Context) {
 		})
 	}
 
+	// v2: best-effort per-domain queue counts. On any agent failure every row's
+	// queue stays nil (omitted) so the UI renders "unknown", not a false 0.
+	h.attachQueueCounts(ctx, out)
+
 	// House list envelope (docs/CONVENTIONS.md) so panel-ui useListQuery reads
 	// .data. A tenant has few mail domains, so this is unpaginated by design.
 	c.JSON(http.StatusOK, gin.H{
@@ -121,4 +138,52 @@ func (h *meMailDomainsHandler) list(c *gin.Context) {
 		"page":      1,
 		"page_size": len(out),
 	})
+}
+
+// attachQueueCounts sets each row's Queue to the number of server-queue messages
+// touching that domain (as sender OR recipient), counted at most once per domain
+// per message. The full server queue is pulled and filtered to the caller's own
+// domains here — only per-domain counts ever reach the response. Best-effort: a
+// nil/errored agent, a parse failure, or no rows leaves Queue nil (omitted).
+func (h *meMailDomainsHandler) attachQueueCounts(ctx context.Context, rows []mailDomainRow) {
+	if h.cfg.Agent == nil || len(rows) == 0 {
+		return
+	}
+	qctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(qctx, "mail.queue.list", nil)
+	if err != nil {
+		return
+	}
+	var env struct {
+		Data []mailQueueEntry `json:"data"`
+	}
+	if json.Unmarshal(raw, &env) != nil {
+		return
+	}
+	owned := make(map[string]bool, len(rows))
+	for i := range rows {
+		owned[strings.ToLower(rows[i].Name)] = true
+	}
+	counts := map[string]int64{}
+	for _, e := range env.Data {
+		touched := map[string]bool{}
+		// returnPath may be angle-bracketed or the empty null-sender `<>`; strip
+		// brackets and skip empties (a bounce is attributed only via recipients).
+		if d := emailDomain(strings.Trim(e.From, "<>")); d != "" && owned[d] {
+			touched[d] = true
+		}
+		for _, r := range e.Recipients {
+			if d := emailDomain(strings.Trim(r, "<>")); d != "" && owned[d] {
+				touched[d] = true
+			}
+		}
+		for d := range touched {
+			counts[d]++
+		}
+	}
+	for i := range rows {
+		n := counts[strings.ToLower(rows[i].Name)]
+		rows[i].Queue = &n
+	}
 }

--- a/panel-api/internal/api/me_mail_domains_test.go
+++ b/panel-api/internal/api/me_mail_domains_test.go
@@ -138,6 +138,73 @@ func TestMailDomains_AggregatesAndScopes(t *testing.T) {
 	}
 }
 
+func TestMailDomains_QueueCounts(t *testing.T) {
+	// msg1: a.test sender. msg2: A.test sender (bracketed, mixed case) → a.test,
+	// and b.test recipient. msg3: null-sender bounce to two b.test recipients →
+	// b.test once (deduped per domain per message). msg4: unrelated → ignored.
+	cfg := MeMailDomainsConfig{
+		Domains: mdDomainRepo{ds: []models.Domain{
+			{ID: "da", UserID: "u1", Name: "a.test", EmailEnabled: true},
+			{ID: "db", UserID: "u1", Name: "b.test", EmailEnabled: true},
+		}},
+		Mailboxes: mdMailboxRepo{},
+		MailStats: mdStatsRepo{},
+		Agent: &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+			if cmd == "mail.queue.list" {
+				return json.RawMessage(`{"data":[
+					{"id":"1","from":"x@a.test","recipients":["y@external.com"]},
+					{"id":"2","from":"<z@A.test>","recipients":["w@b.test"]},
+					{"id":"3","from":"<>","recipients":["p@b.test","q@b.test"]},
+					{"id":"4","from":"n@other.com","recipients":["m@other.com"]}
+				]}`), nil
+			}
+			return json.RawMessage(`{}`), nil
+		}},
+	}
+	w := setupMailDomainsRouter(t, "u1", cfg)
+	var resp struct {
+		Data []mailDomainRow `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := map[string]*int64{}
+	for _, r := range resp.Data {
+		got[r.Name] = r.Queue
+	}
+	if got["a.test"] == nil || *got["a.test"] != 2 {
+		t.Fatalf("a.test queue = %v, want 2", got["a.test"])
+	}
+	if got["b.test"] == nil || *got["b.test"] != 2 {
+		t.Fatalf("b.test queue = %v, want 2", got["b.test"])
+	}
+}
+
+func TestMailDomains_QueueUnknownOnAgentError(t *testing.T) {
+	// Agent error → queue field OMITTED (unknown), never a misleading 0.
+	cfg := MeMailDomainsConfig{
+		Domains:   mdDomainRepo{ds: []models.Domain{{ID: "da", UserID: "u1", Name: "a.test", EmailEnabled: true}}},
+		Mailboxes: mdMailboxRepo{},
+		MailStats: mdStatsRepo{},
+		Agent: &mockAgent{callFn: func(context.Context, string, any) (json.RawMessage, error) {
+			return nil, context.DeadlineExceeded
+		}},
+	}
+	w := setupMailDomainsRouter(t, "u1", cfg)
+	var raw struct {
+		Data []map[string]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(raw.Data) != 1 {
+		t.Fatalf("want 1 row, got %d", len(raw.Data))
+	}
+	if _, present := raw.Data[0]["queue"]; present {
+		t.Fatalf("queue must be omitted on agent error, got %s", w.Body.String())
+	}
+}
+
 func TestMailDomains_CrossTenantIsolation(t *testing.T) {
 	// The same config viewed as u2 shows only u2's domain, never u1's.
 	cfg := MeMailDomainsConfig{

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -590,11 +590,13 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			QuotaMount: deps.QuotaMount,
 			Snapshots:  repository.NewDiskUsageSnapshotRepository(deps.DB),
 		})
-		// GH #1387 foundation slice: per-domain mail summary (Mail Domains list).
+		// GH #1387: per-domain mail summary (Mail Domains list) + best-effort
+		// per-domain queue count (v2).
 		api.RegisterMeMailDomainsRoutes(v1, api.MeMailDomainsConfig{
 			Domains:   deps.Domains,
 			Mailboxes: deps.Mailboxes,
 			MailStats: repository.NewMailStatsRepository(deps.DB),
+			Agent:     deps.Agent,
 		})
 		// JAB-171 phase 3b — tenant-facing notification channels + routing.
 		// Gated behind ServerSettings.TenantNotificationsEnabled (default OFF,

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -13,6 +13,9 @@ interface MailDomainRow {
   mail_bytes: number;
   sent_30d: number;
   received_30d: number;
+  // Omitted by the API when the queue couldn't be read (agent unavailable) —
+  // shown as "—", never a misleading 0.
+  queue?: number | null;
 }
 
 const num = (n: number | null | undefined): string => (n ?? 0).toLocaleString();
@@ -68,6 +71,15 @@ export function MailDomainsPage() {
             key="received_30d"
             align="right"
             render={(n: number) => num(n)}
+          />
+          <Table.Column<MailDomainRow>
+            title="Queue"
+            dataIndex="queue"
+            key="queue"
+            align="right"
+            render={(q: number | null | undefined) =>
+              q === null || q === undefined ? "—" : num(q)
+            }
           />
         </Table>
       )}


### PR DESCRIPTION
v2 of the Mail Domains summary (#1387): the deferred **queue** column, best-effort with an honest "unknown". Builds on #1425.

## Change (panel-api + UI)
- `GET /me/mail-domains` now includes an optional **`queue`** per domain: the number of queued messages touching that domain, as **sender or any recipient**, counted at most once per domain per message.
  - Derived server-side from the agent's full server queue (`mail.queue.list`) and **filtered to the caller's own domains** — only per-domain counts ever reach the response, never other tenants' queue contents.
  - 5s timeout; on any agent error/parse failure the `queue` field is **omitted** (nil) so the UI shows **"—"**, never a misleading 0 (the same honest-unknown pattern as `always_on` in #1412).
  - Address parsing strips angle brackets and skips the null-sender bounce (`<>`); matching is case-insensitive.
- UI: a **Queue** column that renders "—" when unknown.

Reuses the existing `mailQueueEntry` shape + `emailDomain` helper from the admin mail-queue handler. No agent / migration / openapi change (a field added to an existing route). The account drill-down + tab migration remain your restructure.

## Test plan
- Unit: attribution (sender + recipient), dedup per (domain, message), angle-bracket stripping, null-sender bounce attributed only via recipients, and **queue omitted on agent error**. `go test ./panel-api/internal/api ./panel-api/internal/app` + coverage golden green; `tsc -b` green.
- **Box-drilled on .60**: `queue` field **present and 0** on the (empty) live queue — proving the real `mail.queue.list` path executed, not the omit branch. (`mail.queue.list` returns in ~20ms there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
