### PR TITLE
feat(files): async copy with a real byte-progress bar on Paste (GH #1392)

### DIFF
--- a/internal/filesafe/openat2.go
+++ b/internal/filesafe/openat2.go
@@ -452,6 +452,15 @@ func removeAllAt(ctx context.Context, dirFd int, name string) error {
 // target string is data, not followed). Each created file/dir is chowned to
 // uid:gid. Returns total bytes of regular-file content copied.
 func (s *Scope) CopyTreeInScope(ctx context.Context, srcPath, dstPath string, uid, gid int) (int64, error) {
+	return s.CopyTreeInScopeProgress(ctx, srcPath, dstPath, uid, gid, nil)
+}
+
+// CopyTreeInScopeProgress is CopyTreeInScope with an optional onBytes callback,
+// invoked with the byte delta after each chunk of regular-file data is written,
+// so a caller (GH #1392 async copy) can drive a progress bar. onBytes may be
+// nil. The callback only ever sees a byte count — it touches no fds or paths,
+// so it cannot weaken the escape-proof O_NOFOLLOW descent.
+func (s *Scope) CopyTreeInScopeProgress(ctx context.Context, srcPath, dstPath string, uid, gid int, onBytes func(int64)) (int64, error) {
 	srcInfo, err := s.StatInScope(srcPath)
 	if err != nil {
 		return 0, err
@@ -500,7 +509,7 @@ func (s *Scope) CopyTreeInScope(ctx context.Context, srcPath, dstPath string, ui
 			unix.Close(dfd)
 			return 0, fmt.Errorf("chown copied dir: %w", chErr) // GH #662
 		}
-		n, cerr := copyDirContents(ctx, int(sfd.Fd()), dfd, uid, gid)
+		n, cerr := copyDirContents(ctx, int(sfd.Fd()), dfd, uid, gid, onBytes)
 		unix.Close(dfd)
 		return n, cerr
 
@@ -521,7 +530,7 @@ func (s *Scope) CopyTreeInScope(ctx context.Context, srcPath, dstPath string, ui
 			_ = out.Close()
 			return 0, fmt.Errorf("chown copied file %q: %w", dstLeaf, chErr)
 		}
-		n, cerr := io.Copy(out, in)
+		n, cerr := io.Copy(progressDst(out, onBytes), in)
 		if closeErr := out.Close(); cerr == nil {
 			cerr = closeErr
 		}
@@ -534,7 +543,7 @@ func (s *Scope) CopyTreeInScope(ctx context.Context, srcPath, dstPath string, ui
 
 // copyDirContents copies every entry under srcFd into dstFd (both open dir fds),
 // recursing with O_NOFOLLOW so neither side can be redirected mid-walk.
-func copyDirContents(ctx context.Context, srcFd, dstFd, uid, gid int) (int64, error) {
+func copyDirContents(ctx context.Context, srcFd, dstFd, uid, gid int, onBytes func(int64)) (int64, error) {
 	dup, err := unix.Dup(srcFd)
 	if err != nil {
 		return 0, err
@@ -556,7 +565,7 @@ func copyDirContents(ctx context.Context, srcFd, dstFd, uid, gid int) (int64, er
 			continue
 		}
 		li := statToLeaf(name, &st)
-		n, err := copyEntryAt(ctx, srcFd, dstFd, name, li, uid, gid)
+		n, err := copyEntryAt(ctx, srcFd, dstFd, name, li, uid, gid, onBytes)
 		if err != nil {
 			return total, err
 		}
@@ -566,7 +575,7 @@ func copyDirContents(ctx context.Context, srcFd, dstFd, uid, gid int) (int64, er
 }
 
 // copyEntryAt copies a single entry `name` from srcFd to dstFd.
-func copyEntryAt(ctx context.Context, srcFd, dstFd int, name string, li LeafInfo, uid, gid int) (int64, error) {
+func copyEntryAt(ctx context.Context, srcFd, dstFd int, name string, li LeafInfo, uid, gid int, onBytes func(int64)) (int64, error) {
 	switch {
 	case li.IsSymlink:
 		target, err := readlinkat(srcFd, name)
@@ -599,19 +608,19 @@ func copyEntryAt(ctx context.Context, srcFd, dstFd int, name string, li LeafInfo
 			unix.Close(ndst)
 			return 0, err
 		}
-		n, cerr := copyDirContents(ctx, nsrc, ndst, uid, gid)
+		n, cerr := copyDirContents(ctx, nsrc, ndst, uid, gid, onBytes)
 		unix.Close(nsrc)
 		unix.Close(ndst)
 		return n, cerr
 	case li.Mode.IsRegular():
-		return copyRegularAt(srcFd, dstFd, name, li.Mode.Perm(), uid, gid)
+		return copyRegularAt(srcFd, dstFd, name, li.Mode.Perm(), uid, gid, onBytes)
 	default:
 		return 0, nil // skip devices/sockets/fifos
 	}
 }
 
 // copyRegularAt copies a regular file `name` from srcFd to dstFd via openat.
-func copyRegularAt(srcFd, dstFd int, name string, perm os.FileMode, uid, gid int) (int64, error) {
+func copyRegularAt(srcFd, dstFd int, name string, perm os.FileMode, uid, gid int, onBytes func(int64)) (int64, error) {
 	ifd, err := unix.Openat(srcFd, name, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return 0, err
@@ -628,11 +637,110 @@ func copyRegularAt(srcFd, dstFd int, name string, perm os.FileMode, uid, gid int
 		_ = out.Close()
 		return 0, fmt.Errorf("chown copied file %q: %w", name, chErr)
 	}
-	n, cerr := io.Copy(out, in)
+	n, cerr := io.Copy(progressDst(out, onBytes), in)
 	if closeErr := out.Close(); cerr == nil {
 		cerr = closeErr
 	}
 	return n, cerr
+}
+
+// progressWriter wraps a writer, invoking cb with the byte count after each
+// successful write. Used to drive an async copy's progress bar (GH #1392). It
+// carries no fd/path state, so it cannot affect the escape-proof copy descent.
+type progressWriter struct {
+	w  io.Writer
+	cb func(int64)
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n, err := p.w.Write(b)
+	if n > 0 {
+		p.cb(int64(n))
+	}
+	return n, err
+}
+
+// progressDst returns w wrapped to report bytes to onBytes, or w unchanged when
+// onBytes is nil (the synchronous copy path pays nothing).
+func progressDst(w io.Writer, onBytes func(int64)) io.Writer {
+	if onBytes == nil {
+		return w
+	}
+	return &progressWriter{w: w, cb: onBytes}
+}
+
+// CountTreeBytesInScope sums the regular-file bytes under srcPath using the same
+// fd-based O_NOFOLLOW descent as the copy, so a symlink can never redirect the
+// walk out of the scope or inflate the total from outside the jail (GH #1392).
+// Symlinks and directory entries contribute 0 — it mirrors what the byte-
+// progress copy will actually write. Best-effort for a progress denominator: it
+// returns whatever it counted alongside any error.
+func (s *Scope) CountTreeBytesInScope(ctx context.Context, srcPath string) (int64, error) {
+	info, err := s.StatInScope(srcPath)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case info.IsSymlink:
+		return 0, nil
+	case info.IsDir:
+		sfd, err := s.OpenDirInScope(srcPath)
+		if err != nil {
+			return 0, err
+		}
+		defer sfd.Close()
+		return countDirBytes(ctx, int(sfd.Fd()))
+	case info.Mode.IsRegular():
+		return info.Size, nil
+	default:
+		return 0, nil
+	}
+}
+
+// countDirBytes recurses srcFd counting regular-file bytes, O_NOFOLLOW at every
+// level so it cannot be redirected outside the scope. Unreadable entries are
+// skipped (same tolerance as the copy walk), so the total is a best-effort
+// denominator, never a hard failure.
+func countDirBytes(ctx context.Context, srcFd int) (int64, error) {
+	dup, err := unix.Dup(srcFd)
+	if err != nil {
+		return 0, err
+	}
+	sdir := os.NewFile(uintptr(dup), ".")
+	names, err := sdir.Readdirnames(-1)
+	sdir.Close()
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		var st unix.Stat_t
+		if err := unix.Fstatat(srcFd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			continue
+		}
+		li := statToLeaf(name, &st)
+		switch {
+		case li.IsSymlink:
+			// counts as 0, like the copy
+		case li.IsDir:
+			nsrc, err := unix.Openat(srcFd, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+			if err != nil {
+				continue
+			}
+			n, cerr := countDirBytes(ctx, nsrc)
+			unix.Close(nsrc)
+			if cerr != nil {
+				return total + n, cerr
+			}
+			total += n
+		case li.Mode.IsRegular():
+			total += li.Size
+		}
+	}
+	return total, nil
 }
 
 // ReadlinkInScope reads the symlink target at pathStr fd-safely: the parent is

--- a/internal/filesafe/openat2_func_test.go
+++ b/internal/filesafe/openat2_func_test.go
@@ -2,6 +2,8 @@ package filesafe
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -124,6 +126,31 @@ func TestCopyProgress_SingleFile(t *testing.T) {
 	}
 	if ticked != 10 {
 		t.Fatalf("ticks = %d, want 10", ticked)
+	}
+}
+
+// GH #1392: a copy whose destination already exists must fail with an error
+// that errors.Is(err, fs.ErrExist) — the async copy's rollback relies on this
+// to know the copy created NOTHING and must NOT delete the pre-existing dst.
+func TestCopyTree_ExistingDst_IsErrExist(t *testing.T) {
+	scope, docroot := funcScope(t)
+	src := filepath.Join(docroot, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(docroot, "dst")
+	if err := os.MkdirAll(dst, 0o755); err != nil { // dst already present
+		t.Fatal(err)
+	}
+	_, err := scope.CopyTreeInScope(context.Background(), src, dst, os.Getuid(), os.Getgid())
+	if err == nil {
+		t.Fatal("copy into an existing dst must fail")
+	}
+	if !errors.Is(err, fs.ErrExist) {
+		t.Fatalf("err = %v, want errors.Is fs.ErrExist (the rollback guard depends on it)", err)
 	}
 }
 

--- a/internal/filesafe/openat2_func_test.go
+++ b/internal/filesafe/openat2_func_test.go
@@ -65,6 +65,68 @@ func TestCopyTreeInScope_ReproducesTree(t *testing.T) {
 	}
 }
 
+// GH #1392: CountTreeBytesInScope must sum exactly the regular-file bytes the
+// byte-progress copy will write (symlinks + dirs contribute 0), and
+// CopyTreeInScopeProgress must report that same total via onBytes.
+func TestCountAndCopyProgress(t *testing.T) {
+	scope, docroot := funcScope(t)
+	src := filepath.Join(docroot, "src")
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("aaaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "b.txt"), []byte("bbbbbb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("a.txt", filepath.Join(src, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	total, err := scope.CountTreeBytesInScope(context.Background(), src)
+	if err != nil {
+		t.Fatalf("CountTreeBytesInScope: %v", err)
+	}
+	if total != 10 { // 4 + 6; symlink counts 0
+		t.Fatalf("count = %d, want 10", total)
+	}
+
+	var ticked int64
+	dst := filepath.Join(docroot, "dst")
+	n, err := scope.CopyTreeInScopeProgress(context.Background(), src, dst, os.Getuid(), os.Getgid(), func(d int64) { ticked += d })
+	if err != nil {
+		t.Fatalf("CopyTreeInScopeProgress: %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("copied bytes = %d, want 10", n)
+	}
+	if ticked != 10 {
+		t.Fatalf("progress ticks summed to %d, want 10 (must equal bytes copied)", ticked)
+	}
+}
+
+// A single regular file must still report its bytes through onBytes (the
+// worst-case-for-file-count path: one big file).
+func TestCopyProgress_SingleFile(t *testing.T) {
+	scope, docroot := funcScope(t)
+	src := filepath.Join(docroot, "one.bin")
+	if err := os.WriteFile(src, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if c, err := scope.CountTreeBytesInScope(context.Background(), src); err != nil || c != 10 {
+		t.Fatalf("count = %d err=%v, want 10", c, err)
+	}
+	var ticked int64
+	dst := filepath.Join(docroot, "one-copy.bin")
+	if _, err := scope.CopyTreeInScopeProgress(context.Background(), src, dst, os.Getuid(), os.Getgid(), func(d int64) { ticked += d }); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if ticked != 10 {
+		t.Fatalf("ticks = %d, want 10", ticked)
+	}
+}
+
 func TestRemoveAllInScope_RemovesPopulatedTree(t *testing.T) {
 	scope, docroot := funcScope(t)
 	tree := filepath.Join(docroot, "tree")

--- a/panel-agent/internal/commands/file_jobs.go
+++ b/panel-agent/internal/commands/file_jobs.go
@@ -42,19 +42,24 @@ type fileJob struct {
 	mu     sync.Mutex
 	status string
 	done   int64
-	total  int64 // 0 = unknown (streamed tar) → indeterminate
-	result filesExtractResult
+	total  int64 // 0 = unknown (streamed tar / uncounted) → indeterminate
+	// result is the op-specific completion payload (filesExtractResult for
+	// extract, filesCopyJobResult for copy, GH #1392); serialized as-is under
+	// "result" in the snapshot.
+	result any
 	errMsg string
 }
 
 func (j *fileJob) setTotal(n int64) { j.mu.Lock(); j.total = n; j.mu.Unlock() }
 func (j *fileJob) tick(done int64)  { j.mu.Lock(); j.done = done; j.mu.Unlock() }
 
-func (j *fileJob) finish(res filesExtractResult) {
+// finish seals a job: the caller passes the final done value (so the bar can
+// read 100%) and the op-specific result payload.
+func (j *fileJob) finish(done int64, result any) {
 	j.mu.Lock()
 	j.status = fileJobDone
-	j.result = res
-	j.done = int64(res.Extracted + res.Skipped)
+	j.result = result
+	j.done = done
 	j.mu.Unlock()
 }
 
@@ -67,13 +72,13 @@ func (j *fileJob) fail(msg string) {
 
 // fileJobSnapshot is the wire shape returned by files.job.status.
 type fileJobSnapshot struct {
-	JobID     string             `json:"job_id"`
-	Status    string             `json:"status"`
-	Done      int64              `json:"done"`
-	Total     int64              `json:"total"`
-	Result    filesExtractResult `json:"result"`
-	Error     string             `json:"error,omitempty"`
-	StartedAt string             `json:"started_at"`
+	JobID     string `json:"job_id"`
+	Status    string `json:"status"`
+	Done      int64  `json:"done"`
+	Total     int64  `json:"total"`
+	Result    any    `json:"result,omitempty"`
+	Error     string `json:"error,omitempty"`
+	StartedAt string `json:"started_at"`
 }
 
 func (j *fileJob) snapshot() fileJobSnapshot {

--- a/panel-agent/internal/commands/file_jobs_test.go
+++ b/panel-agent/internal/commands/file_jobs_test.go
@@ -35,9 +35,11 @@ func TestFileJobs_OwnershipAndLifecycle(t *testing.T) {
 	if s := j.snapshot(); s.Total != 10 || s.Done != 3 || s.Status != fileJobRunning || s.JobID != j.id {
 		t.Fatalf("running snapshot = %+v", s)
 	}
-	// Finish carries the result and pins done to extracted+skipped.
-	j.finish(filesExtractResult{Extracted: 8, Skipped: 2})
-	if s := j.snapshot(); s.Status != fileJobDone || s.Done != 10 || s.Result.Extracted != 8 || s.Result.Skipped != 2 {
+	// Finish carries the op-specific result and the final done value.
+	j.finish(10, filesExtractResult{Extracted: 8, Skipped: 2})
+	s := j.snapshot()
+	res, ok := s.Result.(filesExtractResult)
+	if s.Status != fileJobDone || s.Done != 10 || !ok || res.Extracted != 8 || res.Skipped != 2 {
 		t.Fatalf("done snapshot = %+v", s)
 	}
 }
@@ -73,7 +75,7 @@ func TestFileJobs_PerUserCap(t *testing.T) {
 			done := j.status == fileJobRunning
 			j.mu.Unlock()
 			if done {
-				j.finish(filesExtractResult{})
+				j.finish(0, filesExtractResult{})
 				break
 			}
 		}
@@ -87,7 +89,7 @@ func TestFileJobs_PerUserCap(t *testing.T) {
 func TestFileJobs_ReapFinished(t *testing.T) {
 	resetFileJobs()
 	j, _ := newFileJob("reap", "extract")
-	j.finish(filesExtractResult{})
+	j.finish(0, filesExtractResult{})
 	j.mu.Lock()
 	j.startedAt = time.Now().Add(-fileJobTTL - time.Minute)
 	j.mu.Unlock()

--- a/panel-agent/internal/commands/files_copy.go
+++ b/panel-agent/internal/commands/files_copy.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -119,7 +121,13 @@ func filesCopyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 
 	bytes, err := scope.CopyTreeInScope(ctx, srcClean, dstClean, uid, gid)
 	if err != nil {
-		// Attempt rollback — copy may have left a partial tree behind.
+		// EEXIST is always the very first dst-side write (Mkdirat / O_EXCL open /
+		// Symlinkat) — the copy created NOTHING, so a dst appeared in the race
+		// window since validation. Never RemoveAll it: that would delete whatever
+		// the other writer just put there. Only roll back a partial tree WE built.
+		if errors.Is(err, fs.ErrExist) {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "target path already exists"}
+		}
 		_ = scope.RemoveAllInScope(context.Background(), dstClean)
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
@@ -169,7 +177,14 @@ func filesCopyStartHandler(_ context.Context, params json.RawMessage) (any, erro
 			job.tick(done)
 		})
 		if cerr != nil {
-			// Roll back the partial tree, same as the sync copy.
+			// EEXIST = a dst appeared during the count window (this async path's
+			// count walk widens that window to seconds on the big trees this
+			// targets). The copy created nothing, so never RemoveAll someone
+			// else's dst — only roll back a partial tree WE built.
+			if errors.Is(cerr, fs.ErrExist) {
+				job.fail("target path already exists")
+				return
+			}
 			_ = scope.RemoveAllInScope(context.Background(), dstClean)
 			job.fail(fmt.Sprintf("copy: %v", cerr))
 			return

--- a/panel-agent/internal/commands/files_copy.go
+++ b/panel-agent/internal/commands/files_copy.go
@@ -4,19 +4,32 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // files.copy — recursively copy a scoped path to a new location, preserving
 // mode bits and reproducing symlinks as symlinks (their target string is data,
 // not chased). Cross-directory by design: used by the Copy / Paste flow.
 //
+// files.copy.start (GH #1392) runs the same copy as a background job so the UI
+// can show a real byte-percentage progress bar: it validates synchronously
+// (user errors stay immediate 400s), then a detached goroutine counts the
+// source bytes, copies with per-chunk progress ticks, and seals the job.
+//
 // Security (Gitea #422): both src and dst are resolved escape-proof and the
 // copy descends via O_NOFOLLOW directory fds on both sides (CopyTreeInScope),
 // so a tenant-planted PARENT symlink — or a symlink swapped into the
 // partially-built copy mid-walk — can never redirect a root-side write out of
-// the docroot.
+// the docroot. The progress callback only sees a byte count, so it adds nothing
+// to that surface.
+
+// copyWallClockBudget bounds a background copy so a detached goroutine
+// (context.Background) can't run a runaway copy forever. Mirrors
+// extractWallClockBudget.
+const copyWallClockBudget = 5 * time.Minute
 
 type filesCopyParams struct {
 	UserID    string `json:"user_id"`
@@ -32,30 +45,33 @@ type filesCopyResponse struct {
 	Bytes   int64  `json:"bytes"`
 }
 
-func filesCopyHandler(ctx context.Context, params json.RawMessage) (any, error) {
-	var p filesCopyParams
-	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("failed to parse params: %v", err),
-		}
-	}
+// filesCopyJobResult is the completion payload of an async copy job (GH #1392),
+// carried under the job snapshot's "result".
+type filesCopyJobResult struct {
+	SrcPath string `json:"src_path"`
+	DstPath string `json:"dst_path"`
+	Bytes   int64  `json:"bytes"`
+}
+
+// resolveCopyValidated does all the cheap, synchronous validation shared by the
+// blocking and async copy handlers: param presence, escape-proof scoping of both
+// ends (confined to the admin write allow-list, JAB-358), same-path/descendant
+// refusals, and the no-clobber existence check. On success it returns the
+// write-scoped handle, the cleaned paths, and the destination owner ids.
+func resolveCopyValidated(p filesCopyParams) (*filesafe.Scope, string, string, int, int, *agentwire.AgentError) {
 	if p.Username == "" {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username required"}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username required"}
 	}
 	if p.SrcPath == "" {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "src_path required"}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "src_path required"}
 	}
 	if p.DstPath == "" {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "dst_path required"}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "dst_path required"}
 	}
 
 	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("failed to create scope: %v", err),
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to create scope: %v", err)}
 	}
 	// JAB-358: copy reads the source and writes the destination through a SINGLE
 	// escape-proof scope (CopyTreeInScope), so confine BOTH ends to the admin
@@ -64,45 +80,43 @@ func filesCopyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	scope = scope.WriteScope()
 	srcClean, err := scope.Clean(p.SrcPath)
 	if err != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("src_path validation failed: %v", err),
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("src_path validation failed: %v", err)}
 	}
 	dstClean, err := scope.Clean(p.DstPath)
 	if err != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("dst_path validation failed: %v", err),
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("dst_path validation failed: %v", err)}
 	}
 	if srcClean == dstClean {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: "source and destination are the same",
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "source and destination are the same"}
 	}
 	// Refuse copy of a dir into its own descendant — same shape as move.
 	if isDescendant(srcClean, dstClean) {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: "cannot copy into a subdirectory of itself",
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "cannot copy into a subdirectory of itself"}
 	}
 	// dst must not already exist — checked through the escape-proof parent fd.
 	if existing, err := scope.ExistsInScope(dstClean); err != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInternal,
-			Message: fmt.Sprintf("failed to stat destination: %v", err),
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("failed to stat destination: %v", err)}
 	} else if existing != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: "target path already exists",
-		}
+		return nil, "", "", 0, 0, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "target path already exists"}
 	}
 
 	uid, gid := hostingIDs(p.Username)
+	return scope, srcClean, dstClean, uid, gid, nil
+}
+
+func filesCopyHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p filesCopyParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	scope, srcClean, dstClean, uid, gid, aerr := resolveCopyValidated(p)
+	if aerr != nil {
+		return nil, aerr
+	}
+
 	bytes, err := scope.CopyTreeInScope(ctx, srcClean, dstClean, uid, gid)
 	if err != nil {
 		// Attempt rollback — copy may have left a partial tree behind.
@@ -119,6 +133,53 @@ func filesCopyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	}, nil
 }
 
+// filesCopyStartHandler (files.copy.start, GH #1392) validates synchronously,
+// then copies in a detached goroutine so a large tree can't block the request
+// past a proxy timeout and the UI can poll files.job.status for a byte-
+// percentage bar.
+func filesCopyStartHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p filesCopyParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	// Validate up front so user errors are immediate 400s, not jobs that
+	// instantly fail.
+	scope, srcClean, dstClean, uid, gid, aerr := resolveCopyValidated(p)
+	if aerr != nil {
+		return nil, aerr
+	}
+	job, err := newFileJob(p.Username, "copy")
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		// Detached from the request context; bound the copy so it can't run
+		// forever.
+		ctx, cancel := context.WithTimeout(context.Background(), copyWallClockBudget)
+		defer cancel()
+		// Count first (inside the goroutine — a pre-walk of a huge tree in the
+		// start call would re-create the timeout async exists to avoid). A count
+		// error just leaves total=0 → the bar shows indeterminate until done.
+		if total, cerr := scope.CountTreeBytesInScope(ctx, srcClean); cerr == nil {
+			job.setTotal(total)
+		}
+		var done int64
+		bytes, cerr := scope.CopyTreeInScopeProgress(ctx, srcClean, dstClean, uid, gid, func(delta int64) {
+			done += delta
+			job.tick(done)
+		})
+		if cerr != nil {
+			// Roll back the partial tree, same as the sync copy.
+			_ = scope.RemoveAllInScope(context.Background(), dstClean)
+			job.fail(fmt.Sprintf("copy: %v", cerr))
+			return
+		}
+		job.finish(bytes, &filesCopyJobResult{SrcPath: srcClean, DstPath: dstClean, Bytes: bytes})
+	}()
+	return map[string]string{"job_id": job.id}, nil
+}
+
 func init() {
 	Default.Register("files.copy", filesCopyHandler)
+	Default.Register("files.copy.start", filesCopyStartHandler)
 }

--- a/panel-agent/internal/commands/files_copy_test.go
+++ b/panel-agent/internal/commands/files_copy_test.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// GH #1392: files.copy.start must reject bad input SYNCHRONOUSLY (immediate
+// 400), before registering a job — a user error should never become a job that
+// instantly fails and burns a per-user slot.
+func TestFilesCopyStart_ValidatesBeforeJob(t *testing.T) {
+	resetFileJobs()
+	cases := []struct {
+		name   string
+		params string
+	}{
+		{"missing username", `{"src_path":"/home/u/a","dst_path":"/home/u/b"}`},
+		{"missing src", `{"username":"u","dst_path":"/home/u/b"}`},
+		{"missing dst", `{"username":"u","src_path":"/home/u/a"}`},
+		{"bad json", `{`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := filesCopyStartHandler(context.Background(), json.RawMessage(c.params))
+			if err == nil {
+				t.Fatalf("want error, got out=%v", out)
+			}
+			ae, ok := err.(*agentwire.AgentError)
+			if !ok || ae.Code != agentwire.CodeInvalidArgument {
+				t.Fatalf("want InvalidArgument AgentError, got %T %v", err, err)
+			}
+		})
+	}
+	// None of the rejected requests may have registered a job.
+	fileJobs.mu.Lock()
+	n := len(fileJobs.m)
+	fileJobs.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("validation failures must not create jobs, got %d", n)
+	}
+}

