### PR TITLE
feat(mail): Mail Domains drill-down — per-domain accounts + settings (GH #1387 PR-A)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -109,6 +109,8 @@ const AdminCronList = lazy(() => import("./shells/admin/cron/AdminCronList").the
 const MailTabsPage = lazy(() => import("./shells/user/mail/MailTabsPage").then((m) => ({ default: m.MailTabsPage })));
 // GH #1387 foundation slice: per-domain Mail Domains summary list.
 const MailDomainsPage = lazy(() => import("./shells/user/mail/MailDomainsPage").then((m) => ({ default: m.MailDomainsPage })));
+// GH #1387 drill-down: per-domain mail page (accounts + domain settings, scoped).
+const MailDomainPage = lazy(() => import("./shells/user/mail/MailDomainPage").then((m) => ({ default: m.MailDomainPage })));
 const AdminApplicationList = lazy(() => import("./shells/admin/applications/AdminApplicationList").then((m) => ({ default: m.AdminApplicationList })));
 const AdminDockerAppsPage = lazy(() => import("./shells/admin/docker-apps/AdminDockerAppsPage").then((m) => ({ default: m.AdminDockerAppsPage })));
 const LogsPage = lazy(() => import("./shells/admin/logs/LogsPage").then((m) => ({ default: m.LogsPage })));
@@ -440,6 +442,24 @@ const ThemedApp = () => {
               element={
                 <CapabilityRoute cap="mail_enabled" fallback="/jabali-panel/dashboard">
                   <MailDomainsPage />
+                </CapabilityRoute>
+              }
+            />
+            {/* GH #1387 drill-down: a single domain's mail (accounts + settings),
+                scoped to :domainId. */}
+            <Route
+              path="mail-domains/:domainId"
+              element={
+                <CapabilityRoute cap="mail_enabled" fallback="/jabali-panel/dashboard">
+                  <MailDomainPage />
+                </CapabilityRoute>
+              }
+            />
+            <Route
+              path="mail-domains/:domainId/:tab"
+              element={
+                <CapabilityRoute cap="mail_enabled" fallback="/jabali-panel/dashboard">
+                  <MailDomainPage />
                 </CapabilityRoute>
               }
             />

--- a/panel-ui/src/shells/user/mail/MailDomainPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainPage.tsx
@@ -1,0 +1,138 @@
+// MailDomainPage — GH #1387 drill-down: Mail → Mail Domains → this domain →
+// accounts. Everything here is scoped to one domain (the :domainId route param,
+// resolved through the owner-scoped GET /domains/:id so a foreign id renders an
+// error, never another tenant's data). The account/domain tabs reuse the mail
+// tab components in their single-domain mode. Logs + Statistics scoping and the
+// retirement of the flat Mail page are a follow-up (PR-B).
+import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
+import { ArrowLeftOutlined, MailOutlined, PlusOutlined } from "@icons";
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router";
+
+import { useOneQuery } from "../../../hooks/useQueries";
+import type { Domain } from "../domains/UserDomainList";
+import { MailboxesTab } from "./tabs/MailboxesTab";
+import { GroupsTab } from "./tabs/GroupsTab";
+import { ForwardersTab } from "./tabs/ForwardersTab";
+import { CatchAllTab } from "./tabs/CatchAllTab";
+import { DisclaimerTab } from "./tabs/DisclaimerTab";
+import { SharedFoldersTab } from "./tabs/SharedFoldersTab";
+import { SharedResourcesTab } from "./tabs/SharedResourcesTab";
+import { CreateMailboxWizardModal } from "./CreateMailboxWizardModal";
+
+const TAB_KEYS = [
+  "mailboxes",
+  "forwarders",
+  "groups",
+  "shared",
+  "resources",
+  "catchall",
+  "disclaimer",
+] as const;
+type TabKey = (typeof TAB_KEYS)[number];
+const DEFAULT_TAB: TabKey = "mailboxes";
+
+const TAB_LABELS: Record<TabKey, string> = {
+  mailboxes: "Accounts",
+  forwarders: "Forwarders",
+  groups: "Groups",
+  shared: "Shared Folders",
+  resources: "Shared Resources",
+  catchall: "Catch-All",
+  disclaimer: "Disclaimer",
+};
+
+export const MailDomainPage = () => {
+  const { domainId, tab } = useParams<{ domainId: string; tab?: string }>();
+  const navigate = useNavigate();
+  const [showCreateMailbox, setShowCreateMailbox] = useState(false);
+
+  const domainQ = useOneQuery<Domain>({ resource: "domains", id: domainId });
+  const activeKey: TabKey = (TAB_KEYS as readonly string[]).includes(tab ?? "")
+    ? (tab as TabKey)
+    : DEFAULT_TAB;
+
+  const back = () => navigate("/jabali-panel/mail-domains");
+
+  if (domainQ.isLoading) {
+    return (
+      <div style={{ padding: 20 }}>
+        <Skeleton active />
+      </div>
+    );
+  }
+  if (domainQ.isError || !domainQ.data) {
+    // Owner-scoped GET /domains/:id returns 403/404 for a domain the caller does
+    // not own — surface it as an error, never a blank scoped view.
+    return (
+      <div style={{ padding: 20 }}>
+        <Alert
+          type="error"
+          showIcon
+          message="Domain not available"
+          description="This domain doesn't exist or you don't have access to it."
+          action={<Button onClick={back}>Back to Mail Domains</Button>}
+        />
+      </div>
+    );
+  }
+  const domain = domainQ.data;
+
+  const renderTab = () => {
+    switch (activeKey) {
+      case "mailboxes":
+        return <MailboxesTab domainId={domainId} />;
+      case "forwarders":
+        return <ForwardersTab domainId={domainId} />;
+      case "groups":
+        return <GroupsTab domainId={domainId} />;
+      case "shared":
+        return <SharedFoldersTab domainId={domainId} />;
+      case "resources":
+        return <SharedResourcesTab domainId={domainId} />;
+      case "catchall":
+        return <CatchAllTab domainId={domainId} />;
+      case "disclaimer":
+        return <DisclaimerTab domainId={domainId} />;
+    }
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <Space wrap align="center" style={{ marginBottom: 8 }}>
+        <Button type="text" icon={<ArrowLeftOutlined />} onClick={back}>
+          Mail Domains
+        </Button>
+      </Space>
+      <Space
+        wrap
+        align="center"
+        style={{ marginBottom: 16, width: "100%", justifyContent: "space-between" }}
+      >
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          <MailOutlined /> {domain.name}
+        </Typography.Title>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setShowCreateMailbox(true)}>
+          New Mailbox
+        </Button>
+      </Space>
+
+      <Card
+        tabList={TAB_KEYS.map((k) => ({ key: k, tab: TAB_LABELS[k] }))}
+        activeTabKey={activeKey}
+        onTabChange={(k) => navigate(`/jabali-panel/mail-domains/${domainId}/${k}`)}
+      >
+        {renderTab()}
+      </Card>
+
+      {showCreateMailbox && (
+        <CreateMailboxWizardModal
+          open={showCreateMailbox}
+          domains={[{ id: domain.id, name: domain.name }]}
+          onCancel={() => setShowCreateMailbox(false)}
+          onCreated={() => setShowCreateMailbox(false)}
+        />
+      )}
+    </div>
+  );
+};

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -3,6 +3,7 @@
 // sent/received). The drill-down into a domain's accounts and the mailbox-tab
 // migration are the operator's mail restructure; this is only the entry list.
 import { Card, Empty, Spin, Table, Typography } from "antd";
+import { useNavigate } from "react-router";
 import { useListQuery } from "../../../hooks/useQueries";
 import { humanBytes } from "../../../utils/bytes";
 
@@ -21,6 +22,7 @@ interface MailDomainRow {
 const num = (n: number | null | undefined): string => (n ?? 0).toLocaleString();
 
 export function MailDomainsPage() {
+  const navigate = useNavigate();
   const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
   const rows = query.items;
 
@@ -43,7 +45,14 @@ export function MailDomainsPage() {
           pagination={false}
           scroll={{ x: "max-content" }}
         >
-          <Table.Column<MailDomainRow> title="Domain" dataIndex="name" key="name" />
+          <Table.Column<MailDomainRow>
+            title="Domain"
+            dataIndex="name"
+            key="name"
+            render={(name: string, row) => (
+              <a onClick={() => navigate(`/jabali-panel/mail-domains/${row.id}`)}>{name}</a>
+            )}
+          />
           <Table.Column<MailDomainRow>
             title="Mailboxes"
             dataIndex="mailbox_count"

--- a/panel-ui/src/shells/user/mail/tabs/CatchAllTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/CatchAllTab.tsx
@@ -28,7 +28,7 @@ interface CatchAllRow {
   updated_at: string;
 }
 
-export const CatchAllTab = () => {
+export const CatchAllTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
@@ -36,8 +36,8 @@ export const CatchAllTab = () => {
   });
 
   const emailEnabledDomains = useMemo(
-    () => domains.filter((d) => d.email_enabled),
-    [domains],
+    () => domains.filter((d) => d.email_enabled && (!domainId || d.id === domainId)),
+    [domains, domainId],
   );
 
   const results = useQueries({
@@ -149,11 +149,15 @@ export const CatchAllTab = () => {
           pagination={false}
           scroll={{ x: "max-content" }}
           columns={[
-            {
-              title: "Domain",
-              dataIndex: "domain_name",
-              sorter: (a, b) => a.domain_name.localeCompare(b.domain_name),
-            },
+            ...(domainId
+              ? []
+              : [
+                  {
+                    title: "Domain",
+                    dataIndex: "domain_name",
+                    sorter: (a: CatchAllRow, b: CatchAllRow) => a.domain_name.localeCompare(b.domain_name),
+                  },
+                ]),
             {
               title: "Target",
               dataIndex: "target",

--- a/panel-ui/src/shells/user/mail/tabs/DisclaimerTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/DisclaimerTab.tsx
@@ -18,13 +18,13 @@ interface FormValues {
   text: string;
 }
 
-export const DisclaimerTab = () => {
+export const DisclaimerTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
   });
-  const emailEnabled = useMemo(() => domains.filter((d) => d.email_enabled), [domains]);
+  const emailEnabled = useMemo(() => domains.filter((d) => d.email_enabled && (!domainId || d.id === domainId)), [domains, domainId]);
 
   const results = useQueries({
     queries: emailEnabled.map((d) => ({
@@ -91,11 +91,15 @@ export const DisclaimerTab = () => {
           pagination={false}
           scroll={{ x: "max-content" }}
           columns={[
-            {
-              title: "Domain",
-              dataIndex: "domain_name",
-              sorter: (a: Disclaimer, b: Disclaimer) => a.domain_name.localeCompare(b.domain_name),
-            },
+            ...(domainId
+              ? []
+              : [
+                  {
+                    title: "Domain",
+                    dataIndex: "domain_name",
+                    sorter: (a: Disclaimer, b: Disclaimer) => a.domain_name.localeCompare(b.domain_name),
+                  },
+                ]),
             {
               title: "Status",
               dataIndex: "enabled",

--- a/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
@@ -32,13 +32,13 @@ interface FormValues {
   target: string;
 }
 
-export const ForwardersTab = () => {
+export const ForwardersTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
   });
-  const emailEnabled = useMemo(() => domains.filter((d) => d.email_enabled), [domains]);
+  const emailEnabled = useMemo(() => domains.filter((d) => d.email_enabled && (!domainId || d.id === domainId)), [domains, domainId]);
 
   const mailboxResults = useQueries({
     queries: emailEnabled.map((d) => ({

--- a/panel-ui/src/shells/user/mail/tabs/GroupsTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/GroupsTab.tsx
@@ -43,7 +43,7 @@ import {
 } from "../../../../hooks/useMailGroups";
 
 
-export function GroupsTab() {
+export function GroupsTab({ domainId: scopedDomainId }: { domainId?: string } = {}) {
   const { t } = useTranslation();
   const { message } = App.useApp();
 
@@ -51,10 +51,12 @@ export function GroupsTab() {
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
   });
-  const mailDomains = useMemo(() => domains.filter((d) => d.email_enabled), [domains]);
+  const mailDomains = useMemo(() => domains.filter((d) => d.email_enabled && (!scopedDomainId || d.id === scopedDomainId)), [domains, scopedDomainId]);
 
+  // GH #1387: in the per-domain drill-down (scopedDomainId set) the domain is
+  // fixed and the picker is hidden; otherwise the internal picker drives it.
   const [domainId, setDomainId] = useState<string | undefined>(undefined);
-  const effectiveDomain = domainId ?? mailDomains[0]?.id;
+  const effectiveDomain = scopedDomainId ?? domainId ?? mailDomains[0]?.id;
 
   const { data: groups, isLoading } = useMailGroups(effectiveDomain);
 
@@ -77,14 +79,18 @@ export function GroupsTab() {
   return (
     <Space direction="vertical" size="middle" style={{ width: "100%" }}>
       <Space style={{ width: "100%", justifyContent: "space-between" }} wrap>
-        <Select
-          style={{ minWidth: 240 }}
-          value={effectiveDomain}
-          onChange={setDomainId}
-          options={mailDomains.map((d) => ({ value: d.id, label: d.name }))}
-          showSearch
-          optionFilterProp="label"
-        />
+        {scopedDomainId ? (
+          <span />
+        ) : (
+          <Select
+            style={{ minWidth: 240 }}
+            value={effectiveDomain}
+            onChange={setDomainId}
+            options={mailDomains.map((d) => ({ value: d.id, label: d.name }))}
+            showSearch
+            optionFilterProp="label"
+          />
+        )}
         <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>
           New group
         </Button>

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -48,7 +48,10 @@ type GroupMembership = {
   group_email: string;
 };
 
-export const MailboxesTab = () => {
+// GH #1387: when domainId is set (the per-domain Mail Domains drill-down), the
+// tab scopes to that one domain and hides the Domain column; unset = the flat
+// cross-domain view (unchanged).
+export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
@@ -56,8 +59,8 @@ export const MailboxesTab = () => {
   });
 
   const emailEnabledDomains = useMemo(
-    () => domains.filter((d) => d.email_enabled),
-    [domains],
+    () => domains.filter((d) => d.email_enabled && (!domainId || d.id === domainId)),
+    [domains, domainId],
   );
 
   const mailboxResults = useQueries({
@@ -278,12 +281,17 @@ export const MailboxesTab = () => {
               );
             },
           },
-          {
-            title: "Domain",
-            dataIndex: "domain_name",
-            sorter: (a, b) => a.domain_name.localeCompare(b.domain_name),
-            width: 220,
-          },
+          ...(domainId
+            ? []
+            : [
+                {
+                  title: "Domain",
+                  dataIndex: "domain_name",
+                  sorter: (a: MailboxRow, b: MailboxRow) =>
+                    a.domain_name.localeCompare(b.domain_name),
+                  width: 220,
+                },
+              ]),
           {
             title: "Groups",
             key: "groups",

--- a/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
@@ -42,13 +42,13 @@ interface FormValues {
   rights: (keyof Rights)[];
 }
 
-export const SharedFoldersTab = () => {
+export const SharedFoldersTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
   });
-  const emailEnabled = useMemo(() => domains.filter((d) => d.email_enabled), [domains]);
+  const emailEnabled = useMemo(() => domains.filter((d) => d.email_enabled && (!domainId || d.id === domainId)), [domains, domainId]);
 
   const mailboxResults = useQueries({
     queries: emailEnabled.map((d) => ({

--- a/panel-ui/src/shells/user/mail/tabs/SharedResourcesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedResourcesTab.tsx
@@ -42,13 +42,13 @@ const KIND_COLOR: Record<string, string> = {
 // Kinds offered in the UI (shared mailbox deferred — send-as path pending).
 const OFFERED_KINDS: SharedResourceKind[] = ["calendar", "addressbook", "files"];
 
-export const SharedResourcesTab = () => {
+export const SharedResourcesTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
   });
-  const mailDomains = useMemo(() => domains.filter((d) => d.email_enabled), [domains]);
+  const mailDomains = useMemo(() => domains.filter((d) => d.email_enabled && (!domainId || d.id === domainId)), [domains, domainId]);
 
   const results = useQueries({
     queries: mailDomains.map((d) => ({
@@ -117,11 +117,15 @@ export const SharedResourcesTab = () => {
             sorter: (a: Row, b: Row) => (a.display_name || a.email || a.id).localeCompare(b.display_name || b.email || b.id),
             render: (v, r) => v || r.email || r.id,
           },
-          {
-            title: "Domain",
-            dataIndex: "domain_name",
-            sorter: (a: Row, b: Row) => (a.domain_name ?? "").localeCompare(b.domain_name ?? ""),
-          },
+          ...(domainId
+            ? []
+            : [
+                {
+                  title: "Domain",
+                  dataIndex: "domain_name",
+                  sorter: (a: Row, b: Row) => (a.domain_name ?? "").localeCompare(b.domain_name ?? ""),
+                },
+              ]),
           {
             title: "Address",
             dataIndex: "email",


### PR DESCRIPTION
**PR-A of the mail restructure (#1387): the drill-down.** Mail → Mail Domains → a domain → its accounts. Phase B (Logs/Statistics scoping + retiring the flat Mail page) follows separately.

## Change (UI-only)
- **New `MailDomainPage`** at `/jabali-panel/mail-domains/:domainId(/:tab)`. Tabs scoped to one domain: **Accounts, Forwarders, Groups, Shared Folders, Shared Resources, Catch-All, Disclaimer** — with the **Domain column dropped** (redundant per-domain). "New Mailbox" is **pre-pinned** to the domain.
  - **Security:** `:domainId` is resolved through the owner-scoped `GET /domains/:id` (403/404 for a domain the caller doesn't own) and renders an error state on failure — the raw URL param is never passed into child fetches.
- **Dual-mode tabs:** the 7 mail tabs gain an optional `domainId` prop. Set → scope the existing per-domain fan-out to that one domain + hide the Domain column; unset → the flat cross-domain view, **unchanged**. GroupsTab's internal picker is hidden when scoped. `CreateMailboxWizardModal` + the admin mail page keep the cross-domain path.
- **Mail Domains list:** the Domain name now links into the drill-down.

## Deferred to PR-B (per plan)
- Scoping **Logs** + **Statistics** to a domain (their APIs need a filter check first).
- Retiring/redirecting the **flat Mail page** once the domain page has parity — so `mail/:tab` stays fully functional here (no stranded users mid-migration).

## Test plan
- `tsc -b` green; mail vitest green (incl. the create-mailbox wizard's multi-domain picker, unaffected).
- The `:domainId` ownership guard is the pre-existing, code-verified `GET /domains/:id` (`!isAdmin && domain.UserID != claims.UserID → 403`).
- UI-only, no backend change. Not separately screenshotted (no interactive browser attached this session); scoping is a mechanical narrow-the-fan-out + column-hide, type-checked across all 7 tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
