### PR TITLE
feat(files): live progress for extract + copy/move (GH #1392)

### DIFF
--- a/panel-agent/internal/commands/file_jobs.go
+++ b/panel-agent/internal/commands/file_jobs.go
@@ -1,0 +1,160 @@
+package commands
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// file_jobs.go — GH #1392. In-memory registry for long-running File Manager
+// operations (currently async extract) so the UI can show a progress bar
+// instead of a blank wait, and a large extract can't block the HTTP request
+// past a proxy timeout.
+//
+// Ownership: a job is keyed by the requesting username; files.job.status returns
+// a job ONLY to a caller passing that same username (the panel sends the caller's
+// verified username). Job ids are crypto-random as a second layer. State is
+// in-memory: it is lost on an agent restart (a poll then returns job_not_found;
+// the UI tells the user to refresh the folder) — acceptable for a progress hint.
+//
+// Concurrency: the agent serves each connection in its own goroutine
+// (server.go), so the job goroutine outlives its start request and status polls
+// run concurrently. All job state is guarded by the job mutex.
+
+const (
+	fileJobRunning = "running"
+	fileJobDone    = "done"
+	fileJobError   = "error"
+
+	fileJobTTL     = 10 * time.Minute // reap finished jobs after this
+	maxJobsPerUser = 3                // concurrent running jobs per user
+)
+
+type fileJob struct {
+	id        string
+	username  string
+	op        string
+	startedAt time.Time
+
+	mu     sync.Mutex
+	status string
+	done   int64
+	total  int64 // 0 = unknown (streamed tar) → indeterminate
+	result filesExtractResult
+	errMsg string
+}
+
+func (j *fileJob) setTotal(n int64) { j.mu.Lock(); j.total = n; j.mu.Unlock() }
+func (j *fileJob) tick(done int64)  { j.mu.Lock(); j.done = done; j.mu.Unlock() }
+
+func (j *fileJob) finish(res filesExtractResult) {
+	j.mu.Lock()
+	j.status = fileJobDone
+	j.result = res
+	j.done = int64(res.Extracted + res.Skipped)
+	j.mu.Unlock()
+}
+
+func (j *fileJob) fail(msg string) {
+	j.mu.Lock()
+	j.status = fileJobError
+	j.errMsg = msg
+	j.mu.Unlock()
+}
+
+// fileJobSnapshot is the wire shape returned by files.job.status.
+type fileJobSnapshot struct {
+	JobID     string             `json:"job_id"`
+	Status    string             `json:"status"`
+	Done      int64              `json:"done"`
+	Total     int64              `json:"total"`
+	Result    filesExtractResult `json:"result"`
+	Error     string             `json:"error,omitempty"`
+	StartedAt string             `json:"started_at"`
+}
+
+func (j *fileJob) snapshot() fileJobSnapshot {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return fileJobSnapshot{
+		JobID:     j.id,
+		Status:    j.status,
+		Done:      j.done,
+		Total:     j.total,
+		Result:    j.result,
+		Error:     j.errMsg,
+		StartedAt: j.startedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+var fileJobs = struct {
+	mu sync.Mutex
+	m  map[string]*fileJob
+}{m: map[string]*fileJob{}}
+
+func randomJobID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// newFileJob registers a running job for username, enforcing the per-user cap.
+func newFileJob(username, op string) (*fileJob, error) {
+	fileJobs.mu.Lock()
+	defer fileJobs.mu.Unlock()
+	reapLocked()
+
+	running := 0
+	for _, j := range fileJobs.m {
+		j.mu.Lock()
+		r := j.status == fileJobRunning
+		j.mu.Unlock()
+		if r && j.username == username {
+			running++
+		}
+	}
+	if running >= maxJobsPerUser {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: "too many file operations already running; wait for one to finish",
+		}
+	}
+
+	j := &fileJob{
+		id:        randomJobID(),
+		username:  username,
+		op:        op,
+		startedAt: time.Now(),
+		status:    fileJobRunning,
+	}
+	fileJobs.m[j.id] = j
+	return j, nil
+}
+
+// getFileJob returns the job iff it exists AND belongs to username.
+func getFileJob(id, username string) *fileJob {
+	fileJobs.mu.Lock()
+	defer fileJobs.mu.Unlock()
+	reapLocked()
+	j := fileJobs.m[id]
+	if j == nil || j.username != username {
+		return nil
+	}
+	return j
+}
+
+// reapLocked drops finished jobs older than the TTL. Caller holds fileJobs.mu.
+func reapLocked() {
+	cutoff := time.Now().Add(-fileJobTTL)
+	for id, j := range fileJobs.m {
+		j.mu.Lock()
+		expired := j.status != fileJobRunning && j.startedAt.Before(cutoff)
+		j.mu.Unlock()
+		if expired {
+			delete(fileJobs.m, id)
+		}
+	}
+}

--- a/panel-agent/internal/commands/file_jobs_test.go
+++ b/panel-agent/internal/commands/file_jobs_test.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"testing"
+	"time"
+)
+
+func resetFileJobs() {
+	fileJobs.mu.Lock()
+	fileJobs.m = map[string]*fileJob{}
+	fileJobs.mu.Unlock()
+}
+
+func TestFileJobs_OwnershipAndLifecycle(t *testing.T) {
+	resetFileJobs()
+	j, err := newFileJob("alice", "extract")
+	if err != nil || j == nil {
+		t.Fatalf("newFileJob: %v", err)
+	}
+	// Ownership: another user must never see alice's job.
+	if getFileJob(j.id, "bob") != nil {
+		t.Fatal("bob must not see alice's job")
+	}
+	// Unknown id → nil.
+	if getFileJob("00000000000000000000000000000000", "alice") != nil {
+		t.Fatal("unknown id must be nil")
+	}
+	// Owner → job.
+	if getFileJob(j.id, "alice") == nil {
+		t.Fatal("alice must see her own job")
+	}
+	// Progress.
+	j.setTotal(10)
+	j.tick(3)
+	if s := j.snapshot(); s.Total != 10 || s.Done != 3 || s.Status != fileJobRunning || s.JobID != j.id {
+		t.Fatalf("running snapshot = %+v", s)
+	}
+	// Finish carries the result and pins done to extracted+skipped.
+	j.finish(filesExtractResult{Extracted: 8, Skipped: 2})
+	if s := j.snapshot(); s.Status != fileJobDone || s.Done != 10 || s.Result.Extracted != 8 || s.Result.Skipped != 2 {
+		t.Fatalf("done snapshot = %+v", s)
+	}
+}
+
+func TestFileJobs_FailCarriesMessage(t *testing.T) {
+	resetFileJobs()
+	j, _ := newFileJob("u", "extract")
+	j.fail("not a valid zip")
+	if s := j.snapshot(); s.Status != fileJobError || s.Error != "not a valid zip" {
+		t.Fatalf("fail snapshot = %+v", s)
+	}
+}
+
+func TestFileJobs_PerUserCap(t *testing.T) {
+	resetFileJobs()
+	for i := 0; i < maxJobsPerUser; i++ {
+		if _, err := newFileJob("cap", "extract"); err != nil {
+			t.Fatalf("job %d rejected early: %v", i, err)
+		}
+	}
+	if _, err := newFileJob("cap", "extract"); err == nil {
+		t.Fatal("the (maxJobsPerUser+1)th running job must be rejected")
+	}
+	// A different user is unaffected by another's cap.
+	if _, err := newFileJob("other", "extract"); err != nil {
+		t.Fatalf("other user must not be capped: %v", err)
+	}
+	// A finished job frees a slot.
+	fileJobs.mu.Lock()
+	for _, j := range fileJobs.m {
+		if j.username == "cap" {
+			j.mu.Lock()
+			done := j.status == fileJobRunning
+			j.mu.Unlock()
+			if done {
+				j.finish(filesExtractResult{})
+				break
+			}
+		}
+	}
+	fileJobs.mu.Unlock()
+	if _, err := newFileJob("cap", "extract"); err != nil {
+		t.Fatalf("a freed slot must accept a new job: %v", err)
+	}
+}
+
+func TestFileJobs_ReapFinished(t *testing.T) {
+	resetFileJobs()
+	j, _ := newFileJob("reap", "extract")
+	j.finish(filesExtractResult{})
+	j.mu.Lock()
+	j.startedAt = time.Now().Add(-fileJobTTL - time.Minute)
+	j.mu.Unlock()
+	// getFileJob runs reapLocked first, so the stale finished job is gone.
+	if getFileJob(j.id, "reap") != nil {
+		t.Fatal("a finished job past its TTL must be reaped")
+	}
+	// A running job is never reaped, however old.
+	r, _ := newFileJob("reap", "extract")
+	r.mu.Lock()
+	r.startedAt = time.Now().Add(-fileJobTTL - time.Hour)
+	r.mu.Unlock()
+	if getFileJob(r.id, "reap") == nil {
+		t.Fatal("a running job must not be reaped")
+	}
+}

--- a/panel-agent/internal/commands/files_extract.go
+++ b/panel-agent/internal/commands/files_extract.go
@@ -74,7 +74,14 @@ func filesExtractHandler(ctx context.Context, params json.RawMessage) (any, erro
 	if p.Username == "" || p.Path == "" {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username and path are required"}
 	}
+	return runExtract(ctx, p, nil)
+}
 
+// runExtract performs one archive extraction, sharing the exact scope/zip-slip/
+// decompression-bomb defenses of the synchronous path. When job is non-nil the
+// extractor reports progress into it (GH #1392 async path); nil = the sync
+// handler above.
+func runExtract(ctx context.Context, p filesExtractParams, job *fileJob) (any, error) {
 	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("failed to create scope: %v", err)}
@@ -124,7 +131,7 @@ func filesExtractHandler(ctx context.Context, params json.RawMessage) (any, erro
 	ctx, cancel := context.WithTimeout(ctx, extractWallClockBudget)
 	defer cancel()
 
-	ex := &extractor{ctx: ctx, ed: ed}
+	ex := &extractor{ctx: ctx, ed: ed, job: job}
 
 	// SECURITY (Gitea #423): open the archive through the escape-proof fd. The
 	// previous scope.Open(p.Path) / zip.OpenReader(path) re-resolved the path and
@@ -174,6 +181,15 @@ type extractor struct {
 	extracted int
 	skipped   int
 	total     int64
+	job       *fileJob // GH #1392: non-nil on the async path — receives progress
+}
+
+// tick reports the running entry count into the async job (no-op on the sync
+// path). Called once per processed archive entry.
+func (ex *extractor) tick() {
+	if ex.job != nil {
+		ex.job.tick(int64(ex.extracted + ex.skipped))
+	}
 }
 
 // isUnsafeExtractTarget reports whether an extract create/mkdir error means the
@@ -288,6 +304,9 @@ func (ex *extractor) unzip(f *os.File) error {
 	if err != nil {
 		return &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("not a valid zip: %v", err)}
 	}
+	if ex.job != nil {
+		ex.job.setTotal(int64(len(zr.File))) // zip TOC → a real percentage
+	}
 	for _, zf := range zr.File {
 		if err := ex.ctx.Err(); err != nil { // GH #664
 			return err
@@ -318,6 +337,7 @@ func (ex *extractor) unzip(f *os.File) error {
 				return err
 			}
 		}
+		ex.tick()
 	}
 	return nil
 }
@@ -355,6 +375,7 @@ func (ex *extractor) untar(r io.Reader) error {
 			// Symlink, hardlink, char/block device, fifo — skip (unsafe).
 			ex.skipped++
 		}
+		ex.tick()
 	}
 }
 