--- a/panel-agent/internal/commands/files_extract.go
+++ b/panel-agent/internal/commands/files_extract.go
@@ -445,7 +445,7 @@ func filesExtractStartHandler(_ context.Context, params json.RawMessage) (any, e
 			return
 		}
 		r, _ := res.(filesExtractResult)
-		job.finish(r)
+		job.finish(int64(r.Extracted+r.Skipped), r)
 	}()
 	return map[string]string{"job_id": job.id}, nil
 }

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -1324,6 +1324,20 @@ func (h *filesHandler) copy(c *gin.Context) {
 	if h.rejectAdminWriteOutOfScope(c, req.Path, dst) {
 		return
 	}
+	// GH #1392: ?async=1 runs the copy as a background job and returns a job id
+	// immediately (202), so a large tree doesn't block the request past a proxy
+	// timeout and the UI can poll GET /files/jobs/:id for a byte-percentage bar.
+	if c.Query("async") == "1" {
+		raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.copy.start", filesCopyAgentParams{
+			UserID: userID, Username: username, AdminRoot: h.adminRoot(c), SrcPath: req.Path, DstPath: dst,
+		})
+		if err != nil {
+			respondAgentError(c, err)
+			return
+		}
+		c.Data(http.StatusAccepted, "application/json", raw)
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.copy", filesCopyAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), SrcPath: req.Path, DstPath: dst,
 	})

