### PR TITLE
feat(security): CrowdSec 1.8 AppSec bot detection (per-server, default OFF)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9865,6 +9865,16 @@ install_crowdsec_appsec() {
     _warn "appsec config not present yet (binary not built — fresh install); skipping AppSec acquis. 'jabali update' will wire it after the build."
     rm -f "$acquis_file"   # drop any stale acquis from a prior partial run
   else
+  # AppSec bot detection (CrowdSec 1.8) composes extra appsec-configs into
+  # this acquis via the plural `appsec_configs:` key — written by the agent
+  # (security.crowdsec.appsec.botdetection.set) and owned by it while on. The
+  # singular heredoc below would clobber that composition back to OFF on every
+  # `jabali update`, silently disabling bot detection. So leave the acquis
+  # untouched whenever it is already in the plural (bot-detection-on) form;
+  # the agent rewrites it to the singular form when the operator turns it off.
+  if [[ -f "$acquis_file" ]] && grep -qE '^appsec_configs:' "$acquis_file"; then
+    _log "AppSec acquis is in bot-detection composition mode (agent-managed) — leaving it intact"
+  else
   local desired_acquis=$'# Managed by jabali install.sh — M27 AppSec geoblock.\n# TCP loopback listener. crowdsec-nginx-bouncer dials this via\n# APPSEC_URL=http://127.0.0.1:7422. Not exposed outside the host.\nappsec_config: crowdsecurity/jabali-appsec\nlabels:\n  type: appsec\nlisten_addr: 127.0.0.1:7422\nsource: appsec\n'
   if [[ ! -f "$acquis_file" ]] || ! cmp -s <(printf '%s' "$desired_acquis") "$acquis_file"; then
     _log "writing $acquis_file"
@@ -9873,6 +9883,7 @@ install_crowdsec_appsec() {
     printf '%s' "$desired_acquis" >"$tmp"
     install -m 0644 -o root -g root "$tmp" "$acquis_file"
     rm -f "$tmp"
+  fi
   fi
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -10078,7 +10078,19 @@ install_crowdsec_nginx_bouncer() {
     _spin "apt install crowdsec-nginx-bouncer" \
       apt-get install -y -qq --no-install-recommends crowdsec-nginx-bouncer
   else
-    _log "crowdsec-nginx-bouncer already installed"
+    # Install-only-if-absent freezes existing boxes at whatever bouncer
+    # version first landed (the Adminer-freeze shape,
+    # feedback_install_download_gate_freezes_version). AppSec bot detection
+    # (CrowdSec 1.8) needs the challenge remediation, which the bouncer only
+    # learned to serve in 1.2.x (challenge.lua) — so a fleet box stuck on
+    # 1.1.6 could never enforce it. Pull the packagecloud candidate on every
+    # run. --only-upgrade is a no-op when already current; confold keeps our
+    # managed conf (the jabali-nginx key + APPSEC_URL below are rewritten
+    # regardless), and the new documented default lands as .dpkg-dist.
+    _spin "apt upgrade crowdsec-nginx-bouncer (packagecloud candidate)" \
+      apt-get install -y -qq --only-upgrade \
+        -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef \
+        crowdsec-nginx-bouncer
   fi
 
   local bouncer_conf="/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf"

--- a/install.sh
+++ b/install.sh
@@ -9861,19 +9861,21 @@ install_crowdsec_appsec() {
   local acquis_dir="/etc/crowdsec/acquis.d"
   install -d -m 0755 "$acquis_dir"
   local acquis_file="$acquis_dir/jabali-appsec.yaml"
-  if [[ ! -f "$_appsec_cfg" ]]; then
-    _warn "appsec config not present yet (binary not built — fresh install); skipping AppSec acquis. 'jabali update' will wire it after the build."
-    rm -f "$acquis_file"   # drop any stale acquis from a prior partial run
-  else
   # AppSec bot detection (CrowdSec 1.8) composes extra appsec-configs into
   # this acquis via the plural `appsec_configs:` key — written by the agent
-  # (security.crowdsec.appsec.botdetection.set) and owned by it while on. The
-  # singular heredoc below would clobber that composition back to OFF on every
-  # `jabali update`, silently disabling bot detection. So leave the acquis
-  # untouched whenever it is already in the plural (bot-detection-on) form;
-  # the agent rewrites it to the singular form when the operator turns it off.
+  # (security.crowdsec.appsec.botdetection.set) and owned by it while on.
+  # This plural-check MUST come first — before both the singular heredoc AND
+  # the fresh-install `rm -f` below. The singular heredoc would clobber the
+  # composition back to OFF on every `jabali update`; the `rm -f` (reachable
+  # via `jabali repair` / a half-failed update / a hand-deleted config) would
+  # delete the acquis entirely, leaving a bot-on box with NO AppSec listener
+  # after the next crowdsec restart. So on a plural acquis: touch nothing. The
+  # agent rewrites it to the singular form when the operator turns it off.
   if [[ -f "$acquis_file" ]] && grep -qE '^appsec_configs:' "$acquis_file"; then
     _log "AppSec acquis is in bot-detection composition mode (agent-managed) — leaving it intact"
+  elif [[ ! -f "$_appsec_cfg" ]]; then
+    _warn "appsec config not present yet (binary not built — fresh install); skipping AppSec acquis. 'jabali update' will wire it after the build."
+    rm -f "$acquis_file"   # drop any stale singular acquis from a prior partial run
   else
   local desired_acquis=$'# Managed by jabali install.sh — M27 AppSec geoblock.\n# TCP loopback listener. crowdsec-nginx-bouncer dials this via\n# APPSEC_URL=http://127.0.0.1:7422. Not exposed outside the host.\nappsec_config: crowdsecurity/jabali-appsec\nlabels:\n  type: appsec\nlisten_addr: 127.0.0.1:7422\nsource: appsec\n'
   if [[ ! -f "$acquis_file" ]] || ! cmp -s <(printf '%s' "$desired_acquis") "$acquis_file"; then
@@ -9883,7 +9885,6 @@ install_crowdsec_appsec() {
     printf '%s' "$desired_acquis" >"$tmp"
     install -m 0644 -o root -g root "$tmp" "$acquis_file"
     rm -f "$tmp"
-  fi
   fi
   fi
 

--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -46,6 +46,50 @@ type Opts struct {
 	// startsWith "mail."` is bypassable via arbitrary Host headers
 	// reaching the default_server (which serves phpMyAdmin).
 	WebmailHosts []string
+	// BotDetection selects AppSec bot-detection / challenge mode (CrowdSec
+	// 1.8): "off" (default), "balanced" (reject fingerprint score >= 75) or
+	// "permissive" (>= 100). It changes nothing in the jabali-appsec config
+	// itself — it drives RenderAcquis (which composes the bot-challenge
+	// configs via appsec_configs) and RenderBotExempt.
+	//
+	// SAFETY: emitting bot-challenge config on an engine < 1.8 FATALs
+	// crowdsec (unknown appsec funcs) → AppSec AND all scenario enforcement
+	// go down (fail-open). Callers MUST version-gate (engine >= 1.8, bouncer
+	// >= 1.2.2) BEFORE turning this on, and validate the config before reload.
+	BotDetection string
+	// BotConfigs is the enabled bot-challenge appsec-CONFIG names the caller
+	// discovered from cscli after installing the collection (e.g.
+	// crowdsecurity/appsec-bot-challenge-scoring, -scoring-balanced,
+	// -exclude-api, ...). The leaf set is version-dependent, so — like Inband
+	// — it is a parameter, not hardcoded. Consumed only by RenderAcquis, and
+	// only when BotDetection != "off". A collection NAME here would FATAL the
+	// engine ("no appsec-config found"); pass leaf CONFIG names only.
+	BotConfigs []string
+}
+
+// AppsecListenAddr is the TCP loopback the AppSec engine listens on; the
+// crowdsec-nginx-bouncer dials it via APPSEC_URL=http://127.0.0.1:7422.
+const AppsecListenAddr = "127.0.0.1:7422"
+
+// JabaliAppsecConfigName / JabaliBotExemptConfigName are the appsec-config
+// `name:` values the acquisition references. The exempt config is composed
+// into the acquis (alongside the upstream bot-challenge configs) only when
+// bot detection is on.
+const (
+	JabaliAppsecConfigName    = "crowdsecurity/jabali-appsec"
+	JabaliBotExemptConfigName = "crowdsecurity/jabali-bot-exempt"
+)
+
+// botDetectionMode normalises Opts.BotDetection to one of the three valid
+// values, defaulting anything unknown to "off" (fail-safe: an unrecognised
+// mode never composes bot-challenge config into the acquis).
+func botDetectionMode(o Opts) string {
+	switch o.BotDetection {
+	case "balanced", "permissive":
+		return o.BotDetection
+	default:
+		return "off"
+	}
 }
 
 // allowExpr/denyExpr reproduce panel-agent renderAppSecGeoblockRule
@@ -324,7 +368,12 @@ func Render(o Opts) string {
 	b.WriteString("# POST /api/v1/admin/security/crowdsec/appsec/geoblock.\n")
 	b.WriteString("# jabali-mode: " + mode + "\n")
 	b.WriteString("# jabali-countries: " + csv + "\n")
-	b.WriteString("name: crowdsecurity/jabali-appsec\n")
+	// Round-trips the bot-detection mode so --reconcile preserves the
+	// operator's choice (same mechanism as jabali-mode/jabali-countries).
+	// This config is unchanged by the mode — bot-challenge composition lives
+	// in RenderAcquis + RenderBotExempt — but the header is the state anchor.
+	b.WriteString("# jabali-bot-detection: " + botDetectionMode(o) + "\n")
+	b.WriteString("name: " + JabaliAppsecConfigName + "\n")
 	b.WriteString("default_remediation: ban\n")
 
 	// GH #1044: the CrowdSec AppSec engine drops any request whose body
@@ -439,5 +488,109 @@ func Render(o Opts) string {
     - DropRequest("Forbidden Country (jabali deny-list)")
 `)
 	}
+	return b.String()
+}
+
+// RenderBotExempt returns the crowdsecurity/jabali-bot-exempt appsec-config:
+// the pre_eval ExemptFromChallenge twins of the jabali-appsec on_match
+// allowlist. The upstream appsec-bot-challenge scoring config calls
+// SendChallenge() in pre_eval on EVERY request, so anything that cannot
+// solve a JS / proof-of-work challenge must be exempted here or it breaks:
+//
+//   - /.well-known/acme-challenge/ — Let's Encrypt HTTP-01 validators can't
+//     run JS. Omitting this fails cert renewals SILENTLY; certs expire weeks
+//     later. Exempt on EVERY host (every tenant domain renews).
+//   - /api/v1/ + /.ory/ — the SPA control plane and the Kratos login/session
+//     XHR. Challenging these breaks panel login and every authed API call.
+//   - /phpmyadmin/, /jabali-adminer/, /dav/ — SSO/auth_request-gated tools and
+//     WebDAV clients that are not browsers and can't solve a challenge.
+//   - webmail vhosts — Bulwark/Stalwart JMAP is not browser traffic (M6.6:
+//     challenging it re-breaks webmail SSO).
+//
+// The exempt config is composed into the acquis ONLY when bot detection is on
+// (RenderAcquis), so it never loads on an engine that lacks ExemptFromChallenge.
+// This is a SEPARATE config (not folded into jabali-appsec) so the jabali-appsec
+// schema stays engine-version-agnostic — it must keep loading on fleet boxes
+// still on CrowdSec 1.7.x.
+func RenderBotExempt(o Opts) string {
+	var b strings.Builder
+	b.WriteString("# Managed by jabali — AppSec bot-detection challenge exemptions.\n")
+	b.WriteString("# DO NOT hand-edit. Written by `jabali appsec render-config`.\n")
+	b.WriteString("# Twins of the jabali-appsec on_match allowlist: SendChallenge runs in\n")
+	b.WriteString("# pre_eval on every request, so clients that cannot solve a challenge\n")
+	b.WriteString("# (ACME HTTP-01, panel API + login, DB tools, WebDAV, webmail JMAP) are\n")
+	b.WriteString("# exempted here. Composed into the AppSec acquis only when bot detection\n")
+	b.WriteString("# is on (RenderAcquis).\n")
+	b.WriteString("name: " + JabaliBotExemptConfigName + "\n")
+	b.WriteString("inband:\n")
+	b.WriteString("  pre_eval:\n")
+
+	// ACME HTTP-01 — ALWAYS exempt, on every host. Highest-severity miss if
+	// omitted: silent cert-renewal failure.
+	b.WriteString(`    - filter: req.URL.Path startsWith "/.well-known/acme-challenge/"` + "\n")
+	b.WriteString("      apply:\n")
+	b.WriteString(`        - ExemptFromChallenge("jabali-acme-http01")` + "\n")
+
+	// Panel-owned paths — twins of the ADR-0102 on_match allowlist, scoped to
+	// the panel host (when known) exactly like that allowlist, so a tenant
+	// vhost serving the same paths is still challenge-eligible. req.Host is a
+	// client-controlled header → equality, never a prefix.
+	pathExpr := `req.URL.Path startsWith "/api/v1/" || req.URL.Path startsWith "/.ory/" || req.URL.Path startsWith "/phpmyadmin/" || req.URL.Path startsWith "/jabali-adminer/" || req.URL.Path startsWith "/dav/"`
+	if o.PanelHost != "" {
+		pathExpr = "(" + pathExpr + `) && req.Host == "` + o.PanelHost + `"`
+	}
+	b.WriteString("    - filter: " + pathExpr + "\n")
+	b.WriteString("      apply:\n")
+	b.WriteString(`        - ExemptFromChallenge("jabali-panel-paths")` + "\n")
+
+	// Webmail vhosts — explicit host equality (same managed source + sanitiser
+	// as the on_match webmail allowlist).
+	hosts := sanitizeWebmailHosts(o.WebmailHosts)
+	if len(hosts) > 0 {
+		parts := make([]string, len(hosts))
+		for i, h := range hosts {
+			parts[i] = `req.Host == "` + h + `"`
+		}
+		b.WriteString("    - filter: " + strings.Join(parts, " || ") + "\n")
+		b.WriteString("      apply:\n")
+		b.WriteString(`        - ExemptFromChallenge("jabali-webmail")` + "\n")
+	}
+	return b.String()
+}
+
+// RenderAcquis returns the AppSec acquisition file body (the datasource that
+// binds the AppSec engine to AppsecListenAddr). It is single-sourced here so
+// install.sh and the agent can't drift (the same reason Render exists) — both
+// write it via `jabali appsec render-config`.
+//
+// Off (default): the singular `appsec_config: crowdsecurity/jabali-appsec`,
+// exactly the pre-1.8 shape. On: the CrowdSec 1.8 plural `appsec_configs:`
+// list composing jabali-appsec + jabali-bot-exempt + the caller-discovered
+// bot-challenge leaf configs. BotConfigs is sorted for deterministic,
+// write-on-diff-stable output. If BotConfigs is empty the acquis stays in the
+// singular form even when the mode is set — nothing to compose, so we never
+// emit a plural list that references no bot config.
+func RenderAcquis(o Opts) string {
+	var b strings.Builder
+	b.WriteString("# Managed by jabali — AppSec acquisition (crowdsec-nginx-bouncer dials\n")
+	b.WriteString("# APPSEC_URL=http://" + AppsecListenAddr + "). Written by\n")
+	b.WriteString("# `jabali appsec render-config`; do not hand-edit.\n")
+
+	if botDetectionMode(o) != "off" && len(o.BotConfigs) > 0 {
+		cfgs := append([]string(nil), o.BotConfigs...)
+		sort.Strings(cfgs)
+		b.WriteString("appsec_configs:\n")
+		b.WriteString(" - " + JabaliAppsecConfigName + "\n")
+		b.WriteString(" - " + JabaliBotExemptConfigName + "\n")
+		for _, c := range cfgs {
+			b.WriteString(" - " + c + "\n")
+		}
+	} else {
+		b.WriteString("appsec_config: " + JabaliAppsecConfigName + "\n")
+	}
+	b.WriteString("labels:\n")
+	b.WriteString("  type: appsec\n")
+	b.WriteString("listen_addr: " + AppsecListenAddr + "\n")
+	b.WriteString("source: appsec\n")
 	return b.String()
 }

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -149,6 +149,93 @@ func TestRender_GeoExprAgentParity(t *testing.T) {
 	mustContain(t, d2, `in ["RU"]`, "deny + N")
 }
 
+// CrowdSec 1.8 AppSec bot detection (per-server, default OFF).
+
+func TestRender_BotDetectionHeaderRoundTrips(t *testing.T) {
+	off := Render(Opts{Mode: "off", Inband: []string{"x"}})
+	mustContain(t, off, "# jabali-bot-detection: off", "default off header")
+	// jabali-appsec itself must stay engine-version-agnostic: NONE of the 1.8
+	// challenge funcs may leak into it (it must keep loading on CrowdSec 1.7.x).
+	mustNotContain(t, off, "ExemptFromChallenge", "no challenge funcs in jabali-appsec")
+	mustNotContain(t, off, "SendChallenge", "no challenge funcs in jabali-appsec")
+
+	bal := Render(Opts{Mode: "off", Inband: []string{"x"}, BotDetection: "balanced"})
+	mustContain(t, bal, "# jabali-bot-detection: balanced", "balanced header")
+	mustNotContain(t, bal, "ExemptFromChallenge", "exemptions live in RenderBotExempt, never in jabali-appsec")
+
+	// Unknown mode fails safe to off.
+	weird := Render(Opts{Mode: "off", Inband: []string{"x"}, BotDetection: "aggressive"})
+	mustContain(t, weird, "# jabali-bot-detection: off", "unknown mode → off")
+}
+
+func TestRenderAcquis_OffSingular(t *testing.T) {
+	out := RenderAcquis(Opts{})
+	mustContain(t, out, "appsec_config: crowdsecurity/jabali-appsec\n", "singular form when off")
+	mustNotContain(t, out, "appsec_configs:", "no plural list when off")
+	mustContain(t, out, "listen_addr: 127.0.0.1:7422\n", "listener addr")
+	mustContain(t, out, "source: appsec\n", "appsec source")
+}
+
+func TestRenderAcquis_OnComposesSortedLeafConfigs(t *testing.T) {
+	out := RenderAcquis(Opts{
+		BotDetection: "balanced",
+		BotConfigs: []string{
+			"crowdsecurity/appsec-bot-challenge-scoring",
+			"crowdsecurity/appsec-bot-challenge-scoring-balanced",
+			"crowdsecurity/appsec-bot-challenge-exclude-api",
+		},
+	})
+	mustContain(t, out, "appsec_configs:\n", "plural composition form")
+	mustNotContain(t, out, "appsec_config: crowdsecurity", "must not also emit the singular key")
+	// jabali-appsec + jabali-bot-exempt lead, then the sorted leaf configs.
+	mustContain(t, out, ` - crowdsecurity/jabali-appsec
+ - crowdsecurity/jabali-bot-exempt
+ - crowdsecurity/appsec-bot-challenge-exclude-api
+ - crowdsecurity/appsec-bot-challenge-scoring
+ - crowdsecurity/appsec-bot-challenge-scoring-balanced
+`, "ordered: jabali configs first, then sorted leaf configs")
+}
+
+func TestRenderAcquis_ModeOnButNoConfigsStaysSingular(t *testing.T) {
+	// Belt: a mode with no discovered leaf configs must NOT emit a plural list
+	// referencing nothing (which would be a pointless/needless composition).
+	out := RenderAcquis(Opts{BotDetection: "balanced"})
+	mustContain(t, out, "appsec_config: crowdsecurity/jabali-appsec\n", "singular when no BotConfigs")
+	mustNotContain(t, out, "appsec_configs:", "no empty plural list")
+}
+
+func TestRenderBotExempt_AlwaysExemptsAcme(t *testing.T) {
+	out := RenderBotExempt(Opts{})
+	mustContain(t, out, "name: crowdsecurity/jabali-bot-exempt", "config name")
+	mustContain(t, out, "inband:\n  pre_eval:\n", "inband pre_eval hook (matches upstream exclude configs)")
+	// ACME is the highest-severity exemption: unconditional, every host.
+	mustContain(t, out, `- filter: req.URL.Path startsWith "/.well-known/acme-challenge/"`, "acme exempt filter")
+	mustContain(t, out, `ExemptFromChallenge("jabali-acme-http01")`, "acme exempt action")
+	// Panel + login + tools paths, incl. Kratos /.ory/ (the M6.6/login twin).
+	mustContain(t, out, `startsWith "/api/v1/"`, "panel api exempt")
+	mustContain(t, out, `startsWith "/.ory/"`, "kratos login exempt")
+	mustContain(t, out, `startsWith "/dav/"`, "webdav exempt")
+	mustContain(t, out, `ExemptFromChallenge("jabali-panel-paths")`, "panel paths exempt action")
+}
+
+func TestRenderBotExempt_PanelHostScopesPanelPathsButNotAcme(t *testing.T) {
+	out := RenderBotExempt(Opts{PanelHost: "panel.example.com"})
+	// Panel paths get host-scoped exactly like the on_match allowlist.
+	mustContain(t, out, `) && req.Host == "panel.example.com"`, "panel paths scoped to panel host")
+	// ...but ACME is NOT host-scoped (every tenant domain renews certs).
+	acmeLine := `    - filter: req.URL.Path startsWith "/.well-known/acme-challenge/"` + "\n"
+	if !strings.Contains(out, acmeLine) {
+		t.Fatalf("acme exemption must stay host-agnostic; got:\n%s", out)
+	}
+}
+
+func TestRenderBotExempt_WebmailHostEqualityNeverPrefix(t *testing.T) {
+	out := RenderBotExempt(Opts{WebmailHosts: []string{"Mail.Foo.com", "mail.foo.com", "mail.bar.com"}})
+	mustContain(t, out, `req.Host == "mail.bar.com" || req.Host == "mail.foo.com"`, "sorted, deduped host equality")
+	mustContain(t, out, `ExemptFromChallenge("jabali-webmail")`, "webmail exempt action")
+	mustNotContain(t, out, `startsWith "mail."`, "never a client-controlled Host prefix")
+}
+
 func TestSanitizeWebmailHosts(t *testing.T) {
 	in := []string{
 		"  Mail.Example.Com  ",

--- a/panel-agent/internal/commands/security_crowdsec.go
+++ b/panel-agent/internal/commands/security_crowdsec.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/appseccfg"
 )
 
 // M26 Step 2 (ADR-0053). CrowdSec LAPI surface for the admin Security
@@ -1003,19 +1002,9 @@ func renderAppSecGeoblockRule(mode string, countries []string) string {
 	// allowlist that the panel last wrote. Missing file → nil → no
 	// webmail filter; the panel reconciler writes it within ~60s
 	// of email_enabled changing, so any gap is brief.
-	webmailHosts, _ := appseccfg.LoadWebmailHosts(appseccfg.WebmailHostsPath)
-	return appseccfg.Render(appseccfg.Opts{
-		Mode:      mode,
-		Countries: countries,
-		Inband: []string{
-			"crowdsecurity/base-config",
-			"crowdsecurity/vpatch-*",
-			"crowdsecurity/generic-*",
-		},
-		AdminAllowlist: true,
-		PanelHost:      appsecPanelHost(),
-		WebmailHosts:   webmailHosts,
-	})
+	// Delegate to the shared renderer, preserving the current bot-detection
+	// header marker so toggling geoblock never resets it (and vice-versa).
+	return renderJabaliAppsec(mode, countries, readBotDetectionMode())
 }
 
 // ---- M27 Step 2: security.crowdsec.allowlists.{list,add,remove} -----------
@@ -2008,6 +1997,8 @@ func init() {
 	Default.Register("security.crowdsec.hub.remove", csHubRemoveHandler)
 	Default.Register("security.crowdsec.appsec.geoblock.get", csAppSecGeoblockGetHandler)
 	Default.Register("security.crowdsec.appsec.geoblock.set", csAppSecGeoblockSetHandler)
+	Default.Register("security.crowdsec.appsec.botdetection.get", csBotDetectionGetHandler)
+	Default.Register("security.crowdsec.appsec.botdetection.set", csBotDetectionSetHandler)
 	Default.Register("security.crowdsec.allowlists.list", csAllowlistsListHandler)
 	Default.Register("security.crowdsec.allowlists.add", csAllowlistsAddHandler)
 	Default.Register("security.crowdsec.allowlists.remove", csAllowlistsRemoveHandler)

--- a/panel-agent/internal/commands/security_crowdsec_botdetection.go
+++ b/panel-agent/internal/commands/security_crowdsec_botdetection.go
@@ -71,24 +71,54 @@ func botCollectionsForMode(mode string) []string {
 	}
 }
 
-// readBotDetectionMode parses the `# jabali-bot-detection:` marker written
-// into jabali-appsec.yaml. Missing file / marker → "off".
+// readBotDetectionMode reports the applied bot-detection mode. It prefers the
+// `# jabali-bot-detection:` marker in jabali-appsec.yaml, but falls back to
+// SNIFFING THE ACQUIS when the marker is missing or off — because the acquis
+// is the applied truth: a stale panel binary running the old `render-config`
+// rewrites jabali-appsec.yaml without the marker (the header ages out at the
+// deploy-panel-api-too boundary) while install.sh's plural-guard keeps the
+// composed acquis. Without the fallback the agent's readback would then lie
+// "off" while crowdsec is actively challenging. The threshold is recovered
+// from the scoring config the acquis lists.
 func readBotDetectionMode() string {
-	body, err := os.ReadFile(appsecRulePath)
+	if body, err := os.ReadFile(appsecRulePath); err == nil {
+		for _, line := range strings.Split(string(body), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "# jabali-bot-detection:") {
+				m := strings.TrimSpace(strings.TrimPrefix(line, "# jabali-bot-detection:"))
+				if _, ok := csBotDetectionModes[m]; ok && m != "off" {
+					return m
+				}
+				break // header present but off/unknown → sniff the acquis
+			}
+		}
+	}
+	return sniffBotModeFromAcquis()
+}
+
+// sniffBotModeFromAcquis derives the mode from the AppSec acquisition: a
+// plural `appsec_configs:` list means bot detection is on, and the presence
+// of the permissive scoring config distinguishes the threshold. Singular /
+// absent acquis → off.
+func sniffBotModeFromAcquis() string {
+	body, err := os.ReadFile(appsecAcquisPath)
 	if err != nil {
 		return "off"
 	}
-	for _, line := range strings.Split(string(body), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "# jabali-bot-detection:") {
-			m := strings.TrimSpace(strings.TrimPrefix(line, "# jabali-bot-detection:"))
-			if _, ok := csBotDetectionModes[m]; ok {
-				return m
-			}
-			return "off"
-		}
+	return botModeFromAcquisBody(string(body))
+}
+
+// botModeFromAcquisBody is the pure core of sniffBotModeFromAcquis: a plural
+// `appsec_configs:` list ⇒ on, and the permissive scoring config ⇒ the
+// permissive threshold. Singular / absent ⇒ off.
+func botModeFromAcquisBody(s string) string {
+	if !strings.Contains(s, "appsec_configs:") {
+		return "off"
 	}
-	return "off"
+	if strings.Contains(s, "scoring-permissive") {
+		return "permissive"
+	}
+	return "balanced"
 }
 
 // readGeoblockState parses the geoblock mode + countries back out of the

--- a/panel-agent/internal/commands/security_crowdsec_botdetection.go
+++ b/panel-agent/internal/commands/security_crowdsec_botdetection.go
@@ -1,0 +1,413 @@
+package commands
+
+// CrowdSec 1.8 AppSec bot detection (per-server, default OFF).
+//
+// The upstream crowdsecurity/appsec-bot-challenge collection scores each
+// request's fingerprint and, above a threshold, returns a `challenge`
+// remediation — a self-contained JS / proof-of-work interstitial the
+// crowdsec-nginx-bouncer (>= 1.2.2) serves. This handler composes those
+// configs into the AppSec acquisition alongside jabali-appsec, plus a
+// jabali-bot-exempt config that shields the things that CANNOT solve a
+// challenge (ACME HTTP-01, panel login/API, DB tools, WebDAV, webmail).
+//
+// Two hard-won operational facts (validated on the test box):
+//   - Composing bot-challenge config on a CrowdSec engine < 1.8 FATALs the
+//     process on start → AppSec AND all scenario enforcement go down
+//     (fail-open). So the ON path version-gates (engine >= 1.8, bouncer
+//     >= 1.2.x) and validates with `crowdsec -t` BEFORE touching the
+//     running service, rolling the files back if validation fails.
+//   - A change to the acquisition (adding/removing datasource configs) is
+//     NOT picked up by `systemctl reload` (SIGHUP re-reads rules, not
+//     acquisitions) — it needs a `restart`. Geoblock (which only changes
+//     appsec-config CONTENT) still uses reload; bot detection restarts.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/appseccfg"
+)
+
+const (
+	// botExemptConfigPath is the jabali-owned challenge-exemption config,
+	// composed into the acquis only while bot detection is on.
+	botExemptConfigPath = "/etc/crowdsec/appsec-configs/jabali-bot-exempt.yaml"
+	// appsecAcquisPath is the AppSec acquisition (the :7422 datasource).
+	// install.sh seeds it; this handler rewrites it to add/remove the
+	// bot-challenge composition.
+	appsecAcquisPath = "/etc/crowdsec/acquis.d/jabali-appsec.yaml"
+)
+
+// csBotDetectionModes is the closed enum shared by the UI, panel-api and
+// agent. "balanced" rejects at fingerprint score >= 75, "permissive" >= 100.
+var csBotDetectionModes = map[string]struct{}{
+	"off":        {},
+	"balanced":   {},
+	"permissive": {},
+}
+
+type csBotDetectionResponse struct {
+	Mode string `json:"mode"`
+}
+
+// botCollectionsForMode returns the hub collections to install for an ON
+// mode: the threshold collection plus the good-bot and path exemptions
+// (verified search engines / AI / social / monitoring, and crawler files /
+// static assets / API / feeds / webhooks).
+func botCollectionsForMode(mode string) []string {
+	threshold := "crowdsecurity/appsec-bot-challenge" // balanced
+	if mode == "permissive" {
+		threshold = "crowdsecurity/appsec-bot-challenge-permissive"
+	}
+	return []string{
+		threshold,
+		"crowdsecurity/appsec-bot-challenge-good-bots",
+		"crowdsecurity/appsec-bot-challenge-exclude-paths",
+	}
+}
+
+// readBotDetectionMode parses the `# jabali-bot-detection:` marker written
+// into jabali-appsec.yaml. Missing file / marker → "off".
+func readBotDetectionMode() string {
+	body, err := os.ReadFile(appsecRulePath)
+	if err != nil {
+		return "off"
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# jabali-bot-detection:") {
+			m := strings.TrimSpace(strings.TrimPrefix(line, "# jabali-bot-detection:"))
+			if _, ok := csBotDetectionModes[m]; ok {
+				return m
+			}
+			return "off"
+		}
+	}
+	return "off"
+}
+
+// readGeoblockState parses the geoblock mode + countries back out of the
+// jabali-appsec.yaml header so a bot-detection change re-renders the config
+// without wiping the operator's geoblock selection (and vice-versa).
+func readGeoblockState() (string, []string) {
+	mode := "off"
+	var countries []string
+	body, err := os.ReadFile(appsecRulePath)
+	if err != nil {
+		return mode, countries
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "# jabali-mode:"):
+			mode = strings.TrimSpace(strings.TrimPrefix(line, "# jabali-mode:"))
+		case strings.HasPrefix(line, "# jabali-countries:"):
+			csv := strings.TrimSpace(strings.TrimPrefix(line, "# jabali-countries:"))
+			if csv != "" {
+				countries = strings.Split(csv, ",")
+			}
+		}
+	}
+	if _, ok := csAppSecGeoblockModes[mode]; !ok {
+		mode = "off"
+	}
+	return mode, countries
+}
+
+// renderJabaliAppsec is the single call site for appseccfg.Render used by
+// both the geoblock and bot-detection handlers, so neither resets the
+// other's header marker. Webmail allowlist comes from the panel reconciler's
+// state file (missing → no webmail filter, the safe default).
+func renderJabaliAppsec(geoMode string, countries []string, botMode string) string {
+	webmailHosts, _ := appseccfg.LoadWebmailHosts(appseccfg.WebmailHostsPath)
+	return appseccfg.Render(appseccfg.Opts{
+		Mode:      geoMode,
+		Countries: countries,
+		Inband: []string{
+			"crowdsecurity/base-config",
+			"crowdsecurity/vpatch-*",
+			"crowdsecurity/generic-*",
+		},
+		AdminAllowlist: true,
+		PanelHost:      appsecPanelHost(),
+		WebmailHosts:   webmailHosts,
+		BotDetection:   botMode,
+	})
+}
+
+func csBotDetectionGetHandler(_ context.Context, _ json.RawMessage) (any, error) {
+	return csBotDetectionResponse{Mode: readBotDetectionMode()}, nil
+}
+
+func csBotDetectionSetHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p struct {
+		Mode string `json:"mode"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, csInvalidArg(fmt.Sprintf("parse params: %v", err))
+	}
+	if _, ok := csBotDetectionModes[p.Mode]; !ok {
+		return nil, csInvalidArg("mode must be off|balanced|permissive")
+	}
+	geoMode, countries := readGeoblockState()
+	if p.Mode == "off" {
+		return botDetectionApplyOff(ctx, geoMode, countries)
+	}
+	if err := requireBotDetectionSupport(ctx); err != nil {
+		return nil, err
+	}
+	return botDetectionApplyOn(ctx, p.Mode, geoMode, countries)
+}
+
+// botDetectionApplyOn installs the collections, composes the acquis, and
+// restarts — validating with `crowdsec -t` before the restart and rolling
+// the files back on failure so a bad config can never take AppSec down.
+func botDetectionApplyOn(ctx context.Context, mode, geoMode string, countries []string) (any, error) {
+	if err := installBotCollections(ctx, mode); err != nil {
+		return nil, err
+	}
+	leaves, err := enumerateBotChallengeConfigs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	leaves = filterThreshold(leaves, mode)
+	if len(leaves) == 0 {
+		return nil, csInternal("bot-challenge configs", fmt.Errorf("no appsec-bot-challenge configs found after install — hub fetch may have failed"))
+	}
+
+	if err := os.MkdirAll("/etc/crowdsec/appsec-configs", 0o755); err != nil {
+		return nil, csInternal("mkdir appsec-configs", err)
+	}
+	// Snapshot the files we are about to overwrite, for rollback.
+	prevAcquis, hadAcquis := readFileOK(appsecAcquisPath)
+	prevAppsec, hadAppsec := readFileOK(appsecRulePath)
+	_, hadExempt := readFileOK(botExemptConfigPath)
+
+	if err := writeAppsecFile(botExemptConfigPath, appseccfg.RenderBotExempt(botExemptOpts())); err != nil {
+		return nil, err
+	}
+	if err := writeAppsecFile(appsecRulePath, renderJabaliAppsec(geoMode, countries, mode)); err != nil {
+		return nil, err
+	}
+	acquis := appseccfg.RenderAcquis(appseccfg.Opts{BotDetection: mode, BotConfigs: leaves})
+	if err := writeAppsecFile(appsecAcquisPath, acquis); err != nil {
+		return nil, err
+	}
+
+	if verr := validateCrowdsecConfig(ctx); verr != nil {
+		// Roll the files back to their pre-change state; leave the running
+		// crowdsec untouched (we never restarted), so AppSec keeps serving.
+		rollbackAppsecFiles(prevAcquis, hadAcquis, prevAppsec, hadAppsec, hadExempt)
+		return nil, csInvalidArg(fmt.Sprintf("bot detection config failed validation, no change applied: %v", verr))
+	}
+	if err := restartCrowdsec(ctx); err != nil {
+		return nil, err
+	}
+	return csBotDetectionResponse{Mode: mode}, nil
+}
+
+// botDetectionApplyOff returns the acquis to the singular jabali-appsec form
+// and drops the exemption config. The bot-challenge collections are left
+// installed (harmless while unreferenced — configs load only via an acquis —
+// and a re-enable then skips the hub download).
+func botDetectionApplyOff(ctx context.Context, geoMode string, countries []string) (any, error) {
+	prevAcquis, hadAcquis := readFileOK(appsecAcquisPath)
+	prevAppsec, hadAppsec := readFileOK(appsecRulePath)
+
+	if err := writeAppsecFile(appsecRulePath, renderJabaliAppsec(geoMode, countries, "off")); err != nil {
+		return nil, err
+	}
+	if err := writeAppsecFile(appsecAcquisPath, appseccfg.RenderAcquis(appseccfg.Opts{BotDetection: "off"})); err != nil {
+		return nil, err
+	}
+	if err := os.Remove(botExemptConfigPath); err != nil && !os.IsNotExist(err) {
+		return nil, csInternal("remove bot-exempt config", err)
+	}
+	if verr := validateCrowdsecConfig(ctx); verr != nil {
+		rollbackAppsecFiles(prevAcquis, hadAcquis, prevAppsec, hadAppsec, false)
+		return nil, csInternal("crowdsec -t after disabling bot detection", verr)
+	}
+	if err := restartCrowdsec(ctx); err != nil {
+		return nil, err
+	}
+	return csBotDetectionResponse{Mode: "off"}, nil
+}
+
+// botExemptOpts feeds RenderBotExempt the same panel host + webmail allowlist
+// that jabali-appsec uses, so the challenge exemptions match the on_match
+// allowlist exactly.
+func botExemptOpts() appseccfg.Opts {
+	webmailHosts, _ := appseccfg.LoadWebmailHosts(appseccfg.WebmailHostsPath)
+	return appseccfg.Opts{PanelHost: appsecPanelHost(), WebmailHosts: webmailHosts}
+}
+
+func installBotCollections(ctx context.Context, mode string) error {
+	args := append([]string{"collections", "install"}, botCollectionsForMode(mode)...)
+	if out, err := execCommandContext(ctx, "cscli", args...).CombinedOutput(); err != nil {
+		return csInternal("cscli collections install (bot-challenge)",
+			fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
+	}
+	return nil
+}
+
+// enumerateBotChallengeConfigs lists the enabled appsec-CONFIG names that
+// belong to the bot-challenge set. The leaf set is version-dependent, so we
+// discover it from cscli rather than hardcode it (a collection NAME in the
+// acquis would FATAL the engine — only leaf config names are valid).
+func enumerateBotChallengeConfigs(ctx context.Context) ([]string, error) {
+	out, err := execCommandContext(ctx, "cscli", "appsec-configs", "list", "-o", "json").Output()
+	if err != nil {
+		return nil, csInternal("cscli appsec-configs list", err)
+	}
+	var parsed struct {
+		Configs []struct {
+			Name string `json:"name"`
+		} `json:"appsec-configs"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return nil, csInternal("parse appsec-configs json", err)
+	}
+	var names []string
+	for _, c := range parsed.Configs {
+		if strings.Contains(c.Name, "bot-challenge") {
+			names = append(names, c.Name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// filterThreshold drops the OTHER threshold's scoring config so switching
+// balanced<->permissive can't leave both loaded (double-scoring).
+func filterThreshold(leaves []string, mode string) []string {
+	drop := "scoring-permissive"
+	if mode == "permissive" {
+		drop = "scoring-balanced"
+	}
+	out := make([]string, 0, len(leaves))
+	for _, n := range leaves {
+		if strings.Contains(n, drop) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// requireBotDetectionSupport version-gates: the challenge funcs
+// (SendChallenge/ExemptFromChallenge) exist only in CrowdSec engine >= 1.8,
+// and the bouncer must be >= 1.2.x to serve the challenge (challenge.lua).
+func requireBotDetectionSupport(ctx context.Context) error {
+	ev := crowdsecEngineVersion(ctx)
+	if !versionAtLeast(ev, 1, 8) {
+		return csInvalidArg(fmt.Sprintf(
+			"bot detection needs CrowdSec engine >= 1.8 (have %q) — upgrade crowdsec first",
+			ev))
+	}
+	bv := bouncerVersion(ctx)
+	if !versionAtLeast(bv, 1, 2) {
+		return csInvalidArg(fmt.Sprintf(
+			"bot detection needs crowdsec-nginx-bouncer >= 1.2.2 (have %q) — upgrade the bouncer first",
+			bv))
+	}
+	return nil
+}
+
+func crowdsecEngineVersion(ctx context.Context) string {
+	out, err := execCommandContext(ctx, "cscli", "version").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(line), "version:") {
+			return strings.TrimSpace(line[len("version:"):])
+		}
+	}
+	return ""
+}
+
+func bouncerVersion(ctx context.Context) string {
+	out, err := execCommandContext(ctx, "dpkg-query", "-W", "-f=${Version}", "crowdsec-nginx-bouncer").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// versionAtLeast compares a version string ("v1.8.0-debian-...", "1.2.2") to
+// wantMajor.wantMinor. Unparseable → false (fail-closed: the gate refuses).
+func versionAtLeast(v string, wantMajor, wantMinor int) bool {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	maj, e1 := strconv.Atoi(parts[0])
+	min, e2 := strconv.Atoi(parts[1])
+	if e1 != nil || e2 != nil {
+		return false
+	}
+	if maj != wantMajor {
+		return maj > wantMajor
+	}
+	return min >= wantMinor
+}
+
+func validateCrowdsecConfig(ctx context.Context) error {
+	if out, err := execCommandContext(ctx, "crowdsec", "-t").CombinedOutput(); err != nil {
+		return fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// restartCrowdsec is used (not reloadCrowdsec) whenever the acquisition
+// changes — SIGHUP does not bind new/changed datasources.
+func restartCrowdsec(ctx context.Context) error {
+	if out, err := execCommandContext(ctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err != nil {
+		return csInternal("systemctl restart crowdsec", fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
+	}
+	return nil
+}
+
+func readFileOK(path string) ([]byte, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+// writeAppsecFile wraps the shared writeFileAtomic with a csInternal error so
+// a failure surfaces cleanly over the agent wire.
+func writeAppsecFile(path, body string) error {
+	if err := writeFileAtomic(path, []byte(body), 0o644); err != nil {
+		return csInternal("write "+path, err)
+	}
+	return nil
+}
+
+// rollbackAppsecFiles restores the acquis + jabali-appsec to their pre-change
+// bytes and removes the exemption config if it did not exist before. Called
+// only on a `crowdsec -t` failure, before any restart — so the still-running
+// crowdsec keeps its known-good in-memory config while the files on disk are
+// returned to a state that will start cleanly.
+func rollbackAppsecFiles(prevAcquis []byte, hadAcquis bool, prevAppsec []byte, hadAppsec, hadExempt bool) {
+	if hadAcquis {
+		_ = writeAppsecFile(appsecAcquisPath, string(prevAcquis))
+	}
+	if hadAppsec {
+		_ = writeAppsecFile(appsecRulePath, string(prevAppsec))
+	}
+	if !hadExempt {
+		_ = os.Remove(botExemptConfigPath)
+	}
+}

--- a/panel-agent/internal/commands/security_crowdsec_botdetection_test.go
+++ b/panel-agent/internal/commands/security_crowdsec_botdetection_test.go
@@ -1,0 +1,77 @@
+package commands
+
+import "testing"
+
+// The acquis is the applied truth for bot detection: a stale panel binary can
+// drop the jabali-appsec header, but install.sh's plural-guard keeps the
+// composed acquis. botModeFromAcquisBody recovers the mode (and threshold)
+// from it so the agent's readback never lies "off" while crowdsec challenges.
+func TestBotModeFromAcquisBody(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"singular acquis is off", "appsec_config: crowdsecurity/jabali-appsec\nsource: appsec\n", "off"},
+		{"empty is off", "", "off"},
+		{
+			"plural balanced",
+			"appsec_configs:\n - crowdsecurity/jabali-appsec\n - crowdsecurity/appsec-bot-challenge-scoring\n - crowdsecurity/appsec-bot-challenge-scoring-balanced\n",
+			"balanced",
+		},
+		{
+			"plural permissive",
+			"appsec_configs:\n - crowdsecurity/jabali-appsec\n - crowdsecurity/appsec-bot-challenge-scoring\n - crowdsecurity/appsec-bot-challenge-scoring-permissive\n",
+			"permissive",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := botModeFromAcquisBody(c.body); got != c.want {
+				t.Fatalf("botModeFromAcquisBody = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestVersionAtLeast(t *testing.T) {
+	cases := []struct {
+		v        string
+		maj, min int
+		want     bool
+	}{
+		{"v1.8.0-debian-pragmatic-amd64-cc76dbbc", 1, 8, true},
+		{"1.7.8", 1, 8, false},
+		{"v1.2.2", 1, 2, true},
+		{"1.1.6", 1, 2, false},
+		{"v2.0.0", 1, 8, true},
+		{"garbage", 1, 8, false}, // unparseable → fail-closed
+		{"", 1, 8, false},
+	}
+	for _, c := range cases {
+		if got := versionAtLeast(c.v, c.maj, c.min); got != c.want {
+			t.Errorf("versionAtLeast(%q, %d, %d) = %v, want %v", c.v, c.maj, c.min, got, c.want)
+		}
+	}
+}
+
+func TestFilterThreshold(t *testing.T) {
+	leaves := []string{
+		"crowdsecurity/appsec-bot-challenge-exclude-api",
+		"crowdsecurity/appsec-bot-challenge-scoring",
+		"crowdsecurity/appsec-bot-challenge-scoring-balanced",
+		"crowdsecurity/appsec-bot-challenge-scoring-permissive",
+	}
+	bal := filterThreshold(leaves, "balanced")
+	for _, n := range bal {
+		if n == "crowdsecurity/appsec-bot-challenge-scoring-permissive" {
+			t.Fatal("balanced kept the permissive scoring config")
+		}
+	}
+	perm := filterThreshold(leaves, "permissive")
+	for _, n := range perm {
+		if n == "crowdsecurity/appsec-bot-challenge-scoring-balanced" {
+			t.Fatal("permissive kept the balanced scoring config")
+		}
+	}
+}

--- a/panel-api/cmd/server/appsec_cmd.go
+++ b/panel-api/cmd/server/appsec_cmd.go
@@ -31,6 +31,7 @@ const (
 	appsecRulesDir      = "/etc/crowdsec/appsec-rules"
 	appsecModeHeader    = "# jabali-mode:"
 	appsecCountriesHead = "# jabali-countries:"
+	appsecBotDetectHead = "# jabali-bot-detection:"
 )
 
 // newAppSecRenderConfigCmd is the canonical writer of
@@ -75,13 +76,17 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 			}
 
 			mode := "off"
+			botMode := "off"
 			var countries []string
 			if reconcile {
-				m, c := readOperatorHeader(appsecConfigPath)
+				m, c, bm := readOperatorHeader(appsecConfigPath)
 				if m != "" {
 					mode = m
 				}
 				countries = c
+				if bm != "" {
+					botMode = bm
+				}
 			}
 			inband := detectInbandRules(appsecRulesDir)
 
@@ -101,6 +106,13 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 				Inband:         inband,
 				AdminAllowlist: true,
 				WebmailHosts:   webmailHosts,
+				// Preserve the operator's bot-detection selection across every
+				// re-render (install / `jabali update`). Without this the header
+				// resets to off and the agent's readback disagrees with the
+				// applied acquis. The acquis file itself is owned by install.sh
+				// (singular, OFF state) and the agent (plural, ON state); this
+				// command only keeps the jabali-appsec header honest.
+				BotDetection: botMode,
 			})
 
 			// Write-on-diff: cheap before any nginx/crowdsec reload
@@ -128,10 +140,10 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 // lines from the existing file. Both writers (this subcommand + the agent
 // geoblock handler) emit those lines so the operator state survives every
 // re-render. Missing file → ("", nil) which the caller maps to defaults.
-func readOperatorHeader(path string) (mode string, countries []string) {
+func readOperatorHeader(path string) (mode string, countries []string, botMode string) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", nil
+		return "", nil, ""
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
@@ -152,9 +164,11 @@ func readOperatorHeader(path string) (mode string, countries []string) {
 					countries = append(countries, c)
 				}
 			}
+		case strings.HasPrefix(line, appsecBotDetectHead):
+			botMode = strings.TrimSpace(strings.TrimPrefix(line, appsecBotDetectHead))
 		}
 	}
-	return mode, countries
+	return mode, countries, botMode
 }
 
 // detectInbandRules stats the appsec-rules dir and returns the list of

--- a/panel-api/cmd/server/appsec_cmd_test.go
+++ b/panel-api/cmd/server/appsec_cmd_test.go
@@ -39,7 +39,7 @@ func TestReadOperatorHeader(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			mode, countries := readOperatorHeader(path)
+			mode, countries, _ := readOperatorHeader(path)
 			if mode != c.wantMode {
 				t.Errorf("mode = %q, want %q", mode, c.wantMode)
 			}
@@ -47,6 +47,29 @@ func TestReadOperatorHeader(t *testing.T) {
 				t.Errorf("countries = %v, want %v", countries, c.wantCountries)
 			}
 		})
+	}
+}
+
+func TestReadOperatorHeader_BotDetection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jabali-appsec.yaml")
+	body := "# jabali-mode: off\n# jabali-countries: \n# jabali-bot-detection: balanced\nname: crowdsecurity/jabali-appsec\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mode, _, botMode := readOperatorHeader(path)
+	if mode != "off" {
+		t.Errorf("mode = %q, want off", mode)
+	}
+	if botMode != "balanced" {
+		t.Errorf("botMode = %q, want balanced", botMode)
+	}
+	// Missing marker → "" (caller defaults to off).
+	p2 := filepath.Join(t.TempDir(), "no-bot.yaml")
+	if err := os.WriteFile(p2, []byte("# jabali-mode: off\nname: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, bm := readOperatorHeader(p2); bm != "" {
+		t.Errorf("missing bot marker → %q, want empty", bm)
 	}
 }
 

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1998,6 +1998,19 @@ paths:
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: OK } }
 
