### PR TITLE
feat(notifications): per-account ignore list for SSH-login notifications

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4957,6 +4957,18 @@ paths:
       parameters: [ { in: path, name: kind, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /admin/settings/ssh-login-ignore:
+    get:
+      tags: [Settings]
+      summary: List SSH-login ignored accounts
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Settings]
+      summary: Set SSH-login ignored accounts
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /admin/settings/page-templates:
     get:
       tags: [Settings]

--- a/panel-api/internal/api/ssh_login_ignore.go
+++ b/panel-api/internal/api/ssh_login_ignore.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"regexp"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// SSH-login notification ignore list (GH #1310-adjacent, "drfeed spam"). The
+// admin manages a set of SSH usernames whose successful logins never notify —
+// so a DR feed's SSH pull loop, or any noisy service account, can be silenced
+// without disabling ssh.login for everyone. Surfaced under Notifications →
+// Events → SSH login. The list is persisted on server_settings and read by the
+// ssh.login eventsource.
+
+// sshIgnoreUsernameRe bounds a stored username: no delimiters (comma / newline /
+// whitespace) that would corrupt the stored form, and no surprises.
+var sshIgnoreUsernameRe = regexp.MustCompile(`^[A-Za-z0-9._-]{1,64}$`)
+
+const maxSSHIgnoreAccounts = 200
+
+// SSHLoginIgnoreHandlerConfig wires the handler.
+type SSHLoginIgnoreHandlerConfig struct {
+	Settings repository.ServerSettingsRepository
+	Log      *slog.Logger
+}
+
+// RegisterSSHLoginIgnoreRoutes mounts:
+//
+//	GET /admin/settings/ssh-login-ignore
+//	PUT /admin/settings/ssh-login-ignore
+func RegisterSSHLoginIgnoreRoutes(g *gin.RouterGroup, cfg SSHLoginIgnoreHandlerConfig) {
+	if cfg.Settings == nil {
+		return
+	}
+	if cfg.Log == nil {
+		cfg.Log = slog.Default()
+	}
+	h := &sshLoginIgnoreHandler{cfg: cfg}
+	grp := g.Group("/admin/settings/ssh-login-ignore")
+	grp.Use(middleware.RequireAdmin())
+	grp.GET("", h.get)
+	grp.PUT("", h.put)
+}
+
+type sshLoginIgnoreHandler struct {
+	cfg SSHLoginIgnoreHandlerConfig
+}
+
+type sshLoginIgnoreDTO struct {
+	Accounts []string `json:"accounts"`
+}
+
+func (h *sshLoginIgnoreHandler) get(c *gin.Context) {
+	s, err := h.cfg.Settings.Get(c.Request.Context())
+	if err != nil || s == nil {
+		h.cfg.Log.Error("ssh-login-ignore get: settings load failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, sshLoginIgnoreDTO{
+		Accounts: models.ParseSSHIgnoreAccounts(s.SSHLoginIgnoreAccounts),
+	})
+}
+
+func (h *sshLoginIgnoreHandler) put(c *gin.Context) {
+	var req sshLoginIgnoreDTO
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
+		return
+	}
+	if len(req.Accounts) > maxSSHIgnoreAccounts {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "too_many", "detail": "too many ignored accounts"})
+		return
+	}
+	for _, a := range req.Accounts {
+		if !sshIgnoreUsernameRe.MatchString(a) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_username", "detail": "invalid username: " + a})
+			return
+		}
+	}
+
+	s, err := h.cfg.Settings.Get(c.Request.Context())
+	if err != nil || s == nil {
+		h.cfg.Log.Error("ssh-login-ignore put: settings load failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	// Normalise (trim/dedupe/sort) before persisting.
+	s.SSHLoginIgnoreAccounts = models.JoinSSHIgnoreAccounts(req.Accounts)
+	if err := h.cfg.Settings.Upsert(c.Request.Context(), s); err != nil {
+		h.cfg.Log.Error("ssh-login-ignore put: settings upsert failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, sshLoginIgnoreDTO{
+		Accounts: models.ParseSSHIgnoreAccounts(s.SSHLoginIgnoreAccounts),
+	})
+}

--- a/panel-api/internal/api/ssh_login_ignore_test.go
+++ b/panel-api/internal/api/ssh_login_ignore_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Reuses fakeSettingsRepo from dns_test.go (its Upsert stores into .s).
+func newSSHIgnoreRouter(t *testing.T, repo *fakeSettingsRepo) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "admin", IsAdmin: true})
+		c.Next()
+	})
+	RegisterSSHLoginIgnoreRoutes(v1, SSHLoginIgnoreHandlerConfig{Settings: repo})
+	return r
+}
+
+func TestSSHLoginIgnore_Get(t *testing.T) {
+	repo := &fakeSettingsRepo{s: &models.ServerSettings{SSHLoginIgnoreAccounts: "drfeed\nbackup"}}
+	r := newSSHIgnoreRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/admin/settings/ssh-login-ignore", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Accounts []string `json:"accounts"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Accounts) != 2 || resp.Accounts[0] != "backup" || resp.Accounts[1] != "drfeed" {
+		t.Fatalf("accounts = %v, want [backup drfeed]", resp.Accounts)
+	}
+}
+
+func TestSSHLoginIgnore_PutPersistsNormalised(t *testing.T) {
+	repo := &fakeSettingsRepo{s: &models.ServerSettings{}}
+	r := newSSHIgnoreRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v1/admin/settings/ssh-login-ignore",
+		strings.NewReader(`{"accounts":["zeta","alpha","alpha"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d; body=%s", w.Code, w.Body.String())
+	}
+	// stored form is normalised (dedup + sort + newline-joined)
+	if repo.s.SSHLoginIgnoreAccounts != "alpha\nzeta" {
+		t.Fatalf("stored = %q, want %q", repo.s.SSHLoginIgnoreAccounts, "alpha\nzeta")
+	}
+}
+
+func TestSSHLoginIgnore_PutRejectsBadUsername(t *testing.T) {
+	repo := &fakeSettingsRepo{s: &models.ServerSettings{}}
+	r := newSSHIgnoreRouter(t, repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v1/admin/settings/ssh-login-ignore",
+		strings.NewReader(`{"accounts":["ok","bad name,with-comma"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("code = %d, want 422; body=%s", w.Code, w.Body.String())
+	}
+	// nothing persisted → the seeded empty value is unchanged
+	if repo.s.SSHLoginIgnoreAccounts != "" {
+		t.Fatalf("must not persist on invalid input, got %q", repo.s.SSHLoginIgnoreAccounts)
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1019,6 +1019,13 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Log:  deps.Log,
 			})
 		}
+		// GH #1310-adjacent ("drfeed spam"): per-account ssh.login ignore list.
+		if deps.ServerSettings != nil {
+			api.RegisterSSHLoginIgnoreRoutes(v1, api.SSHLoginIgnoreHandlerConfig{
+				Settings: deps.ServerSettings,
+				Log:      deps.Log,
+			})
+		}
 		// M6.4 Settings → Email: read-only panel-primary domain card.
 		if deps.Domains != nil {
 			api.RegisterSettingsEmailRoutes(v1, api.SettingsEmailHandlerConfig{

--- a/panel-api/internal/db/migrations/000285_ssh_login_ignore_accounts.down.sql
+++ b/panel-api/internal/db/migrations/000285_ssh_login_ignore_accounts.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN ssh_login_ignore_accounts;

--- a/panel-api/internal/db/migrations/000285_ssh_login_ignore_accounts.up.sql
+++ b/panel-api/internal/db/migrations/000285_ssh_login_ignore_accounts.up.sql
@@ -1,0 +1,8 @@
+-- GH #1310-adjacent ("drfeed spam"): a per-account ignore list for ssh.login
+-- notifications. A noisy service account — e.g. a disaster-recovery feed whose
+-- rsync/backup loop logs in over SSH every cycle — can be silenced without
+-- disabling ssh.login for everyone else. Stored as a newline/comma-separated
+-- list of usernames. TEXT (not VARCHAR) so it lives off-page: the
+-- server_settings row is already near the MariaDB row-size ceiling.
+ALTER TABLE server_settings
+  ADD COLUMN ssh_login_ignore_accounts TEXT NOT NULL DEFAULT ('');

--- a/panel-api/internal/eventsources/ssh_login.go
+++ b/panel-api/internal/eventsources/ssh_login.go
@@ -42,6 +42,10 @@ func runSSHLogin(ctx context.Context, d Deps) {
 	// login bursts collapse into counted summaries instead of one notification
 	// per login (the "drfeed spam"). A ticker flushes quiet/rolling summaries.
 	gr := newSSHLoginGrouper(d.Now)
+	// GH #1310-adjacent: per-account ignore list (the "drfeed spam" — a DR feed's
+	// SSH pull loop). Ignored accounts are dropped before the grouper, so they
+	// produce neither an immediate notification nor a digest.
+	ig := newSSHIgnoreCache(d.ServerSettings, d.Now)
 	go func() {
 		t := time.NewTicker(sshFlushInterval)
 		defer t.Stop()
@@ -70,7 +74,7 @@ func runSSHLogin(ctx context.Context, d Deps) {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := tailSSHJournal(ctx, d, gr); err != nil && ctx.Err() == nil {
+		if err := tailSSHJournal(ctx, d, gr, ig); err != nil && ctx.Err() == nil {
 			// SIGTERM to the journalctl child races our ctx propagation
 			// at shutdown — the child returns "signal: terminated" before
 			// our ctx.Done() fires. Treat that as graceful and exit silently
@@ -100,7 +104,7 @@ func runSSHLogin(ctx context.Context, d Deps) {
 // tailSSHJournal runs journalctl in JSON-follow mode until ctx is
 // cancelled or the process exits. Each Accepted line is parsed and
 // published as ssh.login.
-func tailSSHJournal(ctx context.Context, d Deps, gr *sshLoginGrouper) error {
+func tailSSHJournal(ctx context.Context, d Deps, gr *sshLoginGrouper, ig *sshIgnoreCache) error {
 	cmd := exec.CommandContext(ctx,
 		"journalctl",
 		// Match the systemd unit rather than the syslog identifier:
@@ -133,7 +137,7 @@ func tailSSHJournal(ctx context.Context, d Deps, gr *sshLoginGrouper) error {
 		if err := json.Unmarshal(sc.Bytes(), &entry); err != nil {
 			continue
 		}
-		processSSHJournalEntry(ctx, d, gr, entry)
+		processSSHJournalEntry(ctx, d, gr, ig, entry)
 	}
 	// Wait so we collect the exit error if the scanner ended on a
 	// process death rather than ctx cancellation.
@@ -161,7 +165,7 @@ type journalEntry struct {
 // worker (`_COMM=sshd-session`) rather than the listener; older Debians
 // still use `sshd`. Accept both, plus any sshd-* prefix to cover the
 // privsep variants without listing every name explicitly.
-func processSSHJournalEntry(ctx context.Context, d Deps, gr *sshLoginGrouper, entry journalEntry) {
+func processSSHJournalEntry(ctx context.Context, d Deps, gr *sshLoginGrouper, ig *sshIgnoreCache, entry journalEntry) {
 	if entry.Comm != "sshd" && !strings.HasPrefix(entry.Comm, "sshd-") {
 		return
 	}
@@ -170,6 +174,11 @@ func processSSHJournalEntry(ctx context.Context, d Deps, gr *sshLoginGrouper, en
 	}
 	user, ip, method := parseAcceptedLine(entry.Message)
 	if user == "" {
+		return
+	}
+	// GH #1310-adjacent: drop logins by an ignored account (e.g. a DR feed's SSH
+	// pull loop) before they reach the grouper — no immediate, no digest.
+	if ig.ignored(ctx, user) {
 		return
 	}
 	// Smart grouping: a new (user, IP, method) fires immediately; repeats within

--- a/panel-api/internal/eventsources/ssh_login_ignore.go
+++ b/panel-api/internal/eventsources/ssh_login_ignore.go
@@ -1,0 +1,58 @@
+package eventsources
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// sshIgnoreCache resolves the per-account ssh.login ignore list (GH #1310-
+// adjacent, "drfeed spam") with a short TTL so the hot journal-tail path does
+// not hit the DB on every login line. A noisy service account (a DR feed's SSH
+// pull loop) listed here has its logins dropped before they reach the grouper —
+// no immediate notification and no rolling digest.
+//
+// Fail-OPEN: if the settings read fails and no prior set is cached, nothing is
+// ignored (we would rather over-notify than silently swallow a security signal).
+type sshIgnoreCache struct {
+	ss  repository.ServerSettingsRepository
+	now Clock
+
+	mu     sync.Mutex
+	set    map[string]struct{}
+	loaded time.Time
+}
+
+const sshIgnoreTTL = 30 * time.Second
+
+func newSSHIgnoreCache(ss repository.ServerSettingsRepository, now Clock) *sshIgnoreCache {
+	if now == nil {
+		now = time.Now
+	}
+	return &sshIgnoreCache{ss: ss, now: now}
+}
+
+// ignored reports whether logins by user should be suppressed. A nil cache or
+// nil repo (settings unwired) never ignores anyone.
+func (c *sshIgnoreCache) ignored(ctx context.Context, user string) bool {
+	if c == nil || c.ss == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.set == nil || c.now().Sub(c.loaded) > sshIgnoreTTL {
+		s, err := c.ss.Get(ctx)
+		if err == nil && s != nil {
+			c.set = models.SSHIgnoreSet(s.SSHLoginIgnoreAccounts)
+		} else if c.set == nil {
+			c.set = map[string]struct{}{} // fail-open until a good read lands
+		}
+		c.loaded = c.now()
+	}
+	_, ok := c.set[user]
+	return ok
+}

--- a/panel-api/internal/eventsources/ssh_login_ignore_test.go
+++ b/panel-api/internal/eventsources/ssh_login_ignore_test.go
@@ -1,0 +1,117 @@
+package eventsources
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeSettings implements just Get; the embedded nil interface supplies the rest
+// (never called here).
+type fakeSettings struct {
+	repository.ServerSettingsRepository
+	list string
+	err  error
+	gets int
+}
+
+func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) {
+	f.gets++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &models.ServerSettings{SSHLoginIgnoreAccounts: f.list}, nil
+}
+
+func TestSSHIgnoreCache_MatchesExplicitList(t *testing.T) {
+	ss := &fakeSettings{list: "drfeed\nbackup-sync, other"}
+	c := newSSHIgnoreCache(ss, time.Now)
+	ctx := context.Background()
+
+	if !c.ignored(ctx, "drfeed") {
+		t.Error("drfeed should be ignored")
+	}
+	if !c.ignored(ctx, "backup-sync") {
+		t.Error("backup-sync should be ignored")
+	}
+	if c.ignored(ctx, "alice") {
+		t.Error("alice must NOT be ignored")
+	}
+}
+
+func TestSSHIgnoreCache_NilNeverIgnores(t *testing.T) {
+	var c *sshIgnoreCache
+	if c.ignored(context.Background(), "drfeed") {
+		t.Error("nil cache must not ignore")
+	}
+	c2 := newSSHIgnoreCache(nil, time.Now) // settings unwired
+	if c2.ignored(context.Background(), "drfeed") {
+		t.Error("nil settings must not ignore")
+	}
+}
+
+func TestSSHIgnoreCache_TTLAndFailOpen(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	clock := func() time.Time { return now }
+	ss := &fakeSettings{list: "drfeed"}
+	c := newSSHIgnoreCache(ss, clock)
+	ctx := context.Background()
+
+	if !c.ignored(ctx, "drfeed") {
+		t.Fatal("drfeed ignored on first load")
+	}
+	gets := ss.gets
+
+	// Within TTL: list change is NOT observed and Get is not called again.
+	ss.list = ""
+	if !c.ignored(ctx, "drfeed") {
+		t.Error("within TTL the cached set should still ignore drfeed")
+	}
+	if ss.gets != gets {
+		t.Errorf("Get should not be called within TTL (was %d, now %d)", gets, ss.gets)
+	}
+
+	// Past TTL: reloads and picks up the empty list.
+	now = now.Add(sshIgnoreTTL + time.Second)
+	if c.ignored(ctx, "drfeed") {
+		t.Error("past TTL the emptied list should no longer ignore drfeed")
+	}
+
+	// Fail-open: a settings error with no prior good set ignores no one.
+	now = now.Add(sshIgnoreTTL + time.Second)
+	ss.err = context.DeadlineExceeded
+	if c.ignored(ctx, "drfeed") {
+		t.Error("on settings error, must fail open (ignore no one)")
+	}
+}
+
+func TestProcessSSHJournalEntry_DropsIgnoredAccount(t *testing.T) {
+	pub := &capturingPublisher{}
+	ss := &fakeSettings{list: "drfeed"}
+	d := Deps{Queue: pub, ServerSettings: ss, Log: slog.New(slog.DiscardHandler), Now: time.Now}
+	gr := newSSHLoginGrouper(time.Now)
+	ig := newSSHIgnoreCache(ss, time.Now)
+	ctx := context.Background()
+
+	// Ignored account → nothing published.
+	processSSHJournalEntry(ctx, d, gr, ig, journalEntry{
+		Comm:    "sshd",
+		Message: "Accepted publickey for drfeed from 10.0.0.5 port 49152 ssh2: ED25519 SHA256:abc",
+	})
+	if pub.Count() != 0 {
+		t.Fatalf("ignored account must not notify, got %d envelopes", pub.Count())
+	}
+
+	// A different account → notifies (first login in a new group).
+	processSSHJournalEntry(ctx, d, gr, ig, journalEntry{
+		Comm:    "sshd",
+		Message: "Accepted publickey for alice from 10.0.0.5 port 49152 ssh2: ED25519 SHA256:abc",
+	})
+	if pub.Count() != 1 {
+		t.Fatalf("non-ignored account should notify once, got %d", pub.Count())
+	}
+}

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -430,6 +430,14 @@ type ServerSettings struct {
 	StalwartWebadminAllowCIDRs    string `gorm:"column:stalwart_webadmin_allow_cidrs;type:varchar(512);not null;default:''" json:"stalwart_webadmin_allow_cidrs"`
 	PostgresMaxConnectionsPerUser uint16 `gorm:"column:postgres_max_connections_per_user;type:smallint unsigned;not null;default:25" json:"postgres_max_connections_per_user"`
 
+	// SSHLoginIgnoreAccounts — GH #1310-adjacent ("drfeed spam"). A
+	// newline/comma-separated list of SSH usernames whose successful logins are
+	// dropped before they ever notify (no immediate, no digest). Lets a noisy
+	// service account — a DR feed's SSH pull loop, a backup rsync — be silenced
+	// without disabling ssh.login for everyone. TEXT (off-page): the row is near
+	// the MariaDB row-size ceiling.
+	SSHLoginIgnoreAccounts string `gorm:"column:ssh_login_ignore_accounts;type:text;not null;default:''" json:"ssh_login_ignore_accounts"`
+
 	// MigrationAllowPrivateHosts — ADR-0095 decision 8. When TRUE the
 	// SSRF guard for /admin/migrations outbound dials permits RFC1918
 	// targets (10/8, 172.16/12, 192.168/16) as well as IPv6 ULA. DNS

--- a/panel-api/internal/models/ssh_login_ignore.go
+++ b/panel-api/internal/models/ssh_login_ignore.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"sort"
+	"strings"
+)
+
+// SSHLoginIgnoreAccounts is stored as a newline/comma-separated list of SSH
+// usernames (GH #1310-adjacent, "drfeed spam"). These helpers are the single
+// place that parses and re-serialises it, shared by the eventsource that drops
+// ignored logins and the admin handler that edits the list.
+
+// splitSSHIgnore tokenises the raw stored value on commas and newlines.
+func splitSSHIgnore(raw string) []string {
+	return strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r'
+	})
+}
+
+// ParseSSHIgnoreAccounts returns the normalised list: trimmed, empties dropped,
+// de-duplicated, sorted. Sorting keeps the stored form and the API response
+// stable regardless of input order.
+func ParseSSHIgnoreAccounts(raw string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, tok := range splitSSHIgnore(raw) {
+		u := strings.TrimSpace(tok)
+		if u == "" {
+			continue
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SSHIgnoreSet is the same normalised list as a lookup set (for the hot path in
+// the ssh.login eventsource).
+func SSHIgnoreSet(raw string) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, u := range ParseSSHIgnoreAccounts(raw) {
+		set[u] = struct{}{}
+	}
+	return set
+}
+
+// JoinSSHIgnoreAccounts serialises a list back to the stored form (normalised,
+// newline-separated).
+func JoinSSHIgnoreAccounts(accounts []string) string {
+	return strings.Join(ParseSSHIgnoreAccounts(strings.Join(accounts, "\n")), "\n")
+}

--- a/panel-api/internal/models/ssh_login_ignore_test.go
+++ b/panel-api/internal/models/ssh_login_ignore_test.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSSHIgnoreAccounts(t *testing.T) {
+	// commas + newlines + stray whitespace + a duplicate, out of order.
+	got := ParseSSHIgnoreAccounts("drfeed, backup\nother\r\n\n  , drfeed ")
+	want := []string{"backup", "drfeed", "other"} // trimmed, deduped, sorted
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Parse = %v, want %v", got, want)
+	}
+	if len(ParseSSHIgnoreAccounts("")) != 0 {
+		t.Errorf("empty raw must yield empty list")
+	}
+}
+
+func TestSSHIgnoreSet(t *testing.T) {
+	set := SSHIgnoreSet("drfeed, alice")
+	if _, ok := set["drfeed"]; !ok {
+		t.Error("drfeed missing from set")
+	}
+	if _, ok := set["bob"]; ok {
+		t.Error("bob must not be in set")
+	}
+}
+
+func TestJoinSSHIgnoreAccounts(t *testing.T) {
+	got := JoinSSHIgnoreAccounts([]string{"zeta", "alpha", "alpha", " "})
+	if got != "alpha\nzeta" {
+		t.Fatalf("Join = %q, want %q", got, "alpha\nzeta")
+	}
+}

--- a/panel-ui/src/shells/admin/notifications/EventsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.tsx
@@ -29,6 +29,7 @@ import { ReloadOutlined, SearchOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
 import { groupEventsByCategory } from "./eventCategories";
+import { SSHLoginIgnoreEditor } from "./SSHLoginIgnoreEditor";
 
 type Severity = "info" | "warning" | "error" | "critical";
 
@@ -445,6 +446,7 @@ export const EventsTab = () => {
         >
           {e.description}
         </Typography.Paragraph>
+        {e.kind === "ssh.login" && <SSHLoginIgnoreEditor />}
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 14, flex: "none" }}>
         <Tag color={severityColor[e.severity] ?? "default"} style={{ marginInlineEnd: 0 }}>

--- a/panel-ui/src/shells/admin/notifications/SSHLoginIgnoreEditor.tsx
+++ b/panel-ui/src/shells/admin/notifications/SSHLoginIgnoreEditor.tsx
@@ -1,0 +1,76 @@
+// SSHLoginIgnoreEditor — GH #1310-adjacent ("drfeed spam"). A small tag-input
+// under the "SSH login" event row that manages the per-account ignore list:
+// successful logins by a listed username never notify (no immediate, no
+// digest), so a disaster-recovery feed's SSH pull loop — or any noisy service
+// account — can be silenced without turning SSH-login notifications off for
+// everyone.
+import { useState } from "react";
+import { Select, Typography } from "antd";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+
+import { apiClient } from "../../../apiClient";
+import { feedback } from "../../../lib/feedback";
+
+const KEY = ["admin", "ssh-login-ignore"] as const;
+const PATH = "/admin/settings/ssh-login-ignore";
+const USERNAME_RE = /^[A-Za-z0-9._-]{1,64}$/;
+
+export function SSHLoginIgnoreEditor() {
+  const qc = useQueryClient();
+  const [saving, setSaving] = useState(false);
+
+  const q = useQuery<{ accounts: string[] }>({
+    queryKey: KEY,
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ accounts: string[] }>(PATH);
+      return data;
+    },
+  });
+
+  const accounts = q.data?.accounts ?? [];
+
+  const save = async (next: string[]) => {
+    // Client-side guard mirrors the server so an obviously bad tag never round-trips.
+    const bad = next.find((a) => !USERNAME_RE.test(a));
+    if (bad) {
+      feedback.message.error(`Not a valid username: "${bad}"`);
+      return;
+    }
+    setSaving(true);
+    try {
+      await apiClient.put(PATH, { accounts: next });
+      await qc.invalidateQueries({ queryKey: KEY });
+      feedback.message.success("Ignored accounts updated");
+    } catch (err) {
+      const detail = (err as AxiosError<{ detail?: string }>).response?.data?.detail;
+      feedback.message.error(detail ?? "Could not update ignored accounts");
+      await qc.invalidateQueries({ queryKey: KEY });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 10, maxWidth: "64ch" }}>
+      <Typography.Text strong style={{ fontSize: 12.5 }}>
+        Ignored accounts
+      </Typography.Text>
+      <Typography.Paragraph type="secondary" style={{ margin: "2px 0 6px", fontSize: 12 }}>
+        SSH logins by these usernames never notify — useful for a DR feed or backup
+        loop that logs in constantly. Other accounts still notify normally.
+      </Typography.Paragraph>
+      <Select
+        mode="tags"
+        style={{ width: "100%" }}
+        placeholder="e.g. drfeed"
+        value={accounts}
+        loading={q.isLoading || saving}
+        disabled={q.isLoading || saving}
+        tokenSeparators={[",", " "]}
+        onChange={(next: string[]) => void save(next)}
+        aria-label="SSH login ignored accounts"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

A disaster-recovery feed set up on the test box logs into it over SSH on a tight
loop (an rsync/backup pull). Every pull is a successful `ssh.login`, so the
`drfeed` account fired a notification every cycle — the "drfeed spam". Smart
grouping (#1310) only collapsed it into a rolling *"drfeed — 15 logins from …"*
digest every ~10 minutes; it never went fully quiet.

This adds a **targeted ignore list**: mute `ssh.login` for a specific account
without disabling SSH-login notifications for everyone (the only lever that
existed before was the global Notifications → Events toggle).

## How

- **Schema** — `server_settings.ssh_login_ignore_accounts TEXT` (migration
  `000285`). TEXT, not VARCHAR: the `server_settings` row is near the MariaDB
  row-size ceiling, so the value lives off-page. Model field + shared
  parse/serialise helpers (`models.ParseSSHIgnoreAccounts` / `SSHIgnoreSet` /
  `JoinSSHIgnoreAccounts`).
- **Eventsource** — the `ssh.login` source drops a listed account **before** the
  grouper, so an ignored account produces neither an immediate notification nor a
  digest. The lookup is cached for 30s (the journal-tail is hot) and **fails
  open**: if the settings read errors and nothing is cached, no one is ignored —
  we would rather over-notify than silently swallow a security signal.
- **API** — admin `GET`/`PUT /admin/settings/ssh-login-ignore`. Usernames are
  validated (`^[A-Za-z0-9._-]{1,64}$`, no delimiters that would corrupt the
  stored form), the list is normalised (trim/dedupe/sort) and capped at 200.
- **UI** — a tag-input **“Ignored accounts”** editor under Notifications →
  Events → SSH login.

Reuses the already-wired `eventsources.Deps.ServerSettings`, so no new plumbing.
`ServerSettingsRepository.Upsert` is `Select("*")`, so the new column is
persisted (not dropped by an update allowlist).

## Tests

- `models` — parser: commas/newlines/whitespace, dedupe, sort; set + join.
- `eventsources` (`-race`) — cache matches the explicit list; nil cache/settings
  never ignores; TTL (no DB hit within 30s, reload after); fail-open on error;
  `processSSHJournalEntry` drops an ignored account (0 published) while a
  different account still publishes.
- `api` — GET returns the normalised list; PUT persists normalised; a bad
  username → 422 with nothing persisted.
- Full `panel-api` suite green (the `server_settings` column doesn't trip any
  sqlmock arg-count test); OpenAPI coverage golden updated.

## Box drill (test box, restored after)

Rebuilt SPA (the editor is `go:embed`-ed) + binary. Migration applied clean —
`schema_migrations` → 285, column `NOT NULL DEFAULT ''`, `/login` 200, and
`DEFAULT ('')`-on-TEXT accepted on MariaDB 11. Set the ignore list to `drfeed`
(the **real** flooding account, confirmed from the journal): its logins kept
appearing in the SSH journal but produced **0** `notification_history` rows,
while a `root` login (control) still produced one. Box restored to pre-drill
state (old binary, column dropped, `schema_migrations` forced back to 284 per the
migrate-ahead recovery — not `migrate down`).

## Interim relief (until this merges + deploys)

The flood can be stopped now without this change by turning **SSH login** off in
Notifications → Events (global — silences every account, not just the feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