--- a/panel-ui/src/shells/admin/files/adminFilesApi.ts
+++ b/panel-ui/src/shells/admin/files/adminFilesApi.ts
@@ -64,6 +64,14 @@ export const adminFilesApi: FilesApi = {
   copy: async (path, destDir) => {
     await apiClient.post(`${BASE}/copy`, { path, dest_dir: destDir });
   },
+  copyStart: async (path, destDir) =>
+    (
+      await apiClient.post<{ job_id: string }>(
+        `${BASE}/copy`,
+        { path, dest_dir: destDir },
+        { params: { async: 1 } },
+      )
+    ).data,
   archive: async (paths) =>
     (await apiClient.post<Blob>(`${BASE}/archive`, { paths }, { responseType: "blob" })).data,
   delete: async (path, recursive = false) => {

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -1163,11 +1163,11 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
           total: s.total,
         });
         if (s.status === "done") {
-          const skippedN = s.result.skipped ?? 0;
+          const skippedN = s.result?.skipped ?? 0;
           const skipped =
             skippedN > 0 ? `, ${skippedN} unsafe entr(y/ies) skipped` : "";
           feedback.message.success(
-            `Extracted ${s.result.extracted ?? 0} file(s)${skipped}`,
+            `Extracted ${s.result?.extracted ?? 0} file(s)${skipped}`,
           );
           void reloadList(dir);
           setTimeout(() => setExtractJob(null), 500);

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -410,11 +410,25 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
     done: number;
     total: number;
   } | null>(null);
