### PR TITLE
fix(postgres+adminer): pgadmin public-schema access + admin all-DB list (GH #1406)

### DIFF
--- a/install/adminer/jabali-sso-plugin.php
+++ b/install/adminer/jabali-sso-plugin.php
@@ -244,6 +244,10 @@ class JabaliAdminerSSO {
     public function database() {
         $c = $this->fetchCreds();
         if ($c === null) return null;
+        // GH #1406: the admin all-databases handoff (postgres superuser) returns
+        // an EMPTY db on purpose. Don't pin the view to it — return null so
+        // Adminer opens on the server, not a blank database with no list.
+        if (empty($c['db'])) return null;
         return $c['db'];
     }
 
@@ -251,6 +255,10 @@ class JabaliAdminerSSO {
     public function databases($flush = true) {
         $c = $this->fetchCreds();
         if ($c === null) return null;
+        // Empty db = the admin all-databases handoff: return null so Adminer
+        // lists EVERY database instead of restricting the dropdown to one
+        // (which, with an empty name, showed nothing — GH #1406).
+        if (empty($c['db'])) return null;
         return [$c['db']];
     }
 }

--- a/install/adminer/sso_session_test.php
+++ b/install/adminer/sso_session_test.php
@@ -75,5 +75,18 @@ check('failed new token -> null', $c === null);
 $c = req([]);
 check('failed new token dropped cached identity', $c === null);
 
+// 7. GH #1406: the admin all-databases handoff returns an EMPTY db. The plugin
+//    must NOT pin the view/dropdown to it, or Adminer shows no database list.
+$TD = str_repeat('d', 44);
+StubSSO::$map[$TD] = ['driver'=>'pgsql','server'=>'/run/postgresql','username'=>'postgres','password'=>'pp','db'=>''];
+$_GET = ['token'=>$TD]; $_POST = [];
+$admin = new StubSSO('/run/jabali-panel/api.sock');
+check('admin all-DBs: database() not pinned (null)', $admin->database() === null);
+check('admin all-DBs: databases() lists all (null, not [""])', $admin->databases() === null);
+// A normal per-DB tenant handoff still pins to its one database.
+$_GET = ['token'=>$TA]; $_POST = [];
+$tenant = new StubSSO('/run/jabali-panel/api.sock');
+check('tenant: databases() still pinned to its db', $tenant->databases() === ['alice_db']);
+
 echo ($fail === 0 ? "ALL SSO SESSION CHECKS PASSED\n" : "FAILURES: $fail\n");
 exit($fail === 0 ? 0 : 1);

--- a/panel-agent/internal/commands/db_postgres_shadowadmin.go
+++ b/panel-agent/internal/commands/db_postgres_shadowadmin.go
@@ -210,7 +210,73 @@ END$$;`,
 	return dbPgCreateResponse{OK: true}, nil
 }
 
+// db.postgres.shadowadmin.grant_schema — GH #1406 (round 2).
+//
+// Membership (grant_members) lets pgadmin INHERIT privileges on objects the
+// tenant's db-user roles OWN. But a Jabali PostgreSQL database is created
+// OWNER postgres (dbops.go), so its `public` schema is owned by
+// pg_database_owner = postgres, and — since PostgreSQL 15 revoked the default
+// PUBLIC CREATE on `public` — a tenant role can neither CREATE in `public`
+// ("permission denied for schema public") nor SELECT postgres-owned tables in
+// it ("permission denied for table"). Reproduced on PG16 + PG18.
+//
+// So on every Adminer open, grant <user>_pgadmin the schema-level privileges it
+// needs, PER DATABASE (schema grants only affect the connected DB, so this
+// connects to each): ALL ON SCHEMA public (CREATE+USAGE), ALL on existing
+// TABLES/SEQUENCES (covers postgres-owned + restored objects that membership
+// can't reach), and default privileges so future objects stay accessible.
+//
+// SECURITY: db_names is an EXPLICIT list of the tenant's OWN databases from the
+// control-plane (scoped by user_id), never a name pattern — a `datname LIKE
+// '<user>\_%'` would also match a sibling tenant's DB (panel usernames allow
+// '_') and hand pgadmin full table access to another tenant's data. Every name
+// is pgValidIdent-checked. Idempotent + fail-soft per DB.
+type dbPostgresGrantSchemaParams struct {
+	PanelUsername string   `json:"panel_username"`
+	DBNames       []string `json:"db_names"`
+}
+
+func dbPostgresShadowadminGrantSchemaHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dbPostgresGrantSchemaParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if !panelUsernameRegex.MatchString(p.PanelUsername) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid panel username"}
+	}
+	roleName := p.PanelUsername + "_pgadmin"
+	pgIdent := func(s string) string { return `"` + strings.ReplaceAll(s, `"`, `""`) + `"` }
+
+	// Grant statements run against EACH DB (schema/object grants are per-DB).
+	// pgadmin is validated; the DB name is validated + passed via -d, never
+	// interpolated into SQL.
+	roleQ := pgIdent(roleName)
+	grantSQL := strings.Join([]string{
+		"GRANT ALL ON SCHEMA public TO " + roleQ,
+		"GRANT ALL ON ALL TABLES IN SCHEMA public TO " + roleQ,
+		"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO " + roleQ,
+		"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO " + roleQ,
+		"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO " + roleQ,
+	}, "; ") + ";"
+
+	for _, db := range p.DBNames {
+		if !pgValidIdent(db) {
+			continue // skip an unexpected name; never block Adminer login
+		}
+		// -d <db> selects the target database; run as postgres (peer auth).
+		cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
+			"-v", "ON_ERROR_STOP=1", "-XAtq", "-d", db, "-c", grantSQL)
+		if _, err := cmd.CombinedOutput(); err != nil {
+			// Fail-soft: a dropped/renamed DB or a transient error must not block
+			// the Adminer session or the other DBs.
+			continue
+		}
+	}
+	return dbPgCreateResponse{OK: true}, nil
+}
+
 func init() {
 	Default.Register("db.postgres.shadowadmin.ensure", dbPostgresShadowadminEnsureHandler)
 	Default.Register("db.postgres.shadowadmin.grant_members", dbPostgresShadowadminGrantMembersHandler)
+	Default.Register("db.postgres.shadowadmin.grant_schema", dbPostgresShadowadminGrantSchemaHandler)
 }

