### PR TITLE
feat(security): per-domain opt-out from the AppSec bot-detection challenge

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -65,6 +65,12 @@ type Opts struct {
 	// only when BotDetection != "off". A collection NAME here would FATAL the
 	// engine ("no appsec-config found"); pass leaf CONFIG names only.
 	BotConfigs []string
+	// BotExemptHosts is the operator's per-domain opt-out list: FQDNs whose
+	// domains should NOT be bot-challenged even when the server-wide mode is
+	// on (e.g. an API/webhook-heavy site). Consumed by RenderBotExempt as an
+	// additional Host-equality ExemptFromChallenge, sanitised like WebmailHosts.
+	// The caller expands www.<domain>; this only renders what it is given.
+	BotExemptHosts []string
 }
 
 // AppsecListenAddr is the TCP loopback the AppSec engine listens on; the
@@ -554,6 +560,21 @@ func RenderBotExempt(o Opts) string {
 		b.WriteString("    - filter: " + strings.Join(parts, " || ") + "\n")
 		b.WriteString("      apply:\n")
 		b.WriteString(`        - ExemptFromChallenge("jabali-webmail")` + "\n")
+	}
+
+	// Per-domain opt-out (GH bot-detection per-domain). Distinct label so the
+	// "Exempt" metric separates operator domain opt-outs from the built-in
+	// exemptions above. Same sanitiser + explicit host equality (req.Host is a
+	// client-controlled header — never a prefix).
+	optout := sanitizeWebmailHosts(o.BotExemptHosts)
+	if len(optout) > 0 {
+		parts := make([]string, len(optout))
+		for i, h := range optout {
+			parts[i] = `req.Host == "` + h + `"`
+		}
+		b.WriteString("    - filter: " + strings.Join(parts, " || ") + "\n")
+		b.WriteString("      apply:\n")
+		b.WriteString(`        - ExemptFromChallenge("jabali-domain-optout")` + "\n")
 	}
 	return b.String()
 }

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -229,6 +229,22 @@ func TestRenderBotExempt_PanelHostScopesPanelPathsButNotAcme(t *testing.T) {
 	}
 }
 
