### PR TITLE
feat(security): per-domain opt-in (scope=selected) for AppSec bot detection

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -71,6 +71,26 @@ type Opts struct {
 	// additional Host-equality ExemptFromChallenge, sanitised like WebmailHosts.
 	// The caller expands www.<domain>; this only renders what it is given.
 	BotExemptHosts []string
+	// BotScope selects which sites the challenge applies to when BotDetection
+	// is on: "all" (default — challenge every site, carve exceptions via
+	// BotExemptHosts) or "selected" (challenge ONLY BotIncludeHosts; every
+	// other Host is exempted). Unknown → "all" (fail-safe: never silently
+	// un-challenge the whole box).
+	BotScope string
+	// BotIncludeHosts is the per-domain opt-IN list, used only when
+	// BotScope=="selected": these Hosts are challenged and all others exempted.
+	// Empty in selected mode means "challenge nothing" (rendered explicitly as
+	// an unconditional exemption, not left to `not in []` edge semantics).
+	// Caller expands www.<domain>; sanitised like the other host lists.
+	BotIncludeHosts []string
+}
+
+// botScope normalises Opts.BotScope to "all" (default) or "selected".
+func botScope(o Opts) string {
+	if o.BotScope == "selected" {
+		return "selected"
+	}
+	return "all"
 }
 
 // AppsecListenAddr is the TCP loopback the AppSec engine listens on; the
