### PR TITLE
fix(migrate/imap): surface why an IMAP probe failed (GH #1429)

### DIFF
--- a/panel-api/internal/api/admin_migrations_imap.go
+++ b/panel-api/internal/api/admin_migrations_imap.go
@@ -20,7 +20,7 @@ package api
 
 import (
 	"context"
-	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -79,11 +79,18 @@ func (h *adminMigrationsHandler) probeIMAP(c *gin.Context) {
 
 	res, err := imapProbeFn(ctx, req.probeConfig())
 	if err != nil {
-		if errors.Is(err, imap.ErrAuth) {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "auth_failed", "detail": "the remote server rejected the credentials"})
-			return
+		code, hint := imap.Classify(err)
+		// GH #1429: log the REAL error server-side (never the password) so the
+		// operator can actually diagnose a failed probe. The client only ever
+		// sees the safe hint + code — the remote banner is never echoed.
+		slog.WarnContext(ctx, "imap migration probe failed",
+			"host", req.Host, "port", req.Port, "starttls", req.STARTTLS,
+			"user", req.User, "code", code, "err", err)
+		status := http.StatusBadGateway
+		if code == "auth_failed" {
+			status = http.StatusUnauthorized
 		}
-		c.JSON(http.StatusBadGateway, gin.H{"error": "probe_failed", "detail": "could not enumerate the remote account"})
+		c.JSON(status, gin.H{"error": code, "detail": hint})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"folders": res.Folders, "total": len(res.Folders)})

--- a/panel-api/internal/api/admin_migrations_imap_test.go
+++ b/panel-api/internal/api/admin_migrations_imap_test.go
@@ -160,6 +160,31 @@ func TestProbeIMAPAuthFailed(t *testing.T) {
 	}
 }
 
+// GH #1429: a connect failure is classified into an actionable, SAFE hint and a
+// stable code — and the raw error / remote address never reaches the client.
+func TestProbeIMAPClassifiesConnectError(t *testing.T) {
+	orig := imapProbeFn
+	defer func() { imapProbeFn = orig }()
+	imapProbeFn = func(_ context.Context, _ imap.ProbeConfig) (*imap.ProbeResult, error) {
+		return nil, errors.New("imap: connect h:143: ssrf: 10.0.0.5 private range rejected")
+	}
+	h, _ := newIMAPHandler(fakeIMAPAgent{})
+	w := postJSON(h.probeIMAP, `{"host":"h","user":"u","password":"pw"}`)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("code = %d, want 502; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "blocked_host") {
+		t.Errorf("want error code blocked_host: %s", body)
+	}
+	if !strings.Contains(body, "Allow private/LAN host") {
+		t.Errorf("want an actionable hint: %s", body)
+	}
+	if strings.Contains(body, "ssrf:") || strings.Contains(body, "10.0.0.5") {
+		t.Errorf("response leaks raw error text: %s", body)
+	}
+}
+
 func TestProbeIMAPValidation(t *testing.T) {
 	h, _ := newIMAPHandler(fakeIMAPAgent{})
 	w := postJSON(h.probeIMAP, `{"host":"h"}`) // missing user + password

--- a/panel-api/internal/migrate/imap/classify.go
+++ b/panel-api/internal/migrate/imap/classify.go
@@ -1,0 +1,71 @@
+package imap
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// Classify maps a probe/connect error to a stable machine code and a SAFE,
+// operator-facing hint (GH #1429). The hint is one of OUR fixed strings keyed on
+// the failure kind — it never contains the remote server's banner or the raw
+// error text — so it is safe to return to a client, while the caller logs the
+// real error server-side for diagnosis.
+//
+// The previous behaviour returned a single "could not enumerate the remote
+// account" for every non-auth failure and logged nothing, so an operator whose
+// probe failed (wrong port, STARTTLS mismatch, DNS typo, private host blocked by
+// the SSRF guard, timeout, bad cert) had no way to tell which.
+func Classify(err error) (code, hint string) {
+	if err == nil {
+		return "", ""
+	}
+	if errors.Is(err, ErrAuth) {
+		return "auth_failed", "The remote server rejected the credentials. Check the username (usually the full email address) and the password — many providers require an app-specific password rather than the account password."
+	}
+
+	// DNS resolution failure. This MUST be checked before the "ssrf:" string
+	// match below: the SSRF guard resolves the hostname itself and wraps a
+	// lookup failure as `ssrf: resolve <host>: ...`, but the %w chain preserves
+	// the *net.DNSError — so a hostname typo is a DNS problem, not a blocked
+	// private host, and telling the operator to "enable Allow private hosts"
+	// would be actively wrong.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "dns", "Could not resolve the mail host name. Check the hostname for typos."
+	}
+
+	// SSRF guard: migrate.DialTCP wraps private/loopback/rebinding rejections
+	// with an "ssrf:" prefix. This is a very common cause when migrating from a
+	// server on the local network with "Allow private hosts" left off.
+	if strings.Contains(err.Error(), "ssrf:") {
+		return "blocked_host", "The mail host resolved to a private or disallowed network address. If the server is on your internal network, enable “Allow private/LAN host” in the advanced options."
+	}
+
+	// Timeout — context deadline or a net timeout.
+	var netErr net.Error
+	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
+		return "timeout", "The connection to the mail host timed out. Check the host and port, and that the server is reachable and not blocked by a firewall."
+	}
+
+	// Connection refused / reset — usually the wrong port or TLS mode.
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) {
+		return "refused", "The mail host refused the connection on that port. Check the port and whether the server uses implicit TLS (993) or STARTTLS (143)."
+	}
+
+	// TLS / certificate — often implicit-TLS vs STARTTLS confusion.
+	var certErr x509.CertificateInvalidError
+	var caErr x509.UnknownAuthorityError
+	var hostErr x509.HostnameError
+	if errors.As(err, &certErr) || errors.As(err, &caErr) || errors.As(err, &hostErr) ||
+		strings.Contains(err.Error(), "tls handshake") ||
+		strings.Contains(err.Error(), "starttls") ||
+		strings.Contains(err.Error(), "certificate") {
+		return "tls", "The secure connection could not be established. Check whether the server uses implicit TLS (port 993) or STARTTLS (port 143), and that its certificate is valid."
+	}
+
+	return "connect_failed", "Could not connect to the mail host. Check the host, port, and whether the server uses implicit TLS (993) or STARTTLS (143)."
+}

