### PR TITLE
feat(backup): restore an account from an uploaded backup archive (GH #1408)

### DIFF
--- a/panel-agent/internal/commands/backup_restore_from_tar.go
+++ b/panel-agent/internal/commands/backup_restore_from_tar.go
@@ -237,6 +237,55 @@ func stageMaterializedInTar(staging, name string) bool {
 	return err == nil && fi.IsDir()
 }
 
+// backup.inspect_uploaded_tar — GH #1408. Read ONLY the manifest from an
+// uploaded archive (no full extraction) so the panel can show what the backup
+// contains + which components can be restored, before the admin commits to the
+// destructive apply. Cheap: it streams the zstd tar and stops at the manifest.
+type backupInspectUploadedTarParams struct {
+	TarPath string `json:"tar_path"`
+}
+
+type backupInspectUploadedTarResult struct {
+	User       backup.ManifestUser `json:"user"`
+	Components []string            `json:"components"`
+}
+
+func backupInspectUploadedTarHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p backupInspectUploadedTarParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	tarClean := filepath.Clean(p.TarPath)
+	if tarClean != p.TarPath || !strings.HasPrefix(tarClean, restoreUploadsRoot+"/") {
+		return nil, bkInvalidArg("tar_path must be a clean path under " + restoreUploadsRoot)
+	}
+	if fi, err := os.Lstat(tarClean); err != nil || !fi.Mode().IsRegular() {
+		return nil, bkInvalidArg("tar_path is not a regular file")
+	}
+
+	manifestBytes, err := readManifestFromZstdTar(ctx, tarClean)
+	if err != nil {
+		return nil, bkInvalidArg("archive inspect failed: " + err.Error())
+	}
+	manifest, err := backup.AccountManifestFromBytes(manifestBytes)
+	if err != nil {
+		return nil, bkInvalidArg("manifest parse failed: " + err.Error())
+	}
+	// Components the UI can offer = the distinct restorable stage names in the
+	// manifest (manifest/meta are internal). Apply re-gates on actual presence.
+	comps := make([]string, 0, len(manifest.Stages))
+	seen := map[string]bool{}
+	for _, st := range manifest.Stages {
+		if st.Name == "" || st.Name == "manifest" || st.Name == "meta" || seen[st.Name] {
+			continue
+		}
+		comps = append(comps, st.Name)
+		seen[st.Name] = true
+	}
+	return backupInspectUploadedTarResult{User: manifest.User, Components: comps}, nil
+}
+
 func init() {
 	Default.Register("backup.restore_from_tar", backupRestoreFromTarHandler)
+	Default.Register("backup.inspect_uploaded_tar", backupInspectUploadedTarHandler)
 }

