### PR TITLE
fix(backup): unwedge restic retention from stale locks + alert on failure (JAB-392)

### DIFF
--- a/panel-api/cmd/server/backup_retention_cmd.go
+++ b/panel-api/cmd/server/backup_retention_cmd.go
@@ -11,12 +11,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -24,6 +27,7 @@ import (
 	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -118,6 +122,10 @@ by install_backup_foundation in install.sh.`,
 			// Track which destinations had any forget run against them so
 			// we only invoke prune where it would have work to do.
 			pruneDests := map[string]*models.BackupDestination{}
+			// JAB-392: accumulate every forget/prune failure so the sweep exits
+			// non-zero AND fires ONE aggregate admin alert, instead of printing
+			// to a journal nobody reads and exiting 0 (it did that for 52 days).
+			var failures []string
 			for _, s := range scheds {
 				if !s.Enabled {
 					continue
@@ -141,6 +149,7 @@ by install_backup_foundation in install.sh.`,
 					if err := forgetForSchedule(ctx, cmd, s, d, dryRun); err != nil {
 						fmt.Fprintf(cmd.ErrOrStderr(),
 							"schedule %s dest %s forget failed: %v\n", s.ID, d.ID, err)
+						failures = append(failures, fmt.Sprintf("schedule %s dest %s (%s) forget: %v", s.ID, d.ID, d.Name, err))
 						continue
 					}
 					pruneDests[d.ID] = d
@@ -160,7 +169,15 @@ by install_backup_foundation in install.sh.`,
 				if err := pruneOneDestination(ctx, cmd, d, dryRun); err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(),
 						"prune dest %s failed: %v\n", d.ID, err)
+					failures = append(failures, fmt.Sprintf("prune dest %s (%s): %v", d.ID, d.Name, err))
 				}
+			}
+			if len(failures) > 0 {
+				// Alert (best-effort) + exit non-zero. The notification is the
+				// operator-visible signal; the exit code makes `systemctl status`
+				// and any OnFailure= truthful even when Redis is down (JAB-392).
+				publishBackupRetentionFailure(ctx, cmd, failures)
+				return fmt.Errorf("retention sweep completed with %d failure(s): %s", len(failures), strings.Join(failures, "; "))
 			}
 			return nil
 		},
@@ -168,6 +185,83 @@ by install_backup_foundation in install.sh.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"Pass restic --dry-run to forget+prune (lists what would be removed; no destructive ops)")
 	return cmd
+}
+
+// retentionExec is the exec seam for the retention sweep's restic invocations,
+// so tests can drive the JAB-392 stale-lock recovery without spawning restic.
+// Production wiring is exec.CommandContext.
+var retentionExec = func(ctx context.Context, env []string, stdout, stderr io.Writer, name string, args ...string) error {
+	c := exec.CommandContext(ctx, name, args...)
+	c.Env = env
+	c.Stdout, c.Stderr = stdout, stderr
+	return c.Run()
+}
+
+// resticRepoArgs is the shared global-flag prefix every retention restic call
+// needs: the repo URL, the password file, and the destination's -o options.
+func resticRepoArgs(d *models.BackupDestination) []string {
+	args := []string{"--repo", d.URL, "--password-file", resticPasswordFile}
+	for _, opt := range backupwrapperhelpers.ResticOptionsFor(d) {
+		if opt == "" {
+			continue
+		}
+		args = append(args, "-o", opt)
+	}
+	return args
+}
+
+// runResticWithLockRecovery runs a retention restic command against d and
+// recovers from a stale repository lock (JAB-392).
+//
+// A crashed or OOM-killed `restic prune`/`forget` leaves an exclusive lock that
+// restic will NOT auto-remove when it is from the same host and it cannot prove
+// the PID is dead (PID reuse) — so ONE dead prune wedges every future
+// forget/prune forever. Found live on production: 52 days of silently-failed
+// retention, the repo grown to 7,318 snapshots. On the "repository is already
+// locked" error we clear STALE locks with `restic unlock` (NEVER --remove-all —
+// that would also drop a live concurrent backup's lock and let prune race a
+// running backup) and retry the command once. A lock held by a live backup
+// survives the stale-only unlock, so the retry fails again and the caller
+// reports the failure instead of pruning underneath a running backup.
+func runResticWithLockRecovery(ctx context.Context, cmd *cobra.Command, d *models.BackupDestination, args []string) error {
+	env := append(os.Environ(), destEnv(d)...)
+	var errBuf bytes.Buffer
+	err := retentionExec(ctx, env, cmd.OutOrStdout(), io.MultiWriter(cmd.ErrOrStderr(), &errBuf), "restic", args...)
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(errBuf.String(), "already locked") && !strings.Contains(err.Error(), "already locked") {
+		return err
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"restic reports the repository already locked (dest %s / %s) — clearing stale locks with `restic unlock` and retrying once (JAB-392)\n",
+		d.ID, d.Name)
+	unlockArgs := append(resticRepoArgs(d), "unlock")
+	if uerr := retentionExec(ctx, env, cmd.OutOrStdout(), cmd.ErrOrStderr(), "restic", unlockArgs...); uerr != nil {
+		return fmt.Errorf("repository was locked and `restic unlock` failed: %w (original error: %v)", uerr, err)
+	}
+	return retentionExec(ctx, env, cmd.OutOrStdout(), cmd.ErrOrStderr(), "restic", args...)
+}
+
+// publishBackupRetentionFailure fires the JAB-392 admin alert (backup.retention.fail)
+// so a wedged sweep is visible instead of silently bloating the offsite repo.
+// Best-effort: if Redis is down the sweep's non-zero exit is still the truth signal.
+func publishBackupRetentionFailure(ctx context.Context, cmd *cobra.Command, failures []string) {
+	if requireRedis(cmd, nil) != nil || sharedRedis == nil {
+		return
+	}
+	body := fmt.Sprintf(
+		"The nightly backup retention sweep failed for %d (schedule, destination) pair(s); snapshots accumulate unpruned until fixed. A stale restic repository lock is the usual cause — `restic unlock` on the destination clears it. Details:\n  %s",
+		len(failures), strings.Join(failures, "\n  "))
+	if _, err := notifications.NewQueue(sharedRedis).Publish(ctx, notifications.Envelope{
+		EventKind: "backup.retention.fail",
+		Severity:  "error",
+		Title:     "Backup retention sweep failed",
+		Body:      body,
+		Deeplink:  "/jabali-admin/backups",
+	}); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to publish backup.retention.fail notification: %v\n", err)
+	}
 }
 
 func forgetForSchedule(ctx context.Context, cmd *cobra.Command, s models.BackupSchedule, d *models.BackupDestination, dryRun bool) error {
@@ -204,11 +298,7 @@ func forgetForSchedule(ctx context.Context, cmd *cobra.Command, s models.BackupS
 		"schedule %s dest %s (%s): restic forget --tag schedule-id=%s daily=%s weekly=%s monthly=%s\n",
 		s.ID, d.ID, d.Name, s.ID,
 		intPtrStr(s.KeepDaily), intPtrStr(s.KeepWeekly), intPtrStr(s.KeepMonthly))
-	c := exec.CommandContext(ctx, "restic", args...)
-	c.Env = append(os.Environ(), destEnv(d)...)
-	c.Stdout = cmd.OutOrStdout()
-	c.Stderr = cmd.ErrOrStderr()
-	return c.Run()
+	return runResticWithLockRecovery(ctx, cmd, d, args)
 }
 
 func pruneOneDestination(ctx context.Context, cmd *cobra.Command, d *models.BackupDestination, dryRun bool) error {
@@ -227,11 +317,7 @@ func pruneOneDestination(ctx context.Context, cmd *cobra.Command, d *models.Back
 		args = append(args, "--dry-run")
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "running: restic prune (dest %s / %s)\n", d.ID, d.Name)
-	c := exec.CommandContext(ctx, "restic", args...)
-	c.Env = append(os.Environ(), destEnv(d)...)
-	c.Stdout = cmd.OutOrStdout()
-	c.Stderr = cmd.ErrOrStderr()
-	return c.Run()
+	return runResticWithLockRecovery(ctx, cmd, d, args)
 }
 
 func destEnv(d *models.BackupDestination) []string {

--- a/panel-api/cmd/server/backup_retention_lock_test.go
+++ b/panel-api/cmd/server/backup_retention_lock_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func newRetentionTestCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetOut(&bytes.Buffer{})
+	c.SetErr(&bytes.Buffer{})
+	return c
+}
+
+func testDest() *models.BackupDestination {
+	return &models.BackupDestination{ID: "d1", Name: "nightly", URL: "/var/lib/jabali-backups/repo"}
+}
+
+func TestRetention_UnlocksAndRetriesOnStaleLock(t *testing.T) {
+	orig := retentionExec
+	t.Cleanup(func() { retentionExec = orig })
+
+	var seq []string
+	forgetN := 0
+	retentionExec = func(_ context.Context, _ []string, _ io.Writer, stderr io.Writer, _ string, args ...string) error {
+		seq = append(seq, strings.Join(args, " "))
+		if hasArg(args, "unlock") {
+			return nil // unlock succeeds
+		}
+		forgetN++
+		if forgetN == 1 {
+			// First forget: the stale-lock error, written to stderr like restic.
+			io.WriteString(stderr, "unable to create lock in backend: repository is already locked by PID 2540018 on host by root\n")
+			return errors.New("exit status 11")
+		}
+		return nil // retry succeeds
+	}
+
+	err := runResticWithLockRecovery(context.Background(), newRetentionTestCmd(), testDest(),
+		[]string{"--repo", "/var/lib/jabali-backups/repo", "forget", "--tag", "schedule-id=s1"})
+	if err != nil {
+		t.Fatalf("expected recovery to succeed, got %v", err)
+	}
+	if len(seq) != 3 {
+		t.Fatalf("expected forget→unlock→forget (3 calls), got %d: %v", len(seq), seq)
+	}
+	if !hasArg(strings.Fields(seq[1]), "unlock") {
+		t.Fatalf("2nd call must be `restic unlock`, got %q", seq[1])
+	}
+	// Never --remove-all: that would drop a live backup's lock.
+	if hasArg(strings.Fields(seq[1]), "--remove-all") {
+		t.Fatalf("unlock must NOT use --remove-all: %q", seq[1])
+	}
+}
+
+func TestRetention_NoLockRunsOnceNoUnlock(t *testing.T) {
+	orig := retentionExec
+	t.Cleanup(func() { retentionExec = orig })
+
+	var seq []string
+	retentionExec = func(_ context.Context, _ []string, _, _ io.Writer, _ string, args ...string) error {
+		seq = append(seq, strings.Join(args, " "))
+		return nil
+	}
+	if err := runResticWithLockRecovery(context.Background(), newRetentionTestCmd(), testDest(),
+		[]string{"--repo", "/repo", "prune"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(seq) != 1 {
+		t.Fatalf("clean run must be a single call, got %d: %v", len(seq), seq)
+	}
+	if hasArg(strings.Fields(seq[0]), "unlock") {
+		t.Fatalf("must not unlock when there is no lock error")
+	}
+}
+
+func TestRetention_NonLockErrorDoesNotRetry(t *testing.T) {
+	orig := retentionExec
+	t.Cleanup(func() { retentionExec = orig })
+
+	calls := 0
+	retentionExec = func(_ context.Context, _ []string, _, stderr io.Writer, _ string, args ...string) error {
+		calls++
+		io.WriteString(stderr, "Fatal: wrong password or no key found\n")
+		return errors.New("exit status 1")
+	}
+	err := runResticWithLockRecovery(context.Background(), newRetentionTestCmd(), testDest(),
+		[]string{"--repo", "/repo", "forget"})
+	if err == nil {
+		t.Fatalf("expected the original error to surface")
+	}
+	if calls != 1 {
+		t.Fatalf("a non-lock error must NOT trigger unlock+retry, got %d calls", calls)
+	}
+}
+
+func TestRetention_UnlockFailureSurfaces(t *testing.T) {
+	orig := retentionExec
+	t.Cleanup(func() { retentionExec = orig })
+
+	retentionExec = func(_ context.Context, _ []string, _, stderr io.Writer, _ string, args ...string) error {
+		if hasArg(args, "unlock") {
+			return errors.New("unlock exit status 1")
+		}
+		io.WriteString(stderr, "repository is already locked\n")
+		return errors.New("exit status 11")
+	}
+	err := runResticWithLockRecovery(context.Background(), newRetentionTestCmd(), testDest(),
+		[]string{"--repo", "/repo", "forget"})
+	if err == nil || !strings.Contains(err.Error(), "unlock") {
+		t.Fatalf("unlock failure should surface, got %v", err)
+	}
+}
+
+func TestRetention_CatalogHasRetentionFailEvent(t *testing.T) {
+	var meta *models.NotificationEventKindMeta
+	for i := range models.AllNotificationEventKinds {
+		if models.AllNotificationEventKinds[i].Kind == "backup.retention.fail" {
+			meta = &models.AllNotificationEventKinds[i]
+			break
+		}
+	}
+	if meta == nil {
+		t.Fatalf("backup.retention.fail missing from the notification event catalog")
+	}
+	if meta.Severity != "error" || !meta.DefaultOn {
+		t.Fatalf("backup.retention.fail should be severity=error DefaultOn=true, got %q on=%v", meta.Severity, meta.DefaultOn)
+	}
+}

--- a/panel-api/internal/models/notification_event_setting.go
+++ b/panel-api/internal/models/notification_event_setting.go
@@ -136,6 +136,13 @@ var AllNotificationEventKinds = []NotificationEventKindMeta{
 		DefaultOn:   false,
 	},
 	{
+		Kind:        "backup.retention.fail",
+		Label:       "Backup retention failed",
+		Description: "The nightly restic forget/prune retention sweep failed for one or more backup destinations (a stale repository lock is the usual cause). Snapshots accumulate unpruned until fixed, growing the offsite repo toward disk-full (JAB-392).",
+		Severity:    "error",
+		DefaultOn:   true,
+	},
+	{
 		Kind:        "backup.limit.reached",
 		Label:       "Tenant backup limit reached",
 		Description: "A tenant hit their package's max_backups cap. Depending on the package retention policy the backup was blocked (reject) or the oldest was auto-pruned (prune). Notifies the tenant and admins (GH #454).",

--- a/panel-ui/src/shells/admin/notifications/eventCategories.test.ts
+++ b/panel-ui/src/shells/admin/notifications/eventCategories.test.ts
@@ -25,6 +25,7 @@ const CATALOG_KINDS = [
   "service.down",
   "crowdsec.ban.spike",
   "backup.fail",
+  "backup.retention.fail",
   "backup.success",
   "backup.limit.reached",
   "dr.sync.stalled",

--- a/panel-ui/src/shells/admin/notifications/eventCategories.ts
+++ b/panel-ui/src/shells/admin/notifications/eventCategories.ts
@@ -102,6 +102,7 @@ export const EVENT_KIND_CATEGORY: Record<string, EventCategoryId> = {
 
   // Backups
   "backup.fail": "backups",
+  "backup.retention.fail": "backups",
   "backup.success": "backups",
   "backup.limit.reached": "backups",
   "dr.sync.stalled": "backups",


### PR DESCRIPTION
## JAB-392 — backup retention silently broken for 52 days (stale restic lock wedges forget+prune, no alerting)

### Problem (found live on newzaps)
The nightly retention sweep (`jabali-backup-retention.service` → restic `forget --prune` per destination) was wedged for **52 days** by a single stale restic lock, failing **silently every night**. The offsite repo grew to **7,318 snapshots** (271/user) against a 7d/4w/12m keep policy — silent, unbounded growth toward disk-full. Account backups kept succeeding (non-exclusive lock), so the only symptom was repo bloat. Manual fix on prod: `restic unlock` (5 stale locks) → re-ran the sweep → 7,318 → 2,098 snapshots, `restic check` clean.

**Root causes:** (1) restic won't auto-remove a same-host stale lock when it can't prove the PID is dead (reuse) → one crashed/OOM-killed prune wedges every future `forget --prune` forever. (2) The sweep printed failures to the journal and **exited 0**, and there's no `backup.retention.fail` event → a 52-day outage produced **zero signal**.

### Fix
- **`runResticWithLockRecovery`** (both forget and prune): on `repository is already locked`, clear **stale** locks with `restic unlock` (**never `--remove-all`** — that would drop a live backup's lock and let prune race a running backup) and retry once. A live backup's lock survives the stale-only unlock, so the retry fails again and the sweep reports it instead of pruning under a running backup. A `retentionExec` seam makes the recovery sequence unit-testable.
- **Truthful failure**: the sweep now accumulates every forget/prune failure, fires **one aggregate `backup.retention.fail` admin notification** (best-effort via Redis), **and returns non-zero** — the notification is the operator alert, the exit code is the truth signal that works even when Redis is down. No `OnFailure=` existed on the unit, so both layers matter.
- **New event** `backup.retention.fail` (error, default-on) in the Go catalog + the panel-ui `eventCategories.ts` cross-boundary map.

### Deferred (noted on the ticket)
A periodic `restic check` integrity timer with its own alerting — different cadence + offsite-I/O + alerting semantics, its own ticket. (Also: `backup.success` **already ships** since #1231, contrary to the ticket's note.)

### Verification
- [x] Seam-driven unit tests: stale-lock → `unlock`+retry, no-lock single run, non-lock error does **not** retry, unlock-failure surfaces, never `--remove-all`; catalog + TS-sync.
- [x] `go vet` + `panel-api/cmd/server` + `internal/models` (incl. the notif TS-sync contract) green.
- [x] **restic mechanic confirmed on .60** (restic **0.16.4**, fleet version): `restic unlock` runs clean (exit 0), and restic emits the `already locked` string the recovery greps for on a real lock collision.
- **Behavioral proof is production**: the manual `restic unlock` on the actual 52-day-wedged newzaps repo cleared the locks and a fresh `restic check` passed — this change automates exactly that. (Full end-to-end CLI drill on .60 was skipped to avoid the migration-ahead trap; the restic mechanic + error string are confirmed on .60 and the Go wiring is unit-tested.)

### Already-wedged boxes
Manual recovery until this ships: `restic -r <dest> unlock` then `jabali backup retention apply`. A fleet sweep before promotion is prudent (newaramapp had 4 stale non-exclusive locks, cleaned; they hadn't wedged forget yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
