### PR TITLE
fix(postgres): grant Adminer's pgadmin table access, not just CONNECT (GH #1406)

### DIFF
--- a/panel-agent/internal/commands/db_postgres_shadowadmin.go
+++ b/panel-agent/internal/commands/db_postgres_shadowadmin.go
@@ -119,6 +119,98 @@ END$$;`,
 	}, nil
 }
 
+// db.postgres.shadowadmin.grant_members — GH #1406.
+//
+// GRANT ... ON DATABASE (what ensure does) only conveys CONNECT/CREATE/TEMP;
+// it does NOT grant access to the tables inside, so Adminer as <user>_pgadmin
+// could see the catalog ("Show structure") but got "permission denied for
+// table" on the data. The tenant's tables are owned by their per-DB db-user
+// roles (<user>_<name>, see database_users.go). Making pgadmin an INHERITing
+// member of those roles gives it their privileges on every object they own —
+// existing and future, in every schema — and, because Postgres ownership
+// checks go through has_privs_of_role, ALTER/DROP work too. That is exactly the
+// admin capability Adminer needs.
+//
+// SECURITY: the member roles are an EXPLICIT list from the panel (the tenant's
+// own postgres database_users), never a name pattern — panel usernames may
+// contain '_', so a LIKE '<user>\_%' would also match a sibling tenant
+// (<user>_x_*) and hand over their data. Every incoming name is
+// pgValidIdent-checked, and the SQL additionally restricts membership to
+// non-superuser LOGIN roles that are not pgadmin itself (defence in depth: a
+// bad/renamed row can never escalate pgadmin into a superuser).
+type dbPostgresGrantMembersParams struct {
+	PanelUsername string   `json:"panel_username"`
+	MemberRoles   []string `json:"member_roles"`
+}
+
+func dbPostgresShadowadminGrantMembersHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dbPostgresGrantMembersParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	if !panelUsernameRegex.MatchString(p.PanelUsername) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "invalid panel username",
+		}
+	}
+	roleName := p.PanelUsername + "_pgadmin"
+
+	pgStr := func(s string) string {
+		return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+	}
+
+	// Filter to valid identifiers that aren't pgadmin itself. Invalid names are
+	// skipped rather than fatal — one odd row must not block Adminer login.
+	quoted := make([]string, 0, len(p.MemberRoles))
+	for _, r := range p.MemberRoles {
+		if r == roleName || !pgValidIdent(r) {
+			continue
+		}
+		quoted = append(quoted, pgStr(r))
+	}
+	if len(quoted) == 0 {
+		// Nothing to grant (no db-users yet) — success, not an error.
+		return dbPgCreateResponse{OK: true}, nil
+	}
+
+	// Restrict the grant to the passed roles AND to non-superuser LOGIN roles
+	// that exist — so membership can never reach a superuser or a role outside
+	// the explicit list. GRANT membership is idempotent (re-grant is a NOTICE,
+	// not an error), so this is safe to run on every Adminer open.
+	sql := fmt.Sprintf(`DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT rolname FROM pg_roles
+    WHERE rolname = ANY(ARRAY[%s]::text[])
+      AND rolname <> %s
+      AND NOT rolsuper
+      AND rolcanlogin
+  LOOP
+    EXECUTE format('GRANT %%I TO %%I', r.rolname, %s);
+  END LOOP;
+END$$;`,
+		strings.Join(quoted, ","),
+		pgStr(roleName),
+		pgStr(roleName),
+	)
+
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
+		"-v", "ON_ERROR_STOP=1", "-XAtq", "-c", sql)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "failed to grant pgadmin membership: " + strings.TrimSpace(string(out)),
+		}
+	}
+	return dbPgCreateResponse{OK: true}, nil
+}
+
 func init() {
 	Default.Register("db.postgres.shadowadmin.ensure", dbPostgresShadowadminEnsureHandler)
+	Default.Register("db.postgres.shadowadmin.grant_members", dbPostgresShadowadminGrantMembersHandler)
 }

--- a/panel-agent/internal/commands/db_postgres_shadowadmin_test.go
+++ b/panel-agent/internal/commands/db_postgres_shadowadmin_test.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// captureSQL swaps the exec seam for one that records every `-c <sql>` argument
+// and runs a harmless `true`, so a handler's psql calls succeed while the test
+// inspects the SQL text. Non-parallel; restored on cleanup.
+func captureSQL(t *testing.T) *[]string {
+	t.Helper()
+	var seen []string
+	prev := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		for i := 0; i < len(args)-1; i++ {
+			if args[i] == "-c" {
+				seen = append(seen, args[i+1])
+			}
+		}
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { execCommandContext = prev })
+	return &seen
+}
+
+func TestShadowadminGrantMembers_InvalidPanelUsername(t *testing.T) {
+	_ = captureSQL(t)
+	_, err := dbPostgresShadowadminGrantMembersHandler(context.Background(),
+		json.RawMessage(`{"panel_username":"Bad Name","member_roles":["x"]}`))
+	if err == nil {
+		t.Fatal("expected invalid_argument for a bad panel username")
+	}
+}
+
+func TestShadowadminGrantMembers_EmptyIsNoop(t *testing.T) {
+	seen := captureSQL(t)
+	_, err := dbPostgresShadowadminGrantMembersHandler(context.Background(),
+		json.RawMessage(`{"panel_username":"alice","member_roles":[]}`))
+	if err != nil {
+		t.Fatalf("empty member list should be a no-op success, got %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("no SQL should run for an empty member list, got %v", *seen)
+	}
+}
+
+func TestShadowadminGrantMembers_GrantsExplicitListWithGuards(t *testing.T) {
+	seen := captureSQL(t)
+	// alice_pgadmin (self) and "bad;name" (invalid ident) must be filtered out;
+	// alice_app and alice_web must be granted.
+	_, err := dbPostgresShadowadminGrantMembersHandler(context.Background(),
+		json.RawMessage(`{"panel_username":"alice","member_roles":["alice_app","alice_pgadmin","bad;name","alice_web"]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected exactly one GRANT statement, got %d: %v", len(*seen), *seen)
+	}
+	sql := (*seen)[0]
+
+	// Explicit allow-list, not a pattern.
+	if !strings.Contains(sql, `'alice_app'`) || !strings.Contains(sql, `'alice_web'`) {
+		t.Fatalf("SQL must reference the passed roles explicitly:\n%s", sql)
+	}
+	if strings.Contains(sql, "LIKE") {
+		t.Fatalf("membership must NOT use a LIKE pattern (cross-tenant risk):\n%s", sql)
+	}
+	// Self and invalid ident filtered out.
+	if strings.Contains(sql, "'bad;name'") {
+		t.Fatalf("invalid identifier leaked into SQL:\n%s", sql)
+	}
+	if strings.Count(sql, "'alice_pgadmin'") != 2 {
+		// appears exactly twice: the `<> 'alice_pgadmin'` guard and the grantee —
+		// never as a membership TARGET in the ARRAY.
+		t.Fatalf("alice_pgadmin should appear only as the guard + grantee, not as a target:\n%s", sql)
+	}
+	// Defence-in-depth guards.
+	for _, want := range []string{"NOT rolsuper", "rolcanlogin", "<> 'alice_pgadmin'", "GRANT %I TO %I"} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("SQL missing guard %q:\n%s", want, sql)
+		}
+	}
+}