+  // GH #1392: async copy (paste) progress. Non-null while a paste runs; the
+  // clipboard can hold several items, so the modal shows "item i/N" plus that
+  // item's byte-percentage bar. `total === 0` means the byte count isn't in yet
+  // (or was uncountable) → indeterminate for that moment.
+  const [copyJob, setCopyJob] = useState<{
+    name: string;
+    index: number;
+    count: number;
+    status: "running" | "done" | "error";
+    done: number;
+    total: number;
+  } | null>(null);
   // Flips true on unmount so an in-flight poll loop stops touching state.
   const extractCancelRef = useRef(false);
+  const copyCancelRef = useRef(false);
   useEffect(() => {
     return () => {
       extractCancelRef.current = true;
+      copyCancelRef.current = true;
     };
   }, []);
 
@@ -979,11 +993,78 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
     setSelectedNames([]);
   }, [selectedPaths]);
 
+  // handlePaste (GH #1392) copies each clipboard item as a background job and
+  // polls its byte-progress so paste shows a real progress bar instead of a
+  // frozen menu. Items run ONE AT A TIME: a single in-flight job stays under the
+  // agent's per-user job cap, and the modal reports "item i/N". A large tree no
+  // longer blocks the request past a proxy timeout. If the agent restarts
+  // mid-copy the poll 404s — we stop that item's bar and move on.
   const handlePaste = useCallback(async () => {
     if (!currentPath || clipboard.length === 0) return;
-    await runBulk("Pasted", clipboard, (p) => api.copy(p, currentPath));
+    const dir = currentPath;
+    const items = clipboard;
+    copyCancelRef.current = false;
+    let ok = 0;
+    let failed = 0;
+    for (let idx = 0; idx < items.length; idx++) {
+      if (copyCancelRef.current) return;
+      const src = items[idx];
+      const name = src.split("/").filter(Boolean).pop() || src;
+      setCopyJob({ name, index: idx + 1, count: items.length, status: "running", done: 0, total: 0 });
+      try {
+        const { job_id } = await api.copyStart(src, dir);
+        let terminal = false;
+        // 1.5s cadence + ~1200-iteration cap mirrors the extract poller (well
+        // under the agent's 10-min job TTL and any flood threshold).
+        for (let i = 0; i < 1200 && !terminal; i++) {
+          await new Promise((r) => setTimeout(r, 1500));
+          if (copyCancelRef.current) return;
+          let s: Awaited<ReturnType<typeof api.jobStatus>>;
+          try {
+            s = await api.jobStatus(job_id);
+          } catch {
+            // Unknown/foreign id or agent restart — this item's job is gone.
+            feedback.message.warning(
+              "Copy status is no longer available — refreshing folder",
+            );
+            failed++;
+            terminal = true;
+            break;
+          }
+          if (copyCancelRef.current) return;
+          setCopyJob({
+            name,
+            index: idx + 1,
+            count: items.length,
+            status: s.status,
+            done: s.done,
+            total: s.total,
+          });
+          if (s.status === "done") {
+            ok++;
+            terminal = true;
+          } else if (s.status === "error") {
+            feedback.message.error(`Copy failed for ${name}: ${s.error || "unknown error"}`);
+            failed++;
+            terminal = true;
+          }
+        }
+      } catch (err) {
+        feedback.message.error(`Copy failed for ${name}: ${errMessage(err)}`);
+        failed++;
+      }
+    }
+    setCopyJob(null);
     setClipboard([]);
-  }, [clipboard, currentPath, runBulk]);
+    if (failed === 0) {
+      feedback.message.success(`Pasted ${ok} item${ok === 1 ? "" : "s"}`);
+    } else if (ok === 0) {
+      feedback.message.error(`Paste failed for all ${failed} item${failed === 1 ? "" : "s"}`);
+    } else {
+      feedback.message.warning(`Pasted ${ok}/${items.length} — ${failed} failed`);
+    }
+    void reloadList(dir);
+  }, [clipboard, currentPath, api, reloadList]);
 
   const handleMove = useCallback(
     async (srcPath: string, destDir: string) => {
@@ -1082,12 +1163,11 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
           total: s.total,
         });
         if (s.status === "done") {
+          const skippedN = s.result.skipped ?? 0;
           const skipped =
-            s.result.skipped > 0
-              ? `, ${s.result.skipped} unsafe entr(y/ies) skipped`
-              : "";
+            skippedN > 0 ? `, ${skippedN} unsafe entr(y/ies) skipped` : "";
           feedback.message.success(
-            `Extracted ${s.result.extracted} file(s)${skipped}`,
+            `Extracted ${s.result.extracted ?? 0} file(s)${skipped}`,
           );
           void reloadList(dir);
           setTimeout(() => setExtractJob(null), 500);
@@ -1905,6 +1985,50 @@ export const FileManagerPage = ({ api = tenantFilesApi, rootPath: rootPathProp }
               <Spin />
               <span>
                 Extracting {extractJob.done > 0 ? `${extractJob.done} file(s)` : ""}…
+              </span>
+            </Space>
+          ))}
+      </Modal>
+
+      {/* GH #1392: async copy (paste) progress. Byte-percentage per item, with
+          "item i/N" when the clipboard holds several. Non-dismissable while
+          running so a second paste can't stack over the first. */}
+      <Modal
+        title={
+          copyJob
+            ? `Copying ${copyJob.name}${copyJob.count > 1 ? ` (${copyJob.index}/${copyJob.count})` : ""}`
+            : "Copying"
+        }
+        open={copyJob !== null}
+        footer={null}
+        closable={false}
+        maskClosable={false}
+        destroyOnHidden
+      >
+        {copyJob &&
+          (copyJob.total > 0 ? (
+            <Progress
+              percent={
+                copyJob.status === "done"
+                  ? 100
+                  : Math.min(
+                      99, // clamp <100 until done: the tree can drift between count and copy
+                      Math.floor((copyJob.done / copyJob.total) * 100),
+                    )
+              }
+              status={
+                copyJob.status === "error"
+                  ? "exception"
+                  : copyJob.status === "done"
+                    ? "success"
+                    : "active"
+              }
+            />
+          ) : (
+            <Space>
+              <Spin />
+              <span>
+                Copying {copyJob.done > 0 ? `${formatBytes(copyJob.done)} ` : ""}…
               </span>
             </Space>
           ))}