@@ -371,7 +392,9 @@ func (ex *extractor) gunzipSingle(r io.Reader, outName string) error {
 	if err != nil {
 		return err
 	}
-	return ex.writeFile(dest, 0o644, gz)
+	werr := ex.writeFile(dest, 0o644, gz)
+	ex.tick()
+	return werr
 }
 
 // hostingIDs returns the uid + the www-data gid for the hosting user (matching
@@ -392,6 +415,66 @@ func hostingIDs(username string) (int, int) {
 	return uid, gid
 }
 
+// filesExtractStartHandler (files.extract.start, GH #1392) kicks off an
+// extraction in a background goroutine and returns a job id immediately, so a
+// large archive can't block the HTTP request past a proxy timeout and the UI can
+// poll files.job.status for a progress bar. Same params + defenses as the
+// synchronous files.extract.
+func filesExtractStartHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p filesExtractParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if p.Username == "" || p.Path == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username and path are required"}
+	}
+	job, err := newFileJob(p.Username, "extract")
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		// Detached from the request context (which ends when the start call
+		// returns): runExtract caps its own wall-clock at extractWallClockBudget.
+		res, rerr := runExtract(context.Background(), p, job)
+		if rerr != nil {
+			msg := "extract failed"
+			if ae, ok := rerr.(*agentwire.AgentError); ok && ae.Message != "" {
+				msg = ae.Message
+			}
+			job.fail(msg)
+			return
+		}
+		r, _ := res.(filesExtractResult)
+		job.finish(r)
+	}()
+	return map[string]string{"job_id": job.id}, nil
+}
+
+type filesJobStatusParams struct {
+	JobID    string `json:"job_id"`
+	Username string `json:"username"`
+}
+
+// filesJobStatusHandler (files.job.status) returns a job's progress ONLY to a
+// caller passing the username the job was started for (the panel sends the
+// caller's verified username). Unknown id or wrong owner → not_found.
+func filesJobStatusHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p filesJobStatusParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if p.JobID == "" || p.Username == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "job_id and username are required"}
+	}
+	j := getFileJob(p.JobID, p.Username)
+	if j == nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeNotFound, Message: "job not found"}
+	}
+	return j.snapshot(), nil
+}
+
 func init() {
 	Default.Register("files.extract", filesExtractHandler)
+	Default.Register("files.extract.start", filesExtractStartHandler)
+	Default.Register("files.job.status", filesJobStatusHandler)
 }

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -297,6 +297,7 @@ func RegisterFilesRoutes(g *gin.RouterGroup, cfg FilesHandlerConfig) {
 	grp.POST("/chmod", h.chmod)
 	grp.POST("/archive", h.archive)
 	grp.POST("/extract", h.extract)
+	grp.GET("/jobs/:id", h.jobStatus) // GH #1392: async file-op progress
 	grp.POST("/copy", h.copy)
 	// /write carries whole file contents (Monaco save) — exempt from the
 	// global 1 MiB JSON cap (JAB-246), bounded by the upload knob instead.
@@ -331,6 +332,7 @@ func RegisterFilesRoutes(g *gin.RouterGroup, cfg FilesHandlerConfig) {
 	adm.POST("/chmod", h.chmod)
 	adm.POST("/archive", h.archive)
 	adm.POST("/extract", h.extract)
+	adm.GET("/jobs/:id", h.jobStatus) // GH #1392: async file-op progress
 	adm.POST("/copy", h.copy)
 	adm.POST("/write", filesUploadSizeLimit(func(c *gin.Context) int64 {
 		return h.resolveMaxUploadBytes(c.Request.Context())
@@ -1057,6 +1059,20 @@ func (h *filesHandler) extract(c *gin.Context) {
 	if h.rejectAdminWriteOutOfScope(c, extractDest) {
 		return
 	}
+	// GH #1392: ?async=1 runs the extraction as a background job and returns a
+	// job id immediately (202), so a large archive doesn't block the request past
+	// a proxy timeout and the UI can poll GET /files/jobs/:id for a progress bar.
+	if c.Query("async") == "1" {
+		raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.extract.start", filesExtractAgentParams{
+			UserID: userID, Username: username, AdminRoot: h.adminRoot(c), Path: req.Path, Dest: req.Dest,
+		})
+		if err != nil {
+			respondAgentError(c, err)
+			return
+		}
+		c.Data(http.StatusAccepted, "application/json", raw)
+		return
+	}
 	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.extract", filesExtractAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), Path: req.Path, Dest: req.Dest,
 	})
@@ -1066,6 +1082,26 @@ func (h *filesHandler) extract(c *gin.Context) {
 	}
 	var res json.RawMessage = raw
 	c.Data(http.StatusOK, "application/json", res)
+}
+
+// jobStatus handles GET /files/jobs/:id — the progress of an async File Manager
+// operation (GH #1392). The agent returns the job ONLY when it was started for
+// this caller's username (sent from verified claims), so one tenant can never
+// poll another's job; an unknown id or wrong owner is a 404.
+func (h *filesHandler) jobStatus(c *gin.Context) {
+	_, username, ok := h.requireClaimsAndUsername(c)
+	if !ok {
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.job.status", map[string]string{
+		"job_id":   c.Param("id"),
+		"username": username,
+	})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	c.Data(http.StatusOK, "application/json", raw)
 }
 
 func (h *filesHandler) rename(c *gin.Context) {

--- a/panel-api/internal/api/files_async_test.go
+++ b/panel-api/internal/api/files_async_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// GH #1392 — async extract + job-status polling.
+//
+// The security property under test is that the username the agent uses to gate
+// job ownership comes from the caller's verified claims, never from the request:
+// the panel forwards claims-derived "alice", so one tenant can't poll another's
+// job by guessing a job id.
+
+func TestExtractAsync_Returns202AndStartsJob(t *testing.T) {
+	var gotCmd string
+	var gotParams json.RawMessage
+	agent := &mockAgent{callFn: func(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+		gotCmd = cmd
+		gotParams, _ = json.Marshal(params)
+		return json.RawMessage(`{"job_id":"abc123"}`), nil
+	}}
+	r := setupFilesRouter(t, "user1", agent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/extract?async=1",
+		strings.NewReader(`{"path":"/home/alice/big.zip"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if gotCmd != "files.extract.start" {
+		t.Fatalf("agent command = %q, want files.extract.start", gotCmd)
+	}
+	if !strings.Contains(string(gotParams), `"username":"alice"`) {
+		t.Fatalf("start params must carry the claims username: %s", gotParams)
+	}
+	if !strings.Contains(w.Body.String(), `"job_id":"abc123"`) {
+		t.Fatalf("body should relay the job id: %s", w.Body.String())
+	}
+}
+
+func TestExtractSync_UsesBlockingVerb(t *testing.T) {
+	agent := &mockAgent{callFn: func(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+		return json.RawMessage(`{"extracted":3}`), nil
+	}}
+	r := setupFilesRouter(t, "user1", agent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/extract",
+		strings.NewReader(`{"path":"/home/alice/big.zip"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if agent.lastCommand != "files.extract" {
+		t.Fatalf("without async the sync verb must be used, got %q", agent.lastCommand)
+	}
+}
+
+func TestJobStatus_ForwardsClaimsUsername(t *testing.T) {
+	var gotParams json.RawMessage
+	agent := &mockAgent{callFn: func(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+		if cmd != "files.job.status" {
+			t.Fatalf("command = %q, want files.job.status", cmd)
+		}
+		gotParams, _ = json.Marshal(params)
+		return json.RawMessage(`{"job_id":"j1","status":"running","done":2,"total":10}`), nil
+	}}
+	r := setupFilesRouter(t, "user1", agent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/jobs/j1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	// The username is claims-derived (alice), and the job id comes from the path.
+	if !strings.Contains(string(gotParams), `"username":"alice"`) {
+		t.Fatalf("job.status must use the claims username, not a client value: %s", gotParams)
+	}
+	if !strings.Contains(string(gotParams), `"job_id":"j1"`) {
+		t.Fatalf("job id must come from the path: %s", gotParams)
+	}
+}
+
+func TestJobStatus_AgentNotFoundIs404(t *testing.T) {
+	agent := &mockAgent{callFn: func(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeNotFound, Message: "job not found"}
+	}}
+	r := setupFilesRouter(t, "user1", agent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/jobs/nope", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unknown/foreign job must be 404, got %d; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestJobStatus_RequiresAuth(t *testing.T) {
+	agent := &mockAgent{callFn: func(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+		t.Fatal("agent must not be called without claims")
+		return nil, nil
+	}}
+	r := setupFilesRouter(t, "", agent) // no claims
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/jobs/j1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3104,6 +3104,14 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/files/jobs/{id}:
+    get:
+      tags: [Files]
+      summary: Admin async file-operation job progress
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
   /admin/files/upload:
     post:
       tags: [Files]
@@ -3177,6 +3185,14 @@ paths:
       tags: [Files]
       summary: Create extract
       security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /files/jobs/{id}:
+    get:
+      tags: [Files]
+      summary: Get async file-operation job progress
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
   /files/home:

--- a/panel-ui/src/shells/admin/files/adminFilesApi.ts
+++ b/panel-ui/src/shells/admin/files/adminFilesApi.ts
@@ -11,6 +11,7 @@ import {
   type FileListResponse,
   type FilePreviewResponse,
   type FilesExtractResult,
+  type FilesJobStatus,
   type FilesDuResponse,
 } from "../../user/files/filesApi";
 
@@ -37,6 +38,20 @@ export const adminFilesApi: FilesApi = {
   },
   extract: async (path, dest) =>
     (await apiClient.post<FilesExtractResult>(`${BASE}/extract`, { path, dest })).data,
+  extractStart: async (path, dest) =>
+    (
+      await apiClient.post<{ job_id: string }>(
+        `${BASE}/extract`,
+        { path, dest },
+        { params: { async: 1 } },
+      )
+    ).data,
+  jobStatus: async (jobId) =>
+    (
+      await apiClient.get<FilesJobStatus>(
+        `${BASE}/jobs/${encodeURIComponent(jobId)}`,
+      )
+    ).data,
   rename: async (path, newName) => {
     await apiClient.post(`${BASE}/rename`, { path, new_name: newName });
   },

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
-import { Breadcrumb, Button, Card, Drawer, Dropdown, Empty, Grid, Input, Modal, Space, Spin, Table, Tag, Tooltip, Tree, Typography, theme } from "antd";
+import { Breadcrumb, Button, Card, Drawer, Dropdown, Empty, Grid, Input, Modal, Progress, Space, Spin, Table, Tag, Tooltip, Tree, Typography, theme } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { DataNode } from "antd/es/tree";
 import {
@@ -400,6 +400,23 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
   // button is enough for the most common case, and move is already
   // one drag away.
   const [clipboard, setClipboard] = useState<string[]>([]);
+
+  // GH #1392: async extract progress. Non-null while an extraction is running;
+  // `total === 0` means the archive kind (streamed tar) doesn't expose a count,
+  // so the modal shows an indeterminate spinner instead of a percentage.
+  const [extractJob, setExtractJob] = useState<{
+    name: string;
+    status: "running" | "done" | "error";
+    done: number;
+    total: number;
+  } | null>(null);
+  // Flips true on unmount so an in-flight poll loop stops touching state.
+  const extractCancelRef = useRef(false);
+  useEffect(() => {
+    return () => {
+      extractCancelRef.current = true;
+    };
+  }, []);
 
   // Editor — Monaco-based. editTarget holds the path of the file
   // being edited; null means the modal is closed.
@@ -858,15 +875,25 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
       paths: string[],
       op: (p: string) => Promise<void>,
     ) => {
+      // GH #1392: show a live "working…" spinner while the batch runs; the
+      // terminal toast reuses the same key so the spinner is replaced, not
+      // stacked. Bulk copy/move/delete/chmod can take a while on big trees.
+      const key = `files-bulk-${verb}-${Date.now()}`;
+      feedback.message.open({
+        type: "loading",
+        content: `${verb.replace(/ed$/, "ing")} ${paths.length} item${paths.length === 1 ? "" : "s"}…`,
+        key,
+        duration: 0,
+      });
       const results = await Promise.allSettled(paths.map(op));
       const ok = results.filter((r) => r.status === "fulfilled").length;
       const fail = results.length - ok;
       if (fail === 0) {
-        feedback.message.success(`${verb} ${ok} item${ok === 1 ? "" : "s"}`);
+        feedback.message.success({ content: `${verb} ${ok} item${ok === 1 ? "" : "s"}`, key });
       } else if (ok === 0) {
-        feedback.message.error(`${verb} failed for all ${fail} items`);
+        feedback.message.error({ content: `${verb} failed for all ${fail} items`, key });
       } else {
-        feedback.message.warning(`${verb} ${ok}/${results.length} — ${fail} failed`);
+        feedback.message.warning({ content: `${verb} ${ok}/${results.length} — ${fail} failed`, key });
       }
       // Log failures for debug — the toast can't surface per-item detail.
       results.forEach((r, i) => {
@@ -967,12 +994,14 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
       const lastSlash = srcPath.lastIndexOf("/");
       const srcParent = lastSlash > 0 ? srcPath.slice(0, lastSlash) : "/";
       if (srcParent === destDir) return;
+      const key = `files-move-${Date.now()}`;
+      feedback.message.open({ type: "loading", content: "Moving…", key, duration: 0 });
       try {
         await api.move(srcPath, destDir);
-        feedback.message.success("Moved");
+        feedback.message.success({ content: "Moved", key });
         if (currentPath) void reloadList(currentPath);
       } catch (err) {
-        feedback.message.error(`Move failed: ${errMessage(err)}`);
+        feedback.message.error({ content: `Move failed: ${errMessage(err)}`, key });
       }
     },
     [currentPath, reloadList],
@@ -1010,16 +1039,71 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
     return EXTRACTABLE_EXTS.some((e) => n.endsWith(e));
   };
 
+  // handleExtract (GH #1392) kicks off the extraction as a background job and
+  // polls its progress so the user sees a live progress bar instead of a frozen
+  // menu. A large archive no longer blocks the HTTP request past a proxy
+  // timeout. If the agent restarts mid-extract the poll 404s — we stop the bar
+  // and just refresh the folder rather than claiming success or failure.
   const handleExtract = async (entry: FileEntry) => {
     if (!currentPath) return;
-    const path = joinPath(currentPath, entry.name);
+    const dir = currentPath;
+    const path = joinPath(dir, entry.name);
+    extractCancelRef.current = false;
+    setExtractJob({ name: entry.name, status: "running", done: 0, total: 0 });
     try {
-      const res = await api.extract(path);
-      const skipped =
-        res.skipped > 0 ? `, ${res.skipped} unsafe entr(y/ies) skipped` : "";
-      feedback.message.success(`Extracted ${res.extracted} file(s)${skipped}`);
-      void reloadList(currentPath);
+      const { job_id } = await api.extractStart(path);
+      // Poll until the job is terminal. The agent reaps a finished job after
+      // ~10 min, so a stuck "running" state resolves itself to a 404 and exits.
+      // 1.5s cadence keeps the bar responsive while staying well under any
+      // flood threshold (≈40 req/min) — the async DB-restore poll uses 3s, but
+      // a progress bar wants a little more frequency. ~1200 iterations caps the
+      // loop past the agent's 10-min job TTL as a hard backstop.
+      for (let i = 0; i < 1200; i++) {
+        await new Promise((r) => setTimeout(r, 1500));
+        if (extractCancelRef.current) return;
+        let s: Awaited<ReturnType<typeof api.jobStatus>>;
+        try {
+          s = await api.jobStatus(job_id);
+        } catch {
+          // Unknown/foreign id or agent restart — the job is gone.
+          if (extractCancelRef.current) return;
+          setExtractJob(null);
+          feedback.message.warning(
+            "Extraction status is no longer available — refreshing folder",
+          );
+          void reloadList(dir);
+          return;
+        }
+        if (extractCancelRef.current) return;
+        setExtractJob({
+          name: entry.name,
+          status: s.status,
+          done: s.done,
+          total: s.total,
+        });
+        if (s.status === "done") {
+          const skipped =
+            s.result.skipped > 0
+              ? `, ${s.result.skipped} unsafe entr(y/ies) skipped`
+              : "";
+          feedback.message.success(
+            `Extracted ${s.result.extracted} file(s)${skipped}`,
+          );
+          void reloadList(dir);
+          setTimeout(() => setExtractJob(null), 500);
+          return;
+        }
+        if (s.status === "error") {
+          feedback.message.error(`Extract failed: ${s.error || "unknown error"}`);
+          setExtractJob(null);
+          return;
+        }
+      }
+      // Safety net: never poll forever.
+      setExtractJob(null);
     } catch (err) {
+      if (extractCancelRef.current) return;
+      setExtractJob(null);
       feedback.message.error(`Extract failed: ${errMessage(err)}`);
     }
   };
@@ -1785,6 +1869,45 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
             </pre>
           )}
         </Spin>
+      </Modal>
+
+      {/* GH #1392: async extract progress. Non-dismissable while running so the
+          user can't fire a second extract over the first; auto-closes on done. */}
+      <Modal
+        title={extractJob ? `Extracting ${extractJob.name}` : "Extracting"}
+        open={extractJob !== null}
+        footer={null}
+        closable={false}
+        maskClosable={false}
+        destroyOnHidden
+      >
+        {extractJob &&
+          (extractJob.total > 0 ? (
+            <Progress
+              percent={
+                extractJob.status === "done"
+                  ? 100 // zip `total` counts dir entries too, so done<total at the end
+                  : Math.min(
+                      100,
+                      Math.floor((extractJob.done / extractJob.total) * 100),
+                    )
+              }
+              status={
+                extractJob.status === "error"
+                  ? "exception"
+                  : extractJob.status === "done"
+                    ? "success"
+                    : "active"
+              }
+            />
+          ) : (
+            <Space>
+              <Spin />
+              <span>
+                Extracting {extractJob.done > 0 ? `${extractJob.done} file(s)` : ""}…
+              </span>
+            </Space>
+          ))}
       </Modal>
 
       <Modal

--- a/panel-ui/src/shells/user/files/filesApi.ts
+++ b/panel-ui/src/shells/user/files/filesApi.ts
@@ -228,6 +228,43 @@ export async function filesExtract(
   return data;
 }
 
+// GH #1392: async extract. filesExtractStart kicks off the extraction as a
+// background job on the agent and returns immediately with a job id (HTTP 202);
+// the caller polls filesJobStatus for a progress bar. Same defenses as the
+// blocking filesExtract — the agent runs the identical extract core.
+export async function filesExtractStart(
+  path: string,
+  dest?: string,
+): Promise<{ job_id: string }> {
+  const { data } = await apiClient.post<{ job_id: string }>(
+    "/files/extract",
+    { path, dest },
+    { params: { async: 1 } },
+  );
+  return data;
+}
+
+export interface FilesJobStatus {
+  job_id: string;
+  status: "running" | "done" | "error";
+  done: number;
+  total: number; // 0 = unknown (streamed tar) → indeterminate progress
+  result: FilesExtractResult;
+  error?: string;
+  started_at: string;
+}
+
+// filesJobStatus polls a background file-operation job (GH #1392). The backend
+// returns the job only to the tenant that started it; an unknown/foreign id is
+// a 404 (surfaced as a rejected promise), which the poller treats as "the job
+// is gone — refresh the folder".
+export async function filesJobStatus(jobId: string): Promise<FilesJobStatus> {
+  const { data } = await apiClient.get<FilesJobStatus>(
+    `/files/jobs/${encodeURIComponent(jobId)}`,
+  );
+  return data;
+}
+
 export async function filesRename(path: string, newName: string): Promise<void> {
   await apiClient.post("/files/rename", { path, new_name: newName });
 }
@@ -314,6 +351,8 @@ export type FilesApi = {
   write: typeof filesWrite;
   mkdir: typeof filesMkdir;
   extract: typeof filesExtract;
+  extractStart: typeof filesExtractStart;
+  jobStatus: typeof filesJobStatus;
   rename: typeof filesRename;
   move: typeof filesMove;
   chmod: typeof filesChmod;
@@ -334,6 +373,8 @@ export const tenantFilesApi: FilesApi = {
   write: filesWrite,
   mkdir: filesMkdir,
   extract: filesExtract,
+  extractStart: filesExtractStart,
+  jobStatus: filesJobStatus,
   rename: filesRename,
   move: filesMove,
   chmod: filesChmod,

--- a/panel-ui/src/shells/user/files/filesAsyncApi.test.ts
+++ b/panel-ui/src/shells/user/files/filesAsyncApi.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+import { filesExtractStart, filesJobStatus } from "./filesApi";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+// GH #1392 — the async-extract client helpers.
+describe("filesExtractStart", () => {
+  beforeEach(() => {
+    mocked.get.mockReset();
+    mocked.post.mockReset();
+  });
+
+  it("posts the archive with async=1 and returns the job id", async () => {
+    mocked.post.mockResolvedValue({ data: { job_id: "abc123" } });
+    const out = await filesExtractStart("/home/u/big.zip");
+    expect(out).toEqual({ job_id: "abc123" });
+    expect(mocked.post).toHaveBeenCalledWith(
+      "/files/extract",
+      { path: "/home/u/big.zip", dest: undefined },
+      { params: { async: 1 } },
+    );
+  });
+});
+
+describe("filesJobStatus", () => {
+  beforeEach(() => {
+    mocked.get.mockReset();
+    mocked.post.mockReset();
+  });
+
+  it("GETs the job by url-encoded id and returns its status", async () => {
+    mocked.get.mockResolvedValue({
+      data: {
+        job_id: "j1",
+        status: "running",
+        done: 2,
+        total: 10,
+        result: { dest: "", extracted: 0, skipped: 0 },
+        started_at: "2026-08-31T00:00:00Z",
+      },
+    });
+    const s = await filesJobStatus("j 1/x");
+    expect(mocked.get).toHaveBeenCalledWith("/files/jobs/j%201%2Fx");
+    expect(s.status).toBe("running");
+    expect(s.total).toBe(10);
+  });
+});


### PR DESCRIPTION
## What & why

GH #1392 — *Files: add realtime feedback on Copy/Move/Extracting with a progress bar.*

Extraction previously ran as one blocking HTTP call: the row menu sat frozen with no
feedback, and a large archive could outlast a proxy timeout. This makes extract a
background job on the agent with a real progress bar, and gives copy/move/paste an
in-flight indicator.

## How

**Agent**
- `file_jobs.go` — in-memory job registry keyed by **username** (ownership), crypto-random
  job ids (second layer), a per-user running cap, and a 10-min reap. State is in-memory:
  lost on agent restart (a poll then 404s → the UI just refreshes the folder).
- New verbs:
  - `files.extract.start` — spawns the extraction in a detached goroutine, returns a job id.
  - `files.job.status` — returns progress **only** to a caller passing the username the job
    was started for; unknown/foreign id → `not_found`.
- The extract core is shared via `runExtract`, so every existing defense (zip-slip, symlink,
  decompression-bomb, wall-clock budget) is reused unchanged. `zip` reports a real
  percentage from its table of contents; streamed `tar` reports total=0 (indeterminate).

**Panel**
- `POST /files/extract?async=1` → `202 {job_id}`; `GET /files/jobs/:id` forwards the caller's
  **verified** username (from claims, never the request body) so one tenant can't poll
  another's job. The same handlers back the `/admin/files` mount (GH #1184), so the admin
  File Manager gets the same behaviour.

**UI**
- Extract polls the job every 1.5 s and renders an AntD `Progress` bar (percentage for zip,
  spinner for tar), auto-closing on completion; a 404 mid-poll stops the bar and refreshes.
- Copy / move / paste and the bulk actions now show an indeterminate "working…" toast that
  is replaced by the terminal result, so an operation is always visibly in flight.

Async copy/move is **deferred** — those keep the indeterminate loading indicator for now.

## Tests

- Agent: `file_jobs_test.go` — ownership gate, per-user cap (+ slot freed on finish), reap of
  finished-past-TTL vs. never-reap-while-running, progress/finish/fail snapshots. Passes `-race`.
- Panel: `files_async_test.go` — `?async=1` → 202 uses `files.extract.start` and carries the
  claims username; sync path still uses `files.extract`; `jobStatus` forwards the claims
  username + path id; agent `not_found` → HTTP 404; missing claims → 401.
- UI: `filesAsyncApi.test.ts` — `filesExtractStart` posts `async=1`, `filesJobStatus` GETs the
  url-encoded id. `tsc -b` clean; existing files suites green.
- OpenAPI coverage golden updated for both new routes.

## Box drill (test box .60, restored after)

Rebuilt SPA + both binaries (SPA is `go:embed`-ed into panel-api), deployed, agent **restarted**
(not stopped — the panel `Requires=` it). Real 602-entry zip extracted for tenant `testing44`
over the agent socket:
- progress caught mid-flight (`done=391 total=602`), completed `done=601 total=602`
  (the extra TOC entry is the archive's `.` dir — this is why the bar snaps to 100% on done),
  601 files extracted and chowned to `testing44`.
- ownership: another tenant polling the job id → `not_found`; unknown id → `not_found`.
- error propagation: a bad dest surfaced through the job as `status=error` with the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