--- a/panel-api/internal/sso/adminer.go
+++ b/panel-api/internal/sso/adminer.go
@@ -122,6 +122,9 @@ func (s *AdminerService) EnsurePgShadow(ctx context.Context, userID string) erro
 	// after the first open are picked up. Non-fatal — a failure here must not
 	// block the Adminer session.
 	s.syncPgShadowMembers(ctx, userID, *user.Username)
+	// GH #1406 (round 2): membership isn't enough for the postgres-owned `public`
+	// schema — also grant pgadmin per-DB schema access so it can CREATE/SELECT.
+	s.syncPgShadowSchema(ctx, userID, *user.Username)
 	return nil
 }
 
@@ -149,6 +152,38 @@ func (s *AdminerService) syncPgShadowMembers(ctx context.Context, userID, panelU
 	if _, err := s.base.agent.Call(ctx, "db.postgres.shadowadmin.grant_members",
 		map[string]interface{}{"panel_username": panelUsername, "member_roles": roles}); err != nil {
 		s.base.log.WarnContext(ctx, "pg shadow: grant_members failed",
+			"err", err, "user_id", userID)
+	}
+}
+
+// syncPgShadowSchema grants <user>_pgadmin the public-schema privileges it needs
+// in EACH of the tenant's PostgreSQL databases (GH #1406). Jabali creates those
+// DBs OWNER postgres, so — with PG15+ locking the `public` schema — membership
+// alone doesn't let pgadmin CREATE tables or read postgres-owned ones; the
+// per-DB schema grant does. The DB NAMES are the explicit control-plane list
+// (scoped by user_id), never a pattern — a sibling tenant's DB must never be
+// handed over. Runs on every Adminer open (idempotent); non-fatal.
+func (s *AdminerService) syncPgShadowSchema(ctx context.Context, userID, panelUsername string) {
+	var rows []models.Database
+	if err := s.base.db.WithContext(ctx).
+		Where("user_id = ? AND engine = ?", userID, "postgres").
+		Find(&rows).Error; err != nil {
+		s.base.log.WarnContext(ctx, "pg shadow: list databases failed",
+			"err", err, "user_id", userID)
+		return
+	}
+	names := make([]string, 0, len(rows))
+	for _, d := range rows {
+		if d.Name != "" {
+			names = append(names, d.Name)
+		}
+	}
+	if len(names) == 0 {
+		return // no PG databases yet — nothing to grant
+	}
+	if _, err := s.base.agent.Call(ctx, "db.postgres.shadowadmin.grant_schema",
+		map[string]interface{}{"panel_username": panelUsername, "db_names": names}); err != nil {
+		s.base.log.WarnContext(ctx, "pg shadow: grant_schema failed",
 			"err", err, "user_id", userID)
 	}
 }


