### PR TITLE
feat(backup): Full Server backup — package a run into one downloadable container (GH #1408, #502)

### DIFF
--- a/panel-agent/internal/commands/system_fullbackup_pack.go
+++ b/panel-agent/internal/commands/system_fullbackup_pack.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+// system.fullbackup.pack — GH #1408 / #502. Package a whole Full Server backup
+// RUN (the system job + one job per hosting user, all sharing a run_id) into a
+// SINGLE downloadable container so an operator can move an entire server in one
+// file. The container is a PLAIN tar of:
+//
+//	full-server-backup/
+//	├── manifest.json
+//	├── system.tar.zst              (the system leg, when present)
+//	└── users/<username>.tar.zst    (one per user)
+//
+// Each inner <label>.tar.zst is BYTE-IDENTICAL to that job's normal per-account
+// download (materialize → tar -C <downloads> <job_id> | zstd), so the restore
+// side feeds each straight into backup.restore_from_tar with no special-casing.
+// The outer tar is uncompressed — the inners are already zstd, so wrapping them
+// again would burn CPU on GBs for ~0 gain.
+//
+// Disk: each job is materialized (≈ its data size), tarred, then its tree is
+// DELETED before the next — so peak usage is ~one account's data + the growing
+// container, not the whole server at once. A host-reserve check gates each job.
+
+const (
+	fullpkgTmpRoot   = "/var/lib/jabali-backups/fullpkg-tmp"
+	fullpkgStageRoot = "/var/lib/jabali-backups/fullpkg-stage"
+	fullpkgOutRoot   = downloadRoot // /var/lib/jabali-backups/downloads (jabali-readable)
+)
+
+var fullpkgLabelRE = regexp.MustCompile(`^(system|users/[a-z][a-z0-9_-]{0,31})$`)
+
+type fullpkgJob struct {
+	JobID          string            `json:"job_id"`
+	Label          string            `json:"label"` // "system" or "users/<username>"
+	RepoURL        string            `json:"repo_url,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
+}
+
+type systemFullbackupPackParams struct {
+	RunID string       `json:"run_id"`
+	Jobs  []fullpkgJob `json:"jobs"`
+}
+
+type systemFullbackupPackResult struct {
+	Path    string   `json:"path"`
+	Bytes   int64    `json:"bytes"`
+	Packed  []string `json:"packed"`  // labels successfully packed
+	Skipped []string `json:"skipped"` // labels skipped (no snapshot / restore error)
+}
+
+func systemFullbackupPackHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p systemFullbackupPackParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("invalid_arg: %w", err)
+	}
+	if !jobIDRE.MatchString(p.RunID) {
+		return nil, fmt.Errorf("invalid_arg: run_id must be a 26-char ULID")
+	}
+	if len(p.Jobs) == 0 {
+		return nil, fmt.Errorf("invalid_arg: no jobs to pack")
+	}
+
+	tmpRoot := filepath.Join(fullpkgTmpRoot, p.RunID)
+	stage := filepath.Join(fullpkgStageRoot, p.RunID)
+	_ = os.RemoveAll(tmpRoot)
+	_ = os.RemoveAll(stage)
+	if err := os.MkdirAll(filepath.Join(stage, "users"), 0o750); err != nil {
+		return nil, fmt.Errorf("mkdir stage: %w", err)
+	}
+	defer os.RemoveAll(tmpRoot)
+	defer os.RemoveAll(stage)
+
+	out := systemFullbackupPackResult{}
+	type manifestUser struct {
+		Username string `json:"username,omitempty"`
+		Label    string `json:"label"`
+		JobID    string `json:"job_id"`
+	}
+	var manifestEntries []manifestUser
+
+	for _, j := range p.Jobs {
+		if !jobIDRE.MatchString(j.JobID) || !fullpkgLabelRE.MatchString(j.Label) {
+			out.Skipped = append(out.Skipped, j.Label)
+			continue
+		}
+		// Gate each job on the host reserve so a big run can't wedge the box.
+		if err := hostreserve.CheckReserve("/var/lib/jabali-backups", 0); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "packaging paused: under host disk reserve: " + err.Error()}
+		}
+		innerTar := filepath.Join(stage, j.Label+".tar.zst")
+		if err := os.MkdirAll(filepath.Dir(innerTar), 0o750); err != nil {
+			return nil, fmt.Errorf("mkdir inner: %w", err)
+		}
+		if err := packOneJob(ctx, j, filepath.Join(tmpRoot, j.JobID), innerTar); err != nil {
+			// One account failing must not sink the whole server package.
+			out.Skipped = append(out.Skipped, j.Label)
+			_ = os.RemoveAll(filepath.Join(tmpRoot, j.JobID))
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(tmpRoot, j.JobID)) // delete-as-you-go
+		out.Packed = append(out.Packed, j.Label)
+		username := ""
+		if len(j.Label) > len("users/") && j.Label[:len("users/")] == "users/" {
+			username = j.Label[len("users/"):]
+		}
+		manifestEntries = append(manifestEntries, manifestUser{Username: username, Label: j.Label, JobID: j.JobID})
+	}
+
+	manifest := map[string]any{"run_id": p.RunID, "schema": 1, "entries": manifestEntries}
+	mb, _ := json.MarshalIndent(manifest, "", "  ")
+	if err := os.WriteFile(filepath.Join(stage, "manifest.json"), mb, 0o640); err != nil {
+		return nil, fmt.Errorf("write manifest: %w", err)
+	}
+
+	// Outer container: a PLAIN tar of the stage (inners already zstd). Land it in
+	// the jabali-readable downloads dir so panel-api can stream it.
+	if err := os.MkdirAll(fullpkgOutRoot, 0o750); err != nil {
+		return nil, fmt.Errorf("mkdir out: %w", err)
+	}
+	containerPath := filepath.Join(fullpkgOutRoot, "fullpkg-"+p.RunID+".tar")
+	_ = os.Remove(containerPath)
+	tarCmd := execCommandContext(ctx, "tar", "-cf", containerPath, "-C", stage, ".")
+	if o, err := tarCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("build container: %v: %s", err, bytesTrim(o))
+	}
+	// Hand read access to the jabali user (panel-api) for streaming.
+	_ = execCommand("chgrp", "jabali", containerPath).Run()
+	_ = os.Chmod(containerPath, 0o640)
+	if fi, err := os.Stat(containerPath); err == nil {
+		out.Bytes = fi.Size()
+	}
+	out.Path = containerPath
+	return out, nil
+}
+
+// packOneJob restores every snapshot tagged with the job into tmpDir/<stage>/…
+// (the same layout materialize produces) and tars it to innerTar as
+// `<job_id>/<stage>/…` — byte-identical to that job's per-account download.
+func packOneJob(ctx context.Context, j fullpkgJob, tmpDir, innerTar string) error {
+	cfg, cerr := bkResticConfigWithPassword(j.RepoURL, j.CredentialsRef, j.PasswordFile, j.SFTP)
+	if cerr != nil {
+		return fmt.Errorf("restic config: %w", cerr)
+	}
+	c := backup.New(cfg)
+	snaps, err := c.Snapshots(ctx, []backup.Tag{backup.MakeTag(backup.TagKeyJobID, j.JobID)})
+	if err != nil {
+		return fmt.Errorf("list snapshots: %w", err)
+	}
+	if len(snaps) == 0 {
+		return fmt.Errorf("no snapshots for job %s", j.JobID)
+	}
+	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
+		return err
+	}
+	for _, s := range snaps {
+		stage := stageFromTags(s.Tags)
+		if !materializeStageNameRe.MatchString(stage) {
+			stage = s.ID[:8]
+		}
+		target := filepath.Join(tmpDir, stage)
+		if err := os.MkdirAll(target, 0o750); err != nil {
+			return err
+		}
+		if err := c.Restore(ctx, backup.RestoreOpts{SnapshotID: s.ID, Target: target}); err != nil {
+			return fmt.Errorf("restore %s: %w", stage, err)
+		}
+	}
+	// tar -C <parent> <job_id> | zstd -> innerTar  (prefix = <job_id>/, exactly
+	// what the per-account download and restore_from_tar expect). Piped in Go —
+	// no shell, no attacker-derived args (all paths are agent-built), no
+	// intermediate uncompressed copy on disk.
+	parent := filepath.Dir(tmpDir)
+	jobDir := filepath.Base(tmpDir)
+	tarCmd := execCommandContext(ctx, "tar", "-cf", "-", "-C", parent, jobDir)
+	zstdCmd := execCommandContext(ctx, "zstd", "-q", "-o", innerTar, "-f")
+	pr, perr := tarCmd.StdoutPipe()
+	if perr != nil {
+		return fmt.Errorf("pipe: %w", perr)
+	}
+	zstdCmd.Stdin = pr
+	if err := zstdCmd.Start(); err != nil {
+		return fmt.Errorf("zstd start: %w", err)
+	}
+	tarErr := tarCmd.Run() // closes the pipe's write end on return
+	zstdErr := zstdCmd.Wait()
+	if tarErr != nil {
+		return fmt.Errorf("tar: %w", tarErr)
+	}
+	if zstdErr != nil {
+		return fmt.Errorf("zstd: %w", zstdErr)
+	}
+	return nil
+}
+
+func init() {
+	Default.Register("system.fullbackup.pack", systemFullbackupPackHandler)
+}

--- a/panel-agent/internal/commands/system_fullbackup_pack_test.go
+++ b/panel-agent/internal/commands/system_fullbackup_pack_test.go
@@ -1,0 +1,25 @@
+package commands
+
+import "testing"
+
+// GH #1408: a pack label becomes a path under the stage dir (system.tar.zst or
+// users/<username>.tar.zst), so it must be a strict allowlist — a traversal or
+// odd label could write outside the container staging.
+func TestFullpkgLabelRE(t *testing.T) {
+	good := []string{"system", "users/alice", "users/a", "users/a_b-c", "users/user01"}
+	bad := []string{
+		"", "system/x", "users", "users/", "users/../etc", "../system",
+		"users/UPPER", "users/1abc", "users/a/b", "users/a;b", "users//x",
+		"System", "sys tem",
+	}
+	for _, g := range good {
+		if !fullpkgLabelRE.MatchString(g) {
+			t.Fatalf("label %q should be valid", g)
+		}
+	}
+	for _, b := range bad {
+		if fullpkgLabelRE.MatchString(b) {
+			t.Fatalf("label %q should be rejected", b)
+		}
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -136,6 +136,10 @@ func RegisterBackupRoutes(rg *gin.RouterGroup, cfg BackupHandlerConfig) {
 	admin.DELETE("/backup-runs/:run_id/jobs", h.deleteRunJobs)
 	admin.POST("/system/backups", h.systemCreate)
 	admin.GET("/system/backups", h.systemList)
+	// GH #1408: package a Full Server backup run into one downloadable container.
+	admin.POST("/system/full-backup/:run_id/package", h.fullBackupPackage)
+	admin.GET("/system/full-backup/:run_id/package-status", h.fullBackupPackageStatus)
+	admin.GET("/system/full-backup/:run_id/download", h.fullBackupDownload)
 	admin.POST("/system/backups/:job_id/cancel", h.systemCancel)
 	admin.GET("/system/backups/:job_id/logs", h.logs)
 }

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2425,9 +2425,30 @@ paths:
   /admin/backups/restore-upload/apply:
     post:
       tags: [Backups]
-      summary: Restore an uploaded backup archive into an existing user (step-up)
+      summary: Restore an uploaded backup archive into an existing user
       security: [ { KratosSession: [] } ]
       responses: { "202": { description: Accepted } }
+
+  /admin/system/full-backup/{run_id}/package:
+    post:
+      tags: [Backups]
+      summary: Package a Full Server backup run into one downloadable container (GH #1408)
+      security: [ { KratosSession: [] } ]
+      responses: { "202": { description: Accepted } }
+
+  /admin/system/full-backup/{run_id}/package-status:
+    get:
+      tags: [Backups]
+      summary: Poll the status of a Full Server backup packaging job
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/system/full-backup/{run_id}/download:
+    get:
+      tags: [Backups]
+      summary: Download the packaged Full Server backup container
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
 
   /admin/backups/restore-upload/status:
     get:

--- a/panel-api/internal/api/system_fullbackup.go
+++ b/panel-api/internal/api/system_fullbackup.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// system_fullbackup.go — GH #1408 / #502. Package a whole Full Server backup RUN
+// (system + one job per user, sharing a run_id) into ONE downloadable container,
+// so an operator can move an entire server in a single file.
+//
+// Packaging materializes every job and can take many minutes on a big server, so
+// it's a detached JOB (like the system backup itself): POST .../package returns
+// 202, the agent packs in the background (system.fullbackup.pack), the client
+// polls .../package-status, then GETs .../download to stream the finished
+// container. The inner per-user archives are byte-identical to a normal account
+// download, so the (phase 2) restore feeds each straight into restore_from_tar.
+
+const fullBackupContainerDir = "/var/lib/jabali-backups/downloads"
+
+func fullBackupMarkerPath(runID string) string {
+	return filepath.Join(restoreUploadDir, "fullpkg-"+runID+".json")
+}
+
+type fullBackupOutcome struct {
+	Status  string   `json:"status"` // packaging | done | failed
+	TS      int64    `json:"ts"`
+	Path    string   `json:"path,omitempty"`
+	Bytes   int64    `json:"bytes,omitempty"`
+	Packed  []string `json:"packed,omitempty"`
+	Skipped []string `json:"skipped,omitempty"`
+	Error   string   `json:"error,omitempty"`
+}
+
+func writeFullBackupOutcome(path string, o fullBackupOutcome) {
+	o.TS = time.Now().Unix()
+	if len(o.Error) > 600 {
+		o.Error = o.Error[:600] + "…"
+	}
+	b, _ := json.Marshal(o)
+	writeOutcomeFile(path, b) // atomic swap, shared with #1323/#1408
+}
+
+// fullBackupPackage handles POST /admin/system/full-backup/:run_id/package.
+func (h *backupHandler) fullBackupPackage(c *gin.Context) {
+	runID := c.Param("run_id")
+	if !uploadIDRE.MatchString(runID) { // ULID also satisfies this format
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_run_id"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	jobs, err := h.cfg.Jobs.ListByRun(c.Request.Context(), runID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db_list"})
+		return
+	}
+
+	// Build the pack list: each SUCCEEDED/PARTIAL job that has a snapshot, with a
+	// stable label ("system" or "users/<username>"). All jobs in a run share one
+	// destination, so resolve it once.
+	type packItem struct{ jobID, label string }
+	var items []packItem
+	var dest *models.BackupDestination
+	var destParams map[string]any
+	for i := range jobs {
+		j := &jobs[i]
+		if j.Status != models.BackupJobStatusSucceeded && j.Status != models.BackupJobStatusPartial {
+			continue
+		}
+		if j.SnapshotID == "" {
+			continue
+		}
+		if dest == nil {
+			dest, destParams = materializeDest(c.Request.Context(), h.cfg.Destinations, j)
+		}
+		label := "system"
+		if j.UserID != "system" {
+			u, uerr := h.cfg.Users.FindByID(c.Request.Context(), j.UserID)
+			if uerr != nil || u == nil || u.Username == nil || *u.Username == "" {
+				continue // can't label a user job without its username
+			}
+			label = "users/" + *u.Username
+		}
+		items = append(items, packItem{jobID: j.ID, label: label})
+	}
+	if len(items) == 0 {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "nothing_to_package", "detail": "run has no completed backups"})
+		return
+	}
+
+	c.Set("audit_target", runID)
+	c.Set("audit_target_type", "backup_run")
+
+	marker := fullBackupMarkerPath(runID)
+	writeFullBackupOutcome(marker, fullBackupOutcome{Status: "packaging"})
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+		defer cancel()
+		runPack := func(pwFile string) error {
+			wire := make([]map[string]any, 0, len(items))
+			for _, it := range items {
+				m := map[string]any{"job_id": it.jobID, "label": it.label}
+				for k, v := range destParams {
+					m[k] = v
+				}
+				if pwFile != "" {
+					m["password_file"] = pwFile
+				}
+				wire = append(wire, m)
+			}
+			raw, cerr := h.cfg.Agent.Call(ctx, "system.fullbackup.pack",
+				map[string]any{"run_id": runID, "jobs": wire})
+			if cerr != nil {
+				writeFullBackupOutcome(marker, fullBackupOutcome{Status: "failed", Error: restoreFailureDetail(cerr)})
+				return nil
+			}
+			var res struct {
+				Path    string   `json:"path"`
+				Bytes   int64    `json:"bytes"`
+				Packed  []string `json:"packed"`
+				Skipped []string `json:"skipped"`
+			}
+			_ = json.Unmarshal(raw, &res)
+			writeFullBackupOutcome(marker, fullBackupOutcome{
+				Status: "done", Path: res.Path, Bytes: res.Bytes, Packed: res.Packed, Skipped: res.Skipped,
+			})
+			return nil
+		}
+		if dest != nil {
+			_ = backupwrapperhelpers.WithOptionalDestPassword(ctx, dest, h.cfg.Agent, h.cfg.SSOKey, runPack)
+		} else {
+			_ = runPack("")
+		}
+	}()
+
+	c.JSON(http.StatusAccepted, gin.H{"status": "packaging", "run_id": runID})
+}
+
+// fullBackupPackageStatus handles GET /admin/system/full-backup/:run_id/package-status.
+func (h *backupHandler) fullBackupPackageStatus(c *gin.Context) {
+	runID := c.Param("run_id")
+	if !uploadIDRE.MatchString(runID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_run_id"})
+		return
+	}
+	b, err := os.ReadFile(fullBackupMarkerPath(runID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", b)
+}
+
+// fullBackupDownload handles GET /admin/system/full-backup/:run_id/download —
+// streams the packaged container file the agent built.
+func (h *backupHandler) fullBackupDownload(c *gin.Context) {
+	runID := c.Param("run_id")
+	if !uploadIDRE.MatchString(runID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_run_id"})
+		return
+	}
+	b, err := os.ReadFile(fullBackupMarkerPath(runID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_packaged"})
+		return
+	}
+	var o fullBackupOutcome
+	if json.Unmarshal(b, &o) != nil || o.Status != "done" || o.Path == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "not_ready", "status": o.Status})
+		return
+	}
+	// The container is under the agent's downloads dir; confine to it so a
+	// tampered marker can't point the stream at an arbitrary file.
+	clean := filepath.Clean(o.Path)
+	if filepath.Dir(clean) != fullBackupContainerDir {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "bad_container_path"})
+		return
+	}
+	f, ferr := os.Open(clean)
+	if ferr != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "container_missing"})
+		return
+	}
+	defer f.Close()
+	fi, _ := f.Stat()
+
+	// Multi-GB stream: clear the 30s write deadline (nginx allows an hour).
+	_ = http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{})
+	c.Header("Content-Type", "application/x-tar")
+	c.Header("Content-Disposition", contentDisposition("attachment", "full-server-backup-"+runID+".tar"))
+	if fi != nil {
+		c.Header("Content-Length", strconv.FormatInt(fi.Size(), 10))
+	}
+	if _, err := io.Copy(c.Writer, f); err != nil && h.cfg.Log != nil {
+		h.cfg.Log.Warn("full-backup stream failed", "err", err, "run_id", runID)
+	}
+}

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -39,6 +39,7 @@ const isRestoreKind = (kind: string): boolean =>
 import { BackupSettingsTab } from "./BackupSettingsTab";
 import { CreateBackupDrawer } from "./CreateBackupDrawer";
 import { RestoreFromUploadDrawer } from "./RestoreFromUploadDrawer";
+import { FullServerPackageModal } from "./FullServerPackageModal";
 import { DestinationsTab } from "./DestinationsTab";
 import { EncryptionKeyCard } from "./EncryptionKeyCard";
 import { SchedulesTab } from "./SchedulesTab";
@@ -147,6 +148,7 @@ const RunStatusSummary = ({ run }: { run: BackupRun }) => {
 export const AdminBackupsPage = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [uploadRestoreOpen, setUploadRestoreOpen] = useState(false);
+  const [packageRunId, setPackageRunId] = useState<string | null>(null);
   const [logJob, setLogJob] = useState<BackupJob | null>(null);
   const [activeTab, setActiveTab] = useTabParam<TabKey>("backups");
   const [runs, setRuns] = useState<BackupRun[]>([]);
@@ -652,6 +654,15 @@ export const AdminBackupsPage = () => {
                       </Typography.Link>
                       <RowActions
                         actions={[
+                          // GH #1408: a Full Server run (has account jobs) can be
+                          // packaged into ONE downloadable container.
+                          {
+                            key: "package-full",
+                            label: "Package & download",
+                            icon: <DownloadOutlined />,
+                            hidden: !row.run.has_accounts,
+                            onClick: () => setPackageRunId(row.run.run_id),
+                          },
                           {
                             key: "delete-all",
                             label: "Delete all jobs",
@@ -712,6 +723,12 @@ export const AdminBackupsPage = () => {
       <RestoreFromUploadDrawer
         open={uploadRestoreOpen}
         onClose={() => setUploadRestoreOpen(false)}
+      />
+
+      <FullServerPackageModal
+        runId={packageRunId}
+        open={packageRunId !== null}
+        onClose={() => setPackageRunId(null)}
       />
     </div>
   );

--- a/panel-ui/src/shells/admin/backups/FullServerPackageModal.tsx
+++ b/panel-ui/src/shells/admin/backups/FullServerPackageModal.tsx
@@ -1,0 +1,160 @@
+// FullServerPackageModal — GH #1408 / #502. Package a whole backup RUN (the
+// system leg + every account) into ONE downloadable container. Packaging
+// materializes every account, so it runs as a background job the modal polls;
+// when it's ready the admin downloads a single file — the basis for moving or
+// recovering a full server in one archive.
+import { useEffect, useRef, useState } from "react";
+import { Alert, Button, Modal, Progress, Space, Typography } from "antd";
+import { feedback } from "../../../lib/feedback";
+import { apiClient } from "../../../apiClient";
+import { downloadUrl } from "../../../utils/download";
+import { extractApiError } from "../../../apiErrors";
+
+interface Props {
+  runId: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+type Phase = "warn" | "packaging" | "ready" | "failed";
+interface Status {
+  status: "packaging" | "done" | "failed";
+  bytes?: number;
+  packed?: string[];
+  skipped?: string[];
+  error?: string;
+}
+
+export function FullServerPackageModal({ runId, open, onClose }: Props) {
+  const [phase, setPhase] = useState<Phase>("warn");
+  const [status, setStatus] = useState<Status | null>(null);
+  const cancelled = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      setPhase("warn");
+      setStatus(null);
+      cancelled.current = false;
+    }
+    return () => {
+      cancelled.current = true;
+    };
+  }, [open, runId]);
+
+  const startPackaging = async () => {
+    if (!runId) return;
+    setPhase("packaging");
+    try {
+      await apiClient.post(`/admin/system/full-backup/${runId}/package`);
+    } catch (err) {
+      feedback.message.error(extractApiError(err, "Could not start packaging"));
+      setPhase("warn");
+      return;
+    }
+    // Poll the packaging job until it seals.
+    const deadline = Date.now() + 60 * 60 * 1000;
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 3000));
+      if (cancelled.current) return;
+      try {
+        const { data } = await apiClient.get<Status>(
+          `/admin/system/full-backup/${runId}/package-status`,
+        );
+        setStatus(data);
+        if (data.status === "done") {
+          setPhase("ready");
+          return;
+        }
+        if (data.status === "failed") {
+          setPhase("failed");
+          return;
+        }
+      } catch {
+        // transient — keep polling until the deadline
+      }
+      if (Date.now() > deadline) {
+        setPhase("failed");
+        setStatus({ status: "failed", error: "packaging timed out" });
+        return;
+      }
+    }
+  };
+
+  const download = () => {
+    if (!runId) return;
+    downloadUrl(`/api/v1/admin/system/full-backup/${runId}/download`);
+  };
+
+  return (
+    <Modal
+      title="Full server backup — package & download"
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      maskClosable={phase !== "packaging"}
+      closable={phase !== "packaging"}
+    >
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Bundles this run — the system backup and every account backup — into one
+          archive you can download and move to another server.
+        </Typography.Paragraph>
+
+        <Alert
+          type="warning"
+          showIcon
+          message="Disk space"
+          description="Packaging temporarily writes the accounts to disk before compressing them — plan for up to about 2× this server's account data in free space while it runs."
+        />
+
+        {phase === "warn" && (
+          <Button type="primary" onClick={startPackaging}>
+            Package for download
+          </Button>
+        )}
+
+        {phase === "packaging" && (
+          <Space direction="vertical" style={{ width: "100%" }}>
+            <Progress percent={100} status="active" showInfo={false} />
+            <Typography.Text type="secondary">
+              Packaging in the background… this can take several minutes for a full
+              server. You can leave this open; the archive is prepared on the server.
+            </Typography.Text>
+          </Space>
+        )}
+
+        {phase === "ready" && status && (
+          <>
+            <Alert
+              type="success"
+              showIcon
+              message="Archive ready"
+              description={
+                <Space direction="vertical" size={0}>
+                  <span>{(status.packed?.length ?? 0)} backup(s) packaged.</span>
+                  {(status.skipped?.length ?? 0) > 0 && (
+                    <Typography.Text type="warning">
+                      Skipped (no snapshot): {status.skipped?.join(", ")}
+                    </Typography.Text>
+                  )}
+                </Space>
+              }
+            />
+            <Button type="primary" icon={null} onClick={download}>
+              Download full server backup
+            </Button>
+          </>
+        )}
+
+        {phase === "failed" && (
+          <Alert
+            type="error"
+            showIcon
+            message="Packaging failed"
+            description={status?.error || "The full server backup could not be packaged."}
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+}


### PR DESCRIPTION
**Phase 1** of the reporter's full-server DR archive — agreed with the operator: a **container of the existing per-user tars**, not a re-packed monolith. Lets an admin turn a whole Full Server backup run into **one downloadable file** to move to another server.

A Full Server backup already exists (#502): a run holding the system job + one job per user, sharing a `run_id`. This adds the "compress everything → download" it was missing.

## Agent — `system.fullbackup.pack`
For each job in the run: restore its snapshots, tar+zstd them into an inner `<label>.tar.zst` that is **byte-identical to that job's normal per-account download**, then **delete the materialized tree before the next** (peak disk ≈ one account + the growing container, not the whole server). Wrap them in a **plain** outer tar (inners already zstd — no double compression):

```
full-server-backup/
├── manifest.json
├── system.tar.zst
└── users/<username>.tar.zst
```

So phase-2 restore feeds each inner straight into `restore_from_tar`. Each job is gated on the host disk reserve; a per-account failure is skipped, not fatal; labels are a strict allowlist (`system` | `users/<username>`) since they become paths.

**Box-drilled** on the test box: 2 real jobs → a 224 MB container with the expected layout; inners confirmed `restore_from_tar`-compatible (`<job>/manifest/manifest.json`).

## Panel (admin)
Packaging is a **detached job** (minutes): `POST .../full-backup/:run_id/package` → 202, agent packs in the background inside the destination-password scope; `.../package-status` polls; `.../download` streams the finished container (write-deadline cleared; streamed path confined to the downloads dir).

## UI
A run with account jobs gets a **"Package & download"** action → a modal that warns about disk (**~2× the account data during packaging**), starts the job, shows a background-running state, and offers the download when ready.

## Phase 2 (next)
Restore from an uploaded container — extract + loop the existing per-user restore, select which users; system restore stays manual/CLI (the step-up-worthy one).

`go vet` + `tsc` clean; agent (incl. exec-seam) + panel-api suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)