### PR TITLE
fix(ui): relabel the user Backups nav item (GH #1391)

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -73,7 +73,7 @@
       "ssl": "SSL Manager",
       "php-settings": "PHP Settings",
       "cron": "Cron",
-      "backups": "Backup/Restore"
+      "backups": "Backups"
     }
   },
   "login": {


### PR DESCRIPTION
@johnnyq — the tenant side-nav item read **Backup/Restore**; restore is assumed within the section, so it now reads just **Backups** (matching the admin nav, which already said "Backups").

en locale label only; ro falls back to it. tsc/build unaffected (string change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)