### PR TITLE
feat(backup): restore a full server from an uploaded container (GH #1408 phase 2)

### DIFF
--- a/panel-agent/internal/commands/backup_restore_from_tar.go
+++ b/panel-agent/internal/commands/backup_restore_from_tar.go
@@ -60,17 +60,27 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
 	}
-	if !jobIDRE.MatchString(p.JobID) {
+	apply := true
+	if p.ApplyStaged != nil {
+		apply = *p.ApplyStaged
+	}
+	return restoreAccountFromTar(ctx, p.JobID, p.TarPath, p.TargetUsername, p.Components, apply)
+}
+
+// restoreAccountFromTar is the reusable core: extract an untrusted account backup
+// tar and apply it to targetUsername. Shared by the single-upload restore handler
+// and the full-server container restore (which calls it once per inner user tar).
+func restoreAccountFromTar(ctx context.Context, jobID, tarPath, targetUsername string, components []string, apply bool) (*backupRestoreFromTarResult, error) {
+	if !jobIDRE.MatchString(jobID) {
 		return nil, bkInvalidArg("job_id must be a 26-char ULID")
 	}
-	if !backupUsernameRE.MatchString(p.TargetUsername) {
+	if !backupUsernameRE.MatchString(targetUsername) {
 		return nil, bkInvalidArg("target_username must match ^[a-z][a-z0-9_-]{0,31}$")
 	}
-	// The tar path is provided by the panel (the reassembled chunked upload). It
-	// MUST live under the uploads handoff dir and contain no traversal — never
-	// let the caller point the extractor at an arbitrary file.
-	tarClean := filepath.Clean(p.TarPath)
-	if tarClean != p.TarPath || !strings.HasPrefix(tarClean, restoreUploadsRoot+"/") {
+	// The tar path MUST live under the uploads handoff dir and contain no
+	// traversal — never let the caller point the extractor at an arbitrary file.
+	tarClean := filepath.Clean(tarPath)
+	if tarClean != tarPath || !strings.HasPrefix(tarClean, restoreUploadsRoot+"/") {
 		return nil, bkInvalidArg("tar_path must be a clean path under " + restoreUploadsRoot)
 	}
 	if fi, err := os.Lstat(tarClean); err != nil || !fi.Mode().IsRegular() {
@@ -86,7 +96,7 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 		}
 	}
 
-	staging := filepath.Join("/var/lib/jabali-backups/restore-staging", p.JobID+"-upload")
+	staging := filepath.Join("/var/lib/jabali-backups/restore-staging", jobID+"-upload")
 	_ = os.RemoveAll(staging)
 	if err := os.MkdirAll(staging, 0o750); err != nil {
 		return nil, bkInternal("mkdir staging", err)
@@ -120,17 +130,17 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 		return nil, bkInvalidArg("manifest parse failed: " + err.Error())
 	}
 
-	out := backupRestoreFromTarResult{JobID: p.JobID, User: manifest.User, BytesExtracted: written}
+	out := backupRestoreFromTarResult{JobID: jobID, User: manifest.User, BytesExtracted: written}
 
 	// v1 restores into the SAME username the backup was taken from — the home
 	// tree inside the archive is /home/<backup-user> and applyAccountRestore
 	// keys the source path by the target name, so a mismatch silently leaves
 	// home unrestored. The panel sets target = the manifest's username; warn if
 	// a caller passes something else (renaming on restore is a follow-up).
-	if p.TargetUsername != manifest.User.Username {
+	if targetUsername != manifest.User.Username {
 		out.Warnings = append(out.Warnings, fmt.Sprintf(
 			"target_username %q differs from the backup's user %q; the home stage will be skipped (restore into the same username)",
-			p.TargetUsername, manifest.User.Username))
+			targetUsername, manifest.User.Username))
 	}
 
 	// Best-effort metadata (FTP subaccount hashes etc.) from the meta stage.
@@ -142,7 +152,7 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 	// (no component filter, or the filter selected it). Aligned by manifest-stage
 	// index — same discipline as backup.restore (docker/db fan out same-named
 	// stages, so a name-keyed gate would collapse them, GH #1360).
-	want := componentFilter(p.Components)
+	want := componentFilter(components)
 	stageResults := make([]backupRestoreStage, len(manifest.Stages))
 	for i, st := range manifest.Stages {
 		res := backupRestoreStage{Name: st.Name, Status: backup.StageStatusSkipped}
@@ -154,17 +164,13 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 	}
 	out.Stages = stageResults
 
-	apply := true
-	if p.ApplyStaged != nil {
-		apply = *p.ApplyStaged
-	}
 	if !apply {
 		out.Warnings = append(out.Warnings, "apply_staged=false — extracted to "+staging+"; nothing applied")
 		out.StagingCleanup = "kept (recon mode)"
-		return out, nil
+		return &out, nil
 	}
 
-	applied, warnings := applyAccountRestore(ctx, root, p.TargetUsername, manifest.User, manifest.Stages, stageResults)
+	applied, warnings := applyAccountRestore(ctx, root, targetUsername, manifest.User, manifest.Stages, stageResults)
 	out.Applied = applied
 	out.Warnings = append(out.Warnings, warnings...)
 
@@ -178,7 +184,7 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 	} else {
 		out.StagingCleanup = "kept (no stages applied)"
 	}