--- a/panel-ui/src/shells/user/files/filesApi.ts
+++ b/panel-ui/src/shells/user/files/filesApi.ts
@@ -263,7 +263,9 @@ export interface FilesJobStatus {
   // 0 = unknown → indeterminate. Extract counts entries; a streamed tar reports
   // 0. Copy counts bytes; done/total is a byte fraction.
   total: number;
-  result: FilesJobResult;
+  // Omitted by the agent (omitempty) until the job seals — only a done job
+  // carries a result — so treat it as optional at every read.
+  result?: FilesJobResult;
   error?: string;
   started_at: string;
 }

--- a/panel-ui/src/shells/user/files/filesApi.ts
+++ b/panel-ui/src/shells/user/files/filesApi.ts
@@ -244,12 +244,26 @@ export async function filesExtractStart(
   return data;
 }
 
+// Per-op completion payload carried under `result`. Extract fills
+// extracted/skipped/dest; copy (GH #1392) fills bytes/src_path/dst_path. All
+// optional so one shape covers both job kinds.
+export interface FilesJobResult {
+  dest?: string;
+  extracted?: number;
+  skipped?: number;
+  bytes?: number;
+  src_path?: string;
+  dst_path?: string;
+}
+
 export interface FilesJobStatus {
   job_id: string;
   status: "running" | "done" | "error";
   done: number;
-  total: number; // 0 = unknown (streamed tar) → indeterminate progress
-  result: FilesExtractResult;
+  // 0 = unknown → indeterminate. Extract counts entries; a streamed tar reports
+  // 0. Copy counts bytes; done/total is a byte fraction.
+  total: number;
+  result: FilesJobResult;
   error?: string;
   started_at: string;
 }