### PR DESCRIPTION
Round-2 fixes on GH #1406 from @lxsdevcode's testing. The reporter confirmed the SSO/session fix (#1444) works; this PR addresses the two remaining items.

## 1. Tenant Adminer can't use its PostgreSQL database (the main bug)
On a **brand-new** tenant DB, on the **dev channel** + **PG 18.6**, Adminer as `<user>_pgadmin` still fails: `permission denied for schema public` on `CREATE TABLE`, `permission denied for table` on reading existing tables.

**Root cause:** a Jabali PG database is created **`OWNER postgres`** (`dbops.go`), so its `public` schema is owned by `pg_database_owner` = postgres. Since **PostgreSQL 15** revoked the default `PUBLIC CREATE` on `public`, a tenant role can neither create objects in `public` nor read postgres-owned ones. The #1433 membership fix only conveys privileges on objects the tenant's **db-user roles own** — it can't reach the postgres-owned schema. Reproduced on PG16 **and** PG18.

**Fix:** a new agent verb `db.postgres.shadowadmin.grant_schema` grants `<user>_pgadmin`, **per database** (schema grants are per-DB, so it connects to each): `ALL ON SCHEMA public` + `ALL` on existing `TABLES`/`SEQUENCES` + default privileges. `EnsurePgShadow` runs it on every Adminer open (idempotent) — existing installs self-heal, new DBs are picked up.

**Security:** the DB names are the **explicit control-plane list scoped by `user_id`**, never a `datname LIKE '<user>\_%'` pattern (panel usernames allow `_`, so a pattern would leak a sibling tenant's DB). Every name `pgValidIdent`-checked; grants run as postgres with the DB via `-d`, never interpolated.

## 2. Admin all-databases handoff showed no database list
The admin → `postgres` handoff intentionally returns an **empty db** ("list all"), but the Adminer plugin's `database()`/`databases()` pinned the view to that empty name, so it opened on a blank database with no list. Fix: return `null` on an empty db so Adminer lists every database; a normal per-DB tenant handoff still pins to its one DB.

## Verified
- Reproduced the exact CREATE + SELECT errors with Jabali's real `owner=postgres` shape; **after** the grant, pgadmin can CREATE/INSERT/SELECT in `public` (PG18 container returned the inserted row; live PG16 via the real agent verb on the test box).
- SSO plugin: `php -l` clean, `sso_session_test.php` 12/12 (incl. the admin all-DBs cases).
- `go vet` + exec-seam guard clean.

Note: `db.postgres.grant` (a db-USER's access to a DB) has the same schema-level gap for tenant **apps** connecting as their db-user — related, out of scope here; follow-up if apps hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