--- a/panel-api/internal/sso/adminer.go
+++ b/panel-api/internal/sso/adminer.go
@@ -64,7 +64,7 @@ func (s *AdminerService) EnsurePgShadow(ctx context.Context, userID string) erro
 		return errors.New("user has no username")
 	}
 
-	return s.base.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := s.base.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var current models.User
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			First(&current, "id = ?", userID).Error; err != nil {
@@ -110,7 +110,47 @@ func (s *AdminerService) EnsurePgShadow(ctx context.Context, userID string) erro
 		return tx.Model(&models.User{}).
 			Where("id = ?", userID).
 			Updates(updates).Error
-	})
+	}); err != nil {
+		return err
+	}
+
+	// GH #1406: keep pgadmin's role membership in sync on every Adminer open.
+	// The one-time provisioning above only mints the role + database CONNECT
+	// grant; without membership in the tenant's db-user roles, Adminer can see
+	// the schema but not the table data. Running this every open (not just at
+	// first provision) means existing accounts self-heal and db-users created
+	// after the first open are picked up. Non-fatal — a failure here must not
+	// block the Adminer session.
+	s.syncPgShadowMembers(ctx, userID, *user.Username)
+	return nil
+}
+
+// syncPgShadowMembers grants <user>_pgadmin membership in the tenant's own
+// postgres db-user roles so it inherits their table privileges (GH #1406). The
+// role list is read from the control-plane DB (the source of truth) and passed
+// EXPLICITLY to the agent — never derived from a name pattern, since panel
+// usernames may contain '_' and a pattern could match a sibling tenant.
+func (s *AdminerService) syncPgShadowMembers(ctx context.Context, userID, panelUsername string) {
+	var rows []models.DatabaseUser
+	if err := s.base.db.WithContext(ctx).
+		Where("user_id = ? AND engine = ?", userID, "postgres").
+		Find(&rows).Error; err != nil {
+		s.base.log.WarnContext(ctx, "pg shadow: list db-users failed",
+			"err", err, "user_id", userID)
+		return
+	}
+	roles := make([]string, 0, len(rows))
+	for _, du := range rows {
+		roles = append(roles, du.Username)
+	}
+	if len(roles) == 0 {
+		return // no db-users yet — nothing to grant
+	}
+	if _, err := s.base.agent.Call(ctx, "db.postgres.shadowadmin.grant_members",
+		map[string]interface{}{"panel_username": panelUsername, "member_roles": roles}); err != nil {
+		s.base.log.WarnContext(ctx, "pg shadow: grant_members failed",
+			"err", err, "user_id", userID)
+	}
 }
 
 // MintAdminerToken issues a fresh single-use token bound to the