--- a/panel-api/internal/migrate/imap/classify_test.go
+++ b/panel-api/internal/migrate/imap/classify_test.go
@@ -1,0 +1,59 @@
+package imap
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{"nil", nil, ""},
+		{"auth", fmt.Errorf("%w: remote said NO [AUTHENTICATIONFAILED]", ErrAuth), "auth_failed"},
+		{"ssrf", fmt.Errorf("imap: connect h:143: ssrf: 192.168.1.10 private range rejected"), "blocked_host"},
+		{"dns", fmt.Errorf("imap: connect h:993: %w", &net.DNSError{Err: "no such host", Name: "nope.example", IsNotFound: true}), "dns"},
+		// Real shape: the SSRF guard resolves the host itself and wraps a lookup
+		// failure with an "ssrf:" prefix — must still classify as DNS, not
+		// blocked_host (the %w chain preserves the *net.DNSError).
+		{"dns-via-ssrf", fmt.Errorf("imap: connect h:993: %w",
+			fmt.Errorf("ssrf: resolve nope.example: %w", &net.DNSError{Err: "no such host", Name: "nope.example", IsNotFound: true})), "dns"},
+		{"ctx-timeout", fmt.Errorf("imap: connect h:993: %w", context.DeadlineExceeded), "timeout"},
+		{"net-timeout", &net.OpError{Op: "dial", Err: os.ErrDeadlineExceeded}, "timeout"},
+		{"refused", fmt.Errorf("imap: connect h:993: dial tcp: %w", syscall.ECONNREFUSED), "refused"},
+		{"tls-type", fmt.Errorf("imap: tls handshake h: %w", x509.UnknownAuthorityError{}), "tls"},
+		{"tls-string", errors.New("imap: tls handshake h: remote error: tls: handshake failure"), "tls"},
+		{"generic", errors.New("imap: something unexpected"), "connect_failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, hint := Classify(tc.err)
+			if code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", code, tc.wantCode)
+			}
+			if tc.err == nil {
+				if hint != "" {
+					t.Fatalf("nil error must yield empty hint, got %q", hint)
+				}
+				return
+			}
+			if hint == "" {
+				t.Fatalf("non-nil error must yield a hint")
+			}
+			// The hint must never echo the raw error / remote banner.
+			if strings.Contains(hint, "imap:") || strings.Contains(hint, "ssrf:") ||
+				strings.Contains(hint, "AUTHENTICATIONFAILED") || strings.Contains(hint, "192.168") {
+				t.Fatalf("hint leaks raw error text: %q", hint)
+			}
+		})
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.tsx
@@ -75,8 +75,14 @@ export function MigrateImapDrawer({ open, onClose }: Props) {
       setFolders(f);
       feedback.message.success(`Found ${f.length} folder(s) on the remote account`);
     },