@@ -291,6 +305,22 @@ export async function filesChmod(path: string, mode: string): Promise<void> {
 // destination path.
 export async function filesCopy(path: string, destDir: string): Promise<void> {
   await apiClient.post("/files/copy", { path, dest_dir: destDir });
+}
+
+// GH #1392: async copy. filesCopyStart kicks off the recursive copy as a
+// background job on the agent and returns immediately with a job id (HTTP 202);
+// the caller polls filesJobStatus for a byte-percentage progress bar. Same
+// escape-proof copy core + validation as the blocking filesCopy.
+export async function filesCopyStart(
+  path: string,
+  destDir: string,
+): Promise<{ job_id: string }> {
+  const { data } = await apiClient.post<{ job_id: string }>(
+    "/files/copy",
+    { path, dest_dir: destDir },
+    { params: { async: 1 } },
+  );
+  return data;
 }
 
 // filesArchive posts the selection and streams back a tar.gz download.
@@ -357,6 +387,7 @@ export type FilesApi = {
   move: typeof filesMove;
   chmod: typeof filesChmod;
   copy: typeof filesCopy;
+  copyStart: typeof filesCopyStart;
   archive: typeof filesArchive;
   delete: typeof filesDelete;
   du: typeof filesDu;
@@ -379,6 +410,7 @@ export const tenantFilesApi: FilesApi = {
   move: filesMove,
   chmod: filesChmod,
   copy: filesCopy,
+  copyStart: filesCopyStart,
   archive: filesArchive,
   delete: filesDelete,
   du: filesDu,

--- a/panel-ui/src/shells/user/files/filesAsyncApi.test.ts
+++ b/panel-ui/src/shells/user/files/filesAsyncApi.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../../apiClient", () => ({
 }));
 
 import { apiClient } from "../../../apiClient";
