### PR TITLE
fix(adminer): SSO session honors a fresh token + a real logout (GH #1406)

### DIFF
--- a/install/adminer/jabali-sso-plugin.php
+++ b/install/adminer/jabali-sso-plugin.php
@@ -58,31 +58,82 @@ class JabaliAdminerSSO {
             session_name('jabali_adminer_sid');
             @session_start();
         }
+
+        // GH #1406: Adminer's Logout ($_POST['logout']) clears Adminer's own
+        // auth but NOT our cached SSO creds — so the plugin would re-authenticate
+        // on the post-logout redirect and Logout would appear to do nothing.
+        // Drop our creds (and the validated-token marker) here, before Adminer
+        // runs, so Logout actually ends the session.
+        if (!empty($_POST['logout'])) {
+            unset($_SESSION['jabali_adminer_creds'], $_SESSION['jabali_adminer_token']);
+        }
     }
 
     /**
-     * Lazy fetch — first checks $_SESSION, then mints a new validation
-     * call when a fresh `?token=` is in the URL. Returns null when
-     * neither path yields creds (Adminer falls through to its
-     * default form so the failure surface is visible).
+     * Lazy fetch of the SSO creds for this request.
+     *
+     * GH #1406 — fresh-token-wins. A `?token=` that is NOT the one already
+     * validated for this session is a NEW SSO entry: it is always re-validated
+     * and REPLACES any cached identity. This is what stops a second panel user
+     * (or a tenant opening Adminer in a browser that previously opened the admin
+     * all-DBs view, which caches the `postgres` superuser) from silently landing
+     * in the PREVIOUS user's session. Adminer's own auto-submit re-POSTs the
+     * SAME (already-consumed) token, so only a *different* token counts as a new
+     * entry — the consumed one is served from cache, never re-validated.
+     *
+     * A new token that FAILS validation drops the cached creds and returns null,
+     * so a failed entry never continues as the previously cached identity.
+     * With no token at all, the session cache is reused (Adminer's in-UI
+     * navigation). Returns null when nothing yields creds, so Adminer falls
+     * through to its default form and the failure is visible.
      */
     private function fetchCreds() {
         if ($this->creds !== null) {
             return $this->creds === false ? null : $this->creds;
         }
+        $token = isset($_GET['token']) ? $_GET['token'] : '';
+        $tokenValid = ($token !== '' && preg_match('/^[A-Za-z0-9_-]{40,200}$/', $token));
+
+        if ($tokenValid &&
+            (empty($_SESSION['jabali_adminer_token']) || $_SESSION['jabali_adminer_token'] !== $token)) {
+            $creds = $this->validateToken($token);
+            if ($creds === null) {
+                // A new token that fails MUST NOT fall back to stale creds.
+                unset($_SESSION['jabali_adminer_creds'], $_SESSION['jabali_adminer_token']);
+                $this->creds = false;
+                return null;
+            }
+            // New identity — rotate the session id so it can't be fixated to the
+            // prior user's, then replace the cached creds + validated-token marker.
+            @session_regenerate_id(true);
+            $_SESSION['jabali_adminer_creds'] = $creds;
+            $_SESSION['jabali_adminer_token'] = $token;
+            $this->creds = $creds;
+            return $creds;
+        }
+
+        // No new token: reuse the session-cached creds (Adminer navigates its UI
+        // with more requests, and the auto-submit POST re-includes the already-
+        // validated token — neither should burn or re-validate a token).
         if (!empty($_SESSION['jabali_adminer_creds'])) {
             $this->creds = $_SESSION['jabali_adminer_creds'];
             return $this->creds;
         }
-        $token = isset($_GET['token']) ? $_GET['token'] : '';
-        if ($token === '' || !preg_match('/^[A-Za-z0-9_-]{40,200}$/', $token)) {
-            $this->creds = false;
-            return null;
-        }
+        $this->creds = false;
+        return null;
+    }
+
+    /**
+     * validateToken POSTs the single-use token to the panel over the Unix
+     * socket; the server consumes it (FOR UPDATE + DELETE) and returns
+     * {driver, server, username, password, db}. Returns the creds array, or
+     * null on any transport/format/HTTP failure. Marked protected so a test can
+     * stub the socket hop. Does NOT touch $_SESSION — the caller owns caching.
+     */
+    protected function validateToken($token) {
         $body = json_encode(['token' => $token]);
         $fp = @stream_socket_client('unix://' . $this->socket_path, $errno, $errstr, 5);
         if (!$fp) {
-            $this->creds = false;
             return null;
         }
         $req = "POST /sso/adminer/validate HTTP/1.1\r\n"
@@ -99,13 +150,11 @@ class JabaliAdminerSSO {
         fclose($fp);
         $sep = strpos($resp, "\r\n\r\n");
         if ($sep === false) {
-            $this->creds = false;
             return null;
         }
         $headers = substr($resp, 0, $sep);
         $payload = substr($resp, $sep + 4);
         if (!preg_match('#^HTTP/1\\.\\d\\s+200\\b#', $headers)) {
-            $this->creds = false;
             return null;
         }
         if (stripos($headers, 'Transfer-Encoding: chunked') !== false) {
@@ -114,11 +163,8 @@ class JabaliAdminerSSO {
         $j = json_decode($payload, true);
         if (!is_array($j) || !isset($j['driver']) || !isset($j['username']) ||
             !isset($j['password']) || !isset($j['db'])) {
-            $this->creds = false;
             return null;
         }
-        $this->creds = $j;
-        $_SESSION['jabali_adminer_creds'] = $j;
         return $j;
     }
 

--- a/install/adminer/sso_session_test.php
+++ b/install/adminer/sso_session_test.php
@@ -1,0 +1,79 @@
+<?php
+// GH #1406 — drive the Adminer SSO plugin's token/session branching without a
+// browser. Stubs the socket validation; asserts fresh-token-wins, cache-on-same
+// -token, logout-clears, and that a failed new token drops the cached identity.
+error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
+require __DIR__ . '/jabali-sso-plugin.php';
+
+use Adminer\JabaliAdminerSSO;
+
+// Test double: canned creds per token, and a call counter so we can prove a
+// consumed token is served from cache (not re-validated).
+class StubSSO extends JabaliAdminerSSO {
+    public static $map = [];
+    public static $calls = 0;
+    protected function validateToken($token) {
+        self::$calls++;
+        return isset(self::$map[$token]) ? self::$map[$token] : null;
+    }
+}
+
+// 40+ char tokens to satisfy the plugin's format regex.
+$TA = str_repeat('a', 44);
+$TB = str_repeat('b', 44);
+$TC = str_repeat('c', 44);
+StubSSO::$map = [
+    $TA => ['driver'=>'pgsql','server'=>'/run/postgresql','username'=>'alice_pgadmin','password'=>'pa','db'=>'alice_db'],
+    $TB => ['driver'=>'pgsql','server'=>'/run/postgresql','username'=>'bob_pgadmin','password'=>'pb','db'=>'bob_db'],
+    // $TC intentionally absent → validateToken returns null.
+];
+
+$fail = 0;
+function check($label, $cond) {
+    global $fail;
+    echo ($cond ? "  PASS " : "  FAIL ") . $label . "\n";
+    if (!$cond) $fail++;
+}
+// Simulate one HTTP request: set superglobals, build a fresh plugin (as Adminer
+// does per request), return credentials().
+function req($get, $post = []) {
+    $_GET = $get; $_POST = $post;
+    $p = new StubSSO('/run/jabali-panel/api.sock');
+    return $p->credentials();
+}
+
+// 1. First SSO entry for Alice.
+$c = req(['token'=>$TA]);
+check('alice entry -> alice creds', $c && $c[1] === 'alice_pgadmin');
+$after1 = StubSSO::$calls;
+
+// 2. Adminer auto-submit re-POSTs the SAME token -> served from cache, NOT re-validated.
+$c = req(['token'=>$TA]);
+check('same token -> still alice (cache)', $c && $c[1] === 'alice_pgadmin');
+check('same token did NOT re-validate (single-use safe)', StubSSO::$calls === $after1);
+
+// 3. In-UI navigation (no token) -> cache.
+$c = req([]);
+check('no token -> alice from cache', $c && $c[1] === 'alice_pgadmin');
+
+// 4. Bob opens in the SAME browser (new token) -> fresh token WINS, Alice gone.
+$c = req(['token'=>$TB]);
+check('bob new token -> bob creds (fresh-token-wins)', $c && $c[1] === 'bob_pgadmin');
+$c = req([]);
+check('no token after bob -> bob (not alice)', $c && $c[1] === 'bob_pgadmin');
+
+// 5. Logout clears the session -> no creds afterwards.
+req([], ['logout'=>1]);           // the logout POST (constructor clears)
+$c = req([]);
+check('after logout -> no creds (logout actually ends session)', $c === null);
+
+// 6. Re-enter as Alice, then a NEW token that FAILS validation must drop the
+//    cached identity (never continue as Alice).
+req(['token'=>$TA]);
+$c = req(['token'=>$TC]);          // $TC not in map -> validateToken null
+check('failed new token -> null', $c === null);
+$c = req([]);
+check('failed new token dropped cached identity', $c === null);
+
+echo ($fail === 0 ? "ALL SSO SESSION CHECKS PASSED\n" : "FAILURES: $fail\n");
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
Addresses @lxsdevcode's follow-up on GH #1406 — the Adminer SSO/session half. (The PostgreSQL table-permission half is the already-merged role-membership fix #1433; see note below.)

## The bug (long-standing, not an Adminer 6 regression)
The SSO plugin cached the validated creds in `$_SESSION` and returned them **before** looking at the request's `?token=`. On a shared/sequential browser this means:

- A **second panel user** — or a **tenant** opening Adminer after the admin *all-databases* view, which legitimately hands out the `postgres` superuser (ADR-0099) — arrived with a fresh token but was silently dropped into the **previous** user's cached session. That's the "logged in as postgres" and "same session reused across accounts" the reporter saw, and it's a cross-user / privilege leak.
- Adminer's **Logout** (`$_POST['logout']`) clears Adminer's own auth but not our cached creds, so the plugin re-authenticated on the redirect → Logout appeared to do nothing.

The `$_SESSION`-before-`?token=` ordering dates to the original m37 SSO (`060ec5e6b`) and was carried through the Adminer 6 port (#1438) — so it's long-standing, not new.

## Fix — fresh-token-wins
- A `?token=` that isn't the one already validated for this session is a **new SSO entry**: always re-validate and **replace** the cached identity (rotating the session id). Adminer's auto-submit re-POSTs the **same**, already-consumed token, so only a *different* token re-validates — the consumed one is served from cache (single-use safe, both the "same token" and "no token" paths converge on the cache).
- A new token that **fails** validation drops the cached creds and returns null — a failed entry never continues as the prior user.
- On `$_POST['logout']` the plugin clears its cached creds + validated-token marker, so Logout actually ends the session.

Socket validation extracted into a protected `validateToken()` so the branching is testable.

## Tests
`install/adminer/sso_session_test.php` drives the whole matrix — fresh-token-wins, cache-on-same-token (no re-validation of a consumed token), logout-clears, failed-token-drops-identity — **9/9 pass on real PHP** (run on the test box); plugin passes `php -l`.

## On the PostgreSQL permission half
Verified in a `postgres:18` container that the #1433 role-membership grant confers table `SELECT` by inheritance **identically on PG16 and PG18** — so that fix is correct. The reporter's box still shows "permission denied" because its `stable` tag predates #1433/#1438; both land on the next `stable` promotion. If denial persists **after** that, the remaining cause would be tables owned by a role outside the tenant's db-users (e.g. a dump restored as `postgres`) — a data question for the reporter, not a code fix.

Rollout: `install.sh` copies `index.php` + `jabali-sso-plugin.php` by name every run (no freeze gate), so this ships on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)