### PR TITLE
fix(domains): default Mail to None when the mail module isn't installed (GH #1409)

### DIFF
--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -73,6 +73,17 @@ func (e *createDomainError) Error() string { return e.Code }
 // against the handler's deps. On success it returns the created domain (with
 // any in-place mutations from shared-cert attach / inline email). On failure it
 // returns a createDomainError the caller renders verbatim.
+// mailProviderForServer coerces "jabali" to "none" when the mail module isn't
+// installed on this server (GH #1409) — Jabali Mail can't be hosted without it,
+// so a domain must not be created with email_enabled=true. Every other provider
+// (none / external m365 / google) is untouched.
+func mailProviderForServer(provider string, mailModuleEnabled bool) string {
+	if provider == models.MailProviderJabali && !mailModuleEnabled {
+		return models.MailProviderNone
+	}
+	return provider
+}
+
 func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput) (*models.Domain, *createDomainError) {
 	// SECURITY: validate domain name (XSS / path traversal). Name is assumed
 	// already normalized + HTML-stripped by the caller.
@@ -137,6 +148,19 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 	if !models.ValidMailProvider(mailProvider) {
 		return nil, &createDomainError{http.StatusBadRequest, "invalid_mail_provider", ""}
 	}
+	// GH #1409: never enable Jabali mail on a domain when the mail module isn't
+	// installed — coerce to "none" so we don't provision mail that can't run.
+	// The GUI already defaults to None; this guards API / automation callers
+	// (and the "" → jabali default above) so email_enabled is never set on a
+	// mail-less server. Fail-open (assume installed) if server_settings is
+	// unreadable — never block domain creation on this check.
+	mailModuleEnabled := true
+	if h.cfg.ServerSettings != nil {
+		if st, sErr := h.cfg.ServerSettings.Get(ctx); sErr == nil && st != nil {
+			mailModuleEnabled = st.MailEnabled
+		}
+	}
+	mailProvider = mailProviderForServer(mailProvider, mailModuleEnabled)
 	m365Tenant, err := dnscompile.NormaliseM365Onmicrosoft(in.M365Onmicrosoft)
 	if err != nil {
 		return nil, &createDomainError{http.StatusBadRequest, "invalid_m365_onmicrosoft", err.Error()}

--- a/panel-api/internal/api/domain_mail_capability_test.go
+++ b/panel-api/internal/api/domain_mail_capability_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1409: a domain must never be created with Jabali Mail when the mail module
+// isn't installed — the provider is coerced to "none" (email stays off). Other
+// providers are untouched regardless of the module.
+func TestMailProviderForServer(t *testing.T) {
+	cases := []struct {
+		provider string
+		mailOn   bool
+		want     string
+	}{
+		{models.MailProviderJabali, true, models.MailProviderJabali},  // installed → keep
+		{models.MailProviderJabali, false, models.MailProviderNone},   // NOT installed → None
+		{models.MailProviderNone, false, models.MailProviderNone},     // already none
+		{models.MailProviderM365, false, models.MailProviderM365},     // external, unaffected
+		{models.MailProviderGoogle, false, models.MailProviderGoogle}, // external, unaffected
+	}
+	for _, c := range cases {
+		if got := mailProviderForServer(c.provider, c.mailOn); got != c.want {
+			t.Fatalf("mailProviderForServer(%q, mailOn=%v) = %q, want %q", c.provider, c.mailOn, got, c.want)
+		}
+	}
+	// And the coerced provider derives email OFF.
+	if em, _ := models.DeriveMailFlags(mailProviderForServer(models.MailProviderJabali, false)); em {
+		t.Fatal("coerced-to-none provider must derive email_enabled=false")
+	}
+}

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -7,10 +7,12 @@ import { useTranslation } from "react-i18next";
 import { Button, Card, Checkbox, Form, Input, Select, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { apiClient } from "../../../apiClient";
 import { useNavigate } from "react-router";
 
 import { useCreateMutation } from "../../../hooks/useQueries";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 
 export type DomainCreateInput = {
   name: string;
@@ -33,10 +35,23 @@ export const DomainCreate = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [form] = Form.useForm<DomainCreateInput>();
-  const mailProvider = Form.useWatch("mail_provider", form) ?? "jabali";
+  // GH #1409: default Mail to None (and disable Jabali Mail) when the mail
+  // module isn't installed. `!== false` treats the brief pre-load state as
+  // installed so a mail-enabled server never flickers to None.
+  const { data: caps } = useServerCapabilities();
+  const mailInstalled = caps?.mail_enabled !== false;
+  const mailProvider =
+    Form.useWatch("mail_provider", form) ?? (mailInstalled ? "jabali" : "none");
   const createMutation = useCreateMutation<DomainCreated, DomainCreateInput>({
     resource: "domains",
   });
+  // Once we learn the module is absent, drop the static Jabali-Mail default —
+  // but never override an admin's explicit choice.
+  useEffect(() => {
+    if (!mailInstalled && form.getFieldValue("mail_provider") === "jabali") {
+      form.setFieldValue("mail_provider", "none");
+    }
+  }, [mailInstalled, form]);
   const usersQ = useQuery({
     queryKey: ["admin-users-for-domain-create"],
     queryFn: async () => {
@@ -128,7 +143,13 @@ export const DomainCreate = () => {
         >
           <Select
             options={[
-              { value: "jabali", label: "Jabali mail (this server)" },
+              {
+                value: "jabali",
+                label: mailInstalled
+                  ? "Jabali mail (this server)"
+                  : "Jabali mail (not installed)",
+                disabled: !mailInstalled,
+              },
               { value: "none", label: "No mail" },
               { value: "m365", label: "Microsoft 365" },
               { value: "google", label: "Google Workspace" },

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
@@ -1,0 +1,42 @@
+// GH #1409: the Add-domain drawer must default Mail to None when the mail module
+// isn't installed, and to Jabali Mail when it is.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const caps = vi.hoisted(() => ({ mail: false }));
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: { mail_enabled: caps.mail } }),
+}));
+vi.mock("../../../hooks/useQueries", () => ({
+  useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { UserDomainDrawer } from "./UserDomainDrawer";
+
+function renderDrawer() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <UserDomainDrawer open onClose={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("UserDomainDrawer mail default (GH #1409)", () => {
+  it("defaults Mail to None when the mail module is NOT installed", async () => {
+    caps.mail = false;
+    renderDrawer();
+    // The Select shows its selected option's label; None must be selected.
+    await waitFor(() => expect(screen.getByText("No mail")).toBeInTheDocument());
+    expect(screen.queryByText("Jabali mail (this server)")).not.toBeInTheDocument();
+  });
+
+  it("defaults Mail to Jabali Mail when the module IS installed", async () => {
+    caps.mail = true;
+    renderDrawer();
+    await waitFor(() =>
+      expect(screen.getByText("Jabali mail (this server)")).toBeInTheDocument(),
+    );
+  });
+});

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -6,6 +6,7 @@ import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
 import { useCreateMutation } from "../../../hooks/useQueries";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 
 type UserDomainCreateInput = {
   name: string;
@@ -33,7 +34,13 @@ export interface UserDomainDrawerProps {
 export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
   const { t } = useTranslation();
   const [form] = Form.useForm<UserDomainCreateInput>();
-  const mailProvider = Form.useWatch("mail_provider", form) ?? "jabali";
+  // GH #1409: when the mail module isn't installed, Jabali Mail isn't a real
+  // choice — default to None and disable it. `!== false` treats the brief
+  // pre-load state as installed so a mail-enabled server never flickers to None.
+  const { data: caps } = useServerCapabilities();
+  const mailInstalled = caps?.mail_enabled !== false;
+  const mailProvider =
+    Form.useWatch("mail_provider", form) ?? (mailInstalled ? "jabali" : "none");
   const reverseProxy = Form.useWatch("reverse_proxy", form) ?? false;
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
@@ -43,8 +50,11 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
   });
 
   useEffect(() => {
-    if (open) form.resetFields();
-  }, [open, form]);
+    if (!open) return;
+    form.resetFields();
+    // Override the static Jabali-Mail default when mail isn't installed.
+    if (!mailInstalled) form.setFieldValue("mail_provider", "none");
+  }, [open, mailInstalled, form]);
 
   const handleFinish = async (values: UserDomainCreateInput) => {
     try {
@@ -102,7 +112,13 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         >
           <Select
             options={[
-              { value: "jabali", label: "Jabali mail (this server)" },
+              {
+                value: "jabali",
+                label: mailInstalled
+                  ? "Jabali mail (this server)"
+                  : "Jabali mail (not installed)",
+                disabled: !mailInstalled,
+              },
               { value: "none", label: "No mail" },
               { value: "m365", label: "Microsoft 365" },
               { value: "google", label: "Google Workspace" },


### PR DESCRIPTION
Adding a domain defaulted **Mail** to **Jabali Mail** even when the mail module isn't installed — preselecting a service that can't be used. It should default to **None** in that case.

## UI (both forms)
Tenant **Add-domain** drawer + admin **DomainCreate**: read the `mail_enabled` server capability. When the module isn't installed, the Mail select defaults to **None** and the "Jabali mail" option is **disabled** (relabelled "not installed"). `!== false` treats the brief pre-load window as installed so a mail-enabled server never flickers to None; an explicit admin choice is never overridden.

## Backend (defense in depth)
`createDomainOp` — shared by the GUI, the automation API, and the CLI, and which defaults an empty provider to `jabali` — now coerces `jabali` → `none` when `server_settings.mail_enabled` is false. So a domain can never be created with `email_enabled=true` on a mail-less server via a non-GUI caller or a stale form. Fail-open if server_settings is unreadable (never blocks creation).

## Tests
- `mailProviderForServer`: jabali + mail-off → none; installed + external (m365/google) providers untouched; the coerced provider derives `email_enabled=false`.
- `UserDomainDrawer` render: mail off → **None** default; mail on → **Jabali Mail**.
- `go vet` + `tsc` clean; automation domain-create tests still green.

Can't be box-drilled on the test box (it has mail installed, so the default is correctly Jabali there) — verified via the unit + render tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)