-	return out, nil
+	return &out, nil
 }
 
 // componentFilter builds a set of stage names to apply, or nil to apply all.

--- a/panel-agent/internal/commands/safe_tar_extract.go
+++ b/panel-agent/internal/commands/safe_tar_extract.go
@@ -148,6 +148,50 @@ func extractTarStream(r io.Reader, destRoot string) (int64, error) {
 	return written, nil
 }
 
+// safeExtractPlainTar extracts an UNTRUSTED plain (uncompressed) tar with the
+// same allowlist as safeExtractZstdTar. Used for the full-server container,
+// whose members are already-zstd inner archives (GH #1408) — the outer tar adds
+// no compression, so it's read directly.
+func safeExtractPlainTar(srcPath, destRoot string) (int64, error) {
+	if !filepath.IsAbs(destRoot) || destRoot != filepath.Clean(destRoot) {
+		return 0, fmt.Errorf("destRoot must be an absolute clean path")
+	}
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	return extractTarStream(f, destRoot)
+}
+
+// readFileFromPlainTar returns the bytes of a named member (e.g. "manifest.json")
+// from a plain tar, read-only, or an error if it's absent. Bounded to 8 MiB.
+func readFileFromPlainTar(srcPath, name string) ([]byte, error) {
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar: %w", err)
+		}
+		rel, rerr := safeRelPath(hdr.Name)
+		if rerr != nil || rel == "" {
+			continue
+		}
+		if rel == name && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(io.LimitReader(tr, 8<<20))
+		}
+	}
+	return nil, fmt.Errorf("%s not found in container", name)
+}
+
 // readManifestFromZstdTar streams the zstd tar read-only (writes NOTHING) and
 // returns the account manifest bytes (<job-id>/manifest/manifest.json). Used by
 // the inspect step to show what a backup holds before the destructive apply. It

--- a/panel-agent/internal/commands/safe_tar_extract_test.go
+++ b/panel-agent/internal/commands/safe_tar_extract_test.go
@@ -161,6 +161,45 @@ func TestWriteRegularNoFollow_BudgetGuard(t *testing.T) {
 	}
 }
 
