### PR TITLE
fix(files): File Manager uploads must not hit the 15s client timeout (GH #1410)

### DIFF
--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -16,11 +16,13 @@ const API_BASE = "/api/v1";
 export const apiClient = axios.create({
   baseURL: API_BASE,
   withCredentials: true, // send the Kratos session cookie
-  // 15s hard ceiling — without a timeout, any network hang (proxy, dropped
-  // connection, Firefox's Opaque-Response-Blocking cache caught mid-flight)
-  // freezes <Authenticated>'s check() indefinitely and the SPA renders
-  // blank. Anything legitimate on this API completes in <1s.
-  timeout: 15000,
+  // Default network-hang guard so a dropped proxy/connection can't freeze
+  // <Authenticated>'s check() forever and blank the SPA. GH #1410: 15s was too
+  // tight — synchronous agent operations (adding a domain, etc.) legitimately
+  // run longer and were failing with "timeout of 15000ms exceeded". 60s keeps
+  // the guard while covering those; genuinely long-running work (uploads,
+  // restores) opts out per-request with `timeout: 0` and its own progress/poll.
+  timeout: 60000,
 });
 
 // ADR-0128 — inject the admin act-as grant id on every request when one is

--- a/panel-ui/src/shells/user/files/filesApi.ts
+++ b/panel-ui/src/shells/user/files/filesApi.ts
@@ -90,6 +90,10 @@ export async function filesUpload(
   if (opts?.name) q.set("name", opts.name);
   await apiClient.post(`${base}/upload?${q.toString()}`, fd, {
     headers: { "Content-Type": "multipart/form-data" },
+    // GH #1410: an upload is bounded by its own progress, not the client's
+    // default request timeout — a large file (or a slow uplink) legitimately
+    // takes longer than 60s and was failing with "timeout of 15000ms exceeded".
+    timeout: 0,
     onUploadProgress: (e) => {
       if (!onProgress) return;
       const total = e.total ?? file.size;
@@ -111,7 +115,10 @@ export async function filesUpload(
 export async function filesUploadChunked(
   dirPath: string,
   file: File,
-  chunkSize = 10 * 1024 * 1024,
+  // GH #1410: 25 MB chunks (was 10) — a quarter the requests for a big upload,
+  // still well under the ~100 MB proxy/Cloudflare request cap chunking exists to
+  // dodge. Each chunk opts out of the client timeout (progress-bounded).
+  chunkSize = 25 * 1024 * 1024,
   onProgress?: (frac: number) => void,
   opts?: UploadOpts,
   base = "/files",
@@ -163,6 +170,7 @@ export async function filesUploadChunked(
     });
     await apiClient.post(`${base}/upload-chunk?${params.toString()}`, blob, {
       headers: { "Content-Type": "application/octet-stream" },
+      timeout: 0, // GH #1410: a slow chunk mustn't hit the client request timeout
     });
     if (onProgress) onProgress((i + 1) / totalChunks);
   }

--- a/panel-ui/src/shells/user/files/filesUploadTimeout.test.ts
+++ b/panel-ui/src/shells/user/files/filesUploadTimeout.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+import { filesUpload } from "./filesApi";
+
+const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+// GH #1410: File Manager uploads must opt OUT of the client's default request
+// timeout — a large file / slow uplink legitimately runs past it. Progress
+// bounds the upload, not a fixed timeout.
+describe("File Manager upload timeout (GH #1410)", () => {
+  beforeEach(() => mocked.post.mockReset().mockResolvedValue({ data: {} }));
+
+  it("single upload sends timeout: 0", async () => {
+    const f = new File(["x"], "a.txt");
+    await filesUpload("/home/u", f);
+    const opts = mocked.post.mock.calls[0]?.[2] as { timeout?: number };
+    expect(opts?.timeout).toBe(0);
+  });
+});


### PR DESCRIPTION
@lxsdevcode hit `timeout of 15000ms exceeded` across the panel — multi-file uploads, extracting a large ZIP, and adding a domain — and correctly guessed a **global 15s request timeout**.

## Root cause
The axios client's default `timeout: 15000`. Any legitimately-longer operation that doesn't opt out fails at 15 seconds. A 30×5 MB folder upload on a slow uplink, a big direct upload, or a synchronous domain-create all trip it.

## Fixes
- **Global default 15s → 60s.** Synchronous agent operations (adding a domain, etc.) legitimately run past 15s. Still a hang guard so a dropped proxy can't freeze the auth check and blank the SPA; long-running work opts out per-request.
- **File Manager uploads (single + chunked) send `timeout: 0`** — an upload is bounded by its own **progress**, not a fixed request timeout, so a large file / slow uplink no longer fails mid-upload. Matches the DB restore-chunk upload.
- **Chunk size 10 MB → 25 MB** — a quarter the requests for a big upload, still well under the ~100 MB proxy/Cloudflare cap chunking exists to dodge (addresses the "far too many requests").

## On the other points
- **Extract timeout** — extraction already runs as a **background job with polling** (GH #1392), so it no longer depends on a single 15s request; that lands on your next update.
- **Upload progress / cancel** — the upload drawer already shows per-file progress; a cancel control and the "direct upload over server IP vs chunked over a domain" mode are reasonable follow-ups (the timeout + bigger chunk fixes remove most of the pain now).

tsc + File Manager vitest green; a new test pins uploads to `timeout: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)