--- a/panel-agent/internal/commands/backup_restore_from_tar.go
+++ b/panel-agent/internal/commands/backup_restore_from_tar.go
@@ -1,0 +1,242 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+// backup.restore_from_tar — GH #1408. Restore an account from a re-UPLOADED
+// backup archive (the .tar the admin downloaded earlier), instead of a restic
+// snapshot. This is the DR / cross-server-migration path: reinstall a box,
+// upload a user's backup, restore.
+//
+// The uploaded tar is untrusted, so it is extracted through safeExtractZstdTar
+// (allowlist: regular/dir/in-tree-symlink; no ../ absolute hardlink device;
+// bomb-bounded). The extracted tree has the SAME per-stage layout a restic
+// restore produces (materialize built the downloaded tar from those very
+// snapshots), so once staged it reuses the exact same applyAccountRestore path
+// as backup.restore — home rsync + chown, per-DB mariadb load. mail is not
+// auto-applied (same as backup.restore).
+//
+// v1 scope (see GH #1408): admin-only, one tar = one account, target user must
+// already exist (the panel enforces this). Component selection gates which
+// manifest stages are applied.
+
+const restoreUploadsRoot = "/var/lib/jabali-uploads"
+
+type backupRestoreFromTarParams struct {
+	JobID          string `json:"job_id"`
+	TarPath        string `json:"tar_path"`
+	TargetUsername string `json:"target_username"`
+	// Components names the manifest stages to apply (e.g. "home","db","dns").
+	// Empty = apply every stage present (a full account restore).
+	Components []string `json:"components,omitempty"`
+	// ApplyStaged=false stages the extracted tree without touching the live
+	// system (recon), mirroring backup.restore.
+	ApplyStaged *bool `json:"apply_staged,omitempty"`
+}
+
+type backupRestoreFromTarResult struct {
+	JobID          string               `json:"job_id"`
+	User           backup.ManifestUser  `json:"user"`
+	Stages         []backupRestoreStage `json:"stages"`
+	Applied        []string             `json:"applied,omitempty"`
+	Warnings       []string             `json:"warnings,omitempty"`
+	Metadata       json.RawMessage      `json:"metadata,omitempty"`
+	StagingCleanup string               `json:"staging_cleanup,omitempty"`
+	BytesExtracted int64                `json:"bytes_extracted"`
+}
+
+func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p backupRestoreFromTarParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	if !jobIDRE.MatchString(p.JobID) {
+		return nil, bkInvalidArg("job_id must be a 26-char ULID")
+	}
+	if !backupUsernameRE.MatchString(p.TargetUsername) {
+		return nil, bkInvalidArg("target_username must match ^[a-z][a-z0-9_-]{0,31}$")
+	}
+	// The tar path is provided by the panel (the reassembled chunked upload). It
+	// MUST live under the uploads handoff dir and contain no traversal — never
+	// let the caller point the extractor at an arbitrary file.
+	tarClean := filepath.Clean(p.TarPath)
+	if tarClean != p.TarPath || !strings.HasPrefix(tarClean, restoreUploadsRoot+"/") {
+		return nil, bkInvalidArg("tar_path must be a clean path under " + restoreUploadsRoot)
+	}
+	if fi, err := os.Lstat(tarClean); err != nil || !fi.Mode().IsRegular() {
+		return nil, bkInvalidArg("tar_path is not a regular file")
+	}
+
+	// Refuse to stage under the host disk reserve (same guard the DB/PG restore
+	// paths use) so a large archive can't wedge the box.
+	if err := hostreserve.CheckReserve("/var/lib/jabali-backups", 0); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeUnavailable,
+			Message: "restore staging is under the host disk reserve: " + err.Error(),
+		}
+	}
+
+	staging := filepath.Join("/var/lib/jabali-backups/restore-staging", p.JobID+"-upload")
+	_ = os.RemoveAll(staging)
+	if err := os.MkdirAll(staging, 0o750); err != nil {
+		return nil, bkInternal("mkdir staging", err)
+	}
+
+	written, err := safeExtractZstdTar(ctx, tarClean, staging)
+	if err != nil {
+		_ = os.RemoveAll(staging)
+		return nil, bkInvalidArg("archive rejected: " + err.Error())
+	}
+
+	// The downloaded archive is tarred as `<source-job-id>/<stage>/…` (the panel
+	// runs `tar -C <downloads> <job-id>`), so the extracted tree has a single
+	// job-id dir on top. Descend into it — that dir IS the per-stage staging
+	// root applyAccountRestore expects (identical to backup.restore's staging).
+	root, rerr := resolveExtractedRoot(staging)
+	if rerr != nil {
+		_ = os.RemoveAll(staging)
+		return nil, bkInvalidArg(rerr.Error())
+	}
+
+	// manifest lives under the manifest stage: <root>/manifest/manifest.json.
+	manifestBytes, err := os.ReadFile(filepath.Join(root, "manifest", "manifest.json"))
+	if err != nil {
+		_ = os.RemoveAll(staging)
+		return nil, bkInvalidArg("archive has no manifest/manifest.json (not a Jabali account backup)")
+	}
+	manifest, err := backup.AccountManifestFromBytes(manifestBytes)
+	if err != nil {
+		_ = os.RemoveAll(staging)
+		return nil, bkInvalidArg("manifest parse failed: " + err.Error())
+	}
+
+	out := backupRestoreFromTarResult{JobID: p.JobID, User: manifest.User, BytesExtracted: written}
+
+	// v1 restores into the SAME username the backup was taken from — the home
+	// tree inside the archive is /home/<backup-user> and applyAccountRestore
+	// keys the source path by the target name, so a mismatch silently leaves
+	// home unrestored. The panel sets target = the manifest's username; warn if
+	// a caller passes something else (renaming on restore is a follow-up).
+	if p.TargetUsername != manifest.User.Username {
+		out.Warnings = append(out.Warnings, fmt.Sprintf(
+			"target_username %q differs from the backup's user %q; the home stage will be skipped (restore into the same username)",
+			p.TargetUsername, manifest.User.Username))
+	}
+
+	// Best-effort metadata (FTP subaccount hashes etc.) from the meta stage.
+	if mb, mErr := os.ReadFile(filepath.Join(root, "meta", "metadata.json")); mErr == nil {
+		out.Metadata = mb
+	}
+
+	// Per-stage gate: a stage is applied only when it materialized in the tar AND
+	// (no component filter, or the filter selected it). Aligned by manifest-stage
+	// index — same discipline as backup.restore (docker/db fan out same-named
+	// stages, so a name-keyed gate would collapse them, GH #1360).
+	want := componentFilter(p.Components)
+	stageResults := make([]backupRestoreStage, len(manifest.Stages))
+	for i, st := range manifest.Stages {
+		res := backupRestoreStage{Name: st.Name, Status: backup.StageStatusSkipped}
+		selected := want == nil || want[st.Name]
+		if selected && stageMaterializedInTar(root, st.Name) {
+			res.Status = backup.StageStatusOK
+		}
+		stageResults[i] = res
+	}
+	out.Stages = stageResults
+
+	apply := true
+	if p.ApplyStaged != nil {
+		apply = *p.ApplyStaged
+	}
+	if !apply {
+		out.Warnings = append(out.Warnings, "apply_staged=false — extracted to "+staging+"; nothing applied")
+		out.StagingCleanup = "kept (recon mode)"
+		return out, nil
+	}
+
+	applied, warnings := applyAccountRestore(ctx, root, p.TargetUsername, manifest.User, manifest.Stages, stageResults)
+	out.Applied = applied
+	out.Warnings = append(out.Warnings, warnings...)
+
+	if len(applied) > 0 {
+		if rmErr := os.RemoveAll(staging); rmErr != nil {
+			out.StagingCleanup = "cleanup_failed: " + rmErr.Error()
+			out.Warnings = append(out.Warnings, "staging cleanup failed: "+rmErr.Error())
+		} else {
+			out.StagingCleanup = "removed"
+		}
+	} else {
+		out.StagingCleanup = "kept (no stages applied)"
+	}
+	return out, nil
+}
+
+// componentFilter builds a set of stage names to apply, or nil to apply all.
+func componentFilter(components []string) map[string]bool {
+	if len(components) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(components))
+	for _, c := range components {
+		if c = strings.TrimSpace(c); c != "" {
+			m[c] = true
+		}
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// resolveExtractedRoot returns the per-stage staging root inside the extracted
+// tree. The downloaded archive wraps everything in a single <source-job-id>
+// directory (the panel runs `tar -C <downloads> <job-id>`), so the real root is
+// that lone child. A defensively un-prefixed archive (manifest directly under
+// staging) returns staging itself. Anything else is not a Jabali account backup.
+func resolveExtractedRoot(staging string) (string, error) {
+	if fi, err := os.Stat(filepath.Join(staging, "manifest", "manifest.json")); err == nil && fi.Mode().IsRegular() {
+		return staging, nil
+	}
+	ents, err := os.ReadDir(staging)
+	if err != nil {
+		return "", fmt.Errorf("read extracted tree: %v", err)
+	}
+	var dirs []string
+	for _, e := range ents {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	if len(dirs) == 1 {
+		root := filepath.Join(staging, dirs[0])
+		if fi, err := os.Stat(filepath.Join(root, "manifest", "manifest.json")); err == nil && fi.Mode().IsRegular() {
+			return root, nil
+		}
+	}
+	return "", fmt.Errorf("archive is not a Jabali account backup (no manifest/manifest.json)")
+}
+
+// stageMaterializedInTar reports whether the extracted tree carries this stage's
+// directory (the tar is a merge of the per-stage snapshots, so stage <name>
+// lands at staging/<name>/).
+func stageMaterializedInTar(staging, name string) bool {
+	if name == "" {
+		return false
+	}
+	fi, err := os.Stat(filepath.Join(staging, name))
+	return err == nil && fi.IsDir()
+}
+
+func init() {
+	Default.Register("backup.restore_from_tar", backupRestoreFromTarHandler)
+}

--- a/panel-agent/internal/commands/safe_tar_extract.go
+++ b/panel-agent/internal/commands/safe_tar_extract.go
@@ -1,0 +1,256 @@
+package commands
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// safe_tar_extract.go — GH #1408. Extract an UNTRUSTED, zstd-compressed tar
+// (a re-uploaded account backup) into a root-owned staging dir.
+//
+// Unlike the restic restore path, whose input is a snapshot WE created, this tar
+// is attacker-controllable: a tampered archive is extracted as root and its
+// contents are later rsync'd into /home and loaded into databases. So the
+// extractor is an allowlist, not a denylist:
+//
+//   - regular files, directories, and symlinks (preserved verbatim — a real home
+//     legitimately carries absolute + out-of-tree symlinks, and the trusted
+//     restic restore keeps them too).
+//   - REJECT absolute entry PATHS and any ".." component (per-component, post-Clean).
+//   - REJECT hardlinks (TypeLink) — a hardlink to /etc/shadow followed by an
+//     entry that "overwrites" it is the classic root-extraction escape; our own
+//     materialized backups never contain them.
+//   - REJECT device / fifo / char / block special files.
+//   - never write THROUGH a symlinked parent: every path component is created as
+//     a real directory (refuse a pre-existing symlink component) and every file
+//     is opened O_EXCL|O_NOFOLLOW. This — not the symlink target — is the real
+//     boundary: an inert symlink is never followed during extraction, so where
+//     it points can't redirect a root-side write.
+//   - bounded: a max total-bytes budget (decompression bomb) and a max entry
+//     count, both abort the extraction.
+//
+// zstd is streamed through `zstd -dc <src>` — src is a path WE chose (the
+// upload staging file), never a value from the archive, so no attacker arg.
+
+const (
+	// safeTarMaxBytes caps the total uncompressed bytes written — a
+	// decompression-bomb guard. 200 GiB is generous for a full account
+	// (a per-user backup this large is already an outlier) while still
+	// bounding a malicious 100:1 zstd bomb.
+	safeTarMaxBytes = int64(200) << 30
+	// safeTarMaxEntries caps the number of members so a tar of millions of
+	// empty files can't exhaust inodes / spin forever.
+	safeTarMaxEntries = 2_000_000
+)
+
+// safeExtractZstdTar decompresses the zstd tar at srcPath and extracts it into
+// destRoot (which must already exist). Returns the number of bytes written.
+// destRoot must be an absolute, cleaned path with no symlink components — the
+// caller owns creating it fresh.
+func safeExtractZstdTar(ctx context.Context, srcPath, destRoot string) (int64, error) {
+	if !filepath.IsAbs(destRoot) || destRoot != filepath.Clean(destRoot) {
+		return 0, fmt.Errorf("destRoot must be an absolute clean path")
+	}
+	// Decompress through the zstd CLI; srcPath is our own staging path.
+	zstd := exec.CommandContext(ctx, "zstd", "-dc", srcPath)
+	stdout, err := zstd.StdoutPipe()
+	if err != nil {
+		return 0, fmt.Errorf("zstd pipe: %w", err)
+	}
+	zstd.Stderr = io.Discard
+	if err := zstd.Start(); err != nil {
+		return 0, fmt.Errorf("zstd start: %w", err)
+	}
+	// Always drain/kill the decompressor so a rejected archive can't leave a
+	// blocked child holding the pipe.
+	defer func() {
+		_ = stdout.Close()
+		_ = zstd.Wait()
+	}()
+
+	written, err := extractTarStream(stdout, destRoot)
+	if err != nil {
+		return written, err
+	}
+	// The archive body was accepted; make sure the decompressor itself didn't
+	// fail (truncated/corrupt zstd frame the tar reader didn't notice).
+	if werr := zstd.Wait(); werr != nil {
+		return written, fmt.Errorf("zstd decode failed (corrupt or not a zstd archive): %w", werr)
+	}
+	return written, nil
+}
+
+// extractTarStream reads a plain (already-decompressed) tar from r into destRoot
+// with the allowlist + budget above. Split from the zstd wrapper so tests can
+// drive it with a tar built in-memory.
+func extractTarStream(r io.Reader, destRoot string) (int64, error) {
+	tr := tar.NewReader(r)
+	var written int64
+	entries := 0
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return written, fmt.Errorf("read tar entry: %w", err)
+		}
+		entries++
+		if entries > safeTarMaxEntries {
+			return written, fmt.Errorf("archive has too many entries (> %d)", safeTarMaxEntries)
+		}
+
+		rel, rerr := safeRelPath(hdr.Name)
+		if rerr != nil {
+			return written, fmt.Errorf("unsafe entry %q: %w", hdr.Name, rerr)
+		}
+		if rel == "" {
+			continue // "." / root entry — nothing to create
+		}
+		dest := filepath.Join(destRoot, rel)
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := safeMkdirAll(destRoot, rel, 0o750); err != nil {
+				return written, err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := safeMkdirAll(destRoot, filepath.Dir(rel), 0o750); err != nil {
+				return written, err
+			}
+			n, werr := writeRegularNoFollow(dest, tr, hdr.FileInfo().Mode().Perm(), safeTarMaxBytes-written)
+			written += n
+			if werr != nil {
+				return written, fmt.Errorf("write %q: %w", rel, werr)
+			}
+		case tar.TypeSymlink:
+			if err := safeMkdirAll(destRoot, filepath.Dir(rel), 0o750); err != nil {
+				return written, err
+			}
+			if err := safeSymlink(destRoot, rel, hdr.Linkname); err != nil {
+				return written, fmt.Errorf("symlink %q: %w", rel, err)
+			}
+		case tar.TypeLink:
+			return written, fmt.Errorf("refusing hardlink entry %q (target %q)", hdr.Name, hdr.Linkname)
+		case tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
+			return written, fmt.Errorf("refusing special (device/fifo) entry %q", hdr.Name)
+		default:
+			// TypeXGlobalHeader / pax extensions / unknown → skip silently.
+			continue
+		}
+	}
+	return written, nil
+}
+
+// safeRelPath normalizes a tar member name to a relative path under the root, or
+// errors if it is absolute or escapes via "..". Returns "" for the root itself.
+func safeRelPath(name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	// Reject a Windows-style or POSIX absolute path outright.
+	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, `\`) {
+		return "", fmt.Errorf("absolute path")
+	}
+	clean := filepath.Clean("/" + name) // anchor, then strip — collapses any "..".
+	rel := strings.TrimPrefix(clean, "/")
+	if rel == "" || rel == "." {
+		return "", nil
+	}
+	// After anchoring at "/", a Clean result can never contain "..", but check
+	// the raw components too so a "foo/../../bar" that Clean would collapse to an
+	// in-root path is still rejected as suspicious input.
+	for _, comp := range strings.Split(filepath.ToSlash(name), "/") {
+		if comp == ".." {
+			return "", fmt.Errorf("contains a .. component")
+		}
+	}
+	return rel, nil
+}
+
+// safeMkdirAll creates rel (a cleaned, escape-checked relative path) under root,
+// component by component, refusing to traverse an existing symlink — so an
+// earlier in-tree symlink entry can't redirect a later mkdir out of the tree.
+func safeMkdirAll(root, rel string, perm os.FileMode) error {
+	if rel == "" || rel == "." {
+		return nil
+	}
+	cur := root
+	for _, comp := range strings.Split(rel, string(filepath.Separator)) {
+		if comp == "" {
+			continue
+		}
+		cur = filepath.Join(cur, comp)
+		fi, err := os.Lstat(cur)
+		if err == nil {
+			if fi.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to descend through symlink component %q", cur)
+			}
+			if !fi.IsDir() {
+				return fmt.Errorf("path component %q exists and is not a directory", cur)
+			}
+			continue
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Mkdir(cur, perm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeRegularNoFollow writes a regular file, refusing to follow a symlink at the
+// leaf (O_EXCL|O_NOFOLLOW), and copies at most `budget` bytes before aborting as
+// a decompression-bomb guard.
+func writeRegularNoFollow(dest string, src io.Reader, perm os.FileMode, budget int64) (int64, error) {
+	if budget <= 0 {
+		return 0, fmt.Errorf("total extraction budget (%d bytes) exceeded", safeTarMaxBytes)
+	}
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, perm&0o777)
+	if err != nil {
+		return 0, err
+	}
+	// +1 so a file exactly at the remaining budget still copies, and a file that
+	// would push us over trips the guard instead of silently truncating.
+	n, cerr := io.CopyN(f, src, budget+1)
+	closeErr := f.Close()
+	if cerr != nil && cerr != io.EOF {
+		return n, cerr
+	}
+	if n > budget {
+		return n, fmt.Errorf("total extraction budget (%d bytes) exceeded", safeTarMaxBytes)
+	}
+	if closeErr != nil {
+		return n, closeErr
+	}
+	return n, nil
+}
+
+// safeSymlink creates the symlink at rel pointing to linkname, VERBATIM — a real
+// home legitimately carries absolute (e.g. ~/.jabali/bin/php8.5 -> /usr/bin/
+// php8.5) and out-of-tree symlinks, and the trusted restic restore preserves
+// them the same way. The link target is never a write vector here: extraction
+// never follows a symlink, safeMkdirAll refuses to descend through a symlink
+// parent, and files open O_NOFOLLOW — so a symlink can't redirect any root-side
+// write no matter where it points. The parent chain was already created as real
+// directories by the caller's safeMkdirAll before this runs.
+func safeSymlink(root, rel, linkname string) error {
+	if linkname == "" {
+		return fmt.Errorf("empty symlink target")
+	}
+	dest := filepath.Join(root, rel)
+	// No-clobber: refuse to replace an existing leaf.
+	if _, err := os.Lstat(dest); err == nil {
+		return fmt.Errorf("target already exists")
+	}
+	return os.Symlink(linkname, dest)
+}

--- a/panel-agent/internal/commands/safe_tar_extract.go
+++ b/panel-agent/internal/commands/safe_tar_extract.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -59,7 +58,7 @@ func safeExtractZstdTar(ctx context.Context, srcPath, destRoot string) (int64, e
 		return 0, fmt.Errorf("destRoot must be an absolute clean path")
 	}
 	// Decompress through the zstd CLI; srcPath is our own staging path.
-	zstd := exec.CommandContext(ctx, "zstd", "-dc", srcPath)
+	zstd := execCommandContext(ctx, "zstd", "-dc", srcPath)
 	stdout, err := zstd.StdoutPipe()
 	if err != nil {
 		return 0, fmt.Errorf("zstd pipe: %w", err)
@@ -147,6 +146,52 @@ func extractTarStream(r io.Reader, destRoot string) (int64, error) {
 		}
 	}
 	return written, nil
+}
+
+// readManifestFromZstdTar streams the zstd tar read-only (writes NOTHING) and
+// returns the account manifest bytes (<job-id>/manifest/manifest.json). Used by
+// the inspect step to show what a backup holds before the destructive apply. It
+// stops as soon as the manifest is found.
+func readManifestFromZstdTar(ctx context.Context, srcPath string) ([]byte, error) {
+	zstd := execCommandContext(ctx, "zstd", "-dc", srcPath)
+	stdout, err := zstd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	zstd.Stderr = io.Discard
+	if err := zstd.Start(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = stdout.Close()
+		_ = zstd.Wait()
+	}()
+
+	tr := tar.NewReader(stdout)
+	entries := 0
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar: %w", err)
+		}
+		entries++
+		if entries > safeTarMaxEntries {
+			break
+		}
+		rel, rerr := safeRelPath(hdr.Name)
+		if rerr != nil || rel == "" {
+			continue
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) >= 3 && parts[1] == "manifest" &&
+			parts[len(parts)-1] == "manifest.json" && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(io.LimitReader(tr, 8<<20)) // 8 MiB cap — a manifest is tiny
+		}
+	}
+	return nil, fmt.Errorf("no manifest/manifest.json in archive")
 }
 
 // safeRelPath normalizes a tar member name to a relative path under the root, or

--- a/panel-agent/internal/commands/safe_tar_extract_test.go
+++ b/panel-agent/internal/commands/safe_tar_extract_test.go
@@ -1,0 +1,183 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #1408 — the untrusted-tar extractor is the security contract of the
+// upload-restore feature. These prove it accepts a well-formed backup tree and
+// rejects every classic root-extraction escape.
+
+type tentry struct {
+	typ   byte
+	name  string
+	body  string
+	link  string
+	mode  int64
+	major int64
+	minor int64
+}
+
+func buildTar(t *testing.T, entries []tentry) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range entries {
+		mode := e.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		hdr := &tar.Header{
+			Typeflag: e.typ,
+			Name:     e.name,
+			Linkname: e.link,
+			Mode:     mode,
+			Size:     int64(len(e.body)),
+			Devmajor: e.major,
+			Devminor: e.minor,
+		}
+		if e.typ == tar.TypeDir && !strings.HasSuffix(hdr.Name, "/") {
+			hdr.Name += "/"
+		}
+		if e.typ != tar.TypeReg {
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %q: %v", e.name, err)
+		}
+		if e.typ == tar.TypeReg && e.body != "" {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write body %q: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func TestExtractTarStream_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	buf := buildTar(t, []tentry{
+		{typ: tar.TypeDir, name: "home"},
+		{typ: tar.TypeReg, name: "home/a.txt", body: "hello"},
+		{typ: tar.TypeDir, name: "db"},
+		{typ: tar.TypeReg, name: "db/site.sql", body: "CREATE TABLE t();"},
+		{typ: tar.TypeReg, name: "manifest.json", body: "{}"},
+		{typ: tar.TypeSymlink, name: "home/link", link: "a.txt"}, // in-tree, allowed
+	})
+	n, err := extractTarStream(buf, root)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if n != int64(len("hello")+len("CREATE TABLE t();")+len("{}")) {
+		t.Fatalf("bytes written = %d, unexpected", n)
+	}
+	if b, _ := os.ReadFile(filepath.Join(root, "home", "a.txt")); string(b) != "hello" {
+		t.Fatalf("home/a.txt content wrong")
+	}
+	if fi, err := os.Lstat(filepath.Join(root, "home", "link")); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("home/link should be a symlink: %v", err)
+	}
+}
+
+func TestExtractTarStream_RejectsEscapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []tentry
+		wantSub string
+	}{
+		{"absolute path", []tentry{{typ: tar.TypeReg, name: "/etc/passwd", body: "x"}}, "absolute"},
+		{"dotdot traversal", []tentry{{typ: tar.TypeReg, name: "../../etc/cron.d/x", body: "x"}}, ".."},
+		{"hardlink", []tentry{{typ: tar.TypeLink, name: "shadow", link: "/etc/shadow"}}, "hardlink"},
+		{"char device", []tentry{{typ: tar.TypeChar, name: "dev", major: 1, minor: 3}}, "special"},
+		{"fifo", []tentry{{typ: tar.TypeFifo, name: "pipe"}}, "special"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			_, err := extractTarStream(buildTar(t, tc.entries), root)
+			if err == nil {
+				t.Fatalf("expected rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q missing %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// A real home carries absolute + out-of-tree symlinks (php shims, etc.). They
+// are inert during extraction (never followed), so they must be preserved
+// verbatim, exactly as the trusted restic restore does — NOT rejected.
+func TestExtractTarStream_PreservesSymlinksVerbatim(t *testing.T) {
+	root := t.TempDir()
+	buf := buildTar(t, []tentry{
+		{typ: tar.TypeDir, name: "home"},
+		{typ: tar.TypeSymlink, name: "home/php", link: "/usr/bin/php8.5"}, // absolute
+		{typ: tar.TypeSymlink, name: "home/up", link: "../../../etc"},     // out-of-tree
+	})
+	if _, err := extractTarStream(buf, root); err != nil {
+		t.Fatalf("real-home symlinks must extract, got %v", err)
+	}
+	if tgt, _ := os.Readlink(filepath.Join(root, "home", "php")); tgt != "/usr/bin/php8.5" {
+		t.Fatalf("absolute symlink target = %q, want /usr/bin/php8.5", tgt)
+	}
+	if tgt, _ := os.Readlink(filepath.Join(root, "home", "up")); tgt != "../../../etc" {
+		t.Fatalf("out-of-tree symlink target = %q, want ../../../etc", tgt)
+	}
+}
+
+// A symlink component must never be traversed by a later entry: "s" -> "home"
+// (in-tree, allowed to create), then a regular file "s/evil" must be refused
+// rather than written through the symlink.
+func TestExtractTarStream_NoWriteThroughSymlinkParent(t *testing.T) {
+	root := t.TempDir()
+	buf := buildTar(t, []tentry{
+		{typ: tar.TypeDir, name: "home"},
+		{typ: tar.TypeSymlink, name: "s", link: "home"},
+		{typ: tar.TypeReg, name: "s/evil", body: "x"},
+	})
+	_, err := extractTarStream(buf, root)
+	if err == nil || !strings.Contains(err.Error(), "symlink component") {
+		t.Fatalf("expected refusal to descend through symlink parent, got %v", err)
+	}
+}
+
+// The decompression-bomb budget aborts a file that would exceed the remaining
+// allowance rather than writing it.
+func TestWriteRegularNoFollow_BudgetGuard(t *testing.T) {
+	root := t.TempDir()
+	dest := filepath.Join(root, "big")
+	_, err := writeRegularNoFollow(dest, strings.NewReader(strings.Repeat("A", 100)), 0o644, 10)
+	if err == nil || !strings.Contains(err.Error(), "budget") {
+		t.Fatalf("expected budget-exceeded, got %v", err)
+	}
+}
+
+func TestSafeRelPath(t *testing.T) {
+	ok := map[string]string{
+		"home/a.txt": "home/a.txt",
+		"./db/x.sql": "db/x.sql",
+		"manifest.json": "manifest.json",
+		".":          "",
+		"":           "",
+	}
+	for in, want := range ok {
+		got, err := safeRelPath(in)
+		if err != nil || got != want {
+			t.Fatalf("safeRelPath(%q) = %q,%v want %q", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"/abs", "../up", "a/../../b", `\abs`} {
+		if _, err := safeRelPath(bad); err == nil {
+			t.Fatalf("safeRelPath(%q) should error", bad)
+		}
+	}
+}

--- a/panel-api/internal/api/backup_restore_upload.go
+++ b/panel-api/internal/api/backup_restore_upload.go
@@ -1,0 +1,264 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+)
+
+// backup_restore_upload.go — GH #1408. Admin "restore from an uploaded backup
+// archive" (DR / cross-server migration): upload the .tar an admin downloaded
+// earlier, inspect it, then restore selected components into an existing user.
+//
+// Upload is CHUNKED (reuses the #1323 pattern that already beat Cloudflare's
+// origin timeout on big DB restores): each chunk is an octet-stream POST
+// appended at `offset`; the file reassembles under /var/lib/jabali-uploads (the
+// agent-readable handoff dir). The path is derived from the AUTHENTICATED admin
+// + the client upload_id, so one admin can never point the restore at another's
+// staged file. The apply is step-up gated (destructive) and hands the reassembled
+// tar to the agent's untrusted-tar extractor (backup.restore_from_tar).
+
+const (
+	restoreUploadDir      = "/var/lib/jabali-uploads"
+	restoreUploadTTL      = 24 * time.Hour
+	maxInFlightRestoreTar = 2
+	// maxRestoreUploadBytes bounds a single reassembled archive so a stuck /
+	// malicious upload can't fill the service partition before the extractor's
+	// own budget kicks in. 300 GiB covers the largest realistic per-account tar.
+	maxRestoreUploadBytes = int64(300) << 30
+)
+
+var (
+	uploadIDRE               = regexp.MustCompile(`^[A-Za-z0-9_-]{8,128}$`)
+	restoreTargetUsernameRE  = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,31}$`)
+)
+
+func restoreUploadAdminTag(userID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-upload-admin:" + userID))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// restoreUploadPath derives the reassembly path from the server-side admin
+// userID + the client upload_id (Gitea #426 pattern), so it can't be steered
+// across admins or out of the uploads dir.
+func restoreUploadPath(adminUserID, uploadID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-upload:" + adminUserID + ":" + uploadID))
+	return filepath.Join(restoreUploadDir, "rup-"+restoreUploadAdminTag(adminUserID)+"-"+hex.EncodeToString(sum[:])+".tar.zst")
+}
+
+func evictStaleRestoreUploads(adminUserID string) {
+	matches, _ := filepath.Glob(filepath.Join(restoreUploadDir, "rup-"+restoreUploadAdminTag(adminUserID)+"-*.tar.zst"))
+	cutoff := time.Now().Add(-restoreUploadTTL)
+	for _, m := range matches {
+		if fi, err := os.Stat(m); err == nil && fi.ModTime().Before(cutoff) {
+			_ = os.Remove(m)
+		}
+	}
+}
+
+func (h *backupHandler) restoreUploadAdminID(c *gin.Context) (string, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil || claims.UserID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return "", false
+	}
+	return claims.UserID, true
+}
+
+// restoreUploadChunk handles POST /admin/backups/restore-upload?upload_id=&offset=[&final=1].
+// Body is a raw octet-stream chunk appended at offset. Exempt from the global
+// body limit (see bodyLimitExemptRoutes).
+func (h *backupHandler) restoreUploadChunk(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	uploadID := c.Query("upload_id")
+	if !uploadIDRE.MatchString(uploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	offset, err := strconv.ParseInt(c.Query("offset"), 10, 64)
+	if err != nil || offset < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_offset"})
+		return
+	}
+	if err := os.MkdirAll(restoreUploadDir, 0o750); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "staging_unavailable"})
+		return
+	}
+	evictStaleRestoreUploads(adminID)
+
+	path := restoreUploadPath(adminID, uploadID)
+	if offset == 0 {
+		if _, statErr := os.Stat(path); statErr != nil {
+			matches, _ := filepath.Glob(filepath.Join(restoreUploadDir, "rup-"+restoreUploadAdminTag(adminID)+"-*.tar.zst"))
+			if len(matches) >= maxInFlightRestoreTar {
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "too_many_uploads", "detail": "finish or wait for an in-flight restore upload"})
+				return
+			}
+		}
+	}
+	if offset >= maxRestoreUploadBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "archive_too_large"})
+		return
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "open_staging_failed"})
+		return
+	}
+	defer f.Close()
+	if _, err := f.Seek(offset, 0); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "seek_failed"})
+		return
+	}
+	// LimitReader bounds the write so a chunk can't push the file past the cap;
+	// the extractor enforces the real decompression-bomb budget later.
+	written, werr := io.Copy(f, io.LimitReader(c.Request.Body, maxRestoreUploadBytes-offset))
+	if werr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "write_failed", "detail": werr.Error()})
+		return
+	}
+	if c.Query("final") == "1" {
+		size := offset + written
+		if fi, serr := f.Stat(); serr == nil {
+			size = fi.Size()
+		}
+		c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "size": size})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "written": written, "offset": offset + written})
+}
+
+type restoreUploadInspectRequest struct {
+	UploadID string `json:"upload_id"`
+}
+
+// restoreUploadInspect returns the backup's user + restorable components for the
+// UI to present a selection before the destructive apply.
+func (h *backupHandler) restoreUploadInspect(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	var req restoreUploadInspectRequest
+	if err := c.ShouldBindJSON(&req); err != nil || !uploadIDRE.MatchString(req.UploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	path := restoreUploadPath(adminID, req.UploadID)
+	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "backup.inspect_uploaded_tar", map[string]string{"tar_path": path})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	c.Data(http.StatusOK, "application/json", raw)
+}
+
+type restoreUploadApplyRequest struct {
+	UploadID       string   `json:"upload_id"`
+	TargetUsername string   `json:"target_username"`
+	Components     []string `json:"components,omitempty"`
+}
+
+// restoreUploadApply restores the uploaded archive into an EXISTING user.
+// Destructive → step-up gated. Reuses applyRestoreMetadata (JAB-312) to rebuild
+// the panel DB rows from the backup's metadata bundle, exactly like the snapshot
+// restore path.
+func (h *backupHandler) restoreUploadApply(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	// Destructive admin action → recent-auth (MFA step-up), same bar as the
+	// admin File Manager's sensitive operations.
+	if !requireRecentAuth(c, h.cfg.KratosClient, stepUpWindow) {
+		return
+	}
+	var req restoreUploadApplyRequest
+	if err := c.ShouldBindJSON(&req); err != nil || !uploadIDRE.MatchString(req.UploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	if !restoreTargetUsernameRE.MatchString(req.TargetUsername) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_target_username"})
+		return
+	}
+	// v1: the target user must already exist (no create-from-manifest).
+	target, uerr := h.cfg.Users.FindByUsername(c.Request.Context(), req.TargetUsername)
+	if uerr != nil || target == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "target_user_not_found", "detail": "create the user first, then restore into it"})
+		return
+	}
+	path := restoreUploadPath(adminID, req.UploadID)
+	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+
+	c.Set("audit_target", req.TargetUsername)
+	c.Set("audit_target_type", "user")
+
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "backup.restore_from_tar", map[string]any{
+		"job_id":          ids.NewULID(),
+		"tar_path":        path,
+		"target_username": req.TargetUsername,
+		"components":      req.Components,
+	})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	var result struct {
+		User     json.RawMessage `json:"user"`
+		Applied  []string        `json:"applied"`
+		Warnings []string        `json:"warnings"`
+		Metadata json.RawMessage `json:"metadata"`
+	}
+	_ = json.Unmarshal(raw, &result)
+
+	// Rebuild panel DB rows (domains, mailboxes, db-users, …) from the backup's
+	// metadata bundle — the same step the snapshot restore runs (JAB-312).
+	var metaErrs []string
+	if len(result.Metadata) > 0 {
+		metaErrs = h.applyRestoreMetadata(c.Request.Context(), result.Metadata)
+	}
+
+	// The archive is consumed — drop it so a downloaded backup with real data
+	// doesn't linger in the uploads dir.
+	_ = os.Remove(path)
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":          "ok",
+		"user":            result.User,
+		"applied":         result.Applied,
+		"warnings":        result.Warnings,
+		"metadata_errors": metaErrs,
+	})
+}