+  /admin/security/crowdsec/appsec/bot-detection:
+    get:
+      tags: [CrowdSec]
+      summary: Get AppSec bot-detection mode
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [CrowdSec]
+      summary: Update AppSec bot-detection mode (off|balanced|permissive)
+      security: [ { KratosSession: [] } ]
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: OK } }
+
   /admin/security/crowdsec/country-exemption:
     get:
       tags: [CrowdSec]

--- a/panel-api/internal/api/security_crowdsec.go
+++ b/panel-api/internal/api/security_crowdsec.go
@@ -613,6 +613,63 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 		c.JSON(http.StatusOK, appsecGeoblockResponse(s))
 	})
 
+	// CrowdSec 1.8 AppSec bot detection. Same shape as geoblock: DB is the
+	// source of truth, the agent composes the bot-challenge configs into the
+	// AppSec acquisition and restarts crowdsec. Agent dispatched FIRST so a
+	// version-gate rejection (engine < 1.8 / bouncer < 1.2.2) or a config
+	// validation failure never leaves the DB drifted from the host.
+	g.GET("/bot-detection", func(c *gin.Context) {
+		s, err := settings.Get(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"status": "error", "error": "settings_read", "detail": err.Error(),
+			})
+			return
+		}
+		c.JSON(http.StatusOK, appsecBotDetectionResponse(s))
+	})
+
+	g.PUT("/bot-detection", func(c *gin.Context) {
+		var body struct {
+			Mode string `json:"mode"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_json"})
+			return
+		}
+		if _, ok := appsecBotDetectionModes[body.Mode]; !ok {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "error", "error": "invalid_mode",
+				"detail": "mode must be off|balanced|permissive",
+			})
+			return
+		}
+		ctx, cancel := context.WithTimeout(c.Request.Context(), csCallTimeout)
+		defer cancel()
+		if _, err := cli.Call(ctx, "security.crowdsec.appsec.botdetection.set", map[string]any{
+			"mode": body.Mode,
+		}); err != nil {
+			status, errBody := translateAgentError(err)
+			c.JSON(status, errBody)
+			return
+		}
+		s, err := settings.Get(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"status": "error", "error": "settings_read", "detail": err.Error(),
+			})
+			return
+		}
+		s.AppSecBotDetection = body.Mode
+		if err := settings.Upsert(c.Request.Context(), s); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"status": "error", "error": "settings_write", "detail": err.Error(),
+			})
+			return
+		}
+		c.JSON(http.StatusOK, appsecBotDetectionResponse(s))
+	})
+
 	// ADR-0166 — country ban exemption. State lives in server_settings;
 	// the agent renders the s02-enrich GeoIP parser whitelist, and a
 	// background sync (countryexempt) keeps the jabali-country-allowlist
@@ -720,6 +777,20 @@ func appsecGeoblockResponse(s *models.ServerSettings) gin.H {
 		"mode":      s.AppSecGeoblockMode,
 		"countries": countries,
 	}
+}
+
+// appsecBotDetectionModes mirrors the agent's csBotDetectionModes, duplicated
+// at the API edge so bad input gets a 400 without an agent round-trip.
+var appsecBotDetectionModes = map[string]struct{}{
+	"off": {}, "balanced": {}, "permissive": {},
+}
+
+func appsecBotDetectionResponse(s *models.ServerSettings) gin.H {
+	mode := s.AppSecBotDetection
+	if _, ok := appsecBotDetectionModes[mode]; !ok {
+		mode = "off" // empty / legacy row → off
+	}
+	return gin.H{"mode": mode}
 }
 
 // countryExemptResponse renders the ADR-0166 state. Empty selection is

--- a/panel-api/internal/api/security_crowdsec.go
+++ b/panel-api/internal/api/security_crowdsec.go
@@ -23,6 +23,15 @@ import (
 
 const csCallTimeout = 10 * time.Second
 
+// csBotDetectionTimeout is the wider ceiling for the bot-detection apply,
+// which does far more than the 10s render+SIGHUP the other verbs assume:
+// a hub collection install (download), a full `crowdsec -t` parse, and a
+// crowdsec RESTART (5-10s alone on a 2GB fleet box). Too tight and the
+// panel times out while the agent finishes anyway — the DB never persists
+// (Upsert runs after the Call) and the state drifts, the exact failure the
+// agent-first ordering exists to avoid (#1323 class).
+const csBotDetectionTimeout = 120 * time.Second
+
 // csMetricsTimeout is the wider ceiling for /metrics specifically.
 // cscli metrics fans out three sub-calls (metrics + decisions list +
 // alerts list); decisions list scans the LAPI's decision table which
@@ -644,7 +653,7 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 			})
 			return
 		}
-		ctx, cancel := context.WithTimeout(c.Request.Context(), csCallTimeout)
+		ctx, cancel := context.WithTimeout(c.Request.Context(), csBotDetectionTimeout)
 		defer cancel()
 		if _, err := cli.Call(ctx, "security.crowdsec.appsec.botdetection.set", map[string]any{
 			"mode": body.Mode,

--- a/panel-api/internal/db/migrations/000286_appsec_bot_detection.down.sql
+++ b/panel-api/internal/db/migrations/000286_appsec_bot_detection.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+  DROP COLUMN appsec_bot_detection;

--- a/panel-api/internal/db/migrations/000286_appsec_bot_detection.up.sql
+++ b/panel-api/internal/db/migrations/000286_appsec_bot_detection.up.sql
@@ -1,0 +1,12 @@
+-- CrowdSec 1.8 AppSec bot detection (per-server, default OFF).
+-- Mode ∈ {"off","balanced","permissive"}: off = no challenge;
+-- balanced rejects at fingerprint score >= 75; permissive >= 100.
+-- The agent (security.crowdsec.appsec.botdetection.set) composes the
+-- upstream appsec-bot-challenge configs into the AppSec acquisition and
+-- serves a self-contained JS/proof-of-work challenge via the nginx bouncer.
+--
+-- TEXT (not VARCHAR) so it lives off-page: the server_settings row already
+-- sits near InnoDB's 65535-byte in-row ceiling (see migrations 000264 /
+-- 000285). A parenthesized default is required for TEXT/BLOB in MariaDB.
+ALTER TABLE server_settings
+  ADD COLUMN appsec_bot_detection TEXT NOT NULL DEFAULT ('off');

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -220,6 +220,20 @@ type ServerSettings struct {
 	AppSecGeoblockMode      string `gorm:"column:appsec_geoblock_mode;type:varchar(10);not null;default:'off'"    json:"appsec_geoblock_mode"`
 	AppSecGeoblockCountries string `gorm:"column:appsec_geoblock_countries;type:varchar(1000);not null;default:''" json:"appsec_geoblock_countries"`
 
+	// AppSecBotDetection (CrowdSec 1.8, migration 000286). Server-wide
+	// AppSec bot-detection challenge mode ∈ {"off","balanced","permissive"}:
+	//   off        — no challenge
+	//   balanced   — reject at fingerprint score >= 75
+	//   permissive — reject at >= 100
+	// Applied by the agent (security.crowdsec.appsec.botdetection.set), which
+	// composes the upstream appsec-bot-challenge configs into the AppSec
+	// acquisition and serves a self-contained JS/proof-of-work challenge via
+	// the nginx bouncer. Default "off" — this is tenant-facing (challenges
+	// suspected bots across every hosted site) and needs CrowdSec engine
+	// >= 1.8 + bouncer >= 1.2.2, which the agent version-gates. TEXT column,
+	// off-page (server_settings row-size ceiling).
+	AppSecBotDetection string `gorm:"column:appsec_bot_detection;type:text;not null;default:'off'" json:"appsec_bot_detection"`
+
 	// Country ban exemption (ADR-0166, migration 000262). Countries whose
 	// IPs must never be blocked by CrowdSec from any decision source
 	// (scenario bans, AppSec inband, CAPI/console blocklists, captchas).

--- a/panel-ui/src/hooks/useSecurityCrowdsec.ts
+++ b/panel-ui/src/hooks/useSecurityCrowdsec.ts
@@ -267,6 +267,46 @@ export function useUpdateAppSecGeoblock() {
   });
 }
 
+// AppSec bot detection (CrowdSec 1.8) — server-wide challenge mode. Tenant-
+// facing: suspected bots get a self-contained JS / proof-of-work interstitial
+// before reaching any hosted site. server_settings is truth; the agent
+// composes the upstream appsec-bot-challenge configs into the AppSec
+// acquisition and restarts crowdsec. Needs CrowdSec engine >= 1.8 + bouncer
+// >= 1.2.2 (the agent version-gates and returns a 400 otherwise).
+export type AppSecBotDetectionMode = "off" | "balanced" | "permissive";
+
+export type AppSecBotDetection = { mode: AppSecBotDetectionMode };
+
+export function useAppSecBotDetection() {
+  return useQuery({
+    queryKey: ["security", "crowdsec", "appsec", "bot-detection"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<AppSecBotDetection>(
+        `${BASE}/appsec/bot-detection`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useUpdateAppSecBotDetection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: AppSecBotDetection) => {
+      const { data } = await apiClient.put<AppSecBotDetection>(
+        `${BASE}/appsec/bot-detection`,
+        input,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: ["security", "crowdsec", "appsec", "bot-detection"],
+      });
+    },
+  });
+}
+
 // Country ban exemption (ADR-0166) — selected countries are never blocked
 // from any CrowdSec decision source (scenario bans, AppSec inband, CAPI/
 // console blocklists, captchas). server_settings is truth; the agent renders

--- a/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
@@ -53,10 +53,13 @@ import {
   useRemoveCrowdsecAllowlist,
   useSyncCountryExemption,
   useUpdateAppSecGeoblock,
+  useAppSecBotDetection,
+  useUpdateAppSecBotDetection,
   useUpdateCountryExemption,
   useUpdateCrowdsecCaptcha,
   useUpdateCrowdsecProfiles,
   type AppSecGeoblockMode,
+  type AppSecBotDetectionMode,
   type CrowdsecAlert,
   type CrowdsecAllowlistEntry,
   type CrowdsecCaptchaProvider,
@@ -162,6 +165,7 @@ export const AdminSecurityCrowdsec = () => {
     "alerts",
     "captcha",
     "appsec",
+    "botdetection",
     "settings",
     "blocklists",
     "hub",
@@ -330,6 +334,7 @@ export const AdminSecurityCrowdsec = () => {
           { key: "alerts", label: "Alerts", children: <AlertsCard /> },
           { key: "captcha", label: "Captcha", children: <CaptchaPanel /> },
           { key: "appsec", label: "Block Country", children: <AppSecGeoblockCard /> },
+          { key: "botdetection", label: "Bot Detection", children: <AppSecBotDetectionCard /> },
           { key: "settings", label: "Settings", children: <SettingsPanel /> },
           { key: "blocklists", label: "Blocklists", children: <BlocklistsCard /> },
         ]}
@@ -590,6 +595,111 @@ const AppSecGeoblockCard = () => {
                 if (geoblock.data) {
                   setMode(geoblock.data.mode);
                   setCountries(geoblock.data.countries);
+                }
+              }}
+            >
+              Reset
+            </Button>
+          )}
+        </Space>
+      </Space>
+    </Card>
+  );
+};
+
+// AppSecBotDetectionCard — CrowdSec 1.8 AppSec bot detection (per-server,
+// default OFF). When on, the upstream appsec-bot-challenge scoring composes
+// into the AppSec engine and suspected bots get a self-contained JS /
+// proof-of-work interstitial before reaching ANY hosted site. Verified good
+// bots (search engines, AI crawlers, social, monitoring) and challenge-unsafe
+// paths (ACME HTTP-01, the panel API + login, DB tools, WebDAV, webmail) are
+// exempt automatically. Needs CrowdSec engine >= 1.8 + bouncer >= 1.2.2 — the
+// agent version-gates and surfaces a clear error otherwise.
+const AppSecBotDetectionCard = () => {
+  const bot = useAppSecBotDetection();
+  const updateBot = useUpdateAppSecBotDetection();
+
+  const [mode, setMode] = useState<AppSecBotDetectionMode>("off");
+
+  useEffect(() => {
+    if (bot.data) {
+      setMode(bot.data.mode);
+    }
+  }, [bot.data]);
+
+  const dirty = bot.data !== undefined && mode !== bot.data.mode;
+
+  const apply = async () => {
+    try {
+      await updateBot.mutateAsync({ mode });
+      feedback.message.success(
+        mode === "off"
+          ? "Bot detection disabled — crowdsec restarted"
+          : `Bot detection set to ${mode} — crowdsec restarted`,
+      );
+    } catch (e: unknown) {
+      feedback.message.error(
+        e instanceof Error ? e.message : "Failed to apply bot detection",
+      );
+    }
+  };
+
+  return (
+    <Card size="small" title="AppSec bot detection (server-wide)" loading={bot.isLoading}>
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Challenges suspected bots with a JavaScript / proof-of-work page
+          before they reach any hosted site (CrowdSec 1.8 AppSec). Balanced
+          rejects at a fingerprint score ≥ 75, Permissive at ≥ 100. Verified
+          good bots (search engines, AI crawlers, social, monitoring) and
+          challenge-unsafe paths (Let&apos;s Encrypt validation, the panel and
+          its APIs, DB tools, WebDAV, webmail) are exempt automatically.
+        </Typography.Paragraph>
+        <Alert
+          type="warning"
+          showIcon
+          message="This affects every site on the server"
+          description={
+            "Suspected bots on ALL hosted domains get an interstitial challenge. " +
+            "Legitimate non-browser clients that can't run JavaScript (some API " +
+            "clients, uptime monitors, scripted integrations) may be blocked — the " +
+            "built-in exemptions cover common cases, but test after enabling. " +
+            "Requires CrowdSec engine ≥ 1.8 and the nginx bouncer ≥ 1.2.2."
+          }
+        />
+        <div>
+          <Typography.Text strong>Mode: </Typography.Text>
+          <Segmented
+            value={mode}
+            onChange={(v) => setMode(v as AppSecBotDetectionMode)}
+            options={[
+              { label: "Off", value: "off" },
+              { label: "Balanced", value: "balanced" },
+              { label: "Permissive", value: "permissive" },
+            ]}
+          />
+        </div>
+        <Space>
+          <Popconfirm
+            title="Apply bot detection?"
+            description={
+              mode === "off"
+                ? "Disables the bot challenge server-wide. CrowdSec restarts (brief AppSec gap)."
+                : `${mode === "balanced" ? "Balanced" : "Permissive"} challenge mode across every hosted site. CrowdSec restarts (brief AppSec gap) — this can take up to a minute.`
+            }
+            okText="Apply"
+            onConfirm={apply}
+            disabled={!dirty || updateBot.isPending}
+          >
+            <Button type="primary" disabled={!dirty} loading={updateBot.isPending}>
+              Apply
+            </Button>
+          </Popconfirm>
+          {dirty && (
+            <Button
+              onClick={() => {
+                if (bot.data) {
+                  setMode(bot.data.mode);
                 }
               }}
             >


### PR DESCRIPTION
## What

Adds **CrowdSec 1.8 AppSec bot detection** as a per-server, **default-OFF** admin control. When enabled, the upstream `appsec-bot-challenge` scoring composes into the AppSec engine and suspected bots get a self-contained JS / proof-of-work interstitial (served by the nginx bouncer) before reaching any hosted site — no third-party captcha keys, no Kubernetes.

Admin → Security → CrowdSec → **Bot Detection**: Off / Balanced (reject score ≥ 75) / Permissive (≥ 100).

## Why it's built the way it is (the load-bearing decisions)

- **Composition = `appsec_configs:` plural, leaf config names only.** Confirmed on a real 1.8 engine: a *collection* name in the acquis FATALs crowdsec. The leaf set is version-dependent, so the agent **discovers it from `cscli`** rather than hardcoding.
- **`SendChallenge()` runs in `pre_eval` on every request** — so anything that can't solve a challenge must be exempted or it breaks. A separate `jabali-bot-exempt` config carries the twins of our `on_match` allowlist, most importantly **`/.well-known/acme-challenge/` on every host** (Let's Encrypt HTTP-01 can't run JS — omitting it fails cert renewals *silently*). Also exempt: `/api/v1/` + Kratos `/.ory/` (panel login), phpMyAdmin/Adminer, `/dav/`, and the webmail JMAP vhosts.
- **Fail-closed.** The agent version-gates (engine ≥ 1.8, bouncer ≥ 1.2.2), then validates with `crowdsec -t` **before** touching the service and rolls the files back on failure — a bad config can never take the WAF down. Composing 1.8 config on an older engine would FATAL crowdsec (AppSec + all scenarios down), so this gate is mandatory.
- **Restart, not reload.** A change to the AppSec *acquisition* isn't picked up by SIGHUP; the apply restarts crowdsec (geoblock still reloads). The panel PUT gets a dedicated 120s timeout to cover the collection install + `crowdsec -t` + restart.
- **`jabali update` clobber fixed.** `install_crowdsec_appsec` now leaves the acquis untouched when it's already in the plural (bot-on) form — the guard is placed ahead of both the singular heredoc *and* the fresh-install `rm -f` (which recovery paths could otherwise use to delete a bot-on acquis → no AppSec listener). `render-config` preserves the `# jabali-bot-detection:` header, and the agent falls back to sniffing the acquis if a stale panel binary drops it.
- **Bouncer freeze-fix.** `install_crowdsec_nginx_bouncer` now `--only-upgrade`s on every run so fleet boxes actually reach 1.2.2 (they were frozen at whatever first installed — the Adminer-freeze shape).

## Layers

| Stage | Files |
|---|---|
| appseccfg foundation | `internal/appseccfg/appseccfg.go` — `RenderBotExempt`, `RenderAcquis`, `BotDetection` mode |
| agent apply verb | `panel-agent/.../security_crowdsec_botdetection.go` — `botdetection.{get,set}` |
| install.sh | bouncer `--only-upgrade` + acquis plural-guard |
| panel-api | `server_settings.appsec_bot_detection` (migration 000286, TEXT off-page), GET/PUT endpoint (agent-first), openapi |
| admin UI | `useSecurityCrowdsec.ts` hooks + `AdminSecurityCrowdsec.tsx` Bot Detection tab |

## Tested

- **Live drill on the .60 test box via the real agent** (built + deployed): `set balanced` (38.8s) → acquis composed, `# jabali-bot-detection: balanced`, exempt config written; live `:7422` decisions — `/wp-login.php` → **challenge**, `/.well-known/acme-challenge/` → **allow**, `/api/v1/` → **allow**; `set off` (6.1s) → singular acquis, exempt removed, WAF still blocking. `.60` restored to baseline.
- Unit: appseccfg (exempt/acquis/header), agent (`botModeFromAcquisBody`, `versionAtLeast`, `filterThreshold`), CLI header round-trip. AST agent-first-ordering test covers the new endpoint. openapi-conformance + migrations-completeness green. `go build`/`vet`/exec-seam across both modules; `tsc -b`; `bash -n install.sh`.

## Rollout

Default OFF, version-gated, nothing touches the fleet on merge. `.60` is left on crowdsec 1.8.0 + bouncer 1.2.2 (the go-forward versions). Enabling is a deliberate admin action per box; it restarts crowdsec (brief AppSec gap) and is tenant-facing — the UI warns accordingly.

Refs the CrowdSec 1.8 upgrade.
