### PR TITLE
chore(deps): track Adminer in the monthly dependency review (GH #1405)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8016,13 +8016,20 @@ DROPINEOF
 install_adminer() {
   _log "installing Adminer (multi-engine DB admin) — M37 Phase 4"
 
+  # Pin as a plain VAR (not baked into the URLs) so scripts/deps-check.sh can
+  # read it and the monthly dependency review tracks Adminer drift like every
+  # other install.sh pin (phpMyAdmin, Stalwart, Kratos, …). Bump this one line,
+  # then `scripts/deps-check.sh --refresh-sha adminer_version` to re-capture the
+  # checksum.
+  local adminer_version="4.8.1"
   local adminer_dir="/var/www/jabali-adminer"
-  local adminer_url="https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php"
-  local adminer_plugin_url="https://raw.githubusercontent.com/vrana/adminer/v4.8.1/plugins/plugin.php"
+  local adminer_url="https://github.com/vrana/adminer/releases/download/v${adminer_version}/adminer-${adminer_version}.php"
+  local adminer_plugin_url="https://raw.githubusercontent.com/vrana/adminer/v${adminer_version}/plugins/plugin.php"
 
   mkdir -p "${adminer_dir}"
 
-  # Upstream single-file Adminer build. Pin v4.8.1 for reproducibility.
+  # Upstream single-file Adminer build, pinned via ${adminer_version} above for
+  # reproducibility.
   #
   # Checksum-verified like every other third-party artifact in this file
   # (wp-cli, phpMyAdmin, Stalwart, Kratos, Bulwark, maldet, yara-x). Adminer is

--- a/scripts/deps-check.sh
+++ b/scripts/deps-check.sh
@@ -42,6 +42,7 @@ MANIFEST=(
   "kratos_version|ory/kratos|v|install/kratos.sha256|https://github.com/ory/kratos/releases/download/v{V}/kratos_{V}-linux_64bit.tar.gz"
   "wp_version|wp-cli/wp-cli|v|install/wp-cli.sha256|https://github.com/wp-cli/wp-cli/releases/download/v{V}/wp-cli-{V}.phar"
   "pma_version|phpmyadmin/phpmyadmin|RELEASE_|install/phpmyadmin.sha256|-"
+  "adminer_version|vrana/adminer|v|install/adminer.sha256|https://github.com/vrana/adminer/releases/download/v{V}/adminer-{V}.php"
   "snuf_version|jvoisin/snuffleupagus|v|-|-"
   "LMD_VERSION|rfxn/linux-malware-detect|v|-|-"
   "YARAX_VERSION|VirusTotal/yara-x|v|-|-"


### PR DESCRIPTION
## What & why

GH #1405 asks to update the bundled Adminer (4.8.1 → 6.0.1). Before doing the
bump itself, this closes the *reason it went unnoticed*: Adminer was the one
`install.sh` pin the **monthly dependency review** (`monthly-deps.yml` →
`scripts/deps-check.sh`) didn't track, so its drift never showed up next to
phpMyAdmin, Stalwart, Kratos, wp-cli, etc.

Root cause: `deps-check.sh` reads each pin as a `VAR="x.y"` in `install.sh`.
Adminer was pinned as a URL literal (`.../v4.8.1/adminer-4.8.1.php`), with no
version variable, so the extractor never saw it.

## Changes

- **install.sh** — hoist the pin to `adminer_version="4.8.1"` and build both the
  release URL and the plugin-loader URL from it. The resolved URLs are
  byte-identical to before, so the install is unchanged.
- **scripts/deps-check.sh** — add one manifest row:
  `adminer_version|vrana/adminer|v|install/adminer.sha256|.../v{V}/adminer-{V}.php`

## Verify

- `bash -n` clean on both files; pin extraction returns `4.8.1`; resolved URLs
  match the originals exactly.
- `scripts/deps-check.sh` now prints `adminer  4.8.1  6.0.1  UPGRADE` and counts
  it under "install.sh pins needing upgrade".
- CI's `check-pinned-downloads.sh` is unaffected (it carries its own URL list).

## Not in this PR

The actual 4.8.1 → 6.0.1 upgrade is a **major-version** jump (Adminer 5/6
restructure + `jabali-sso-plugin.php` compatibility) and needs a box E2E — left
as a separate task. This PR just makes the monthly review surface it from now on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