-    onError: (err: AxiosError<{ error?: string }>) => {
-      if (err.response?.status === 401) {
+    onError: (err: AxiosError<{ error?: string; detail?: string }>) => {
+      // GH #1429: the API now returns a safe, actionable hint (wrong port /
+      // STARTTLS mismatch / DNS / private host blocked / timeout / bad cert /
+      // auth) in `detail`. Prefer it; fall back to the old generic strings.
+      const hint = err.response?.data?.detail;
+      if (hint) {
+        feedback.message.error(hint);
+      } else if (err.response?.status === 401) {
         feedback.message.error("The remote server rejected the credentials — check the app-password.");
       } else {
         feedback.message.error("Could not connect to the remote IMAP account.");


### PR DESCRIPTION
## The problem (GH #1429)

Previewing folders for an IMAP migration failed with a flat toast — *"Could not
connect to the remote IMAP account"* — and, as the reporter noted, the server
logs carried nothing to point at the cause. The probe couldn't be diagnosed: a
wrong port, a STARTTLS mismatch, a DNS typo, a private/LAN host blocked by the
SSRF guard, a timeout, or a bad certificate all looked identical.

## Cause

`imap.Probe` already returns rich errors (connect / starttls / tls handshake /
auth / list), but the `probeIMAP` handler discarded `err` entirely: it logged
nothing and returned one fixed `detail` for every non-auth failure.

## Fix

- **`imap.Classify(err)`** — maps a probe error to a stable code and a **safe**,
  operator-facing hint: `auth_failed`, `dns`, `blocked_host`, `timeout`,
  `refused`, `tls`, `connect_failed`. The hint is one of our fixed strings keyed
  on the failure kind — it never echoes the remote banner or the raw error.
- **handler** — logs the **real** error server-side (`host`/`port`/`starttls`/
  `user` + `err`, never the password) via `slog`, and returns the classified
  code + hint (401 for auth, 502 otherwise).
- **UI** — the migrate drawer shows the returned hint instead of the flat string.

### A subtle ordering point

DNS is classified **before** the `ssrf:` string match. The SSRF guard resolves
the hostname itself and wraps a lookup failure as `ssrf: resolve <host>: ...`,
but the `%w` chain preserves the `*net.DNSError` — so a hostname typo is reported
as **DNS**, not as a blocked private host (which would be actively wrong advice).

## Tests / verification

- `classify_test.go` — every branch, including the real `dns-via-ssrf` shape, and
  an assertion that no hint leaks the raw error / remote address.
- `admin_migrations_imap_test.go` — a connect error returns `blocked_host` + the
  actionable hint with a 502, and the body never contains `ssrf:` or the IP.
- Existing probe/run tests + the `MigrateImapDrawer` UI tests still pass.
- Ran the **real** `connect → DialTCP → resolver` chain once locally (throwaway,
  not committed): a nonexistent host produces `ssrf: resolve <h>: … no such host`
  and classifies as `dns`; loopback classifies as `blocked_host`.

## Note for the reporter

This doesn't diagnose their specific failure — it makes the next attempt
diagnosable. After updating: retry the preview; the new on-screen hint should
name the cause, and the `imap migration probe failed` log line now carries the
real error to paste back if it's still unclear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
