### PR TITLE
fix(postgres): a db-user granted to a database gets usable schema access (GH #1406)

### DIFF
--- a/panel-agent/internal/commands/db_postgres.go
+++ b/panel-agent/internal/commands/db_postgres.go
@@ -178,11 +178,44 @@ func dbPgGrantHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	if !pgValidIdent(p.DBName) || !pgValidIdent(p.Role) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid name"}
 	}
+	// Database-level grant (CONNECT/CREATE/TEMP) — run against the maintenance DB.
 	sql := fmt.Sprintf(`GRANT ALL PRIVILEGES ON DATABASE "%s" TO "%s"`, p.DBName, p.Role)
 	if err := pgRunSQL(ctx, sql); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "grant: " + err.Error()}
 	}
+	// GH #1406: DATABASE-level alone is NOT usable — a Jabali PG database is owned
+	// by postgres, and since PG15 revoked the default PUBLIC CREATE on `public`,
+	// a "Full Access" db-user still gets "permission denied for schema public".
+	// Grant the role full schema-level access on the target DB too (schema grants
+	// only affect the connected DB, so this runs with -d <db>): CREATE+USAGE on
+	// public, ALL on existing tables/sequences (postgres-owned + others), and
+	// default privileges so future objects stay accessible. Same as the pgadmin
+	// shadow fix (db.postgres.shadowadmin.grant_schema).
+	role := `"` + strings.ReplaceAll(p.Role, `"`, `""`) + `"`
+	schemaSQL := strings.Join([]string{
+		"GRANT ALL ON SCHEMA public TO " + role,
+		"GRANT ALL ON ALL TABLES IN SCHEMA public TO " + role,
+		"GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO " + role,
+		"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO " + role,
+		"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO " + role,
+	}, "; ") + ";"
+	if err := pgRunSQLOnDB(ctx, p.DBName, schemaSQL); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "grant schema: " + err.Error()}
+	}
 	return dbPgCreateResponse{OK: true}, nil
+}
+
+// pgRunSQLOnDB runs SQL against a SPECIFIC database (schema/object grants only
+// affect the connected DB). dbName is pgValidIdent-checked by the caller and
+// passed via -d, never interpolated into SQL.
+func pgRunSQLOnDB(ctx context.Context, dbName, sql string) error {
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
+		"-v", "ON_ERROR_STOP=1", "-XAtq", "-d", dbName, "-c", sql)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("psql -d %s: %w (%s)", dbName, err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 // ---- db.postgres.revoke ----


### PR DESCRIPTION
@lxsdevcode confirmed the earlier three fixes work, then found the **same class of bug for regular db-users**: assigning a PostgreSQL user to a database with **Full Access** shows Full Access in the panel, but the role can't actually use the database — `permission denied for schema public` on CREATE, `permission denied for table` on reads.

## Cause
`db.postgres.grant` did only `GRANT ALL PRIVILEGES ON DATABASE` (CONNECT / CREATE-schema). A Jabali PG database is owned by `postgres`, and since PostgreSQL 15 revoked the default `PUBLIC CREATE` on `public`, database-level access alone is unusable — the exact gap already fixed for the Adminer shadow role (#1446), now closed for **db-users** too.

## Fix
After the database-level grant, `db.postgres.grant` also grants the role **full schema-level access on the target database** (schema grants are per-DB, so it connects with `-d <db>`): `ALL ON SCHEMA public`, `ALL` on existing tables/sequences, and default privileges for future objects. Every PG grant path shares this verb, so re-assigning a user re-applies it.

## Verified
Box-drilled on the test box's live PostgreSQL: before the grant the role can neither create in `public` nor read existing tables; **after**, it can create, insert, and read (returned the inserted row).

Note: the panel's PostgreSQL grant is full-access (it doesn't pass a granular level to the agent); read-only / granular PG privileges would be a separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)