+func TestRenderBotExempt_PerDomainOptOut(t *testing.T) {
+	out := RenderBotExempt(Opts{
+		BotExemptHosts: []string{"Api.Example.com", "www.api.example.com", "api.example.com"},
+	})
+	mustContain(t, out, `req.Host == "api.example.com" || req.Host == "www.api.example.com"`, "sorted, deduped opt-out hosts")
+	mustContain(t, out, `ExemptFromChallenge("jabali-domain-optout")`, "distinct opt-out label")
+	// ACME + panel exemptions always present alongside.
+	mustContain(t, out, `ExemptFromChallenge("jabali-acme-http01")`, "acme still exempt")
+	mustNotContain(t, out, `startsWith "api."`, "host equality, never prefix")
+}
+
+func TestRenderBotExempt_NoOptOutWhenListEmpty(t *testing.T) {
+	out := RenderBotExempt(Opts{})
+	mustNotContain(t, out, "jabali-domain-optout", "no opt-out filter when list empty")
+}
+
 func TestRenderBotExempt_WebmailHostEqualityNeverPrefix(t *testing.T) {
 	out := RenderBotExempt(Opts{WebmailHosts: []string{"Mail.Foo.com", "mail.foo.com", "mail.bar.com"}})
 	mustContain(t, out, `req.Host == "mail.bar.com" || req.Host == "mail.foo.com"`, "sorted, deduped host equality")

--- a/internal/appseccfg/state.go
+++ b/internal/appseccfg/state.go
@@ -32,11 +32,45 @@ import (
 // const, so both writer + readers follow the move.
 const WebmailHostsPath = "/var/lib/jabali-panel/webmail-hosts.list"
 
+// BotExemptHostsPath is the state file listing the FQDNs whose domains the
+// operator has marked exempt from the AppSec bot-detection challenge
+// (per-domain opt-out). Written by the panel reconciler (write-on-diff each
+// pass) and read by RenderBotExempt so those Hosts get an ExemptFromChallenge
+// pre_eval alongside the built-in exemptions. Same location + safe-default
+// semantics as WebmailHostsPath. Missing/empty → no per-domain exemptions.
+const BotExemptHostsPath = "/var/lib/jabali-panel/bot-exempt-hosts.list"
+
+// LoadBotExemptHosts reads + sanitizes the per-domain bot-challenge exempt
+// list. Missing file is not an error (nil, nil) — the safe default is "no
+// per-domain exemptions", exactly like LoadWebmailHosts.
+func LoadBotExemptHosts(path string) ([]string, error) {
+	return loadHostList(path)
+}
+
+// WriteBotExemptHosts writes the sanitized, sorted exempt-host list atomically.
+// Returns (changed, error); write-on-diff so a caller can gate a reload.
+func WriteBotExemptHosts(path string, hosts []string) (changed bool, err error) {
+	return writeHostList(
+		path,
+		"# Managed by jabali-panel reconciler — DO NOT hand-edit.\n"+
+			"# FQDNs exempt from the AppSec bot-detection challenge (per-domain\n"+
+			"# opt-out). Read by internal/appseccfg.RenderBotExempt. One FQDN per line.\n",
+		hosts,
+	)
+}
+
 // LoadWebmailHosts reads and sanitizes the state file at the given
 // path. Missing file is NOT an error (returns nil, nil) — fresh
 // installs before the first reconciler pass have no allowlist, which
 // is the right safe default. Anything failing sanitize is dropped.
 func LoadWebmailHosts(path string) ([]string, error) {
+	return loadHostList(path)
+}
+
+// loadHostList reads a one-FQDN-per-line state file, ignoring blanks and
+// comments, and returns the sanitized list. Missing file → (nil, nil): the
+// safe default for every AppSec host-list feature.
+func loadHostList(path string) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -66,12 +100,24 @@ func LoadWebmailHosts(path string) ([]string, error) {
 // already matches what would be written, this is a no-op and changed
 // is false — callers can gate a downstream reload on changed=true.
 func WriteWebmailHosts(path string, hosts []string) (changed bool, err error) {
+	return writeHostList(
+		path,
+		"# Managed by jabali-panel reconciler — DO NOT hand-edit.\n"+
+			"# Source of truth for the CrowdSec AppSec webmail-vhost allowlist\n"+
+			"# (internal/appseccfg.Render). Re-rendered every reconciler pass\n"+
+			"# from the domain repo + panel-primary row. One FQDN per line.\n",
+		hosts,
+	)
+}
+
+// writeHostList writes a sanitized, sorted host list atomically (tmp+rename)
+// with the given managed-by header. Returns (changed, error); a no-op with
+// changed=false when the on-disk content already matches, so callers can gate
+// a downstream reload on changed=true.
+func writeHostList(path, header string, hosts []string) (changed bool, err error) {
 	clean := sanitizeWebmailHosts(hosts)
 	var b strings.Builder
-	b.WriteString("# Managed by jabali-panel reconciler — DO NOT hand-edit.\n")
-	b.WriteString("# Source of truth for the CrowdSec AppSec webmail-vhost allowlist\n")
-	b.WriteString("# (internal/appseccfg.Render). Re-rendered every reconciler pass\n")
-	b.WriteString("# from the domain repo + panel-primary row. One FQDN per line.\n")
+	b.WriteString(header)
 	for _, h := range clean {
 		b.WriteString(h + "\n")
 	}

--- a/panel-agent/internal/commands/security_crowdsec.go
+++ b/panel-agent/internal/commands/security_crowdsec.go
@@ -1999,6 +1999,7 @@ func init() {
 	Default.Register("security.crowdsec.appsec.geoblock.set", csAppSecGeoblockSetHandler)
 	Default.Register("security.crowdsec.appsec.botdetection.get", csBotDetectionGetHandler)
 	Default.Register("security.crowdsec.appsec.botdetection.set", csBotDetectionSetHandler)
+	Default.Register("security.crowdsec.appsec.botdetection.refresh_exempt", csBotDetectionRefreshExemptHandler)
 	Default.Register("security.crowdsec.allowlists.list", csAllowlistsListHandler)
 	Default.Register("security.crowdsec.allowlists.add", csAllowlistsAddHandler)
 	Default.Register("security.crowdsec.allowlists.remove", csAllowlistsRemoveHandler)

--- a/panel-agent/internal/commands/security_crowdsec_botdetection.go
+++ b/panel-agent/internal/commands/security_crowdsec_botdetection.go
@@ -268,12 +268,47 @@ func botDetectionApplyOff(ctx context.Context, geoMode string, countries []strin
 	return csBotDetectionResponse{Mode: "off"}, nil
 }
 
-// botExemptOpts feeds RenderBotExempt the same panel host + webmail allowlist
-// that jabali-appsec uses, so the challenge exemptions match the on_match
-// allowlist exactly.
+// botExemptOpts feeds RenderBotExempt the panel host + webmail allowlist that
+// jabali-appsec uses (so the built-in exemptions match the on_match allowlist)
+// PLUS the operator's per-domain opt-out list (both from the panel reconciler's
+// state files; missing → the safe default of no exemption).
 func botExemptOpts() appseccfg.Opts {
 	webmailHosts, _ := appseccfg.LoadWebmailHosts(appseccfg.WebmailHostsPath)
-	return appseccfg.Opts{PanelHost: appsecPanelHost(), WebmailHosts: webmailHosts}
+	exemptHosts, _ := appseccfg.LoadBotExemptHosts(appseccfg.BotExemptHostsPath)
+	return appseccfg.Opts{
+		PanelHost:      appsecPanelHost(),
+		WebmailHosts:   webmailHosts,
+		BotExemptHosts: exemptHosts,
+	}
+}
+
+// csBotDetectionRefreshExemptHandler re-renders jabali-bot-exempt.yaml from the
+// current per-domain opt-out state file and reloads crowdsec on a real change.
+// The panel reconciler calls this EVERY pass while bot detection is on (a
+// per-tick idempotent loop, not a change-triggered one — a single failed call
+// must never leave the exemptions stale: write-on-diff makes the steady state a
+// cheap render+memcmp, and convergence is guaranteed).
+//
+// A change here is to an appsec-config's CONTENT, not the acquisition's
+// datasource list, so SIGHUP (reload) is enough — same as geoblock. Bot
+// detection off ⇒ the exempt config isn't composed into the acquis, so there is
+// nothing to reload; the next botdetection.set renders it fresh.
+func csBotDetectionRefreshExemptHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	mode := readBotDetectionMode()
+	if mode == "off" {
+		return map[string]any{"mode": "off", "reloaded": false}, nil
+	}
+	body := appseccfg.RenderBotExempt(botExemptOpts())
+	if existing, err := os.ReadFile(botExemptConfigPath); err == nil && string(existing) == body {
+		return map[string]any{"mode": mode, "reloaded": false}, nil
+	}
+	if err := writeAppsecFile(botExemptConfigPath, body); err != nil {
+		return nil, err
+	}
+	if err := reloadCrowdsec(ctx); err != nil {
+		return nil, err
+	}
+	return map[string]any{"mode": mode, "reloaded": true}, nil
 }
 
 func installBotCollections(ctx context.Context, mode string) error {

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -222,6 +222,11 @@ type updateDomainRequest struct {
 	WebmailEnabled        *bool                    `json:"webmail_enabled,omitempty"`
 	// TempURLEnabled toggles the preview URL vhost block. Owner or admin.
 	TempURLEnabled *bool `json:"temp_url_enabled,omitempty"`
+	// BotChallengeExempt — per-domain opt-out from the server-wide AppSec
+	// bot-detection challenge. ADMIN-ONLY: a tenant must not be able to weaken
+	// the operator's security posture on their own domain. Silently ignored
+	// for a non-admin PATCH (pointer pattern), never 403.
+	BotChallengeExempt *bool `json:"bot_challenge_exempt,omitempty"`
 	// GH #648 (DMARCbis): per-domain settable np (non-existent subdomain
 	// policy) + t=y testing tag, folded into the canonical _dmarc record.
 	DmarcNP      *string `json:"dmarc_np,omitempty"`
@@ -787,6 +792,13 @@ func (h *domainHandler) update(c *gin.Context) {
 				return
 			}
 			domain.NginxCustomDirectives = req.NginxCustomDirectives
+		}
+
+		// Per-domain bot-detection opt-out (admin-only). The reconciler picks
+		// up the flag on its next pass, writes the exempt-hosts state file, and
+		// (while bot detection is on) has the agent re-render jabali-bot-exempt.
+		if req.BotChallengeExempt != nil {
+			domain.BotChallengeExempt = *req.BotChallengeExempt
 		}
 
 		if req.NginxRules != nil {

--- a/panel-api/internal/db/migrations/000287_domain_bot_challenge_exempt.down.sql
+++ b/panel-api/internal/db/migrations/000287_domain_bot_challenge_exempt.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE domains
+  DROP COLUMN bot_challenge_exempt;

--- a/panel-api/internal/db/migrations/000287_domain_bot_challenge_exempt.up.sql
+++ b/panel-api/internal/db/migrations/000287_domain_bot_challenge_exempt.up.sql
@@ -1,0 +1,6 @@
+-- Per-domain opt-out from the server-wide AppSec bot-detection challenge
+-- (CrowdSec 1.8). Admin-only flag: when set, the domain (and www.<domain>) is
+-- exempted from the JS/proof-of-work challenge even while server-wide bot
+-- detection is on — for API/webhook-heavy sites. Default 0 (not exempt).
+ALTER TABLE domains
+  ADD COLUMN bot_challenge_exempt TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -501,6 +501,16 @@ type Domain struct {
 	// from the scar list cannot bite).
 	TempURLEnabled bool `gorm:"column:temp_url_enabled;type:tinyint(1);not null" json:"temp_url_enabled"`
 
+	// BotChallengeExempt (migration 000287) — per-domain opt-out from the
+	// server-wide AppSec bot-detection challenge. Admin-only: when set, this
+	// domain (and www.<domain>) is exempted from the JS/proof-of-work challenge
+	// even while server-wide bot detection is on — for API/webhook-heavy sites
+	// whose non-browser clients can't solve it. The panel reconciler writes the
+	// exempt FQDNs to appseccfg.BotExemptHostsPath; the agent renders them into
+	// jabali-bot-exempt. Opt-in (default 0 — zero value, no GORM default-tag
+	// insert trap).
+	BotChallengeExempt bool `gorm:"column:bot_challenge_exempt;type:tinyint(1);not null" json:"bot_challenge_exempt"`
+
 	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }

--- a/panel-api/internal/reconciler/bot_exempt_reconcile.go
+++ b/panel-api/internal/reconciler/bot_exempt_reconcile.go
@@ -1,0 +1,61 @@
+package reconciler
+
+import (
+	"context"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/appseccfg"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+const botExemptAgentTimeout = 30 * time.Second
+
+// reconcileBotChallengeExempt keeps the per-domain AppSec bot-detection
+// opt-out in sync. Every pass it writes the exempt-hosts state file
+// (write-on-diff) from the domains flagged bot_challenge_exempt, expanding
+// each to www.<domain>; and, while server-wide bot detection is ON, it asks
+// the agent to re-render jabali-bot-exempt.
+//
+// The agent call is made EVERY pass, not only on a change: refresh_exempt is
+// itself write-on-diff (render → memcmp → reload only on a real diff), so the
+// steady-state cost is one cheap NDJSON round-trip, and convergence is
+// guaranteed even if a single dispatch fails while the agent is busy — a
+// change-triggered call would drop that update forever (feedback_per_tick_
+// idempotent_loops). Same precedent as the webmail loop's per-pass
+// service.start. Off ⇒ the exempt config isn't composed into the acquis, so
+// there is nothing to reload and we skip the agent entirely.
+func (r *Reconciler) reconcileBotChallengeExempt(ctx context.Context) {
+	domains, _, err := r.domains.List(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		r.log.Warn("bot-exempt reconcile: list domains", "err", err)
+		return
+	}
+	var hosts []string
+	for i := range domains {
+		if !domains[i].BotChallengeExempt {
+			continue
+		}
+		n := domains[i].Name
+		hosts = append(hosts, n, "www."+n)
+	}
+	if _, err := appseccfg.WriteBotExemptHosts(appseccfg.BotExemptHostsPath, hosts); err != nil {
+		r.log.Warn("bot-exempt reconcile: write state file", "err", err)
+		// fall through: still try to refresh from whatever is on disk.
+	}
+
+	if r.serverSettings == nil {
+		return
+	}
+	s, err := r.serverSettings.Get(ctx)
+	if err != nil || s == nil {
+		return
+	}
+	if s.AppSecBotDetection == "" || s.AppSecBotDetection == "off" {
+		return
+	}
+	rctx, cancel := context.WithTimeout(ctx, botExemptAgentTimeout)
+	defer cancel()
+	if _, err := r.agent.Call(rctx, "security.crowdsec.appsec.botdetection.refresh_exempt", map[string]any{}); err != nil {
+		r.log.Warn("bot-exempt reconcile: refresh_exempt", "err", err)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1054,6 +1054,7 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// domains.email_enabled. Self-scoping — no-op when sslCerts isn't
 	// wired; per-domain errors don't abort the sweep.
 	r.reconcileWebmailVhosts(ctx)
+	r.reconcileBotChallengeExempt(ctx)
 
 	r.reconcileCronJobs(ctx)
 	// Reconcile cron jobs: apply enabled jobs, remove disabled jobs, cleanup orphans.

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -389,7 +389,7 @@ func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {
 		"nginx_rules", "nginx_safe_options",
 		"redirect_all_to", "redirect_all_type", "page_redirects",
 		"index_priority", "ssl_enabled", "is_quota_suspended", "webmail_enabled",
-		"dmarc_np", "dmarc_testing", "temp_url_enabled", "updated_at",
+		"dmarc_np", "dmarc_testing", "temp_url_enabled", "bot_challenge_exempt", "updated_at",
 	).Updates(d).Error; err != nil {
 		return translate(err)
 	}

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -32,6 +32,7 @@ export type DomainEditInput = {
   is_enabled?: boolean;
   doc_root?: string;
   temp_url_enabled?: boolean;
+  bot_challenge_exempt?: boolean;
 };
 
 export const DomainEdit = () => {
@@ -62,6 +63,7 @@ export const DomainEdit = () => {
         is_enabled: domain.is_enabled,
         doc_root: domain.doc_root,
         temp_url_enabled: domain.temp_url_enabled,
+        bot_challenge_exempt: domain.bot_challenge_exempt,
       });
     }
   }, [domain, form]);
@@ -143,6 +145,24 @@ export const DomainEdit = () => {
         </Form.Item>
         <Typography.Text>
           Preview URL (&lt;slug&gt;.preview.&lt;panel-hostname&gt; serves this docroot)
+        </Typography.Text>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 24 }}>
+        <Form.Item name="bot_challenge_exempt" valuePropName="checked" noStyle>
+          <Switch
+            checkedChildren={<CheckOutlined />}
+            unCheckedChildren={<CloseOutlined />}
+          />
+        </Form.Item>
+        <Typography.Text>
+          Exempt from bot-detection challenge
+          <Typography.Text type="secondary" style={{ display: "block", fontSize: 12 }}>
+            Skip the server-wide AppSec bot challenge on this site — for
+            API/webhook-heavy domains whose non-browser clients can&apos;t solve
+            it. Also covers www.&lt;domain&gt;. No effect unless bot detection is
+            on server-wide (Security → CrowdSec → Bot Detection).
+          </Typography.Text>
         </Typography.Text>
       </div>
 

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -155,6 +155,7 @@ export type Domain = {
   bytes_30d?: number;
   temp_url_enabled?: boolean;
   temp_url?: string | null;
+  bot_challenge_exempt?: boolean;
   nginx_custom_directives: string;
   redirect_all_to?: string | null;
   redirect_all_type?: string | null;


### PR DESCRIPTION
## What

Follow-up to the server-wide bot detection (#1463): an **admin-only per-domain opt-out**. When server-wide bot detection is on, a domain flagged **Exempt from bot-detection challenge** (and `www.<domain>`) is skipped by the JS/proof-of-work challenge — for API/webhook-heavy sites whose non-browser clients can't solve it.

**Opt-out, not opt-in** — chosen deliberately: secure-by-default (protect all, carve the known exceptions rather than leave sites unprotected), and coherent with the shipped server toggle, which stays the master switch. Opt-in ("challenge only selected domains") can layer on the same mechanism later.

## Security

- **Admin-only.** A tenant must not be able to weaken the operator's security posture on their own domain, so `bot_challenge_exempt` is applied only for admin PATCHes — silently ignored for non-admin (pointer-field pattern), never a 403.
- The flag was added to the domain `Update` `Select(...)` allowlist — otherwise GORM silently drops it (the known allowlist scar).
- Host equality only (never a prefix — `req.Host` is client-controlled), distinct `jabali-domain-optout` metric label.

## How it propagates

DB flag → the per-tick `reconcileBotChallengeExempt` writes the exempt FQDNs (each domain + `www.`) to a state file → the agent's `refresh_exempt` verb re-renders `jabali-bot-exempt` and **reloads** crowdsec (SIGHUP) on a real diff. A content change to an appsec-config, not the acquisition, so **reload, not restart**. The reconciler calls `refresh_exempt` **every pass** while bot detection is on — `refresh_exempt` is write-on-diff internally, so a single failed dispatch heals on the next tick (a change-triggered call would drop it forever; same per-tick idempotent precedent as the webmail loop).

## Layers

`appseccfg` (`RenderBotExempt` + state file, shared `loadHostList`/`writeHostList`) · agent (`botExemptOpts` + `refresh_exempt` verb) · `domains.bot_challenge_exempt` (migration 000287, tinyint) + Update allowlist + admin-only handler + per-tick reconciler · admin `DomainEdit` switch.

## Tested — drilled on .60 via the real agent

With bot detection **balanced**:
- exempt `shop.example.test` → AppSec `allow`; non-exempt `other.example.test` → `challenge` (simultaneously)
- `refresh_exempt` applied by **reload** — crowdsec **PID unchanged** (proves reload, not restart)
- a no-diff `refresh_exempt` → `reloaded:false` (idempotent no-op)

`.60` restored to baseline afterward. `go build`/`vet`/exec-seam + appseccfg / migrations-completeness / agent-order tests + `tsc -b` all green. sqlmock unaffected (no test asserts the `Update` statement shape).

## Scope notes

Subdomains are their own domain rows with their own flag; preview URLs stay challenged. Default behaviour unchanged (flag defaults off; whole feature is inert while server-wide bot detection is off). Nothing to the fleet on merge.

Refs #1463.