--- a/panel-api/internal/api/backup_restore_upload.go
+++ b/panel-api/internal/api/backup_restore_upload.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -59,13 +61,51 @@ func restoreUploadPath(adminUserID, uploadID string) string {
 }
 
 func evictStaleRestoreUploads(adminUserID string) {
-	matches, _ := filepath.Glob(filepath.Join(restoreUploadDir, "rup-"+restoreUploadAdminTag(adminUserID)+"-*.tar.zst"))
+	tag := restoreUploadAdminTag(adminUserID)
 	cutoff := time.Now().Add(-restoreUploadTTL)
-	for _, m := range matches {
-		if fi, err := os.Stat(m); err == nil && fi.ModTime().Before(cutoff) {
-			_ = os.Remove(m)
+	for _, pat := range []string{"rup-" + tag + "-*.tar.zst", "ruo-" + tag + "-*.json"} {
+		matches, _ := filepath.Glob(filepath.Join(restoreUploadDir, pat))
+		for _, m := range matches {
+			if fi, err := os.Stat(m); err == nil && fi.ModTime().Before(cutoff) {
+				_ = os.Remove(m)
+			}
 		}
 	}
+}
+
+type restoreUploadOutcome struct {
+	Status   string   `json:"status"` // restoring | done | failed
+	TS       int64    `json:"ts"`
+	Applied  []string `json:"applied,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+func restoreUploadOutcomePath(adminUserID, uploadID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-upload-outcome:" + adminUserID + ":" + uploadID))
+	return filepath.Join(restoreUploadDir, "ruo-"+restoreUploadAdminTag(adminUserID)+"-"+hex.EncodeToString(sum[:])+".json")
+}
+
+func writeRestoreUploadOutcome(path, status string, applied, warnings []string, detail string) {
+	if len(detail) > 600 {
+		detail = detail[:600] + "…"
+	}
+	b, _ := json.Marshal(restoreUploadOutcome{
+		Status: status, TS: time.Now().Unix(), Applied: applied, Warnings: warnings, Error: detail,
+	})
+	writeOutcomeFile(path, b) // atomic swap, shared with the #1323 DB restore
+}
+
+func readRestoreUploadOutcome(path string) (*restoreUploadOutcome, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var o restoreUploadOutcome
+	if err := json.Unmarshal(b, &o); err != nil {
+		return nil, err
+	}
+	return &o, nil
 }
 
 func (h *backupHandler) restoreUploadAdminID(c *gin.Context) (string, bool) {
@@ -128,10 +168,22 @@ func (h *backupHandler) restoreUploadChunk(c *gin.Context) {
 	}
 	// LimitReader bounds the write so a chunk can't push the file past the cap;
 	// the extractor enforces the real decompression-bomb budget later.
-	written, werr := io.Copy(f, io.LimitReader(c.Request.Body, maxRestoreUploadBytes-offset))
+	remaining := maxRestoreUploadBytes - offset
+	written, werr := io.Copy(f, io.LimitReader(c.Request.Body, remaining))
 	if werr != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "write_failed", "detail": werr.Error()})
 		return
+	}
+	// If we wrote exactly up to the cap AND the body still has bytes, the chunk
+	// would have been silently truncated — reject instead so no partial archive
+	// is ever restored.
+	if written == remaining {
+		var probe [1]byte
+		if n, _ := c.Request.Body.Read(probe[:]); n > 0 {
+			_ = os.Remove(path)
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "archive_too_large"})
+			return
+		}
 	}
 	if c.Query("final") == "1" {
 		size := offset + written
@@ -184,9 +236,11 @@ type restoreUploadApplyRequest struct {
 }
 
 // restoreUploadApply restores the uploaded archive into an EXISTING user.
-// Destructive → step-up gated. Reuses applyRestoreMetadata (JAB-312) to rebuild
-// the panel DB rows from the backup's metadata bundle, exactly like the snapshot
-// restore path.
+// Destructive → step-up gated. Runs the agent restore + metadata rebuild in a
+// DETACHED goroutine (like the #1323 chunked DB restore) and returns 202 — a
+// full account restore (extract + rsync home + load DBs) runs for minutes and
+// would otherwise die on the axios/nginx/Cloudflare timeout stack, potentially
+// half-applied. The client polls restore-upload/status.
 func (h *backupHandler) restoreUploadApply(c *gin.Context) {
 	adminID, ok := h.restoreUploadAdminID(c)
 	if !ok {
@@ -224,41 +278,116 @@ func (h *backupHandler) restoreUploadApply(c *gin.Context) {
 
 	c.Set("audit_target", req.TargetUsername)
 	c.Set("audit_target_type", "user")
+	evictStaleRestoreUploads(adminID) // reap abandoned partials + old markers
 
-	raw, err := h.cfg.Agent.Call(c.Request.Context(), "backup.restore_from_tar", map[string]any{
+	outcomePath := restoreUploadOutcomePath(adminID, req.UploadID)
+	writeRestoreUploadOutcome(outcomePath, "restoring", nil, nil, "")
+	go h.runUploadRestore(uploadRestoreArgs{
+		path:        path,
+		outcomePath: outcomePath,
+		username:    req.TargetUsername,
+		targetID:    target.ID,
+		components:  req.Components,
+	})
+
+	c.JSON(http.StatusAccepted, gin.H{"status": "restoring", "upload_id": req.UploadID})
+}
+
+type uploadRestoreArgs struct {
+	path        string
+	outcomePath string
+	username    string
+	targetID    string
+	components  []string
+}
+
+// runUploadRestore performs the detached restore: agent apply → metadata rebuild
+// (remapped to the target user) → seal the outcome marker → drop the archive.
+func (h *backupHandler) runUploadRestore(a uploadRestoreArgs) {
+	ctx, cancel := context.WithTimeout(context.Background(), restoreJobTimeout)
+	defer cancel()
+
+	raw, err := h.cfg.Agent.Call(ctx, "backup.restore_from_tar", map[string]any{
 		"job_id":          ids.NewULID(),
-		"tar_path":        path,
-		"target_username": req.TargetUsername,
-		"components":      req.Components,
+		"tar_path":        a.path,
+		"target_username": a.username,
+		"components":      a.components,
 	})
 	if err != nil {
-		respondAgentError(c, err)
+		writeRestoreUploadOutcome(a.outcomePath, "failed", nil, nil, restoreFailureDetail(err))
+		_ = os.Remove(a.path) // terminal failure — don't strand a huge tar
 		return
 	}
 	var result struct {
-		User     json.RawMessage `json:"user"`
 		Applied  []string        `json:"applied"`
 		Warnings []string        `json:"warnings"`
 		Metadata json.RawMessage `json:"metadata"`
 	}
 	_ = json.Unmarshal(raw, &result)
 
-	// Rebuild panel DB rows (domains, mailboxes, db-users, …) from the backup's
-	// metadata bundle — the same step the snapshot restore runs (JAB-312).
-	var metaErrs []string
-	if len(result.Metadata) > 0 {
-		metaErrs = h.applyRestoreMetadata(c.Request.Context(), result.Metadata)
-	}
+	// Rebuild panel DB rows from the backup's metadata bundle, REMAPPED to this
+	// box's target user. The bundle carries the SOURCE box's user_id; every child
+	// row FKs to it (backupmetadata.Apply). On a cross-server restore that id
+	// isn't this box's target user, so rewrite user.id to the resolved target
+	// before applying — otherwise the rows attach to a non-existent user.
+	metaErrs := h.applyRestoreMetadataForUser(ctx, result.Metadata, a.targetID)
+	result.Warnings = append(result.Warnings, metaErrs...)
 
 	// The archive is consumed — drop it so a downloaded backup with real data
 	// doesn't linger in the uploads dir.
-	_ = os.Remove(path)
+	_ = os.Remove(a.path)
 
-	c.JSON(http.StatusOK, gin.H{
-		"status":          "ok",
-		"user":            result.User,
-		"applied":         result.Applied,
-		"warnings":        result.Warnings,
-		"metadata_errors": metaErrs,
-	})
+	writeRestoreUploadOutcome(a.outcomePath, "done", result.Applied, result.Warnings, "")
+}
+
+// applyRestoreMetadataForUser rewrites the metadata bundle's user id to targetID
+// (so a cross-server bundle's rows attach to THIS box's user) before the shared
+// applyRestoreMetadata rebuild.
+func (h *backupHandler) applyRestoreMetadataForUser(ctx context.Context, metaRaw json.RawMessage, targetID string) []string {
+	if len(metaRaw) == 0 || targetID == "" {
+		return h.applyRestoreMetadata(ctx, metaRaw)
+	}
+	remapped, err := remapMetadataUserID(metaRaw, targetID)
+	if err != nil {
+		return []string{err.Error()}
+	}
+	return h.applyRestoreMetadata(ctx, remapped)
+}
+
+// remapMetadataUserID rewrites the metadata bundle's user.id to targetID. Every
+// child row FKs to user.id in backupmetadata.Apply, so a single rewrite reattaches
+// a cross-server bundle to this box's target user. Pure — unit-tested.
+func remapMetadataUserID(metaRaw json.RawMessage, targetID string) (json.RawMessage, error) {
+	var m map[string]any
+	if err := json.Unmarshal(metaRaw, &m); err != nil {
+		return nil, fmt.Errorf("parse metadata bundle: %w", err)
+	}
+	if u, ok := m["user"].(map[string]any); ok {
+		u["id"] = targetID
+	}
+	remapped, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("remap metadata user: %w", err)
+	}
+	return remapped, nil
+}
+
+// restoreUploadStatus handles GET /admin/backups/restore-upload/status?upload_id=…
+// — polls the detached restore's outcome marker.
+func (h *backupHandler) restoreUploadStatus(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	uploadID := c.Query("upload_id")
+	if !uploadIDRE.MatchString(uploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	o, err := readRestoreUploadOutcome(restoreUploadOutcomePath(adminID, uploadID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, o)
 }

--- a/panel-api/internal/api/backup_restore_upload_test.go
+++ b/panel-api/internal/api/backup_restore_upload_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #1408: the reassembly path must be derived from the authenticated admin +
+// upload_id so one admin can never point the restore at another's staged file,
+// and it must always land under the uploads handoff dir.
+func TestRestoreUploadPath_Isolation(t *testing.T) {
+	a := restoreUploadPath("admin-A", "up-1")
+	b := restoreUploadPath("admin-B", "up-1") // same upload_id, different admin
+	c := restoreUploadPath("admin-A", "up-2") // same admin, different upload_id
+
+	for _, p := range []string{a, b, c} {
+		if !strings.HasPrefix(p, restoreUploadDir+"/") {
+			t.Fatalf("path %q not under %q", p, restoreUploadDir)
+		}
+		if strings.Contains(p, "..") {
+			t.Fatalf("path %q contains ..", p)
+		}
+	}
+	if a == b {
+		t.Fatal("same upload_id across different admins must map to DIFFERENT paths")
+	}
+	if a == c {
+		t.Fatal("different upload_ids for one admin must map to different paths")
+	}
+	// Deterministic for resumed chunks of the same (admin, upload_id).
+	if a != restoreUploadPath("admin-A", "up-1") {
+		t.Fatal("path must be stable for the same admin+upload_id")
+	}
+}
+
+func TestUploadIDValidation(t *testing.T) {
+	good := []string{"abc12345", "a1b2-c3d4_E5", strings.Repeat("x", 128)}
+	bad := []string{"short", "", "has space", "path/traversal", "..", strings.Repeat("x", 129), "semi;colon"}
+	for _, g := range good {
+		if !uploadIDRE.MatchString(g) {
+			t.Fatalf("uploadID %q should be valid", g)
+		}
+	}
+	for _, b := range bad {
+		if uploadIDRE.MatchString(b) {
+			t.Fatalf("uploadID %q should be rejected", b)
+		}
+	}
+}
+
+func TestRestoreTargetUsernameRE(t *testing.T) {
+	for _, g := range []string{"alice", "a", "a_b-c", "user01"} {
+		if !restoreTargetUsernameRE.MatchString(g) {
+			t.Fatalf("username %q should be valid", g)
+		}
+	}
+	for _, b := range []string{"", "Alice", "1abc", "a" + strings.Repeat("x", 40), "a/b", "root;rm"} {
+		if restoreTargetUsernameRE.MatchString(b) {
+			t.Fatalf("username %q should be rejected", b)
+		}
+	}
+}

--- a/panel-api/internal/api/backup_restore_upload_test.go
+++ b/panel-api/internal/api/backup_restore_upload_test.go
@@ -1,9 +1,86 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// GH #1408: a cross-server bundle's rows must reattach to THIS box's target user.
+func TestRemapMetadataUserID(t *testing.T) {
+	in := json.RawMessage(`{"user":{"id":"SRC","username":"alice","email":"a@x"},"domains":[{"id":"d1"}]}`)
+	out, err := remapMetadataUserID(in, "TARGET")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatal(err)
+	}
+	u := m["user"].(map[string]any)
+	if u["id"] != "TARGET" {
+		t.Fatalf("user.id = %v, want TARGET", u["id"])
+	}
+	if u["username"] != "alice" {
+		t.Fatalf("username must be preserved, got %v", u["username"])
+	}
+	if len(m["domains"].([]any)) != 1 {
+		t.Fatal("child rows must be preserved")
+	}
+}
+
+// The detached restore seals its outcome marker and drops the consumed tar, on
+// both success and agent failure.
+func TestRunUploadRestore_Outcome(t *testing.T) {
+	newHandler := func(callErr bool) (*backupHandler, string, string) {
+		dir := t.TempDir()
+		tar := filepath.Join(dir, "up.tar.zst")
+		if err := os.WriteFile(tar, []byte("archive"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		outcome := filepath.Join(dir, "o.json")
+		mock := &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+			if cmd != "backup.restore_from_tar" {
+				t.Fatalf("unexpected agent command %q", cmd)
+			}
+			if callErr {
+				return nil, context.DeadlineExceeded
+			}
+			return json.RawMessage(`{"applied":["home → /home/alice"],"warnings":["mail staged"]}`), nil
+		}}
+		return &backupHandler{cfg: BackupHandlerConfig{Agent: mock}}, tar, outcome
+	}
+
+	t.Run("success", func(t *testing.T) {
+		h, tar, outcome := newHandler(false)
+		h.runUploadRestore(uploadRestoreArgs{path: tar, outcomePath: outcome, username: "alice", targetID: "T", components: []string{"home"}})
+		o, err := readRestoreUploadOutcome(outcome)
+		if err != nil || o.Status != "done" {
+			t.Fatalf("outcome = %+v err=%v, want done", o, err)
+		}
+		if len(o.Applied) != 1 {
+			t.Fatalf("applied = %v, want 1", o.Applied)
+		}
+		if _, err := os.Stat(tar); !os.IsNotExist(err) {
+			t.Fatal("consumed tar must be deleted on success")
+		}
+	})
+
+	t.Run("agent failure", func(t *testing.T) {
+		h, tar, outcome := newHandler(true)
+		h.runUploadRestore(uploadRestoreArgs{path: tar, outcomePath: outcome, username: "alice", targetID: "T"})
+		o, err := readRestoreUploadOutcome(outcome)
+		if err != nil || o.Status != "failed" {
+			t.Fatalf("outcome = %+v err=%v, want failed", o, err)
+		}
+		if _, err := os.Stat(tar); !os.IsNotExist(err) {
+			t.Fatal("tar must be deleted on terminal failure too")
+		}
+	})
+}
 
 // GH #1408: the reassembly path must be derived from the authenticated admin +
 // upload_id so one admin can never point the restore at another's staged file,

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -126,6 +126,10 @@ func RegisterBackupRoutes(rg *gin.RouterGroup, cfg BackupHandlerConfig) {
 	admin.POST("/backups/:job_id/cancel", h.cancel)
 	admin.GET("/backups/:job_id/logs", h.logs)
 	admin.POST("/backups/restore", h.restore)
+	// GH #1408: restore from an uploaded backup archive (DR / migration).
+	admin.POST("/backups/restore-upload", h.restoreUploadChunk)
+	admin.POST("/backups/restore-upload/inspect", h.restoreUploadInspect)
+	admin.POST("/backups/restore-upload/apply", h.restoreUploadApply)
 	admin.GET("/backup-runs", h.listRuns)
 	admin.GET("/backup-runs/:run_id/jobs", h.listRunJobs)
 	admin.DELETE("/backup-runs/:run_id/jobs", h.deleteRunJobs)

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -130,6 +130,7 @@ func RegisterBackupRoutes(rg *gin.RouterGroup, cfg BackupHandlerConfig) {
 	admin.POST("/backups/restore-upload", h.restoreUploadChunk)
 	admin.POST("/backups/restore-upload/inspect", h.restoreUploadInspect)
 	admin.POST("/backups/restore-upload/apply", h.restoreUploadApply)
+	admin.GET("/backups/restore-upload/status", h.restoreUploadStatus)
 	admin.GET("/backup-runs", h.listRuns)
 	admin.GET("/backup-runs/:run_id/jobs", h.listRunJobs)
 	admin.DELETE("/backup-runs/:run_id/jobs", h.deleteRunJobs)

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2427,6 +2427,13 @@ paths:
       tags: [Backups]
       summary: Restore an uploaded backup archive into an existing user (step-up)
       security: [ { KratosSession: [] } ]
+      responses: { "202": { description: Accepted } }
+
+  /admin/backups/restore-upload/status:
+    get:
+      tags: [Backups]
+      summary: Poll the status of an uploaded-archive restore
+      security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
   /admin/backups/{job_id}:

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2408,6 +2408,27 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/backups/restore-upload:
+    post:
+      tags: [Backups]
+      summary: Upload a backup archive chunk to restore from (GH #1408)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/backups/restore-upload/inspect:
+    post:
+      tags: [Backups]
+      summary: Inspect an uploaded backup archive (user + restorable components)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/backups/restore-upload/apply:
+    post:
+      tags: [Backups]
+      summary: Restore an uploaded backup archive into an existing user (step-up)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /admin/backups/{job_id}:
     delete:
       tags: [Backups]

--- a/panel-api/internal/app/body_limit_exempt.go
+++ b/panel-api/internal/app/body_limit_exempt.go
@@ -26,6 +26,10 @@ var bodyLimitExemptRoutes = map[string]struct{}{
 	// large") before the handler's own LimitReader runs, so any dump above the
 	// 90 MB chunk threshold could never restore.
 	"POST /api/v1/databases/:id/restore-chunk": {},
+	// Own cap: io.LimitReader against maxRestoreUploadBytes per chunk (GH #1408).
+	// The chunked backup-archive upload sends multi-MB chunks; without this the
+	// 1 MB global cap 413s every chunk before the handler's own LimitReader runs.
+	"POST /api/v1/admin/backups/restore-upload": {},
 	// GH #1184 admin File Manager — the SAME handlers as the tenant /files
 	// mount (which is exempt above), re-mounted under /admin/files, so they
 	// carry the same own caps and need the same exemptions (GH #1044).

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -462,6 +462,93 @@ export async function restoreDatabaseUploadAuto(
   return restoreDatabaseUpload(databaseId, file, onProgress);
 }
 
+// === GH #1408: restore from an uploaded backup archive (admin) ===
+
+export interface UploadedBackupInfo {
+  user: { id: string; username: string; email?: string; is_admin?: boolean };
+  components: string[];
+}
+
+// uploadBackupArchiveChunked streams a downloaded account backup .tar to the
+// panel in chunks (reusing the DB-restore chunk transport so a hundreds-of-MB
+// archive isn't rejected by a proxy body cap), and returns the upload_id to
+// inspect + apply. No server-side resume — a failed upload just restarts.
+export async function uploadBackupArchiveChunked(
+  file: File,
+  onProgress?: (p: RestoreUploadProgress) => void,
+): Promise<string> {
+  const chunkSize = RESTORE_CHUNK_SIZE;
+  const totalChunks = Math.max(1, Math.ceil(file.size / chunkSize));
+  const uploadId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const started = Date.now();
+  const report = (loaded: number) => {
+    if (!onProgress) return;
+    const elapsed = (Date.now() - started) / 1000;
+    const rate = elapsed > 0 ? loaded / elapsed : undefined;
+    onProgress({
+      frac: file.size > 0 ? Math.min(1, loaded / file.size) : 1,
+      loaded: Math.min(loaded, file.size),
+      total: file.size,
+      rate,
+      estimated: rate && rate > 0 ? (file.size - loaded) / rate : undefined,
+    });
+  };
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * chunkSize;
+    const end = Math.min(start + chunkSize, file.size);
+    const isLast = i === totalChunks - 1;
+    const params = new URLSearchParams({
+      upload_id: uploadId,
+      offset: String(start),
+      ...(isLast ? { final: "1" } : {}),
+    });
+    await apiClient.post(
+      `/admin/backups/restore-upload?${params.toString()}`,
+      file.slice(start, end),
+      {
+        headers: { "Content-Type": "application/octet-stream" },
+        timeout: 0,
+        onUploadProgress: (e) => report(start + (e.loaded ?? 0)),
+      },
+    );
+    report(end);
+  }
+  report(file.size);
+  return uploadId;
+}
+
+export async function inspectUploadedBackup(
+  uploadId: string,
+): Promise<UploadedBackupInfo> {
+  const { data } = await apiClient.post<UploadedBackupInfo>(
+    "/admin/backups/restore-upload/inspect",
+    { upload_id: uploadId },
+  );
+  return data;
+}
+
+export interface UploadedBackupRestoreResult {
+  status: string;
+  applied?: string[] | null;
+  warnings?: string[] | null;
+  metadata_errors?: string[] | null;
+}
+
+export async function applyUploadedBackupRestore(
+  uploadId: string,
+  targetUsername: string,
+  components: string[],
+): Promise<UploadedBackupRestoreResult> {
+  const { data } = await apiClient.post<UploadedBackupRestoreResult>(
+    "/admin/backups/restore-upload/apply",
+    { upload_id: uploadId, target_username: targetUsername, components },
+  );
+  return data;
+}
+
 // === PHP Settings API ===
 
 export interface DomainPHPSettings {

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -537,16 +537,46 @@ export interface UploadedBackupRestoreResult {
   metadata_errors?: string[] | null;
 }
 
+// applyUploadedBackupRestore kicks off the restore (202) and polls the status
+// marker until it seals — the apply runs detached server-side so a minutes-long
+// account restore doesn't span a proxy timeout (same shape as the DB restore).
 export async function applyUploadedBackupRestore(
   uploadId: string,
   targetUsername: string,
   components: string[],
 ): Promise<UploadedBackupRestoreResult> {
-  const { data } = await apiClient.post<UploadedBackupRestoreResult>(
+  await apiClient.post(
     "/admin/backups/restore-upload/apply",
     { upload_id: uploadId, target_username: targetUsername, components },
   );
-  return data;
+  const deadline = Date.now() + 65 * 60 * 1000; // matches the server's 60-min cap
+  for (;;) {
+    await new Promise((r) => setTimeout(r, 2500));
+    let s: RestoreUploadStatus | null = null;
+    try {
+      const resp = await apiClient.get<RestoreUploadStatus>(
+        "/admin/backups/restore-upload/status",
+        { params: { upload_id: uploadId } },
+      );
+      s = resp.data;
+    } catch {
+      // transient poll error — keep trying until the deadline
+    }
+    if (s?.status === "done") {
+      return { status: "ok", applied: s.applied, warnings: s.warnings };
+    }
+    if (s?.status === "failed") {
+      throw new Error(s.error || "restore_failed");
+    }
+    if (Date.now() > deadline) throw new Error("restore_timeout");
+  }
+}
+
+interface RestoreUploadStatus {
+  status: string;
+  applied?: string[];
+  warnings?: string[];
+  error?: string;
 }
 
 // === PHP Settings API ===

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -38,6 +38,7 @@ const isRestoreKind = (kind: string): boolean =>
   kind === "account_restore" || kind === "system_restore";
 import { BackupSettingsTab } from "./BackupSettingsTab";
 import { CreateBackupDrawer } from "./CreateBackupDrawer";
+import { RestoreFromUploadDrawer } from "./RestoreFromUploadDrawer";
 import { DestinationsTab } from "./DestinationsTab";
 import { EncryptionKeyCard } from "./EncryptionKeyCard";
 import { SchedulesTab } from "./SchedulesTab";
@@ -145,6 +146,7 @@ const RunStatusSummary = ({ run }: { run: BackupRun }) => {
 
 export const AdminBackupsPage = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [uploadRestoreOpen, setUploadRestoreOpen] = useState(false);
   const [logJob, setLogJob] = useState<BackupJob | null>(null);
   const [activeTab, setActiveTab] = useTabParam<TabKey>("backups");
   const [runs, setRuns] = useState<BackupRun[]>([]);
@@ -451,13 +453,21 @@ export const AdminBackupsPage = () => {
           <SaveOutlined style={{ marginRight: 8 }} />
           Backups
         </Typography.Title>
-        <Button
-          type="primary"
-          icon={<PlusOutlined />}
-          onClick={() => setDrawerOpen(true)}
-        >
-          Create Backup
-        </Button>
+        <Space>
+          <Button
+            icon={<HardDriveUploadOutlined />}
+            onClick={() => setUploadRestoreOpen(true)}
+          >
+            Restore from Upload
+          </Button>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => setDrawerOpen(true)}
+          >
+            Create Backup
+          </Button>
+        </Space>
       </Space>
 
       <Card
@@ -697,6 +707,11 @@ export const AdminBackupsPage = () => {
       <BackupLogModal
         job={logJob}
         onClose={() => setLogJob(null)}
+      />
+
+      <RestoreFromUploadDrawer
+        open={uploadRestoreOpen}
+        onClose={() => setUploadRestoreOpen(false)}
       />
     </div>
   );

--- a/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
@@ -1,0 +1,253 @@
+// RestoreFromUploadDrawer — GH #1408. Admin restore from an uploaded backup
+// archive (DR / cross-server migration): upload the .tar downloaded earlier,
+// inspect it, pick components + a target user, and restore. The apply is
+// step-up gated server-side; a stepup_required response bounces to re-auth.
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Drawer,
+  Input,
+  Progress,
+  Space,
+  Typography,
+  Upload,
+} from "antd";
+import { InboxOutlined } from "@icons";
+import { feedback } from "../../../lib/feedback";
+import {
+  applyUploadedBackupRestore,
+  inspectUploadedBackup,
+  stepUpRedirect,
+  uploadBackupArchiveChunked,
+  type UploadedBackupInfo,
+  type UploadedBackupRestoreResult,
+} from "../../../apiClient";
+import { extractApiError } from "../../../apiErrors";
+
+const COMPONENT_LABELS: Record<string, string> = {
+  home: "Home directory (website files)",
+  db: "Databases",
+  mail: "Mail (staged for manual apply)",
+  dns: "DNS records",
+  docker: "Docker apps (restored stopped)",
+};
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Phase = "pick" | "uploading" | "inspecting" | "ready" | "applying" | "done";
+
+export function RestoreFromUploadDrawer({ open, onClose }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [phase, setPhase] = useState<Phase>("pick");
+  const [pct, setPct] = useState(0);
+  const [info, setInfo] = useState<UploadedBackupInfo | null>(null);
+  const [uploadId, setUploadId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [targetUser, setTargetUser] = useState("");
+  const [result, setResult] = useState<UploadedBackupRestoreResult | null>(null);
+
+  const reset = () => {
+    setFile(null);
+    setPhase("pick");
+    setPct(0);
+    setInfo(null);
+    setUploadId(null);
+    setSelected([]);
+    setTargetUser("");
+    setResult(null);
+  };
+
+  const close = () => {
+    reset();
+    onClose();
+  };
+
+  const startUpload = async () => {
+    if (!file) return;
+    setPhase("uploading");
+    setPct(0);
+    try {
+      const id = await uploadBackupArchiveChunked(file, (p) =>
+        setPct(Math.round(p.frac * 100)),
+      );
+      setUploadId(id);
+      setPhase("inspecting");
+      const meta = await inspectUploadedBackup(id);
+      setInfo(meta);
+      setSelected(meta.components); // default: everything the archive holds
+      setTargetUser(meta.user.username); // v1: restore into the same username
+      setPhase("ready");
+    } catch (err) {
+      feedback.message.error(extractApiError(err, "Upload / inspect failed"));
+      setPhase("pick");
+    }
+  };
+
+  const apply = async () => {
+    if (!uploadId || !targetUser || selected.length === 0) return;
+    setPhase("applying");
+    try {
+      const r = await applyUploadedBackupRestore(uploadId, targetUser, selected);
+      setResult(r);
+      setPhase("done");
+      const n = r.applied?.length ?? 0;
+      if (n > 0) feedback.message.success(`Restored ${n} item(s) into ${targetUser}`);
+      else feedback.message.warning("Nothing was applied — see details");
+    } catch (err) {
+      // Step-up: the server demands recent auth for this destructive action.
+      const e = err as { response?: { status?: number; data?: { error?: string } } };
+      if (e?.response?.status === 401 && e.response.data?.error === "stepup_required") {
+        feedback.message.info("Please re-authenticate to run a restore");
+        stepUpRedirect();
+        return;
+      }
+      feedback.message.error(extractApiError(err, "Restore failed"));
+      setPhase("ready");
+    }
+  };
+
+  return (
+    <Drawer
+      title="Restore from uploaded backup"
+      width={520}
+      open={open}
+      onClose={close}
+      destroyOnClose
+    >
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Upload a backup archive you downloaded earlier (the per-account{" "}
+          <code>.tar</code>) and restore it into an existing user — useful for
+          disaster recovery or moving a user to a new server. Create the target
+          user first if it doesn&apos;t exist yet.
+        </Typography.Paragraph>
+
+        <Alert
+          type="info"
+          showIcon
+          message="Large archives: upload directly to the server"
+          description="For very large backups, open the panel by the server's IP address rather than through a proxied domain (e.g. Cloudflare) to avoid upload-size limits."
+        />
+
+        {(phase === "pick" || phase === "uploading") && (
+          <>
+            <Upload.Dragger
+              multiple={false}
+              maxCount={1}
+              accept=".tar,.zst,.tar.zst"
+              beforeUpload={(f) => {
+                setFile(f);
+                return false; // don't auto-upload; we drive the chunked upload
+              }}
+              onRemove={() => setFile(null)}
+              disabled={phase === "uploading"}
+            >
+              <p className="ant-upload-drag-icon">
+                <InboxOutlined />
+              </p>
+              <p className="ant-upload-text">Click or drag the backup .tar here</p>
+            </Upload.Dragger>
+            {phase === "uploading" && <Progress percent={pct} status="active" />}
+            <Button
+              type="primary"
+              disabled={!file || phase === "uploading"}
+              loading={phase === "uploading"}
+              onClick={startUpload}
+            >
+              Upload &amp; inspect
+            </Button>
+          </>
+        )}
+
+        {phase === "inspecting" && <Progress percent={100} status="active" />}
+
+        {info && (phase === "ready" || phase === "applying" || phase === "done") && (
+          <>
+            <Alert
+              type="success"
+              showIcon
+              message={`Backup of ${info.user.username}`}
+              description={info.user.email || undefined}
+            />
+            <div>
+              <Typography.Text strong>Restore into user</Typography.Text>
+              <Input
+                value={targetUser}
+                onChange={(e) => setTargetUser(e.target.value.trim())}
+                placeholder="existing username"
+                style={{ marginTop: 4 }}
+                disabled={phase !== "ready"}
+              />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Must be an existing user. Restore into the same username the
+                backup came from.
+              </Typography.Text>
+            </div>
+            <div>
+              <Typography.Text strong>Components</Typography.Text>
+              <Checkbox.Group
+                value={selected}
+                onChange={(v) => setSelected(v as string[])}
+                style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 4 }}
+                options={info.components.map((c) => ({
+                  label: COMPONENT_LABELS[c] ?? c,
+                  value: c,
+                }))}
+              />
+            </div>
+            <Alert
+              type="warning"
+              showIcon
+              message="This overwrites the target user's selected data"
+              description="Restoring the home directory and databases replaces the live contents with the backup. This cannot be undone."
+            />
+            {phase !== "done" && (
+              <Button
+                type="primary"
+                danger
+                loading={phase === "applying"}
+                disabled={!targetUser || selected.length === 0}
+                onClick={apply}
+              >
+                Restore into {targetUser || "user"}
+              </Button>
+            )}
+          </>
+        )}
+
+        {result && phase === "done" && (
+          <Alert
+            type={(result.applied?.length ?? 0) > 0 ? "success" : "info"}
+            showIcon
+            message="Restore result"
+            description={
+              <Space direction="vertical" size={2}>
+                {(result.applied ?? []).map((a) => (
+                  <span key={a}>✓ {a}</span>
+                ))}
+                {(result.warnings ?? []).map((w, i) => (
+                  <Typography.Text type="secondary" key={i}>
+                    {w}
+                  </Typography.Text>
+                ))}
+                {(result.metadata_errors ?? []).map((m, i) => (
+                  <Typography.Text type="danger" key={`m${i}`}>
+                    {m}
+                  </Typography.Text>
+                ))}
+                <Button size="small" onClick={reset} style={{ marginTop: 8 }}>
+                  Restore another
+                </Button>
+              </Space>
+            }
+          />
+        )}
+      </Space>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
Implements the "restore from an uploaded backup archive" feature from GH #1408 — the DR / cross-server-migration path. Two commits: the agent engine, then the panel + admin UI.

Scope decided with the operator: **no single monolithic full-server archive** (per-user tars stay). Genuinely-deferred pieces (need their own design) listed at the bottom.

## Flow
Admin **Backups → Restore from Upload**: drop the account `.tar` you downloaded earlier → it uploads in chunks → the panel inspects it and shows the backup's user + restorable components → pick components + a target user → restore. Destructive, so the apply is **MFA step-up gated**.

## Agent — the security surface
The uploaded tar is attacker-controllable (extracted as root, then rsync'd into `/home` + loaded into DBs), unlike a restic snapshot we made. `safe_tar_extract.go` is an allowlist:
- regular files, dirs, **symlinks preserved verbatim** (a real home has absolute + out-of-tree symlinks — the drill caught this; the trusted restic restore keeps them too);
- **reject** absolute entry paths, any `..` component, hardlinks (the `/etc/shadow` escape), device/fifo;
- **never write through a symlinked parent** (`O_EXCL|O_NOFOLLOW` + real-dir-only parents) — the real boundary, not the symlink target;
- decompression-bomb + entry-count bounded; zstd via `execCommandContext(zstd -dc <our-path>)` (no attacker arg, routed through the #994 exec seam).

`backup.restore_from_tar` extracts → descends the `<source-job-id>/` prefix → reads the manifest → reuses the existing proven `applyAccountRestore` (home rsync+chown, per-DB load; mail stays manual), component-gated. `backup.inspect_uploaded_tar` reads only the manifest (no full extract) for the pre-apply selection.

## Panel (admin, step-up gated)
- `POST /admin/backups/restore-upload` — chunked upload reassembled under `/var/lib/jabali-uploads`; reuses the #1323 chunk transport (beat Cloudflare's origin timeout), in `bodyLimitExemptRoutes` with its own `io.LimitReader` cap. Path derived from the **authenticated admin + upload_id** (Gitea #426) so no cross-admin targeting; per-admin in-flight cap + 24h TTL evict.
- `.../inspect` → user + components. `.../apply` → recent-auth → agent restore → `applyRestoreMetadata` (rebuilds panel DB rows, JAB-312) → deletes the consumed archive. v1: **target user must already exist**, restore into the **same username** the backup came from.

## Verification
- **Extractor security contract** (`safe_tar_extract_test.go`): happy path + reject absolute/`..`/hardlink/device/write-through-symlink-parent + bomb budget; symlinks proven preserved.
- Panel path-isolation + upload_id/username validation tests.
- **Box-drilled** on the test box against a **real 333 MB backup**: recon (extract → root-resolve → manifest → stage-gating), inspect (correct user + components), and a cross-name apply confirming fail-closed home behavior. `applyAccountRestore` itself is the already-shipped restore-apply.
- `go vet` + `tsc -b` clean; agent (incl. the exec-seam guard) + panel-api suites green.

## Deferred (in GH #1408 — need their own design, not built blind)
- **Key-gated credential restore**: the downloaded tar is already the *decrypted, authorized* export, so a restic-repo-key gate doesn't map here; DB-user creds already rebuild via the metadata bundle. Needs a product decision on what "the key" would even gate.
- **Restore into a different/new username** (home is name-keyed) and **create-from-manifest**.
- **System restore from an upload** (v1 is one account; system restore is a bigger, more dangerous flow).
- The reporter's **direct-IP large-upload** ask is surfaced as UI guidance (a docs line, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Review fixes (3rd commit):** the apply now runs **detached (202 + `restore-upload/status` poll)** — a minutes-long account restore was running synchronously in the request and would die on the proxy-timeout stack, possibly half-applied (the #1323 class this repo fixed twice). And the metadata bundle's `user.id` is **remapped to the resolved target user** before rebuild, so a cross-server backup's rows reattach to this box's user instead of the source id. Plus: over-cap chunk → 413 (no silent truncation), delete the consumed tar on terminal failure too, evict stale uploads/markers on apply. Both new behaviors unit-tested via the mock agent.