-import { filesExtractStart, filesJobStatus } from "./filesApi";
+import { filesCopyStart, filesExtractStart, filesJobStatus } from "./filesApi";
 
 const mocked = apiClient as unknown as {
   get: ReturnType<typeof vi.fn>;
@@ -26,6 +26,24 @@ describe("filesExtractStart", () => {
     expect(mocked.post).toHaveBeenCalledWith(
       "/files/extract",
       { path: "/home/u/big.zip", dest: undefined },
+      { params: { async: 1 } },
+    );
+  });
+});
+
+describe("filesCopyStart", () => {
+  beforeEach(() => {
+    mocked.get.mockReset();
+    mocked.post.mockReset();
+  });
+
+  it("posts the copy with async=1 and returns the job id", async () => {
+    mocked.post.mockResolvedValue({ data: { job_id: "cp1" } });
+    const out = await filesCopyStart("/home/u/site", "/home/u/backup");
+    expect(out).toEqual({ job_id: "cp1" });
+    expect(mocked.post).toHaveBeenCalledWith(
+      "/files/copy",
+      { path: "/home/u/site", dest_dir: "/home/u/backup" },
       { params: { async: 1 } },
     );
   });


### PR DESCRIPTION
Follow-up to the extract-progress work (#1431). @johnnyq approved turning Copy/Move into per-file progress jobs; this ships it for **Copy/Paste** as a true byte-percentage bar.

## Why not Move
Move is a single atomic `renameat` (same-filesystem relink) — it completes instantly, so a progress bar would be meaningless. Move/drag keep their existing indeterminate indicator. The real target is **copy/paste**, which recurses a tree.

## filesafe (the security-sensitive core)
- `CopyTreeInScopeProgress` — `CopyTreeInScope` plus an optional `onBytes` callback invoked after each chunk of regular-file data is written. The callback only ever sees a byte count — it touches no fds or paths, so the escape-proof `O_NOFOLLOW` descent is **unchanged**. `CopyTreeInScope` is now a nil-callback wrapper (existing callers/tests untouched).
- `CountTreeBytesInScope` — a read-only, stat-only `O_NOFOLLOW` walk summing the regular-file bytes the copy will write (symlinks/dirs count 0), for the progress denominator. Same fd-based descent, so a symlink can't redirect it out of the jail or inflate the total from outside.

## agent
- `files.copy.start` — validates **synchronously** (immediate 400s for user errors, before a job is registered), then copies in a detached goroutine bounded by a 5-min wall-clock budget. It counts inside the goroutine (`setTotal`), ticks bytes as it copies, and seals the job.
- **Rollback safety (advisor catch):** on error the partial tree is rolled back — **except** `fs.ErrExist`, where the copy created nothing (EEXIST is always the first dst-side write). A dst can appear in the widened count window; never `RemoveAll` someone else's dst. Same guard added to the sync handler.
- Job registry result generalized to `any` with an op-agnostic `finish(done, result)`, shared by extract and copy.

## panel
`POST /files/copy?async=1` → `files.copy.start` → 202 `{job_id}`; reuses the existing owner-scoped `GET /files/jobs/:id` poll. Same for the admin File Manager (both routes share the handler).

## ui
Paste copies each clipboard item as a job, **one at a time** (a single in-flight job stays under the agent's per-user cap), with a byte-percentage modal showing "item i/N". Percent clamps <100 until the job seals (the tree can drift between count and copy).

## Deliberate
A copy exceeding the 5-min budget fails and rolls back — same policy as extract. Big-tree copies are the plausible overrun; called out as intentional.

## Tests
- filesafe: count + progress equal bytes copied (incl. a single big file); a copy into an existing dst is `errors.Is(fs.ErrExist)` (the rollback guard depends on it).
- agent: job registry `any`-result finish; `copy.start` validates before creating a job.
- ui: `copyStart` client helper; `tsc -b` clean.
- `go vet` clean; filesafe / agent (incl. `-race`) / panel-api suites green.
- **Box-drilled** on the test box: a 120 MB tree copied with the bar advancing to 100%, tree intact + tenant-owned; a pre-existing dst is refused **without** deleting its contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)