--- a/panel-api/internal/sso/adminer_members_test.go
+++ b/panel-api/internal/sso/adminer_members_test.go
@@ -1,0 +1,130 @@
+package sso
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	mysqldriver "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newMembersMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+	db, err := gorm.Open(mysqldriver.New(mysqldriver.Config{Conn: raw}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db, mock, raw
+}
+
+// capturingAgent records the last agent Call so a test can assert the exact
+// member_roles list handed to the agent.
+type capturingAgent struct {
+	calls       int
+	lastCommand string
+	lastParams  any
+}
+
+func (c *capturingAgent) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	c.calls++
+	c.lastCommand = command
+	c.lastParams = params
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+func duRows(rows ...[3]string) *sqlmock.Rows {
+	// columns: id, user_id, username, engine, password_hash, created_at, updated_at
+	r := sqlmock.NewRows([]string{"id", "user_id", "username", "engine", "password_hash", "created_at", "updated_at"})
+	now := time.Now()
+	for _, row := range rows {
+		// row = {id, username, engine}
+		r.AddRow(row[0], "user1", row[1], row[2], "x", now, now)
+	}
+	return r
+}
+
+// GH #1406 — the membership sync must hand the agent EXACTLY the caller's own
+// postgres db-user roles: no mariadb roles, nothing from another user, and the
+// list must be explicit (the SQL query itself is filtered by user_id + engine).
+func TestSyncPgShadowMembers_PassesOnlyOwnPostgresRoles(t *testing.T) {
+	db, mock, raw := newMembersMockDB(t)
+	defer raw.Close()
+
+	// The handler filters by user_id + engine='postgres' in the query, so the
+	// mock returns only the two postgres rows for user1.
+	mock.ExpectQuery("SELECT .* FROM `database_users` WHERE user_id = \\? AND engine = \\?").
+		WithArgs("user1", "postgres").
+		WillReturnRows(duRows(
+			[3]string{"du1", "alice_app", "postgres"},
+			[3]string{"du2", "alice_web", "postgres"},
+		))
+
+	key := generateTestKey(t)
+	agent := &capturingAgent{}
+	base := NewService(db, &mockUsersForSSO{}, &mockTokensForSSO{}, agent, &key, slog.Default())
+	svc := NewAdminerService(base, nil)
+
+	svc.syncPgShadowMembers(context.Background(), "user1", "alice")
+
+	if agent.calls != 1 {
+		t.Fatalf("agent should be called once, got %d", agent.calls)
+	}
+	if agent.lastCommand != "db.postgres.shadowadmin.grant_members" {
+		t.Fatalf("command = %q", agent.lastCommand)
+	}
+	params, ok := agent.lastParams.(map[string]interface{})
+	if !ok {
+		t.Fatalf("params type = %T", agent.lastParams)
+	}
+	if params["panel_username"] != "alice" {
+		t.Fatalf("panel_username = %v", params["panel_username"])
+	}
+	roles, ok := params["member_roles"].([]string)
+	if !ok {
+		t.Fatalf("member_roles type = %T", params["member_roles"])
+	}
+	if len(roles) != 2 || roles[0] != "alice_app" || roles[1] != "alice_web" {
+		t.Fatalf("member_roles = %v, want [alice_app alice_web]", roles)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// No postgres db-users → the agent is never called (nothing to grant).
+func TestSyncPgShadowMembers_NoRolesSkipsAgent(t *testing.T) {
+	db, mock, raw := newMembersMockDB(t)
+	defer raw.Close()
+
+	mock.ExpectQuery("SELECT .* FROM `database_users` WHERE user_id = \\? AND engine = \\?").
+		WithArgs("user1", "postgres").
+		WillReturnRows(duRows()) // empty
+
+	key := generateTestKey(t)
+	agent := &capturingAgent{}
+	base := NewService(db, &mockUsersForSSO{}, &mockTokensForSSO{}, agent, &key, slog.Default())
+	svc := NewAdminerService(base, nil)
+
+	svc.syncPgShadowMembers(context.Background(), "user1", "alice")
+
+	if agent.calls != 0 {
+		t.Fatalf("agent must not be called when there are no postgres db-users, got %d", agent.calls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## The bug

Opening a PostgreSQL database in Adminer (connected as `<user>_pgadmin`) showed the
catalog — tables list, **Show structure** — but reading the data failed with:

```
ERROR: permission denied for table <name>
```

## Root cause

The shadow role was only ever given `GRANT ALL PRIVILEGES ON DATABASE`. In Postgres
that conveys **CONNECT / CREATE / TEMP** and nothing else — it grants no privilege on
the tables *inside* the database. The system catalog is world-readable (so structure
shows), but the tenant's tables are owned by their per-DB **db-user** roles
(`<user>_<name>`, `database_users.go`), and `pgadmin` had no grant on them.

(As a secondary point, `GRANT ... ON ALL TABLES IN SCHEMA` only affects the
*currently-connected* database, so the old maintenance-DB grant loop couldn't have
fixed this even if it tried table grants.)

## Fix

Make `pgadmin` an **INHERITing member** of the tenant's db-user roles. A member
inherits the owning role's privileges on every object it owns — existing and future,
across all schemas — and, because Postgres ownership checks resolve through
`has_privs_of_role`, `ALTER`/`DROP` work too. That's exactly the admin capability
Adminer needs, and it's ownership-based so it also covers tables that already existed.

- **agent** — new verb `db.postgres.shadowadmin.grant_members`. Grants membership only
  to the **explicit** roles passed in, and only to **non-superuser LOGIN** roles that
  aren't `pgadmin` itself, so a bad/renamed row can never escalate `pgadmin` into a
  superuser. Idempotent (re-grant is a NOTICE, not an error).
- **panel** — `EnsurePgShadow` now syncs membership on **every** Adminer open, not just
  at first provision, driven by the tenant's `postgres` `database_users` rows from the
  control-plane DB. Running every open means existing accounts self-heal and db-users
  created after the first open are picked up. Non-fatal.

## Security

The member-role list is always the tenant's own db-users, **scoped by `user_id`** in the
panel query and passed **explicitly** — never a `LIKE '<user>\_%'` pattern. Panel
usernames may contain `_` (`^[a-z][a-z0-9_]{0,31}$`), so a pattern would also match a
sibling tenant (`<user>_x_*`) and hand over their data. The agent keeps
`NOT rolsuper` / `rolcanlogin` / `<> pgadmin` as defence-in-depth on whatever arrives.

## Tests

- agent (`db_postgres_shadowadmin_test.go`) — invalid panel username rejected; empty list
  is a no-op (no SQL); the grant uses the explicit list (no `LIKE`), filters out an
  invalid ident and `pgadmin` itself, and carries the `NOT rolsuper` / `rolcanlogin`
  guards. `-race` clean.
- panel (`adminer_members_test.go`) — the sync hands the agent exactly the caller's own
  `postgres` db-user roles (not mariadb, not another user's); no db-users → agent not called.

## Box drill (Postgres 16, test box, restored after)

Reproduced `permission denied for table t` as `pgadmin`; applied the fix over the agent
socket; confirmed **SELECT and ALTER** then succeed; confirmed that passing `postgres`
in the member list does **not** make `pgadmin` a superuser.

## Observation (not fixed here)

`db.postgres.grant` (adding a *second* db-user to a database, `database_users.go`) has the
same shape — `GRANT ON DATABASE` only — so that second user also gets CONNECT but can't
read tables owned by the first. Flagging for a follow-up rather than expanding scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