+// GH #1408 phase 2: the full-server container is a PLAIN tar of already-zstd
+// inners — safeExtractPlainTar extracts it with the same allowlist, and
+// readFileFromPlainTar reads its manifest without extracting.
+func TestPlainTarHelpers(t *testing.T) {
+	root := t.TempDir()
+	container := filepath.Join(root, "container.tar")
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	write := func(name, body string) {
+		_ = tw.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: name, Mode: 0o644, Size: int64(len(body))})
+		_, _ = tw.Write([]byte(body))
+	}
+	write("manifest.json", `{"run_id":"R","entries":[]}`)
+	write("users/alice.tar.zst", "ZSTDINNER")
+	_ = tw.Close()
+	if err := os.WriteFile(container, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mb, err := readFileFromPlainTar(container, "manifest.json")
+	if err != nil || string(mb) != `{"run_id":"R","entries":[]}` {
+		t.Fatalf("readFileFromPlainTar manifest = %q err=%v", mb, err)
+	}
+	if _, err := readFileFromPlainTar(container, "nope.json"); err == nil {
+		t.Fatal("missing member must error")
+	}
+
+	dst := filepath.Join(root, "out")
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := safeExtractPlainTar(container, dst); err != nil {
+		t.Fatalf("safeExtractPlainTar: %v", err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(dst, "users", "alice.tar.zst")); string(b) != "ZSTDINNER" {
+		t.Fatalf("inner not extracted verbatim")
+	}
+}
+
 func TestSafeRelPath(t *testing.T) {
 	ok := map[string]string{
 		"home/a.txt": "home/a.txt",

--- a/panel-agent/internal/commands/system_fullbackup_restore.go
+++ b/panel-agent/internal/commands/system_fullbackup_restore.go
@@ -1,0 +1,192 @@
+package commands
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+// system_fullbackup.restore — GH #1408 phase 2. Restore from an UPLOADED full-
+// server container (produced by system.fullbackup.pack): a PLAIN tar of
+// manifest.json + system.tar.zst + users/<username>.tar.zst, where each inner
+// tar is byte-identical to a per-account backup. So restore = extract the outer
+// container (safe plain-tar extractor) then feed each selected inner tar through
+// the SAME restoreAccountFromTar core the single-upload restore uses.
+//
+// The container itself is untrusted (safe extractor), and each inner tar is
+// untrusted again (restoreAccountFromTar's hardened zstd extractor) — double
+// safe. System restore is deliberately NOT applied here: it changes server
+// config and stays a manual/CLI, step-up-worthy operation in v1.
+
+const crockford = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+func randomULID() string {
+	rnd := make([]byte, 26)
+	_, _ = rand.Read(rnd)
+	b := make([]byte, 26)
+	for i := range b {
+		b[i] = crockford[int(rnd[i])%32]
+	}
+	return string(b)
+}
+
+type fullContainerManifest struct {
+	RunID   string `json:"run_id"`
+	Schema  int    `json:"schema"`
+	Entries []struct {
+		Username string `json:"username,omitempty"`
+		Label    string `json:"label"`
+		JobID    string `json:"job_id"`
+	} `json:"entries"`
+}
+
+func fullContainerPathClean(tarPath string) (string, error) {
+	clean := filepath.Clean(tarPath)
+	if clean != tarPath || !strings.HasPrefix(clean, restoreUploadsRoot+"/") {
+		return "", bkInvalidArg("tar_path must be a clean path under " + restoreUploadsRoot)
+	}
+	if fi, err := os.Lstat(clean); err != nil || !fi.Mode().IsRegular() {
+		return "", bkInvalidArg("tar_path is not a regular file")
+	}
+	return clean, nil
+}
+
+type systemFullbackupInspectParams struct {
+	TarPath string `json:"tar_path"`
+}
+
+// system.fullbackup.inspect_uploaded reads the container's manifest (no full
+// extraction) so the UI can offer System + which users to restore.
+func systemFullbackupInspectUploadedHandler(_ context.Context, raw json.RawMessage) (any, error) {
+	var p systemFullbackupInspectParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	clean, aerr := fullContainerPathClean(p.TarPath)
+	if aerr != nil {
+		return nil, aerr
+	}
+	mb, err := readFileFromPlainTar(clean, "manifest.json")
+	if err != nil {
+		return nil, bkInvalidArg("not a full-server backup container (no manifest.json): " + err.Error())
+	}
+	var man fullContainerManifest
+	if json.Unmarshal(mb, &man) != nil {
+		return nil, bkInvalidArg("container manifest parse failed")
+	}
+	users := make([]string, 0, len(man.Entries))
+	hasSystem := false
+	for _, e := range man.Entries {
+		if e.Label == "system" {
+			hasSystem = true
+			continue
+		}
+		if e.Username != "" {
+			users = append(users, e.Username)
+		}
+	}
+	return map[string]any{"run_id": man.RunID, "users": users, "has_system": hasSystem}, nil
+}
+
+type systemFullbackupRestoreParams struct {
+	TarPath   string   `json:"tar_path"`
+	Usernames []string `json:"usernames"`      // which users to restore
+	System    bool     `json:"include_system"` // v1: acknowledged but not applied
+}
+
+type fullRestoreUserResult struct {
+	Username string   `json:"username"`
+	Applied  []string `json:"applied,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+type systemFullbackupRestoreResult struct {
+	Users      []fullRestoreUserResult `json:"users"`
+	Skipped    []string                `json:"skipped,omitempty"`
+	SystemNote string                  `json:"system_note,omitempty"`
+}
+
+// system.fullbackup.restore_uploaded extracts the container and restores each
+// selected user's inner tar via restoreAccountFromTar.
+func systemFullbackupRestoreUploadedHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p systemFullbackupRestoreParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	clean, aerr := fullContainerPathClean(p.TarPath)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if err := hostreserve.CheckReserve("/var/lib/jabali-backups", 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "restore staging is under the host disk reserve: " + err.Error()}
+	}
+
+	// Extract the container UNDER the uploads root so the inner user tars are
+	// valid inputs to restoreAccountFromTar (which requires that prefix).
+	stage := filepath.Join(restoreUploadsRoot, "fullrestore-"+randomULID())
+	_ = os.RemoveAll(stage)
+	if err := os.MkdirAll(stage, 0o750); err != nil {
+		return nil, bkInternal("mkdir stage", err)
+	}
+	defer os.RemoveAll(stage)
+	if _, err := safeExtractPlainTar(clean, stage); err != nil {
+		return nil, bkInvalidArg("container rejected: " + err.Error())
+	}
+
+	mb, err := readFileFromPlainTar(clean, "manifest.json")
+	if err != nil {
+		return nil, bkInvalidArg("container has no manifest.json")
+	}
+	var man fullContainerManifest
+	if json.Unmarshal(mb, &man) != nil {
+		return nil, bkInvalidArg("container manifest parse failed")
+	}
+
+	want := map[string]bool{}
+	for _, u := range p.Usernames {
+		want[u] = true
+	}
+
+	out := systemFullbackupRestoreResult{}
+	if p.System {
+		out.SystemNote = "system restore is not applied from the panel — run the system_restore CLI on the box"
+	}
+	for _, e := range man.Entries {
+		if e.Label == "system" || e.Username == "" {
+			continue
+		}
+		if len(want) > 0 && !want[e.Username] {
+			out.Skipped = append(out.Skipped, e.Username)
+			continue
+		}
+		inner := filepath.Join(stage, "users", e.Username+".tar.zst")
+		if fi, serr := os.Stat(inner); serr != nil || !fi.Mode().IsRegular() {
+			out.Users = append(out.Users, fullRestoreUserResult{Username: e.Username, Error: "inner archive missing from container"})
+			continue
+		}
+		res, rerr := restoreAccountFromTar(ctx, randomULID(), inner, e.Username, nil, true)
+		if rerr != nil {
+			msg := rerr.Error()
+			if ae, ok := rerr.(*agentwire.AgentError); ok && ae.Message != "" {
+				msg = ae.Message
+			}
+			out.Users = append(out.Users, fullRestoreUserResult{Username: e.Username, Error: msg})
+			continue
+		}
+		out.Users = append(out.Users, fullRestoreUserResult{Username: e.Username, Applied: res.Applied, Warnings: res.Warnings})
+	}
+	return out, nil
+}
+
+func init() {
+	Default.Register("system.fullbackup.inspect_uploaded", systemFullbackupInspectUploadedHandler)
+	Default.Register("system.fullbackup.restore_uploaded", systemFullbackupRestoreUploadedHandler)
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -140,6 +140,10 @@ func RegisterBackupRoutes(rg *gin.RouterGroup, cfg BackupHandlerConfig) {
 	admin.POST("/system/full-backup/:run_id/package", h.fullBackupPackage)
 	admin.GET("/system/full-backup/:run_id/package-status", h.fullBackupPackageStatus)
 	admin.GET("/system/full-backup/:run_id/download", h.fullBackupDownload)
+	// GH #1408 phase 2: restore from an uploaded full-server container.
+	admin.POST("/system/full-restore-upload/inspect", h.fullRestoreInspect)
+	admin.POST("/system/full-restore-upload/apply", h.fullRestoreApply)
+	admin.GET("/system/full-restore-upload/status", h.fullRestoreStatus)
 	admin.POST("/system/backups/:job_id/cancel", h.systemCancel)
 	admin.GET("/system/backups/:job_id/logs", h.logs)
 }

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2450,6 +2450,27 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/system/full-restore-upload/inspect:
+    post:
+      tags: [Backups]
+      summary: Inspect an uploaded Full Server backup container (users + system)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/system/full-restore-upload/apply:
+    post:
+      tags: [Backups]
+      summary: Restore selected users from an uploaded Full Server container
+      security: [ { KratosSession: [] } ]
+      responses: { "202": { description: Accepted } }
+
+  /admin/system/full-restore-upload/status:
+    get:
+      tags: [Backups]
+      summary: Poll the status of a Full Server container restore
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /admin/backups/restore-upload/status:
     get:
       tags: [Backups]

--- a/panel-api/internal/api/system_fullbackup.go
+++ b/panel-api/internal/api/system_fullbackup.go
@@ -210,3 +210,137 @@ func (h *backupHandler) fullBackupDownload(c *gin.Context) {
 		h.cfg.Log.Warn("full-backup stream failed", "err", err, "run_id", runID)
 	}
 }
+
+// --- Restore from an uploaded full-server container (phase 2) ---
+//
+// The container is uploaded via the existing chunked endpoint
+// (POST /admin/backups/restore-upload), so it reassembles at the same
+// restoreUploadPath. These endpoints inspect it and fan the restore out over the
+// selected users, reusing the per-account restore engine.
+
+func fullRestoreMarkerPath(adminID, uploadID string) string {
+	return filepath.Join(restoreUploadDir, "fullrst-"+restoreUploadAdminTag(adminID)+"-"+uploadID+".json")
+}
+
+type fullRestoreInspectRequest struct {
+	UploadID string `json:"upload_id"`
+}
+
+// fullRestoreInspect handles POST /admin/system/full-restore-upload/inspect.
+func (h *backupHandler) fullRestoreInspect(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	var req fullRestoreInspectRequest
+	if err := c.ShouldBindJSON(&req); err != nil || !uploadIDRE.MatchString(req.UploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	path := restoreUploadPath(adminID, req.UploadID)
+	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "system.fullbackup.inspect_uploaded",
+		map[string]string{"tar_path": path})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	c.Data(http.StatusOK, "application/json", raw)
+}
+
+type fullRestoreApplyRequest struct {
+	UploadID      string   `json:"upload_id"`
+	Usernames     []string `json:"usernames"`
+	IncludeSystem bool     `json:"include_system"`
+}
+
+// fullRestoreApply handles POST /admin/system/full-restore-upload/apply — restores
+// the selected users from the uploaded container. Detached job (it can restore
+// many accounts) → 202 + status poll.
+func (h *backupHandler) fullRestoreApply(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	var req fullRestoreApplyRequest
+	if err := c.ShouldBindJSON(&req); err != nil || !uploadIDRE.MatchString(req.UploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	path := restoreUploadPath(adminID, req.UploadID)
+	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	c.Set("audit_target", req.UploadID)
+	c.Set("audit_target_type", "backup_run")
+
+	marker := fullRestoreMarkerPath(adminID, req.UploadID)
+	writeFullBackupOutcome(marker, fullBackupOutcome{Status: "restoring"})
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
+		defer cancel()
+		raw, cerr := h.cfg.Agent.Call(ctx, "system.fullbackup.restore_uploaded", map[string]any{
+			"tar_path":       path,
+			"usernames":      req.Usernames,
+			"include_system": req.IncludeSystem,
+		})
+		if cerr != nil {
+			writeFullBackupOutcome(marker, fullBackupOutcome{Status: "failed", Error: restoreFailureDetail(cerr)})
+			return
+		}
+		// The container is consumed — drop it.
+		_ = os.Remove(path)
+		var res struct {
+			Users []struct {
+				Username string   `json:"username"`
+				Applied  []string `json:"applied"`
+				Error    string   `json:"error"`
+			} `json:"users"`
+			Skipped []string `json:"skipped"`
+		}
+		_ = json.Unmarshal(raw, &res)
+		packed := make([]string, 0, len(res.Users))
+		for _, u := range res.Users {
+			if u.Error != "" {
+				packed = append(packed, u.Username+": "+u.Error)
+			} else {
+				packed = append(packed, u.Username+": restored "+strconv.Itoa(len(u.Applied))+" item(s)")
+			}
+		}
+		writeFullBackupOutcome(marker, fullBackupOutcome{Status: "done", Packed: packed, Skipped: res.Skipped})
+	}()
+
+	c.JSON(http.StatusAccepted, gin.H{"status": "restoring", "upload_id": req.UploadID})
+}
+
+// fullRestoreStatus handles GET /admin/system/full-restore-upload/status?upload_id=…
+func (h *backupHandler) fullRestoreStatus(c *gin.Context) {
+	adminID, ok := h.restoreUploadAdminID(c)
+	if !ok {
+		return
+	}
+	uploadID := c.Query("upload_id")
+	if !uploadIDRE.MatchString(uploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	b, err := os.ReadFile(fullRestoreMarkerPath(adminID, uploadID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", b)
+}

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -579,6 +579,62 @@ interface RestoreUploadStatus {
   error?: string;
 }
 
+// === GH #1408 phase 2: restore from an uploaded full-server container ===
+
+export interface FullContainerInfo {
+  run_id: string;
+  users: string[];
+  has_system: boolean;
+}
+
+export async function inspectFullServerContainer(
+  uploadId: string,
+): Promise<FullContainerInfo> {
+  const { data } = await apiClient.post<FullContainerInfo>(
+    "/admin/system/full-restore-upload/inspect",
+    { upload_id: uploadId },
+  );
+  return data;
+}
+
+export interface FullRestoreResult {
+  status: string;
+  packed?: string[]; // "<user>: restored N item(s)" or "<user>: <error>"
+  skipped?: string[];
+  error?: string;
+}
+
+// applyFullServerRestore kicks off the (detached) container restore and polls
+// its status until it seals.
+export async function applyFullServerRestore(
+  uploadId: string,
+  usernames: string[],
+  includeSystem: boolean,
+): Promise<FullRestoreResult> {
+  await apiClient.post("/admin/system/full-restore-upload/apply", {
+    upload_id: uploadId,
+    usernames,
+    include_system: includeSystem,
+  });
+  const deadline = Date.now() + 65 * 60 * 1000;
+  for (;;) {
+    await new Promise((r) => setTimeout(r, 3000));
+    let s: FullRestoreResult | null = null;
+    try {
+      const { data } = await apiClient.get<FullRestoreResult>(
+        "/admin/system/full-restore-upload/status",
+        { params: { upload_id: uploadId } },
+      );
+      s = data;
+    } catch {
+      // transient — keep polling
+    }
+    if (s?.status === "done") return s;
+    if (s?.status === "failed") throw new Error(s.error || "restore_failed");
+    if (Date.now() > deadline) throw new Error("restore_timeout");
+  }
+}
+
 // === PHP Settings API ===
 
 export interface DomainPHPSettings {

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -40,6 +40,7 @@ import { BackupSettingsTab } from "./BackupSettingsTab";
 import { CreateBackupDrawer } from "./CreateBackupDrawer";
 import { RestoreFromUploadDrawer } from "./RestoreFromUploadDrawer";
 import { FullServerPackageModal } from "./FullServerPackageModal";
+import { RestoreFullServerDrawer } from "./RestoreFullServerDrawer";
 import { DestinationsTab } from "./DestinationsTab";
 import { EncryptionKeyCard } from "./EncryptionKeyCard";
 import { SchedulesTab } from "./SchedulesTab";
@@ -149,6 +150,7 @@ export const AdminBackupsPage = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [uploadRestoreOpen, setUploadRestoreOpen] = useState(false);
   const [packageRunId, setPackageRunId] = useState<string | null>(null);
+  const [fullRestoreOpen, setFullRestoreOpen] = useState(false);
   const [logJob, setLogJob] = useState<BackupJob | null>(null);
   const [activeTab, setActiveTab] = useTabParam<TabKey>("backups");
   const [runs, setRuns] = useState<BackupRun[]>([]);
@@ -463,6 +465,12 @@ export const AdminBackupsPage = () => {
             Restore from Upload
           </Button>
           <Button
+            icon={<HardDriveUploadOutlined />}
+            onClick={() => setFullRestoreOpen(true)}
+          >
+            Restore Full Server
+          </Button>
+          <Button
             type="primary"
             icon={<PlusOutlined />}
             onClick={() => setDrawerOpen(true)}
@@ -729,6 +737,11 @@ export const AdminBackupsPage = () => {
         runId={packageRunId}
         open={packageRunId !== null}
         onClose={() => setPackageRunId(null)}
+      />
+
+      <RestoreFullServerDrawer
+        open={fullRestoreOpen}
+        onClose={() => setFullRestoreOpen(false)}
       />
     </div>
   );

--- a/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
@@ -1,0 +1,202 @@
+// RestoreFullServerDrawer — GH #1408 phase 2. Restore from an uploaded FULL
+// SERVER container: upload the one-file archive produced by "Package & download",
+// pick which users to restore, and each is restored exactly like a normal
+// account restore. System restore is intentionally left to the CLI.
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Drawer,
+  Progress,
+  Space,
+  Typography,
+  Upload,
+} from "antd";
+import { InboxOutlined } from "@icons";
+import { feedback } from "../../../lib/feedback";
+import {
+  applyFullServerRestore,
+  inspectFullServerContainer,
+  uploadBackupArchiveChunked,
+  type FullContainerInfo,
+  type FullRestoreResult,
+} from "../../../apiClient";
+import { extractApiError } from "../../../apiErrors";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Phase = "pick" | "uploading" | "inspecting" | "ready" | "applying" | "done";
+
+export function RestoreFullServerDrawer({ open, onClose }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [phase, setPhase] = useState<Phase>("pick");
+  const [pct, setPct] = useState(0);
+  const [info, setInfo] = useState<FullContainerInfo | null>(null);
+  const [uploadId, setUploadId] = useState<string | null>(null);
+  const [users, setUsers] = useState<string[]>([]);
+  const [result, setResult] = useState<FullRestoreResult | null>(null);
+
+  const reset = () => {
+    setFile(null);
+    setPhase("pick");
+    setPct(0);
+    setInfo(null);
+    setUploadId(null);
+    setUsers([]);
+    setResult(null);
+  };
+  const close = () => {
+    reset();
+    onClose();
+  };
+
+  const startUpload = async () => {
+    if (!file) return;
+    setPhase("uploading");
+    setPct(0);
+    try {
+      const id = await uploadBackupArchiveChunked(file, (p) => setPct(Math.round(p.frac * 100)));
+      setUploadId(id);
+      setPhase("inspecting");
+      const meta = await inspectFullServerContainer(id);
+      setInfo(meta);
+      setUsers(meta.users); // default: restore all users in the container
+      setPhase("ready");
+    } catch (err) {
+      feedback.message.error(extractApiError(err, "Upload / inspect failed"));
+      setPhase("pick");
+    }
+  };
+
+  const apply = async () => {
+    if (!uploadId || users.length === 0) return;
+    setPhase("applying");
+    feedback.message.info("Restore started — running in the background");
+    try {
+      const r = await applyFullServerRestore(uploadId, users, false);
+      setResult(r);
+      setPhase("done");
+      feedback.message.success("Full server restore finished — see details");
+    } catch (err) {
+      feedback.message.error(extractApiError(err, "Restore failed"));
+      setPhase("ready");
+    }
+  };
+
+  return (
+    <Drawer
+      title="Restore full server from upload"
+      width={520}
+      open={open}
+      onClose={close}
+      destroyOnClose
+    >
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Upload a Full Server backup archive (from “Package &amp; download”) and
+          restore the accounts it contains. Each user is restored just like a
+          normal account restore. Create any missing users first.
+        </Typography.Paragraph>
+
+        {(phase === "pick" || phase === "uploading") && (
+          <>
+            <Upload.Dragger
+              multiple={false}
+              maxCount={1}
+              accept=".tar,.zst,.tar.zst"
+              beforeUpload={(f) => {
+                setFile(f);
+                return false;
+              }}
+              onRemove={() => setFile(null)}
+              disabled={phase === "uploading"}
+            >
+              <p className="ant-upload-drag-icon">
+                <InboxOutlined />
+              </p>
+              <p className="ant-upload-text">Click or drag the full-server .tar here</p>
+            </Upload.Dragger>
+            {phase === "uploading" && <Progress percent={pct} status="active" />}
+            <Button type="primary" disabled={!file || phase === "uploading"} loading={phase === "uploading"} onClick={startUpload}>
+              Upload &amp; inspect
+            </Button>
+          </>
+        )}
+
+        {phase === "inspecting" && <Progress percent={100} status="active" />}
+
+        {info && (phase === "ready" || phase === "applying" || phase === "done") && (
+          <>
+            <Alert
+              type="success"
+              showIcon
+              message={`Full server backup — ${info.users.length} user(s)`}
+              description={info.has_system ? "Includes a system backup (restored via the CLI, not here)." : undefined}
+            />
+            <div>
+              <Typography.Text strong>Restore these users</Typography.Text>
+              <Checkbox.Group
+                value={users}
+                onChange={(v) => setUsers(v as string[])}
+                style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 4 }}
+                options={info.users.map((u) => ({ label: u, value: u }))}
+              />
+            </div>
+            <Alert
+              type="warning"
+              showIcon
+              message="This overwrites the selected users' data"
+              description="Each selected account's home directory and databases are replaced with the backup. This cannot be undone. Restore into users with the same names as in the backup."
+            />
+            {phase === "applying" && (
+              <Alert
+                type="info"
+                showIcon
+                message="Restoring in the background"
+                description="Restoring each account can take a while. Keep this drawer open to see the result."
+              />
+            )}
+            {phase !== "done" && (
+              <Button
+                type="primary"
+                danger
+                loading={phase === "applying"}
+                disabled={phase === "applying" || users.length === 0}
+                onClick={apply}
+              >
+                {phase === "applying" ? "Restoring…" : `Restore ${users.length} user(s)`}
+              </Button>
+            )}
+          </>
+        )}
+
+        {result && phase === "done" && (
+          <Alert
+            type="success"
+            showIcon
+            message="Restore result"
+            description={
+              <Space direction="vertical" size={2}>
+                {(result.packed ?? []).map((p, i) => (
+                  <span key={i}>{p}</span>
+                ))}
+                {(result.skipped ?? []).length > 0 && (
+                  <Typography.Text type="secondary">
+                    Skipped: {result.skipped?.join(", ")}
+                  </Typography.Text>
+                )}
+                <Button size="small" onClick={reset} style={{ marginTop: 8 }}>
+                  Restore another
+                </Button>
+              </Space>
+            }
+          />
+        )}
+      </Space>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
**Phase 2** completes the Full Server backup: upload the one-file container from phase 1's **Package & download** (#1450) and restore the accounts it holds — the whole-server DR / migration workflow the reporter asked for.

The container is a plain tar of `manifest.json` + `system.tar.zst` + `users/<username>.tar.zst`, each inner **byte-identical to a per-account backup**. So restore = extract the outer container, then feed each selected inner tar through the **same per-account restore engine**.

## Agent
- Factored `backup.restore_from_tar`'s core into `restoreAccountFromTar` (the handler is now a thin wrapper) so the container restore reuses it **verbatim** — same hardened extractor, same `applyAccountRestore`.
- `safeExtractPlainTar` / `readFileFromPlainTar`: the container is uncompressed (inners already zstd), extracted through the **same allowlist** as the zstd path.
- `system.fullbackup.inspect_uploaded` reads the container manifest (no full extract) → `run_id` + users + `has_system`. `system.fullbackup.restore_uploaded` extracts the container under the uploads root, then loops `restoreAccountFromTar` for each **selected** user. **Double-untrusted-safe** (outer container + each inner tar). **System restore is not applied here** — it changes server config and stays a manual/CLI, step-up-worthy op.

## Panel (admin)
Reuses the chunked upload; new inspect + **detached** apply (202 + status poll) + status endpoints.

## UI
A **"Restore Full Server"** drawer — upload the container, pick which users, watch it run in the background, see per-user results.

## Verification
- Unit: plain-tar extract + manifest read (in-memory container).
- **Box-drilled** on .60: pack a real 2-job container → inspect returns the right users → restore with a **no-match selection** extracts + parses + skips both with **nothing applied** (safe on the shared box). The per-user apply is the already-drilled restore engine (recon + apply drilled in #1445).
- `go vet` + `tsc` clean; agent (incl. exec-seam) + panel-api suites green.

With phase 1 (#1450) this delivers the full workflow: **Package & download → move → upload → restore selected accounts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)