### PR TITLE
feat(cron): allow an ordered sequence of wp/php commands in one job (GH #1435)

### DIFF
--- a/internal/cronvalidate/multi.go
+++ b/internal/cronvalidate/multi.go
@@ -1,0 +1,85 @@
+package cronvalidate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Multi-command cron support (GH #1435). A cron job may hold several commands,
+// one per line, so a tenant can run an ordered sequence — e.g. generate an
+// export then import it — in a single scheduled unit instead of racing two
+// separately-timed jobs.
+//
+// SECURITY: this does NOT loosen the per-command contract. Each non-empty,
+// non-comment line is validated INDEPENDENTLY by ValidateAny — the same closed
+// wp/php (or self-domain http-trigger) allow-list, the same metacharacter and
+// control-character rejection. The agent renders one ExecStart= per validated
+// command into the Type=oneshot unit; systemd runs them in order and stops at
+// the first failure. Splitting on the newline BEFORE validation means a newline
+// never reaches ValidateCommand (which still rejects control chars), so the
+// systemd-unit-injection vector the single-command validator guards against is
+// unchanged.
+
+const (
+	// maxCronCommands caps the number of commands in one job.
+	maxCronCommands = 20
+	// maxMultiCommandBytes matches the cron_jobs.command column (varchar 1024).
+	maxMultiCommandBytes = 1024
+)
+
+// ValidateAnyMulti validates a (possibly multi-line) cron command into an
+// ordered list of validated commands. Blank lines and comment/shebang lines
+// (starting with '#') are skipped, so a pasted script's `#!/bin/bash` header is
+// tolerated — but every executable line must still pass the closed allow-list.
+// A single-line command yields a one-element slice (back-compatible).
+func ValidateAnyMulti(raw string, ownedDocroots, ownedDomains []string) ([]*Command, error) {
+	if len(raw) > maxMultiCommandBytes {
+		return nil, &ValidationError{
+			Code:   ErrCodeTooLong,
+			Detail: fmt.Sprintf("command exceeds %d bytes (%d bytes)", maxMultiCommandBytes, len(raw)),
+		}
+	}
+
+	var cmds []*Command
+	for i, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r"))
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue // blank line or comment/shebang
+		}
+		if len(cmds) >= maxCronCommands {
+			return nil, &ValidationError{
+				Code:   ErrCodeTooLong,
+				Detail: fmt.Sprintf("too many commands (max %d)", maxCronCommands),
+			}
+		}
+		c, err := ValidateAny(trimmed, ownedDocroots, ownedDomains)
+		if err != nil {
+			// Prefix the failing line number so the operator can fix the right line.
+			if ve, ok := err.(*ValidationError); ok {
+				return nil, &ValidationError{Code: ve.Code, Detail: fmt.Sprintf("line %d: %s", i+1, ve.Detail)}
+			}
+			return nil, err
+		}
+		cmds = append(cmds, c)
+	}
+
+	if len(cmds) == 0 {
+		return nil, &ValidationError{Code: ErrCodeEmpty, Detail: "command cannot be empty"}
+	}
+	return cmds, nil
+}
+
+// NormalizeMultiCommand re-serialises the executable lines of a validated
+// multi-command string: blanks and comments dropped, one command per line. The
+// panel stores this so the DB row is exactly what runs.
+func NormalizeMultiCommand(raw string) string {
+	var lines []string
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r"))
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines = append(lines, trimmed)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/cronvalidate/multi_test.go
+++ b/internal/cronvalidate/multi_test.go
@@ -1,0 +1,94 @@
+package cronvalidate
+
+import (
+	"strings"
+	"testing"
+)
+
+var testDocroots = []string{"/home/u/domains/x/public_html"}
+
+func TestValidateAnyMulti_OrderedWPSequence(t *testing.T) {
+	raw := "#!/bin/bash\n" +
+		"wp --path=/home/u/domains/x/public_html keyhook-properties generate-xml --file=/home/u/domains/x/public_html/wp-content/uploads/props.xml\n" +
+		"\n" + // blank line tolerated
+		"# import step\n" +
+		"wp --path=/home/u/domains/x/public_html all-import run 1 --force-run\n"
+	cmds, err := ValidateAnyMulti(raw, testDocroots, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("want 2 commands (shebang/blank/comment skipped), got %d", len(cmds))
+	}
+	if cmds[0].Argv[0] != "wp" || cmds[1].Argv[0] != "wp" {
+		t.Fatalf("both should be wp: %v / %v", cmds[0].Argv, cmds[1].Argv)
+	}
+	if cmds[1].Argv[len(cmds[1].Argv)-1] != "--force-run" {
+		t.Fatalf("second command mis-parsed: %v", cmds[1].Argv)
+	}
+}
+
+func TestValidateAnyMulti_SingleLineBackCompat(t *testing.T) {
+	cmds, err := ValidateAnyMulti("wp --path=/home/u/domains/x/public_html cron event run --due-now", testDocroots, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("single line must yield one command, got %d", len(cmds))
+	}
+}
+
+func TestValidateAnyMulti_RejectsBadLineWithLineNumber(t *testing.T) {
+	// line 2 tries to escape the allow-list.
+	raw := "wp --path=/home/u/domains/x/public_html cron event run\n" +
+		"cd /etc && cat shadow"
+	_, err := ValidateAnyMulti(raw, testDocroots, nil)
+	if err == nil {
+		t.Fatal("expected rejection of the shell line")
+	}
+	if !strings.Contains(err.Error(), "line 2") {
+		t.Fatalf("error should point at line 2: %v", err)
+	}
+}
+
+func TestValidateAnyMulti_MetacharOnAnyLineRejected(t *testing.T) {
+	raw := "wp --path=/home/u/domains/x/public_html cron event run\n" +
+		"php /home/u/domains/x/public_html/a.php; rm -rf /"
+	if _, err := ValidateAnyMulti(raw, testDocroots, nil); err == nil {
+		t.Fatal("a metachar on any line must reject the whole job")
+	}
+}
+
+func TestValidateAnyMulti_EmptyAfterSkips(t *testing.T) {
+	if _, err := ValidateAnyMulti("#!/bin/bash\n\n# only comments\n", testDocroots, nil); err == nil {
+		t.Fatal("a command with no executable lines must be rejected")
+	}
+}
+
+func TestValidateAnyMulti_PathStillEnforcedPerLine(t *testing.T) {
+	// second line's --path points outside the owned docroot.
+	raw := "wp --path=/home/u/domains/x/public_html cron event run\n" +
+		"wp --path=/home/other/domains/y/public_html plugin list"
+	if _, err := ValidateAnyMulti(raw, testDocroots, nil); err == nil {
+		t.Fatal("a --path outside owned docroots must reject the job")
+	}
+}
+
+func TestValidateAnyMulti_TooMany(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < maxCronCommands+1; i++ {
+		b.WriteString("wp --path=/home/u/domains/x/public_html cron event run\n")
+	}
+	if _, err := ValidateAnyMulti(b.String(), testDocroots, nil); err == nil {
+		t.Fatalf("more than %d commands must be rejected", maxCronCommands)
+	}
+}
+
+func TestNormalizeMultiCommand(t *testing.T) {
+	raw := "#!/bin/bash\n wp --path=/x a b \n\n# c\nphp /x/y.php\n"
+	got := NormalizeMultiCommand(raw)
+	want := "wp --path=/x a b\nphp /x/y.php"
+	if got != want {
+		t.Fatalf("Normalize = %q, want %q", got, want)
+	}
+}

--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -92,7 +92,7 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	// ValidateAny routes curl/wget self-domain crons (GH #400 Part B) to the
 	// http-trigger validator (gated on OwnedDomains); everything else stays
 	// the wp/php closed set (gated on OwnedDocroots).
-	cmd, err := cronvalidate.ValidateAny(p.Command, p.OwnedDocroots, p.OwnedDomains)
+	cmds, err := cronvalidate.ValidateAnyMulti(p.Command, p.OwnedDocroots, p.OwnedDomains)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
@@ -186,7 +186,7 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	timerPath := filepath.Join(unitsDir, fmt.Sprintf("jabali-cron-%s.timer", p.JobID))
 
 	// Generate unit file content
-	serviceContent := buildCronServiceContent(p.JobID, p.Name, cmd, p.Username, p.OwnedDocroots)
+	serviceContent := buildCronServiceContent(p.JobID, p.Name, cmds, p.Username, p.OwnedDocroots)
 	timerContent, tcErr := buildCronTimerContent(p.JobID, p.Schedule)
 	if tcErr != nil {
 		return nil, &agentwire.AgentError{
@@ -241,34 +241,57 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	}, nil
 }
 
-// buildCronServiceContent generates the systemd service unit content.
-func buildCronServiceContent(jobID, name string, cmd *cronvalidate.Command, username string, ownedDocroots []string) string {
-	// Build ExecStart with single-quoted tokens (systemd parses whitespace to argv)
-	execStart := "ExecStart="
-	for i, token := range cmd.Argv {
-		if i > 0 {
-			execStart += " "
+// buildCronServiceContent generates the systemd service unit content. GH #1435:
+// a job may carry several validated commands; each renders as its own ExecStart=
+// line. Type=oneshot runs them in order and stops at the first failure — so a
+// tenant can run an ordered sequence (generate then import) in one unit.
+func buildCronServiceContent(jobID, name string, cmds []*cronvalidate.Command, username string, ownedDocroots []string) string {
+	// One ExecStart= per command; systemd parses whitespace-separated,
+	// single-quoted tokens into argv. A newline never appears inside a token
+	// (cronvalidate rejects control chars per line), so no ExecStart= line can
+	// be broken to inject unit directives.
+	var execLines []string
+	// Gate the unit on every distinct owned docroot referenced across the
+	// commands existing (GH #403), so a missing docroot skips the whole job
+	// cleanly with no audited shell exec.
+	seenDoc := map[string]bool{}
+	var condDocroots []string
+	for _, cmd := range cmds {
+		var b strings.Builder
+		b.WriteString("ExecStart=")
+		for i, token := range cmd.Argv {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(singleQuote(token))
 		}
-		execStart += singleQuote(token)
-	}
+		execLines = append(execLines, b.String())
 
-	// For ExecStartPre, determine the docroot to validate
-	// We use the first argument that starts with / and is in an owned docroot
-	docroot := ""
-	for _, arg := range cmd.Argv[1:] {
-		if strings.HasPrefix(arg, "/") {
-			// Check if it's in an owned docroot
+		for i, arg := range cmd.Argv[1:] {
+			// Consider bare /-paths (php script arg, two-token `--path <dir>`) and
+			// the glued `--path=<dir>` form (the common wp shape) — so a deleted
+			// docroot skips the whole job cleanly (GH #403) rather than erroring.
+			cand := ""
+			switch {
+			case strings.HasPrefix(arg, "/"):
+				cand = arg
+			case strings.HasPrefix(arg, "--path="):
+				cand = strings.TrimPrefix(arg, "--path=")
+			case arg == "--path" && i+2 < len(cmd.Argv):
+				cand = cmd.Argv[i+2] // i is index within Argv[1:]; +2 hits the value in Argv
+			}
+			if cand == "" {
+				continue
+			}
 			for _, od := range ownedDocroots {
-				if arg == od || strings.HasPrefix(arg, od+"/") {
-					docroot = od
-					break
+				if (cand == od || strings.HasPrefix(cand, od+"/")) && !seenDoc[od] {
+					seenDoc[od] = true
+					condDocroots = append(condDocroots, od)
 				}
 			}
-			if docroot != "" {
-				break
-			}
 		}
 	}
+	execStart := strings.Join(execLines, "\n")
 
 	// If we have a docroot, gate the whole unit on it existing via a
 	// systemd [Unit] condition (GH #403). This REPLACES the former
@@ -281,8 +304,8 @@ func buildCronServiceContent(jobID, name string, cmd *cronvalidate.Command, user
 	// systemd manager (no exec): a missing docroot skips the unit cleanly,
 	// same outcome as the precheck's exit 1, without an audited shell.
 	condDocroot := ""
-	if docroot != "" {
-		condDocroot = "ConditionPathIsDirectory=" + docroot + "\n"
+	for _, od := range condDocroots {
+		condDocroot += "ConditionPathIsDirectory=" + od + "\n"
 	}
 
 	// ExecSearchPath puts the per-user wrapper dir FIRST in systemd's binary
@@ -523,6 +546,18 @@ func applyRootCron(ctx context.Context, p cronApplyParams) (any, error) {
 //     /var/log/jabali/cron/root/<jobid>.log (kept in sync with
 //     the per-user layout under /var/log/jabali/cron/<user>/).
 func buildRootCronServiceContent(jobID, name, command string) string {
+	// GH #1435: one ExecStart per command line (Type=oneshot runs them in order,
+	// stops at the first failure). Each line was validated by the panel; splitting
+	// here keeps a newline out of any single ExecStart= value.
+	var execLines []string
+	for _, line := range strings.Split(command, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		execLines = append(execLines, "ExecStart=/bin/sh -c "+singleQuote(line))
+	}
+	execStart := strings.Join(execLines, "\n")
 	return fmt.Sprintf(`[Unit]
 Description=Jabali root cron: %s
 After=network-online.target
@@ -530,7 +565,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c %s
+%s
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only
@@ -541,7 +576,7 @@ StandardError=append:/var/log/jabali/cron/root/%s.log
 
 [Install]
 WantedBy=multi-user.target
-`, name, singleQuote(command), jobID, jobID)
+`, name, execStart, jobID, jobID)
 }
 
 func init() {

--- a/panel-agent/internal/commands/cron_apply_test.go
+++ b/panel-agent/internal/commands/cron_apply_test.go
@@ -247,7 +247,7 @@ func TestBuildCronServiceContent(t *testing.T) {
 	}
 	ownedDocroots := []string{"/var/www/site1"}
 
-	content := buildCronServiceContent("job1", "Test Job", cmd, "testuser", ownedDocroots)
+	content := buildCronServiceContent("job1", "Test Job", []*cronvalidate.Command{cmd}, "testuser", ownedDocroots)
 
 	// Verify structure
 	if !contains(content, "[Unit]") {
@@ -305,7 +305,7 @@ func TestBuildCronServiceContent(t *testing.T) {
 // the system dirs must follow.
 func TestCronExecSearchPathIncludesSystemDirs(t *testing.T) {
 	cmd := &cronvalidate.Command{Argv: []string{"wp", "cron", "event", "run", "--due-now"}}
-	content := buildCronServiceContent("job1", "Nightly", cmd, "testuser", []string{"/var/www/site1"})
+	content := buildCronServiceContent("job1", "Nightly", []*cronvalidate.Command{cmd}, "testuser", []string{"/var/www/site1"})
 
 	searchPath := unitDirectiveValue(content, "ExecSearchPath")
 	if searchPath == "" {
@@ -424,7 +424,7 @@ func TestBuildCronServiceContent_HTTPTrigger(t *testing.T) {
 		URL:  "https://own.example.com/wp-cron.php?doing_wp_cron",
 		Argv: []string{"/usr/local/bin/jabali", "cron", "http-trigger", "https://own.example.com/wp-cron.php?doing_wp_cron"},
 	}
-	content := buildCronServiceContent("job1", "Trigger", cmd, "testuser", nil)
+	content := buildCronServiceContent("job1", "Trigger", []*cronvalidate.Command{cmd}, "testuser", nil)
 
 	if !contains(content, "ExecStart='/usr/local/bin/jabali' 'cron' 'http-trigger' 'https://own.example.com/wp-cron.php?doing_wp_cron'") {
 		t.Errorf("ExecStart not the wrapper invocation:\n%s", content)
@@ -441,7 +441,7 @@ func TestBuildCronServiceContent_HTTPTrigger(t *testing.T) {
 func TestBuildCronServiceContent_DocrootCondition(t *testing.T) {
 	dr := "/home/alice/domains/a.example.com/public_html"
 	cmd := &cronvalidate.Command{Argv: []string{"php", dr + "/wp-cron.php"}}
-	content := buildCronServiceContent("job9", "WP cron", cmd, "alice", []string{dr})
+	content := buildCronServiceContent("job9", "WP cron", []*cronvalidate.Command{cmd}, "alice", []string{dr})
 
 	if !contains(content, "ConditionPathIsDirectory="+dr) {
 		t.Errorf("expected ConditionPathIsDirectory for the docroot:\n%s", content)

--- a/panel-agent/internal/commands/cron_multi_test.go
+++ b/panel-agent/internal/commands/cron_multi_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/cronvalidate"
+)
+
+// GH #1435: a multi-command job renders one ExecStart= per command into the
+// Type=oneshot unit, and gates on each referenced docroot exactly once.
+func TestBuildCronServiceContent_MultiCommand(t *testing.T) {
+	dr := "/home/u/domains/x/public_html"
+	raw := "wp --path=" + dr + " keyhook-properties generate-xml --file=" + dr + "/props.xml\n" +
+		"wp --path=" + dr + " all-import run 1 --force-run"
+	cmds, err := cronvalidate.ValidateAnyMulti(raw, []string{dr}, nil)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	content := buildCronServiceContent("job1", "WP import", cmds, "u", []string{dr})
+
+	if n := strings.Count(content, "\nExecStart="); n != 2 {
+		t.Fatalf("want 2 ExecStart lines, got %d:\n%s", n, content)
+	}
+	if !strings.Contains(content, "'generate-xml'") || !strings.Contains(content, "'all-import'") {
+		t.Fatalf("both commands should be present:\n%s", content)
+	}
+	// Both commands reference the same --path=<dr>; it is gated exactly once.
+	if n := strings.Count(content, "ConditionPathIsDirectory="+dr); n != 1 {
+		t.Fatalf("want the docroot gated once (deduped), got %d:\n%s", n, content)
+	}
+	// No raw newline ever appears inside a single ExecStart value.
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "ExecStart=") && strings.Count(line, "ExecStart=") != 1 {
+			t.Fatalf("a command leaked across ExecStart lines: %q", line)
+		}
+	}
+}
+
+// Pins the two-token `--path <dir>` docroot-detection index (distinct code path
+// from the glued `--path=<dir>` form).
+func TestBuildCronServiceContent_TwoTokenPathGates(t *testing.T) {
+	dr := "/home/u/domains/x/public_html"
+	cmds, err := cronvalidate.ValidateAnyMulti("wp --path "+dr+" plugin list", []string{dr}, nil)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	content := buildCronServiceContent("job1", "list", cmds, "u", []string{dr})
+	if !strings.Contains(content, "ConditionPathIsDirectory="+dr) {
+		t.Fatalf("two-token --path should gate the docroot:\n%s", content)
+	}
+}

--- a/panel-agent/internal/commands/cron_precheck_install_test.go
+++ b/panel-agent/internal/commands/cron_precheck_install_test.go
@@ -24,7 +24,7 @@ func TestGeneratedUnitLibexecHelpersAreShipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("validate: %v", err)
 	}
-	svc := buildCronServiceContent("job1", "test", cmd, "u", []string{"/home/u/public_html"})
+	svc := buildCronServiceContent("job1", "test", []*cronvalidate.Command{cmd}, "u", []string{"/home/u/public_html"})
 
 	refs := libexecRefRe.FindAllStringSubmatch(svc, -1)
 	if len(refs) == 0 {

--- a/panel-agent/internal/commands/cron_run_now.go
+++ b/panel-agent/internal/commands/cron_run_now.go
@@ -66,8 +66,8 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 
 	// Defense-in-depth: re-validate the command against the user's owned
 	// docroots (same gate as cron.apply) before executing it. Never trust
-	// the stored command blindly.
-	validated, vErr := cronvalidate.ValidateAny(p.Command, p.OwnedDocroots, p.OwnedDomains)
+	// the stored command blindly. GH #1435: a job may hold several commands.
+	validatedCmds, vErr := cronvalidate.ValidateAnyMulti(p.Command, p.OwnedDocroots, p.OwnedDomains)
 	if vErr != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
@@ -97,27 +97,38 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 	if home == "" {
 		home = "/home/" + p.Username
 	}
-	args := append([]string{"-u", p.Username, "--"}, validated.Argv...)
-	cmd := execCommandContext(ctx, "runuser", args...)
-	cmd.Dir = home
-	cmd.Env = []string{
+	env := []string{
 		"HOME=" + home,
 		"USER=" + p.Username,
 		"LOGNAME=" + p.Username,
 		"PATH=" + home + "/.jabali/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
 	}
 
+	// Run each command in order, exactly like the Type=oneshot timer: stop at
+	// the first non-zero exit and report it, so "Run now" mirrors a scheduled run.
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	runErr := cmd.Run()
-
 	exitCode := 0
-	if runErr != nil {
-		if exitErr, ok := runErr.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = 1
+	multi := len(validatedCmds) > 1
+	for i, vc := range validatedCmds {
+		if multi {
+			// Label each step so the operator can see which command ran.
+			fmt.Fprintf(&stdout, "$ %s\n", strings.Join(vc.Argv, " "))
+		}
+		args := append([]string{"-u", p.Username, "--"}, vc.Argv...)
+		cmd := execCommandContext(ctx, "runuser", args...)
+		cmd.Dir = home
+		cmd.Env = env
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		runErr := cmd.Run()
+		if runErr != nil {
+			if exitErr, ok := runErr.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			} else {
+				exitCode = 1
+			}
+			fmt.Fprintf(&stderr, "(stopped: command %d exited %d)\n", i+1, exitCode)
+			break
 		}
 	}
 

--- a/panel-api/internal/cronops/cronops.go
+++ b/panel-api/internal/cronops/cronops.go
@@ -212,7 +212,7 @@ func Create(ctx context.Context, d Deps, in CreateInput) (*models.CronJob, error
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cronvalidate.ValidateAny(in.Command, docroots, domains); err != nil {
+	if _, err := cronvalidate.ValidateAnyMulti(in.Command, docroots, domains); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrCommandInvalid, err)
 	}
 
@@ -220,7 +220,7 @@ func Create(ctx context.Context, d Deps, in CreateInput) (*models.CronJob, error
 		ID:        ids.NewULID(),
 		UserID:    in.UserID,
 		Name:      in.Name,
-		Command:   in.Command,
+		Command:   cronvalidate.NormalizeMultiCommand(in.Command),
 		Schedule:  in.Schedule,
 		Enabled:   in.Enabled,
 		RunAsRoot: in.RunAsRoot,
@@ -272,10 +272,10 @@ func Update(ctx context.Context, d Deps, jobID string, patch UpdatePatch) (*mode
 		job.Name = *patch.Name
 	}
 	if patch.Command != nil {
-		if _, err := cronvalidate.ValidateAny(*patch.Command, docroots, domains); err != nil {
+		if _, err := cronvalidate.ValidateAnyMulti(*patch.Command, docroots, domains); err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrCommandInvalid, err)
 		}
-		job.Command = *patch.Command
+		job.Command = cronvalidate.NormalizeMultiCommand(*patch.Command)
 	}
 	if patch.Schedule != nil {
 		if err := cronvalidate.ValidateSchedule(*patch.Schedule); err != nil {

--- a/panel-ui/src/shells/user/cron/CreateCronModal.tsx
+++ b/panel-ui/src/shells/user/cron/CreateCronModal.tsx
@@ -189,10 +189,14 @@ export const CreateCronModal = ({
           rules={[
             { required: true, message: "Please enter a command" },
           ]}
+          extra="One wp/php command per line — they run in order and stop at the first failure. Use --path=<docroot> instead of cd."
         >
           <Input.TextArea
-            placeholder="wp cron event run --path=/home/user/example.com/public_html"
-            rows={3}
+            placeholder={
+              "wp --path=/home/user/example.com/public_html keyhook-properties generate-xml --file=/home/user/example.com/public_html/props.xml\n" +
+              "wp --path=/home/user/example.com/public_html all-import run 1 --force-run"
+            }
+            rows={4}
             style={{ fontFamily: "monospace" }}
           />
         </Form.Item>


### PR DESCRIPTION
## Why (GH #1435)

A cron job could hold only a single `wp`/`php` command, so a tenant whose task is
a **dependent sequence** — generate an export, then import it — had to split it
into two separately-timed jobs with no ordering guarantee. This lets one job hold
several commands, one per line, run **in order** by the existing `Type=oneshot`
unit, stopping at the first failure.

## What this is NOT

The per-command security contract is unchanged. Arbitrary shell scripts stay
rejected — `cd`, `$HOME`, pipes, `;`, backticks and friends still fail
validation. The cron unit runs as the tenant **outside the SSH sandbox**, so the
closed `wp`/`php` allow-list is the security boundary; a newline that reached a
systemd `ExecStart=` value could inject unit directives, which is exactly why
`ValidateAnyMulti` splits on the newline **before** validation and runs each line
through the same `ValidateAny` (allow-list + metachar/control-char rejection).

## How

- **cronvalidate** — `ValidateAnyMulti` validates each non-empty, non-comment
  line independently (blank + `#` shebang/comment lines are skipped; cap 20;
  errors are line-numbered). `NormalizeMultiCommand` stores one command per line.
- **agent** — `buildCronServiceContent` emits one `ExecStart=` per command and
  gates the unit on each referenced docroot once (now also recognising the glued
  `--path=<dir>` form, so a deleted docroot skips the whole job cleanly).
  `cron.run_now` runs the sequence, stops at the first non-zero exit, and labels
  each step. Root crons render one `ExecStart=/bin/sh -c` per line.
- **panel** — `cronops` validates via `ValidateAnyMulti` and persists the
  normalised form. **UI** — the command field documents one-command-per-line and
  `--path=<docroot>` instead of `cd`.

**Note for the reviewer:** because glued `--path=<dir>` wp jobs previously had no
`ConditionPathIsDirectory` and now gain one, the first reconcile after deploy
rewrites those existing units (daemon-reload + re-enable, `NoChange=false` once).
That's the intended robustness improvement, not a bug.

## Tests

- `cronvalidate` — ordered sequence; single-line back-compat; a bad line rejects
  the whole job (with the line number); a metachar on any line rejects; empty
  after skips rejects; per-line `--path` docroot enforcement; the 20-command cap;
  normalize.
- `agent` (`-race`) — a 2-command job renders exactly 2 ExecStart lines, both
  commands present, docroot gated once, no command leaks across lines; a separate
  case pins the two-token `--path <dir>` docroot index. Existing render tests
  updated for the slice signature.
- Full `panel-api` + `panel-agent` + `cronvalidate` suites green.

## Box drill (agent, restored after — no migration)

A 2-command unit renders **2 `ExecStart=` lines** and passes
`systemd-analyze --user verify`. `cron.run_now`: on success both commands run in
order (`m1` + `m2` markers, step labels in stdout); on a **failing first command**
the second does **not** run (`m2` absent, exit 3 propagated,
`(stopped: command 1 exited 3)`).

## For the reporter

Their script translates to two lines in one job (replace `cd` with `--path=`,
`$HOME` with the absolute path):

```
wp --path=$HOME/domains/landlordslink.com/public_html keyhook-properties generate-xml --file=$HOME/domains/landlordslink.com/public_html/wp-content/uploads/wpallimport/files/properties.xml
wp --path=$HOME/domains/landlordslink.com/public_html all-import run 1 --force-run
```

(with `$HOME` written out as the absolute `/home/<user>` path — `$` is not allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
