### PR TITLE
feat(adminer): upgrade Adminer 4.8.1 -> 6.0.1 + port the SSO plugin (GH #1405)

### DIFF
--- a/docs/EXTERNAL_DEPS.md
+++ b/docs/EXTERNAL_DEPS.md
@@ -35,7 +35,7 @@ the string to bump it.
 |---|---|---|---|
 | MariaDB | distro 11.x | apt | panel DB + tenant DBs (M7). Reserved-word trap on 11.4+ documented in `feedback_mariadb_reserved_words` |
 | Redis | distro | apt | M14 notifications stream + SSO session store |
-| Adminer | `4.8.1` | `github.com/vrana/adminer` release | M37 DB UI |
+| Adminer | `6.0.1` | `github.com/vrana/adminer` release | M37 DB UI |
 | phpMyAdmin | `5.2.3` | phpmyadmin.net tarball | M7 |
 
 ## DNS

--- a/docs/site/platform/components.md
+++ b/docs/site/platform/components.md
@@ -44,7 +44,7 @@ Version pins shown are the values in `install.sh` at the time of writing. Run `j
 | Component | Version | Role |
 |---|---|---|
 | **phpMyAdmin** | 5.2.3 | MariaDB web UI with single-use SSO (`sso.php`) |
-| **Adminer** | 4.8.1 | Lighter DB web UI + `jabali-sso-plugin.php` |
+| **Adminer** | 6.0.1 | Lighter DB web UI + `jabali-sso-plugin.php` |
 | **WP-CLI** | 2.12.0 | WordPress automation |
 | **GoAccess** | Debian | nginx log analyzer |
 | **Roundcube** | Debian + install snippet | Webmail (served by Bulwark vhost) |

--- a/install.sh
+++ b/install.sh
@@ -8021,10 +8021,10 @@ install_adminer() {
   # other install.sh pin (phpMyAdmin, Stalwart, Kratos, …). Bump this one line,
   # then `scripts/deps-check.sh --refresh-sha adminer_version` to re-capture the
   # checksum.
-  local adminer_version="4.8.1"
+  local adminer_version="6.0.1"
   local adminer_dir="/var/www/jabali-adminer"
   local adminer_url="https://github.com/vrana/adminer/releases/download/v${adminer_version}/adminer-${adminer_version}.php"
-  local adminer_plugin_url="https://raw.githubusercontent.com/vrana/adminer/v${adminer_version}/plugins/plugin.php"
+  local adminer_stamp="${adminer_dir}/.adminer-version"
 
   mkdir -p "${adminer_dir}"
 
@@ -8038,8 +8038,15 @@ install_adminer() {
   # with the operator's DB credentials — and nothing in install or CI would
   # notice. Download to a temp path first so a mismatch can never leave a
   # partially-verified file in the docroot.
-  if [[ ! -f "${adminer_dir}/adminer.php" ]]; then
-    _log "downloading adminer.php"
+  #
+  # Re-download whenever the on-disk build is not the pinned version: a plain
+  # `[[ ! -f ]]` gate would freeze every existing box at whatever it first
+  # installed, so a bump (e.g. 4.8.1 -> 6.0.1) would never roll out on
+  # `jabali update`. The .adminer-version stamp records the last verified build.
+  local adminer_have=""
+  [[ -f "${adminer_stamp}" ]] && adminer_have="$(cat "${adminer_stamp}" 2>/dev/null)"
+  if [[ ! -f "${adminer_dir}/adminer.php" || "${adminer_have}" != "${adminer_version}" ]]; then
+    _log "downloading adminer.php (${adminer_version})"
     local adminer_tmp
     adminer_tmp="$(mktemp)"
     if ! curl -fsSL --retry 4 --retry-delay 2 --retry-connrefused -o "$adminer_tmp" "${adminer_url}"; then
@@ -8055,41 +8062,20 @@ install_adminer() {
       _err "adminer checksum mismatch: expected ${adminer_expected:-<missing pin>}, got $adminer_actual"
       return 1
     fi
+    # Atomic swap: the old adminer.php stays in place until the verified new one
+    # is moved over it, then stamp the version so we don't re-download next tick.
     mv "$adminer_tmp" "${adminer_dir}/adminer.php"
-    _ok "adminer.php checksum verified"
+    echo "${adminer_version}" > "${adminer_stamp}"
+    _ok "adminer.php ${adminer_version} checksum verified"
   else
-    _ok "adminer.php already present"
+    _ok "adminer.php ${adminer_version} already present"
   fi
 
-  # Adminer's plugin loader (separate from the main file). Checksum-verified
-  # too: it is loaded by adminer.php, so it executes with the same privileges.
-  if [[ ! -f "${adminer_dir}/plugin.php" ]]; then
-    _log "downloading Adminer plugin loader"
-    local plugin_tmp
-    plugin_tmp="$(mktemp)"
-    if ! curl -fsSL --retry 4 --retry-delay 2 --retry-connrefused -o "$plugin_tmp" "${adminer_plugin_url}"; then
-      # Non-fatal: the plugin loader only enhances Adminer (jabali-sso plugin).
-      # A transient GitHub-raw hiccup shouldn't brick the whole install; the DB
-      # admin tool still works, and `jabali update` / repair can refetch it.
-      rm -f "$plugin_tmp"
-      _warn "failed to download adminer plugin loader (non-fatal) — Adminer SSO plugin disabled until next update"
-    else
-      local plugin_expected plugin_actual
-      plugin_expected="$(grep -v '^#' "${REPO_DIR}/install/adminer-plugin.sha256" | awk '{print $1}')"
-      plugin_actual="$(sha256sum "$plugin_tmp" | awk '{print $1}')"
-      if [[ -z "$plugin_expected" || "$plugin_expected" != "$plugin_actual" ]]; then
-        # A MISMATCH is not the same as a failed download: the file served is
-        # not the pinned one, so refuse it rather than degrade quietly.
-        rm -f "$plugin_tmp"
-        _warn "adminer plugin loader checksum mismatch (expected ${plugin_expected:-<missing pin>}, got $plugin_actual) — refusing it; SSO plugin disabled"
-      else
-        mv "$plugin_tmp" "${adminer_dir}/plugin.php"
-        _ok "adminer plugin loader checksum verified"
-      fi
-    fi
-  else
-    _ok "adminer plugin loader already present"
-  fi
+  # Adminer 6 bundles its plugin loader inside adminer.php; the 4.x
+  # plugins/plugin.php file is gone (our index.php registers the SSO plugin via
+  # a global adminer_object() instead). Remove any stale copy a prior 4.x
+  # install left so no dead upstream PHP lingers in the www-data docroot.
+  rm -f "${adminer_dir}/plugin.php"
 
   # Drop our index.php + jabali-sso plugin from the repo.
   install -m 0644 "${REPO_DIR}/install/adminer/index.php"            "${adminer_dir}/index.php"

--- a/install/adminer-plugin.sha256
+++ b/install/adminer-plugin.sha256
@@ -1,4 +1,0 @@
-# Adminer 4.8.1 plugin loader (plugins/plugin.php) — loaded by adminer.php,
-# so it executes with the same privileges. Bump together with
-# adminer_plugin_url in install.sh.
-f97b8a530cee342f3fb93816bfad397cd1c27a42cb16b0844a7c42bb66acded1  plugin.php

--- a/install/adminer.sha256
+++ b/install/adminer.sha256
@@ -1,6 +1,7 @@
-# Adminer 4.8.1 — served on the panel vhost behind jabali SSO with full
+# Adminer 6.0.1 — served on the panel vhost behind jabali SSO with full
 # database access, so a swapped file is arbitrary PHP running as www-data
 # with the operator's DB credentials. Pinned per the same rule as every other
 # third-party artifact here (wp-cli, phpMyAdmin, Stalwart, Kratos, Bulwark).
-# Bump together with adminer_url in install.sh.
-2fd7e6d8f987b243ab1839249551f62adce19704c47d3d0c8dd9e57ea5b9c6b3  adminer-4.8.1.php
+# Bump together with adminer_version in install.sh, then
+# `scripts/deps-check.sh --refresh-sha adminer_version` to re-capture this.
+1815c03f26e21d533e729c0b09bc69a59c902a6440409d013105ee679dff006c  adminer-6.0.1.php

--- a/install/adminer/index.php
+++ b/install/adminer/index.php
@@ -1,35 +1,43 @@
 <?php
 /**
- * Jabali Adminer entry-point.
+ * Jabali Adminer entry-point (Adminer 6 — GH #1405).
  *
- * Loads the upstream Adminer single-file build with our jabali-sso
- * plugin, which:
+ * Adminer 6 dropped the 4.x `AdminerPlugin` wrapper + `plugins/plugin.php`
+ * loader. Plugins now live in the `Adminer\` namespace and are registered
+ * through a global `adminer_object()` that returns an `Adminer\Plugins`
+ * instance; Adminer honours it at
+ *   Adminer::$instance = function_exists('adminer_object') ? adminer_object() : …
+ * (verified against adminer-6.0.1.php). The Plugins dispatcher appends a
+ * default Adminer as the final hook, so any method our plugin does NOT
+ * override falls through to Adminer's own behaviour.
+ *
+ * Our plugin:
  *  1. reads ?token=<base64url> from the URL,
  *  2. POSTs it to /sso/adminer/validate over the panel-api UDS,
  *  3. supplies the engine-specific credentials to Adminer,
  *  4. forces a single-database scope (no schema browser leakage).
  *
- * Engine routing:
+ * Engine routing (driver ids unchanged in Adminer 6):
  *   - mariadb  → driver "server" (Adminer's MySQLi/PDO_MySQL)
  *   - postgres → driver "pgsql"  (Adminer's PostgreSQL via libpq)
  *
  * Layout:
- *   /var/www/jabali-adminer/index.php           — this file
- *   /var/www/jabali-adminer/adminer.php         — upstream single-file
- *   /var/www/jabali-adminer/jabali-sso-plugin.php — plugin
+ *   /var/www/jabali-adminer/index.php             — this file
+ *   /var/www/jabali-adminer/adminer.php           — upstream single-file (6.x)
+ *   /var/www/jabali-adminer/jabali-sso-plugin.php — plugin (namespace Adminer)
  */
 
 require_once __DIR__ . '/jabali-sso-plugin.php';
 
+// Global (unnamespaced) so Adminer's function_exists('adminer_object') check
+// finds it. Returns the plugins dispatcher with our SSO plugin registered.
+// \Adminer\Plugins is defined inside adminer.php, which is required below —
+// this function is only CALLED once Adminer runs, by which point the class
+// exists.
 function adminer_object() {
-    $sock = '/run/jabali-panel/sso.sock';
-    $plugins = [
-        new JabaliAdminerSSO($sock),
-    ];
-    if (!class_exists('AdminerPlugin')) {
-        require_once __DIR__ . '/plugin.php';
-    }
-    return new AdminerPlugin($plugins);
+    return new \Adminer\Plugins([
+        new \Adminer\JabaliAdminerSSO('/run/jabali-panel/sso.sock'),
+    ]);
 }
 
 require_once __DIR__ . '/adminer.php';

--- a/install/adminer/jabali-sso-plugin.php
+++ b/install/adminer/jabali-sso-plugin.php
@@ -1,6 +1,13 @@
 <?php
 /**
- * Jabali Adminer SSO plugin (M37 Phase 4).
+ * Jabali Adminer SSO plugin.
+ *
+ * Ported to the Adminer 6 plugin API (GH #1405): plugins live in the
+ * `Adminer\` namespace and are registered via a global adminer_object()
+ * that returns an Adminer\Plugins instance (see index.php). The dispatcher
+ * calls each hook a plugin defines and takes the first non-null result,
+ * falling back to Adminer's own default — so returning null here lets
+ * Adminer render its standard login form when a token is missing/expired.
  *
  * Token flow:
  *   1. Browser hits /jabali-adminer/?token=<base64url>&engine=<eng>&db=<name>
@@ -12,15 +19,18 @@
  *      navigates inside its UI via more requests; without the cache
  *      the token would be replay-rejected on the very next click).
  *   4. Plugin auto-submits the Adminer login form with the cached
- *      creds via a small <form> + JS so the user lands directly on
- *      the database view.
+ *      creds so the user lands directly on the database view.
  *
- * Engine driver mapping:
+ * Engine driver mapping (unchanged in Adminer 6 — verified against the
+ * 6.0.1 driver tables):
  *   - mariadb  → driver "server"  (Adminer's MySQLi/PDO_MySQL backend)
  *   - postgres → driver "pgsql"   (libpq via pg_connect)
  *
  * @see panel-api/internal/api/sso_adminer_validate.go
  */
+
+namespace Adminer;
+
 class JabaliAdminerSSO {
     /** @var string Path to the panel-api Unix socket. */
     private $socket_path;
@@ -130,14 +140,14 @@ class JabaliAdminerSSO {
 
     /**
      * Replace Adminer's login form with a hidden auto-submitting
-     * form. Returning truthy stops Adminer from rendering its own
-     * form below. When there are no creds to inject, return falsy
-     * so Adminer's standard form renders and the user can see
-     * what failed.
+     * form. Returning truthy stops Adminer (and later plugins) from
+     * rendering the default form below. When there are no creds to
+     * inject, return null so Adminer's standard form renders and the
+     * user can see what failed.
      */
     public function loginForm() {
         $c = $this->fetchCreds();
-        if ($c === null) return;
+        if ($c === null) return null;
 
         $h = function ($v) {
             return htmlspecialchars((string)$v, ENT_QUOTES);
@@ -145,9 +155,8 @@ class JabaliAdminerSSO {
 
         // Adminer wraps loginForm() output inside its own <form
         // action="" method="post">. HTML forbids nested forms, so
-        // browsers strip the inner one — getElementById then returns
-        // null and the auto-submit script crashes. Output hidden
-        // <input>s directly into the parent form and submit it.
+        // browsers strip the inner one — output hidden <input>s
+        // directly into the parent form and submit it.
         echo '<input type="hidden" name="auth[driver]"   value="' . $h($c['driver']) . '">';
         echo '<input type="hidden" name="auth[server]"   value="' . $h($c['server']) . '">';
         echo '<input type="hidden" name="auth[username]" value="' . $h($c['username']) . '">';
@@ -156,11 +165,9 @@ class JabaliAdminerSSO {
         echo '<noscript><button type="submit">Continue</button></noscript>';
         echo '<p style="text-align:center;padding:2rem">Signing into Adminer via Jabali SSO…</p>';
         // Adminer ships a strict CSP (script-src ... nonce-... strict-dynamic).
-        // Inline scripts WITHOUT the matching nonce are blocked. Use
-        // Adminer's nonce() helper which returns the full attribute
-        // string (` nonce="..."`).
-        $nonceAttr = function_exists("nonce") ? nonce() : "";
-        echo '<script' . $nonceAttr . '>(document.querySelector("form[method=post]")||document.forms[0]).submit();</script>';
+        // Use Adminer\script(), which emits a <script> carrying the request
+        // nonce, so the inline auto-submit isn't blocked (Adminer 6 helper).
+        echo script('(document.querySelector("form[method=post]")||document.forms[0]).submit();');
         return true;
     }
 
@@ -199,10 +206,5 @@ class JabaliAdminerSSO {
         $c = $this->fetchCreds();
         if ($c === null) return null;
         return [$c['db']];
-    }
-
-    /** No persistent cookie — every fresh entry uses a one-shot token. */
-    public function permanentLogin($create = false) {
-        return false;
     }
 }

--- a/scripts/check-pinned-downloads.sh
+++ b/scripts/check-pinned-downloads.sh
@@ -93,7 +93,7 @@ check_gh  "bulwark-webmail $BW_V" "bulwarkmail/webmail"  "${BW_V}"   # no v-pref
 KR_V="$(pin 'kratos_version="[0-9.]+"')"
 check_url "kratos $KR_V"      "https://github.com/ory/kratos/releases/download/v${KR_V}/kratos_${KR_V}-linux_64bit.tar.gz"
 
-check_url "adminer 4.8.1"     "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php"
+check_url "adminer 6.0.1"     "https://github.com/vrana/adminer/releases/download/v6.0.1/adminer-6.0.1.php"
 
 echo ""
 if [[ $fail -eq 0 ]]; then


### PR DESCRIPTION
## What (GH #1405)

Upgrades bundled Adminer **4.8.1 → 6.0.1** and ports the jabali SSO plugin to
Adminer 6's plugin system. (The monthly-review *tracking* landed earlier in
#1432; this is the actual bump the issue asked for.)

## Why it's a real port, not a pin bump

Adminer 6 rewrote the plugin system:
- `plugins/plugin.php` (the 4.x loader) is **gone** — it now 404s upstream, and
  our install.sh downloaded it.
- Plugins live in the `Adminer\` namespace and extend/duck-type against
  `Adminer\Plugin`; the `AdminerPlugin` wrapper was replaced by an
  `Adminer\Plugins` dispatcher that appends a default `Adminer` as the final
  hook and returns the first non-null plugin result.
- `adminer_object()` **is still honoured** (`Adminer::$instance =
  function_exists('adminer_object') ? adminer_object() : …`), so the bootstrap
  stays a one-liner.

Verified against the fetched v6.0.1 source: the full `adminer-6.0.1.php` bundles
both the `server` (MySQL/MariaDB) and `pgsql` drivers; the `auth[]` field names
and driver ids are **unchanged**, so `sso_adminer_validate.go` needs no change.

## Changes

- **install.sh** — pin `6.0.1`; **fix the upgrade path**: the download was gated
  on `[[ ! -f adminer.php ]]`, which would freeze every existing box at 4.8.1
  forever on a bump. Now gated on a `.adminer-version` stamp (atomic swap; old
  file kept until the new one checksum-verifies) so `jabali update` actually
  rolls it out. Removes the plugin.php download and `rm`s any stale 4.x
  `plugin.php` from the docroot.
- **install/adminer.sha256** — re-pinned for `adminer-6.0.1.php`.
  **install/adminer-plugin.sha256** — deleted (loader no longer exists).
- **index.php** — global `adminer_object()` → `new \Adminer\Plugins([...])`.
- **jabali-sso-plugin.php** — `namespace Adminer`; dropped the `permanentLogin`
  override (now returns string, and the default no-ops without `auth[permanent]`);
  auto-submit uses `Adminer\script()` for the CSP nonce. All other hooks
  unchanged.
- **check-pinned-downloads.sh** + docs bumped to 6.0.1.

No Go / migration / OpenAPI changes.

## E2E (box: real Adminer 6.0.1 + real MariaDB)

Only the token→creds UDS hop was stubbed (that Go code is unchanged); everything
Adminer-6-specific ran for real:
- `php -l` clean on both files.
- **GET `?token=`** → the SSO auto-submit renders with the injected `auth[]`
  fields, no PHP errors (bootstrap + `adminer_object` + `Plugins` + `loginForm`
  + creds fetch all work).
- **auth POST** → **302** (authenticated against real MariaDB).
- **second navigation** → the real DB view lists a seeded table, **no** bounce
  back to the login form, no PHP errors — Adminer 6's per-request auth + our
  `$_SESSION` cache work across clicks (the regression that most needed proving).

Postgres shares the identical plugin code path (only the returned `driver`/
`server` strings differ, both bundled + validated), so it's covered by the same
port.

## Rollout note

This replaces a security-sensitive, DB-admin-privileged component. It ships via
the normal fleet update; the `.adminer-version` stamp ensures existing boxes
actually upgrade (and re-verify the checksum) rather than keeping 4.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
