### PR TITLE
fix(domains): delete-files removes the whole domain folder, not just public_html (GH #1382)

### DIFF
--- a/panel-agent/internal/commands/domain_docroot_delete_test.go
+++ b/panel-agent/internal/commands/domain_docroot_delete_test.go
@@ -15,6 +15,7 @@ func TestDocrootUnderHome(t *testing.T) {
 	}{
 		{"depth-2 public_html/domain", "/home/alice/public_html/example.com", false},
 		{"depth-3 domains/domain/public_html", "/home/alice/domains/example.com/public_html", false},
+		{"depth-2 domains/domain (whole domain folder, GH #1382)", "/home/alice/domains/example.com", false},
 		{"home itself", "/home/alice", true},
 		{"bare public_html", "/home/alice/public_html", true},
 		{"bare domains", "/home/alice/domains", true},

--- a/panel-api/internal/api/domain_delete_files_target_test.go
+++ b/panel-api/internal/api/domain_delete_files_target_test.go
@@ -1,0 +1,48 @@
+package api
+
+import "testing"
+
+// GH #1382 follow-up: "also delete the files" must remove the whole per-domain
+// folder, not just its public_html — but never a docroot that lives outside it.
+func TestDomainDeleteFilesTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		user     string
+		domain   string
+		docroot  string
+		wantPath string
+	}{
+		{
+			name:     "default docroot → whole domain folder",
+			user:     "alice", domain: "example.com",
+			docroot:  "/home/alice/domains/example.com/public_html",
+			wantPath: "/home/alice/domains/example.com",
+		},
+		{
+			name:     "custom docroot under the domain folder → whole domain folder",
+			user:     "alice", domain: "example.com",
+			docroot:  "/home/alice/domains/example.com/current/web",
+			wantPath: "/home/alice/domains/example.com",
+		},
+		{
+			name:     "docroot outside the domain folder → docroot unchanged",
+			user:     "alice", domain: "example.com",
+			docroot:  "/home/alice/public_html",
+			wantPath: "/home/alice/public_html",
+		},
+		{
+			name:     "prefix-sibling domain name is not a match",
+			user:     "alice", domain: "example.com",
+			docroot:  "/home/alice/domains/example.com.bak/public_html",
+			wantPath: "/home/alice/domains/example.com.bak/public_html",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := domainDeleteFilesTarget(tc.user, tc.domain, tc.docroot)
+			if got != tc.wantPath {
+				t.Fatalf("target = %q, want %q", got, tc.wantPath)
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -1196,13 +1196,14 @@ func (h *domainHandler) delete(c *gin.Context) {
 		if owner, uerr := h.cfg.Users.FindByID(ctx, domain.UserID); uerr == nil &&
 			owner != nil && owner.Username != nil && *owner.Username != "" {
 			username, docroot, dname := *owner.Username, domain.DocRoot, domain.Name
+			target := domainDeleteFilesTarget(username, dname, docroot)
 			ag := h.cfg.Agent
 			go func() {
 				dctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 				defer cancel()
 				if _, aerr := ag.Call(dctx, "domain.docroot.delete", map[string]string{
 					"username": username,
-					"docroot":  docroot,
+					"docroot":  target,
 				}); aerr != nil {
 					slog.Warn("domain delete: docroot cleanup failed; files left in place",
 						"domain", dname, "error", aerr)
@@ -1212,6 +1213,22 @@ func (h *domainHandler) delete(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+// domainDeleteFilesTarget picks what "also delete the files" removes (GH #1382
+// follow-up). It returns the whole per-domain folder
+// (/home/<user>/domains/<domain>) when the docroot lives inside it — which is
+// the normal layout, and where GH #526 confines any custom docroot too — so the
+// domain's public_html, logs and siblings all go, not just public_html. If the
+// docroot sits OUTSIDE that folder (e.g. a legacy/primary domain served from
+// ~/public_html) it returns the docroot unchanged, so we never remove an
+// unrelated or shared directory. The agent re-validates whatever we send.
+func domainDeleteFilesTarget(username, domainName, docroot string) string {
+	domainDir := "/home/" + username + "/domains/" + domainName
+	if strings.HasPrefix(docroot, domainDir+"/") {
+		return domainDir
+	}
+	return docroot
 }
 
 // allowedNginxDirectives is a per-line allowlist of nginx directives that users


### PR DESCRIPTION
## What (GH #1382 follow-up)

The reporter confirmed the opt-in "also delete the files" (shipped in #1424)
removed `~/domains/<domain>/public_html` but left the parent
`~/domains/<domain>` folder behind (empty shell + the domain's logs). This makes
it remove the **whole per-domain folder**.

## Fix

Panel-side path change only. When "also delete the files" is ticked, we now send
`/home/<user>/domains/<domain>` to the agent instead of just the docroot:

- The docroot — default *or* a GH #526 custom one — is always confined to
  `/home/<user>/domains/<domain>/`, so removing that folder takes `public_html`,
  the domain's `logs`, and any siblings with it.
- If the stored docroot sits **outside** that folder (e.g. a legacy/primary
  domain served from `~/public_html`), we send the docroot unchanged — an
  unrelated or shared directory is never removed.

Extracted the decision into `domainDeleteFilesTarget()` and unit-tested it
(default docroot → domain folder; custom docroot under it → domain folder;
docroot outside → unchanged; prefix-sibling `example.com.bak` is not a match).

## Agent unchanged

`domain.docroot.delete` still runs `rm -rf` **as the tenant UID** (TOCTOU-safe),
and its `≥2-levels-under-home` guard already **accepts**
`/home/<user>/domains/<domain>` (2 levels) while still **refusing** a bare
`~/domains` — pinned by a new guard test case. No agent change, so nothing new to
deploy on the agent side.

`tsc` n/a; Go build + `api` package + agent guard tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
