### PR TITLE
feat(restore): add "Select all" to the tenant restore drawer (GH #1363)

### DIFF
--- a/panel-ui/src/shells/user/RestoreDrawer.tsx
+++ b/panel-ui/src/shells/user/RestoreDrawer.tsx
@@ -185,6 +185,42 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
             restorable here.
           </Typography.Paragraph>
 
+          {/* GH #1363: one click to select every resource in the backup, so a
+              user doesn't have to tick each one. Home already includes every
+              ~/domains/<d> docroot, so "Domain files" is left unticked to avoid
+              a redundant second apply of the same files. */}
+          {(hasHome ||
+            databases.length > 0 ||
+            mailboxes.length > 0 ||
+            dnsDomains.length > 0) && (
+            <Space>
+              <Button
+                size="small"
+                onClick={() => {
+                  setRestoreHome(hasHome);
+                  setSelected([...databases]);
+                  setSelectedMb([...mailboxes]);
+                  setSelectedDns([...dnsDomains]);
+                  setSelectedDomainFiles([]);
+                }}
+              >
+                Select all
+              </Button>
+              <Button
+                size="small"
+                onClick={() => {
+                  setRestoreHome(false);
+                  setSelected([]);
+                  setSelectedMb([]);
+                  setSelectedDns([]);
+                  setSelectedDomainFiles([]);
+                }}
+              >
+                Clear
+              </Button>
+            </Space>
+          )}
+
           {hasHome && (
             <Checkbox
               checked={restoreHome}


### PR DESCRIPTION
## What (GH #1363)

The reporter asked for a one-click **"select all"** on the tenant self-restore
drawer, which otherwise makes the user tick each resource (databases, mailboxes,
DNS, home, per-domain files) individually.

## Change

Adds a **Select all** button (and a **Clear** companion) at the top of the
restore drawer's resource list. Select all ticks the home directory + every
database, mailbox and DNS domain present in the backup.

It deliberately leaves the per-domain **Domain files** picks empty: the home
directory already contains every `~/domains/<domain>` docroot, so selecting both
would re-apply the same files a second time.

UI-only — the restore POST already accepts all the resource arrays, so no
backend change. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