@@ -379,6 +399,10 @@ func Render(o Opts) string {
 	// This config is unchanged by the mode — bot-challenge composition lives
 	// in RenderAcquis + RenderBotExempt — but the header is the state anchor.
 	b.WriteString("# jabali-bot-detection: " + botDetectionMode(o) + "\n")
+	// Scope round-trips alongside the mode so --reconcile / the agent readback
+	// preserve "selected" across re-renders (a reset to "all" would challenge
+	// every site on the box at once).
+	b.WriteString("# jabali-bot-detection-scope: " + botScope(o) + "\n")
 	b.WriteString("name: " + JabaliAppsecConfigName + "\n")
 	b.WriteString("default_remediation: ban\n")
 
@@ -562,19 +586,42 @@ func RenderBotExempt(o Opts) string {
 		b.WriteString(`        - ExemptFromChallenge("jabali-webmail")` + "\n")
 	}
 
-	// Per-domain opt-out (GH bot-detection per-domain). Distinct label so the
-	// "Exempt" metric separates operator domain opt-outs from the built-in
-	// exemptions above. Same sanitiser + explicit host equality (req.Host is a
-	// client-controlled header — never a prefix).
-	optout := sanitizeWebmailHosts(o.BotExemptHosts)
-	if len(optout) > 0 {
-		parts := make([]string, len(optout))
-		for i, h := range optout {
-			parts[i] = `req.Host == "` + h + `"`
+	// Per-domain scoping (after the built-in exemptions above, which always win
+	// so ACME / panel / webmail are never challenged in either scope).
+	switch botScope(o) {
+	case "selected":
+		// Opt-in: challenge ONLY the listed hosts — exempt everything else.
+		include := sanitizeWebmailHosts(o.BotIncludeHosts)
+		if len(include) == 0 {
+			// No domains selected ⇒ challenge nothing. Render it explicitly
+			// (an unconditional exempt) rather than relying on `not in []`.
+			b.WriteString("    - filter: true\n")
+			b.WriteString("      apply:\n")
+			b.WriteString(`        - ExemptFromChallenge("jabali-selected-none")` + "\n")
+		} else {
+			parts := make([]string, len(include))
+			for i, h := range include {
+				parts[i] = `"` + h + `"`
+			}
+			b.WriteString("    - filter: req.Host not in [" + strings.Join(parts, ", ") + "]\n")
+			b.WriteString("      apply:\n")
+			b.WriteString(`        - ExemptFromChallenge("jabali-selected-exclude")` + "\n")
 		}
-		b.WriteString("    - filter: " + strings.Join(parts, " || ") + "\n")
-		b.WriteString("      apply:\n")
-		b.WriteString(`        - ExemptFromChallenge("jabali-domain-optout")` + "\n")
+	default: // "all"
+		// Opt-out: challenge everything, exempt the listed hosts. Distinct label
+		// so the "Exempt" metric separates operator domain opt-outs from the
+		// built-in exemptions. Explicit host equality (req.Host is a
+		// client-controlled header — never a prefix).
+		optout := sanitizeWebmailHosts(o.BotExemptHosts)
+		if len(optout) > 0 {
+			parts := make([]string, len(optout))
+			for i, h := range optout {
+				parts[i] = `req.Host == "` + h + `"`
+			}
+			b.WriteString("    - filter: " + strings.Join(parts, " || ") + "\n")
+			b.WriteString("      apply:\n")
+			b.WriteString(`        - ExemptFromChallenge("jabali-domain-optout")` + "\n")
+		}
 	}
 	return b.String()
 }

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -243,6 +243,47 @@ func TestRenderBotExempt_PerDomainOptOut(t *testing.T) {
 func TestRenderBotExempt_NoOptOutWhenListEmpty(t *testing.T) {
 	out := RenderBotExempt(Opts{})
 	mustNotContain(t, out, "jabali-domain-optout", "no opt-out filter when list empty")
+	// Default scope is "all" — never the selected-mode exemptions.
+	mustNotContain(t, out, "jabali-selected", "default scope=all emits no selected-mode exempt")
+}
+
+func TestRender_BotScopeHeaderRoundTrips(t *testing.T) {
+	all := Render(Opts{Mode: "off", Inband: []string{"x"}, BotDetection: "balanced"})
+	mustContain(t, all, "# jabali-bot-detection-scope: all", "default scope header")
+	sel := Render(Opts{Mode: "off", Inband: []string{"x"}, BotDetection: "balanced", BotScope: "selected"})
+	mustContain(t, sel, "# jabali-bot-detection-scope: selected", "selected scope header")
+	weird := Render(Opts{Mode: "off", Inband: []string{"x"}, BotScope: "bogus"})
+	mustContain(t, weird, "# jabali-bot-detection-scope: all", "unknown scope → all")
+}
+
+func TestRenderBotExempt_SelectedChallengesOnlyIncluded(t *testing.T) {
+	out := RenderBotExempt(Opts{
+		BotScope:        "selected",
+		BotIncludeHosts: []string{"Shop.example.com", "www.shop.example.com", "shop.example.com"},
+	})
+	// Exempt everyone NOT in the include set → only included hosts are challenged.
+	mustContain(t, out, `req.Host not in ["shop.example.com", "www.shop.example.com"]`, "sorted, deduped include set, negated")
+	mustContain(t, out, `ExemptFromChallenge("jabali-selected-exclude")`, "selected-exclude label")
+	mustNotContain(t, out, "jabali-domain-optout", "opt-out block not emitted in selected scope")
+	// ACME still always exempt.
+	mustContain(t, out, `ExemptFromChallenge("jabali-acme-http01")`, "acme still exempt in selected scope")
+}
+
+func TestRenderBotExempt_SelectedEmptyChallengesNothing(t *testing.T) {
+	out := RenderBotExempt(Opts{BotScope: "selected"})
+	mustContain(t, out, "- filter: true\n", "unconditional exempt when nothing selected")
+	mustContain(t, out, `ExemptFromChallenge("jabali-selected-none")`, "selected-none label")
+}
+
+func TestRenderBotExempt_ExemptListIgnoredInSelectedScope(t *testing.T) {
+	// A stale opt-out list must not leak challenges through in selected mode.
+	out := RenderBotExempt(Opts{
+		BotScope:        "selected",
+		BotIncludeHosts: []string{"a.com"},
+		BotExemptHosts:  []string{"b.com"},
+	})
+	mustNotContain(t, out, `req.Host == "b.com"`, "exempt list is inert in selected scope")
+	mustContain(t, out, `req.Host not in ["a.com"]`, "only the include set drives selected scope")
 }
 
 func TestRenderBotExempt_WebmailHostEqualityNeverPrefix(t *testing.T) {

--- a/internal/appseccfg/state.go
+++ b/internal/appseccfg/state.go
@@ -47,6 +47,31 @@ func LoadBotExemptHosts(path string) ([]string, error) {
 	return loadHostList(path)
 }
 
+// BotIncludeHostsPath is the state file listing the FQDNs whose domains the
+// operator has opted IN to the bot-detection challenge (used only when the
+// server-wide scope is "selected"). Written by the panel reconciler, read by
+// RenderBotExempt to build the `req.Host not in [...]` exemption. Missing/empty
+// in selected scope → challenge nothing (the safe default: never silently
+// challenge sites the operator didn't pick).
+const BotIncludeHostsPath = "/var/lib/jabali-panel/bot-include-hosts.list"
+
+// LoadBotIncludeHosts reads + sanitizes the per-domain opt-in list.
+func LoadBotIncludeHosts(path string) ([]string, error) {
+	return loadHostList(path)
+}
+
+// WriteBotIncludeHosts writes the sanitized, sorted opt-in list atomically.
+func WriteBotIncludeHosts(path string, hosts []string) (changed bool, err error) {
+	return writeHostList(
+		path,
+		"# Managed by jabali-panel reconciler — DO NOT hand-edit.\n"+
+			"# FQDNs opted IN to the AppSec bot-detection challenge (used only\n"+
+			"# when the server-wide scope is 'selected'). Read by\n"+
+			"# internal/appseccfg.RenderBotExempt. One FQDN per line.\n",
+		hosts,
+	)
+}
+
 // WriteBotExemptHosts writes the sanitized, sorted exempt-host list atomically.
 // Returns (changed, error); write-on-diff so a caller can gate a reload.
 func WriteBotExemptHosts(path string, hosts []string) (changed bool, err error) {

--- a/panel-agent/internal/commands/security_crowdsec.go
+++ b/panel-agent/internal/commands/security_crowdsec.go
@@ -1004,7 +1004,7 @@ func renderAppSecGeoblockRule(mode string, countries []string) string {
 	// of email_enabled changing, so any gap is brief.
 	// Delegate to the shared renderer, preserving the current bot-detection
 	// header marker so toggling geoblock never resets it (and vice-versa).
-	return renderJabaliAppsec(mode, countries, readBotDetectionMode())
+	return renderJabaliAppsec(mode, countries, readBotDetectionMode(), readBotScope())
 }
 
 // ---- M27 Step 2: security.crowdsec.allowlists.{list,add,remove} -----------

--- a/panel-agent/internal/commands/security_crowdsec_botdetection.go
+++ b/panel-agent/internal/commands/security_crowdsec_botdetection.go
@@ -153,7 +153,7 @@ func readGeoblockState() (string, []string) {
 // both the geoblock and bot-detection handlers, so neither resets the
 // other's header marker. Webmail allowlist comes from the panel reconciler's
 // state file (missing → no webmail filter, the safe default).
-func renderJabaliAppsec(geoMode string, countries []string, botMode string) string {
+func renderJabaliAppsec(geoMode string, countries []string, botMode, botScope string) string {
 	webmailHosts, _ := appseccfg.LoadWebmailHosts(appseccfg.WebmailHostsPath)
 	return appseccfg.Render(appseccfg.Opts{
 		Mode:      geoMode,
@@ -167,7 +167,33 @@ func renderJabaliAppsec(geoMode string, countries []string, botMode string) stri
 		PanelHost:      appsecPanelHost(),
 		WebmailHosts:   webmailHosts,
 		BotDetection:   botMode,
+		BotScope:       botScope,
 	})
+}
+
+// readBotScope reports the applied challenge scope ("all"|"selected"),
+// preferring the jabali-appsec header and falling back to sniffing the
+// jabali-bot-exempt content (the selected-mode labels appear only in that
+// scope) — same stale-binary resilience as readBotDetectionMode.
+func readBotScope() string {
+	if body, err := os.ReadFile(appsecRulePath); err == nil {
+		for _, line := range strings.Split(string(body), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "# jabali-bot-detection-scope:") {
+				if strings.TrimSpace(strings.TrimPrefix(line, "# jabali-bot-detection-scope:")) == "selected" {
+					return "selected"
+				}
+				return "all"
+			}
+		}
+	}
+	if body, err := os.ReadFile(botExemptConfigPath); err == nil {
+		s := string(body)
+		if strings.Contains(s, "jabali-selected-exclude") || strings.Contains(s, "jabali-selected-none") {
+			return "selected"
+		}
+	}
+	return "all"
 }
 
 func csBotDetectionGetHandler(_ context.Context, _ json.RawMessage) (any, error) {
@@ -176,13 +202,22 @@ func csBotDetectionGetHandler(_ context.Context, _ json.RawMessage) (any, error)
 
 func csBotDetectionSetHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	var p struct {
-		Mode string `json:"mode"`
+		Mode  string `json:"mode"`
+		Scope string `json:"scope"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, csInvalidArg(fmt.Sprintf("parse params: %v", err))
 	}
 	if _, ok := csBotDetectionModes[p.Mode]; !ok {
 		return nil, csInvalidArg("mode must be off|balanced|permissive")
+	}
+	// Scope defaults to "all" (challenge every site) — matches the pre-scope
+	// behaviour, so an old panel that omits the field never lands in "selected".
+	scope := "all"
+	if p.Scope == "selected" {
+		scope = "selected"
+	} else if p.Scope != "" && p.Scope != "all" {
+		return nil, csInvalidArg("scope must be all|selected")
 	}
 	geoMode, countries := readGeoblockState()
 	if p.Mode == "off" {
@@ -191,13 +226,13 @@ func csBotDetectionSetHandler(ctx context.Context, params json.RawMessage) (any,
 	if err := requireBotDetectionSupport(ctx); err != nil {
 		return nil, err
 	}
-	return botDetectionApplyOn(ctx, p.Mode, geoMode, countries)
+	return botDetectionApplyOn(ctx, p.Mode, scope, geoMode, countries)
 }
 
 // botDetectionApplyOn installs the collections, composes the acquis, and
 // restarts — validating with `crowdsec -t` before the restart and rolling
 // the files back on failure so a bad config can never take AppSec down.
-func botDetectionApplyOn(ctx context.Context, mode, geoMode string, countries []string) (any, error) {
+func botDetectionApplyOn(ctx context.Context, mode, scope, geoMode string, countries []string) (any, error) {
 	if err := installBotCollections(ctx, mode); err != nil {
 		return nil, err
 	}
@@ -218,10 +253,10 @@ func botDetectionApplyOn(ctx context.Context, mode, geoMode string, countries []
 	prevAppsec, hadAppsec := readFileOK(appsecRulePath)
 	_, hadExempt := readFileOK(botExemptConfigPath)
 
-	if err := writeAppsecFile(botExemptConfigPath, appseccfg.RenderBotExempt(botExemptOpts())); err != nil {
+	if err := writeAppsecFile(botExemptConfigPath, appseccfg.RenderBotExempt(botExemptOpts(scope))); err != nil {
 		return nil, err
 	}
-	if err := writeAppsecFile(appsecRulePath, renderJabaliAppsec(geoMode, countries, mode)); err != nil {
+	if err := writeAppsecFile(appsecRulePath, renderJabaliAppsec(geoMode, countries, mode, scope)); err != nil {
 		return nil, err
 	}
 	acquis := appseccfg.RenderAcquis(appseccfg.Opts{BotDetection: mode, BotConfigs: leaves})
@@ -249,7 +284,7 @@ func botDetectionApplyOff(ctx context.Context, geoMode string, countries []strin
 	prevAcquis, hadAcquis := readFileOK(appsecAcquisPath)
 	prevAppsec, hadAppsec := readFileOK(appsecRulePath)
 
-	if err := writeAppsecFile(appsecRulePath, renderJabaliAppsec(geoMode, countries, "off")); err != nil {
+	if err := writeAppsecFile(appsecRulePath, renderJabaliAppsec(geoMode, countries, "off", "all")); err != nil {
 		return nil, err
 	}
 	if err := writeAppsecFile(appsecAcquisPath, appseccfg.RenderAcquis(appseccfg.Opts{BotDetection: "off"})); err != nil {
@@ -272,13 +307,16 @@ func botDetectionApplyOff(ctx context.Context, geoMode string, countries []strin
 // jabali-appsec uses (so the built-in exemptions match the on_match allowlist)
 // PLUS the operator's per-domain opt-out list (both from the panel reconciler's
 // state files; missing → the safe default of no exemption).
-func botExemptOpts() appseccfg.Opts {
+func botExemptOpts(scope string) appseccfg.Opts {
 	webmailHosts, _ := appseccfg.LoadWebmailHosts(appseccfg.WebmailHostsPath)
 	exemptHosts, _ := appseccfg.LoadBotExemptHosts(appseccfg.BotExemptHostsPath)
+	includeHosts, _ := appseccfg.LoadBotIncludeHosts(appseccfg.BotIncludeHostsPath)
 	return appseccfg.Opts{
-		PanelHost:      appsecPanelHost(),
-		WebmailHosts:   webmailHosts,
-		BotExemptHosts: exemptHosts,
+		PanelHost:       appsecPanelHost(),
+		WebmailHosts:    webmailHosts,
+		BotScope:        scope,
+		BotExemptHosts:  exemptHosts,
+		BotIncludeHosts: includeHosts,
 	}
 }
 
@@ -298,7 +336,7 @@ func csBotDetectionRefreshExemptHandler(ctx context.Context, _ json.RawMessage) 
 	if mode == "off" {
 		return map[string]any{"mode": "off", "reloaded": false}, nil
 	}
-	body := appseccfg.RenderBotExempt(botExemptOpts())
+	body := appseccfg.RenderBotExempt(botExemptOpts(readBotScope()))
 	if existing, err := os.ReadFile(botExemptConfigPath); err == nil && string(existing) == body {
 		return map[string]any{"mode": mode, "reloaded": false}, nil
 	}

--- a/panel-api/cmd/server/appsec_cmd.go
+++ b/panel-api/cmd/server/appsec_cmd.go
@@ -32,6 +32,7 @@ const (
 	appsecModeHeader    = "# jabali-mode:"
 	appsecCountriesHead = "# jabali-countries:"
 	appsecBotDetectHead = "# jabali-bot-detection:"
+	appsecBotScopeHead  = "# jabali-bot-detection-scope:"
 )
 
 // newAppSecRenderConfigCmd is the canonical writer of
@@ -77,15 +78,19 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 
 			mode := "off"
 			botMode := "off"
+			botScope := "all"
 			var countries []string
 			if reconcile {
-				m, c, bm := readOperatorHeader(appsecConfigPath)
+				m, c, bm, bs := readOperatorHeader(appsecConfigPath)
 				if m != "" {
 					mode = m
 				}
 				countries = c
 				if bm != "" {
 					botMode = bm
+				}
+				if bs != "" {
+					botScope = bs
 				}
 			}
 			inband := detectInbandRules(appsecRulesDir)
@@ -113,6 +118,9 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 				// (singular, OFF state) and the agent (plural, ON state); this
 				// command only keeps the jabali-appsec header honest.
 				BotDetection: botMode,
+				// Preserve scope too — a reset from "selected" to "all" would
+				// challenge every hosted site at once.
+				BotScope: botScope,
 			})
 
 			// Write-on-diff: cheap before any nginx/crowdsec reload
@@ -140,10 +148,10 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 // lines from the existing file. Both writers (this subcommand + the agent
 // geoblock handler) emit those lines so the operator state survives every
 // re-render. Missing file → ("", nil) which the caller maps to defaults.
-func readOperatorHeader(path string) (mode string, countries []string, botMode string) {
+func readOperatorHeader(path string) (mode string, countries []string, botMode, botScope string) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", nil, ""
+		return "", nil, "", ""
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
@@ -164,11 +172,13 @@ func readOperatorHeader(path string) (mode string, countries []string, botMode s
 					countries = append(countries, c)
 				}
 			}
+		case strings.HasPrefix(line, appsecBotScopeHead):
+			botScope = strings.TrimSpace(strings.TrimPrefix(line, appsecBotScopeHead))
 		case strings.HasPrefix(line, appsecBotDetectHead):
 			botMode = strings.TrimSpace(strings.TrimPrefix(line, appsecBotDetectHead))
 		}
 	}
-	return mode, countries, botMode
+	return mode, countries, botMode, botScope
 }
 
 // detectInbandRules stats the appsec-rules dir and returns the list of

--- a/panel-api/cmd/server/appsec_cmd_test.go
+++ b/panel-api/cmd/server/appsec_cmd_test.go
@@ -39,7 +39,7 @@ func TestReadOperatorHeader(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			mode, countries, _ := readOperatorHeader(path)
+			mode, countries, _, _ := readOperatorHeader(path)
 			if mode != c.wantMode {
 				t.Errorf("mode = %q, want %q", mode, c.wantMode)
 			}
@@ -52,23 +52,27 @@ func TestReadOperatorHeader(t *testing.T) {
 
 func TestReadOperatorHeader_BotDetection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "jabali-appsec.yaml")
-	body := "# jabali-mode: off\n# jabali-countries: \n# jabali-bot-detection: balanced\nname: crowdsecurity/jabali-appsec\n"
+	body := "# jabali-mode: off\n# jabali-countries: \n# jabali-bot-detection: balanced\n# jabali-bot-detection-scope: selected\nname: crowdsecurity/jabali-appsec\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	mode, _, botMode := readOperatorHeader(path)
+	mode, _, botMode, botScope := readOperatorHeader(path)
 	if mode != "off" {
 		t.Errorf("mode = %q, want off", mode)
 	}
 	if botMode != "balanced" {
 		t.Errorf("botMode = %q, want balanced", botMode)
 	}
+	// The scope header is a prefix of the mode header — must not be misparsed.
+	if botScope != "selected" {
+		t.Errorf("botScope = %q, want selected", botScope)
+	}
 	// Missing marker → "" (caller defaults to off).
 	p2 := filepath.Join(t.TempDir(), "no-bot.yaml")
 	if err := os.WriteFile(p2, []byte("# jabali-mode: off\nname: x\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, bm := readOperatorHeader(p2); bm != "" {
+	if _, _, bm, _ := readOperatorHeader(p2); bm != "" {
 		t.Errorf("missing bot marker → %q, want empty", bm)
 	}
 }

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -227,6 +227,10 @@ type updateDomainRequest struct {
 	// the operator's security posture on their own domain. Silently ignored
 	// for a non-admin PATCH (pointer pattern), never 403.
 	BotChallengeExempt *bool `json:"bot_challenge_exempt,omitempty"`
+	// BotChallengeInclude — per-domain opt-IN, effective only when the
+	// server-wide bot-detection scope is "selected". Admin-only (same reasoning;
+	// the switch lives in admin DomainEdit).
+	BotChallengeInclude *bool `json:"bot_challenge_include,omitempty"`
 	// GH #648 (DMARCbis): per-domain settable np (non-existent subdomain
 	// policy) + t=y testing tag, folded into the canonical _dmarc record.
 	DmarcNP      *string `json:"dmarc_np,omitempty"`
@@ -799,6 +803,9 @@ func (h *domainHandler) update(c *gin.Context) {
 		// (while bot detection is on) has the agent re-render jabali-bot-exempt.
 		if req.BotChallengeExempt != nil {
 			domain.BotChallengeExempt = *req.BotChallengeExempt
+		}
+		if req.BotChallengeInclude != nil {
+			domain.BotChallengeInclude = *req.BotChallengeInclude
 		}
 
 		if req.NginxRules != nil {

--- a/panel-api/internal/api/security_crowdsec.go
+++ b/panel-api/internal/api/security_crowdsec.go
@@ -640,7 +640,8 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 
 	g.PUT("/bot-detection", func(c *gin.Context) {
 		var body struct {
-			Mode string `json:"mode"`
+			Mode  string `json:"mode"`
+			Scope string `json:"scope"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_json"})
@@ -653,10 +654,23 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 			})
 			return
 		}
+		// Scope defaults to "all" (challenge every site) when omitted.
+		scope := body.Scope
+		if scope == "" {
+			scope = "all"
+		}
+		if _, ok := appsecBotDetectionScopes[scope]; !ok {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "error", "error": "invalid_scope",
+				"detail": "scope must be all|selected",
+			})
+			return
+		}
 		ctx, cancel := context.WithTimeout(c.Request.Context(), csBotDetectionTimeout)
 		defer cancel()
 		if _, err := cli.Call(ctx, "security.crowdsec.appsec.botdetection.set", map[string]any{
-			"mode": body.Mode,
+			"mode":  body.Mode,
+			"scope": scope,
 		}); err != nil {
 			status, errBody := translateAgentError(err)
 			c.JSON(status, errBody)
@@ -670,6 +684,7 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 			return
 		}
 		s.AppSecBotDetection = body.Mode
+		s.AppSecBotDetectionScope = scope
 		if err := settings.Upsert(c.Request.Context(), s); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"status": "error", "error": "settings_write", "detail": err.Error(),
@@ -794,12 +809,20 @@ var appsecBotDetectionModes = map[string]struct{}{
 	"off": {}, "balanced": {}, "permissive": {},
 }
 
+var appsecBotDetectionScopes = map[string]struct{}{
+	"all": {}, "selected": {},
+}
+
 func appsecBotDetectionResponse(s *models.ServerSettings) gin.H {
 	mode := s.AppSecBotDetection
 	if _, ok := appsecBotDetectionModes[mode]; !ok {
 		mode = "off" // empty / legacy row → off
 	}
-	return gin.H{"mode": mode}
+	scope := s.AppSecBotDetectionScope
+	if _, ok := appsecBotDetectionScopes[scope]; !ok {
+		scope = "all" // empty / legacy row → all
+	}
+	return gin.H{"mode": mode, "scope": scope}
 }
 
 // countryExemptResponse renders the ADR-0166 state. Empty selection is

--- a/panel-api/internal/db/migrations/000288_appsec_bot_detection_scope.down.sql
+++ b/panel-api/internal/db/migrations/000288_appsec_bot_detection_scope.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE domains
+  DROP COLUMN bot_challenge_include;
+ALTER TABLE server_settings
+  DROP COLUMN appsec_bot_detection_scope;

--- a/panel-api/internal/db/migrations/000288_appsec_bot_detection_scope.up.sql
+++ b/panel-api/internal/db/migrations/000288_appsec_bot_detection_scope.up.sql
@@ -1,0 +1,12 @@
+-- AppSec bot-detection SCOPE (CrowdSec 1.8, opt-in follow-up).
+--   appsec_bot_detection_scope ∈ {"all","selected"}: "all" challenges every
+--   site when bot detection is on (carve exceptions via domains.bot_challenge_
+--   exempt); "selected" challenges ONLY domains flagged bot_challenge_include.
+-- server_settings string column: TEXT + parenthesized default (row-size
+-- ceiling — migrations 000264/000285/000286). Default 'all' = shipped behaviour.
+ALTER TABLE server_settings
+  ADD COLUMN appsec_bot_detection_scope TEXT NOT NULL DEFAULT ('all');
+
+-- Per-domain opt-IN (used only when the scope is "selected"). Admin-only.
+ALTER TABLE domains
+  ADD COLUMN bot_challenge_include TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -511,6 +511,12 @@ type Domain struct {
 	// insert trap).
 	BotChallengeExempt bool `gorm:"column:bot_challenge_exempt;type:tinyint(1);not null" json:"bot_challenge_exempt"`
 
+	// BotChallengeInclude (migration 000288) — per-domain opt-IN, used only when
+	// the server-wide AppSec bot-detection scope is "selected": these domains
+	// (and www.<domain>) ARE challenged and every other site is exempt.
+	// Admin-only, opt-in (default 0). Inert in scope "all".
+	BotChallengeInclude bool `gorm:"column:bot_challenge_include;type:tinyint(1);not null" json:"bot_challenge_include"`
+
 	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -234,6 +234,12 @@ type ServerSettings struct {
 	// off-page (server_settings row-size ceiling).
 	AppSecBotDetection string `gorm:"column:appsec_bot_detection;type:text;not null;default:'off'" json:"appsec_bot_detection"`
 
+	// AppSecBotDetectionScope (migration 000288) — which sites the bot-detection
+	// challenge applies to when it is on: "all" (default — challenge every site,
+	// carve exceptions via domains.bot_challenge_exempt) or "selected" (challenge
+	// ONLY domains flagged bot_challenge_include). TEXT off-page (row ceiling).
+	AppSecBotDetectionScope string `gorm:"column:appsec_bot_detection_scope;type:text;not null;default:'all'" json:"appsec_bot_detection_scope"`
+
 	// Country ban exemption (ADR-0166, migration 000262). Countries whose
 	// IPs must never be blocked by CrowdSec from any decision source
 	// (scenario bans, AppSec inband, CAPI/console blocklists, captchas).

--- a/panel-api/internal/reconciler/bot_exempt_reconcile.go
+++ b/panel-api/internal/reconciler/bot_exempt_reconcile.go
@@ -30,17 +30,22 @@ func (r *Reconciler) reconcileBotChallengeExempt(ctx context.Context) {
 		r.log.Warn("bot-exempt reconcile: list domains", "err", err)
 		return
 	}
-	var hosts []string
+	var exempt, include []string
 	for i := range domains {
-		if !domains[i].BotChallengeExempt {
-			continue
-		}
 		n := domains[i].Name
-		hosts = append(hosts, n, "www."+n)
+		if domains[i].BotChallengeExempt {
+			exempt = append(exempt, n, "www."+n)
+		}
+		if domains[i].BotChallengeInclude {
+			include = append(include, n, "www."+n)
+		}
 	}
-	if _, err := appseccfg.WriteBotExemptHosts(appseccfg.BotExemptHostsPath, hosts); err != nil {
-		r.log.Warn("bot-exempt reconcile: write state file", "err", err)
+	if _, err := appseccfg.WriteBotExemptHosts(appseccfg.BotExemptHostsPath, exempt); err != nil {
+		r.log.Warn("bot-exempt reconcile: write exempt state file", "err", err)
 		// fall through: still try to refresh from whatever is on disk.
+	}
+	if _, err := appseccfg.WriteBotIncludeHosts(appseccfg.BotIncludeHostsPath, include); err != nil {
+		r.log.Warn("bot-exempt reconcile: write include state file", "err", err)
 	}
 
 	if r.serverSettings == nil {

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -389,7 +389,8 @@ func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {
 		"nginx_rules", "nginx_safe_options",
 		"redirect_all_to", "redirect_all_type", "page_redirects",
 		"index_priority", "ssl_enabled", "is_quota_suspended", "webmail_enabled",
-		"dmarc_np", "dmarc_testing", "temp_url_enabled", "bot_challenge_exempt", "updated_at",
+		"dmarc_np", "dmarc_testing", "temp_url_enabled",
+		"bot_challenge_exempt", "bot_challenge_include", "updated_at",
 	).Updates(d).Error; err != nil {
 		return translate(err)
 	}

--- a/panel-ui/src/hooks/useSecurityCrowdsec.ts
+++ b/panel-ui/src/hooks/useSecurityCrowdsec.ts
@@ -274,8 +274,15 @@ export function useUpdateAppSecGeoblock() {
 // acquisition and restarts crowdsec. Needs CrowdSec engine >= 1.8 + bouncer
 // >= 1.2.2 (the agent version-gates and returns a 400 otherwise).
 export type AppSecBotDetectionMode = "off" | "balanced" | "permissive";
+export type AppSecBotDetectionScope = "all" | "selected";
 
-export type AppSecBotDetection = { mode: AppSecBotDetectionMode };
+export type AppSecBotDetection = {
+  mode: AppSecBotDetectionMode;
+  // "all" = challenge every site (carve exceptions per-domain); "selected" =
+  // challenge only domains flagged bot_challenge_include. Absent on an older
+  // panel-api → treated as "all".
+  scope?: AppSecBotDetectionScope;
+};
 
 export function useAppSecBotDetection() {
   return useQuery({

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -33,6 +33,7 @@ export type DomainEditInput = {
   doc_root?: string;
   temp_url_enabled?: boolean;
   bot_challenge_exempt?: boolean;
+  bot_challenge_include?: boolean;
 };
 
 export const DomainEdit = () => {
@@ -64,6 +65,7 @@ export const DomainEdit = () => {
         doc_root: domain.doc_root,
         temp_url_enabled: domain.temp_url_enabled,
         bot_challenge_exempt: domain.bot_challenge_exempt,
+        bot_challenge_include: domain.bot_challenge_include,
       });
     }
   }, [domain, form]);
@@ -160,8 +162,27 @@ export const DomainEdit = () => {
           <Typography.Text type="secondary" style={{ display: "block", fontSize: 12 }}>
             Skip the server-wide AppSec bot challenge on this site — for
             API/webhook-heavy domains whose non-browser clients can&apos;t solve
-            it. Also covers www.&lt;domain&gt;. No effect unless bot detection is
-            on server-wide (Security → CrowdSec → Bot Detection).
+            it. Also covers www.&lt;domain&gt;. Effective when bot detection is on
+            server-wide in <b>All sites</b> mode (Security → CrowdSec → Bot
+            Detection).
+          </Typography.Text>
+        </Typography.Text>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 24 }}>
+        <Form.Item name="bot_challenge_include" valuePropName="checked" noStyle>
+          <Switch
+            checkedChildren={<CheckOutlined />}
+            unCheckedChildren={<CloseOutlined />}
+          />
+        </Form.Item>
+        <Typography.Text>
+          Include in bot-detection challenge
+          <Typography.Text type="secondary" style={{ display: "block", fontSize: 12 }}>
+            Challenge suspected bots on this site (and www.&lt;domain&gt;).
+            Effective only when bot detection is on server-wide in{" "}
+            <b>Selected domains</b> mode; in that mode, sites not marked here are
+            left alone.
           </Typography.Text>
         </Typography.Text>
       </div>

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -156,6 +156,7 @@ export type Domain = {
   temp_url_enabled?: boolean;
   temp_url?: string | null;
   bot_challenge_exempt?: boolean;
+  bot_challenge_include?: boolean;
   nginx_custom_directives: string;
   redirect_all_to?: string | null;
   redirect_all_type?: string | null;

--- a/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
@@ -60,6 +60,7 @@ import {
   useUpdateCrowdsecProfiles,
   type AppSecGeoblockMode,
   type AppSecBotDetectionMode,
+  type AppSecBotDetectionScope,
   type CrowdsecAlert,
   type CrowdsecAllowlistEntry,
   type CrowdsecCaptchaProvider,
@@ -620,22 +621,26 @@ const AppSecBotDetectionCard = () => {
   const updateBot = useUpdateAppSecBotDetection();
 
   const [mode, setMode] = useState<AppSecBotDetectionMode>("off");
+  const [scope, setScope] = useState<AppSecBotDetectionScope>("all");
 
   useEffect(() => {
     if (bot.data) {
       setMode(bot.data.mode);
+      setScope(bot.data.scope ?? "all");
     }
   }, [bot.data]);
 
-  const dirty = bot.data !== undefined && mode !== bot.data.mode;
+  const dirty =
+    bot.data !== undefined &&
+    (mode !== bot.data.mode || scope !== (bot.data.scope ?? "all"));
 
   const apply = async () => {
     try {
-      await updateBot.mutateAsync({ mode });
+      await updateBot.mutateAsync({ mode, scope });
       feedback.message.success(
         mode === "off"
           ? "Bot detection disabled — crowdsec restarted"
-          : `Bot detection set to ${mode} — crowdsec restarted`,
+          : `Bot detection set to ${mode} (${scope === "selected" ? "selected domains" : "all sites"}) — crowdsec restarted`,
       );
     } catch (e: unknown) {
       feedback.message.error(
@@ -679,6 +684,44 @@ const AppSecBotDetectionCard = () => {
             ]}
           />
         </div>
+        {mode !== "off" && (
+          <div>
+            <Typography.Text strong>Applies to: </Typography.Text>
+            <Segmented
+              value={scope}
+              onChange={(v) => setScope(v as AppSecBotDetectionScope)}
+              options={[
+                { label: "All sites", value: "all" },
+                { label: "Selected domains", value: "selected" },
+              ]}
+            />
+          </div>
+        )}
+        {mode !== "off" && scope === "selected" && (
+          <Alert
+            type="info"
+            showIcon
+            message="Only the domains you mark are challenged"
+            description={
+              "In Selected mode, only domains flagged “Include in bot-detection " +
+              "challenge” (in each domain's settings) get the challenge — every " +
+              "other site is left alone. If no domain is flagged, nothing is " +
+              "challenged."
+            }
+          />
+        )}
+        {mode !== "off" && scope === "all" && (
+          <Alert
+            type="info"
+            showIcon
+            message="Every site is challenged"
+            description={
+              "In All-sites mode, every hosted domain is challenged. Exempt " +
+              "individual sites with “Exempt from bot-detection challenge” in " +
+              "each domain's settings."
+            }
+          />
+        )}
         <Space>
           <Popconfirm
             title="Apply bot detection?"


### PR DESCRIPTION
## What

Completes per-domain scoping for AppSec bot detection (after opt-out #1464). The server-wide setting gains a **scope**:

- **All sites** (default, the shipped behaviour) — challenge every hosted site; carve exceptions with per-domain **Exempt** (#1464).
- **Selected domains** — challenge **only** domains flagged **Include in bot-detection challenge**; every other site is left alone.

Admin → Security → CrowdSec → Bot Detection now has an **Applies to: All sites / Selected domains** control; DomainEdit has the matching **Include** switch alongside **Exempt**.

## Design

Explicit scope + a second admin-only boolean (`bot_challenge_include`) — chosen over a meaning-flipping single flag, a migrated tri-state, or implicit scope (all rejected: a DB column whose semantics invert on a server setting is a future incident). Each per-domain flag has one fixed meaning and is inert outside its scope.

Mechanism: in `selected` scope, `RenderBotExempt` emits `req.Host not in [include-list]` → everything except the included hosts is exempt. An **empty** include list renders an explicit unconditional exempt (challenge nothing) rather than relying on `not in []` edge semantics.

## Safety

- **Scope rides the same clobber-safe rails as mode**: a `# jabali-bot-detection-scope:` header preserved by `render-config` and recoverable by the agent's sniff fallback — a silent reset to `all` would challenge every site on the box at once.
- **Deploy-skew safe both directions**: absent/empty scope → `all` (old panel + new agent, or new panel + old agent, both degrade to shipped behaviour).
- Include flag is **admin-only** (same as exempt); added to the domain `Update` allowlist (silent-drop scar).
- `not in [...]` is the same engine construct geoblock's allow-mode uses — proven live in the drill.

## Tested — drilled on .60 via the real agent

- `selected` + include=[shop] → **shop challenged, other allowed** (header `scope: selected`)
- empty include + refresh → **nothing challenged**, applied by **reload** (crowdsec **PID unchanged**)
- flip to `all` + exempt=[shop] → **shop allowed, other challenged** (opt-out restored)

`.60` restored to baseline. `go build`/`vet`/exec-seam + appseccfg / migrations-completeness / agent-order / CLI-header tests + `tsc -b` all green. sqlmock unaffected. Migration 000288 (one migration, both tables: scope TEXT off-page, include tinyint).

## Not in scope

Tenant self-service opt-in (a domain owner opting their own site *into* protection is harmless) — a one-line follow-up, deferred.

Refs #1463, #1464.
