### PR TITLE
feat(security): tenant self-service bot-detection opt-in (own domains)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -762,6 +762,16 @@ func (h *domainHandler) update(c *gin.Context) {
 		domain.IsEnabled = *req.IsEnabled
 	}
 
+	// Bot-detection opt-IN — OWNER or admin (self-service). A tenant opting
+	// their own site INTO the challenge only adds protection, so unlike the
+	// opt-out (bot_challenge_exempt, admin-only above) it is safe for the owner
+	// to set. Ownership is already enforced by the forbidden gate above, so a
+	// tenant can only flip this on domains they own. Effective only in the
+	// server-wide "selected" scope; inert otherwise.
+	if req.BotChallengeInclude != nil {
+		domain.BotChallengeInclude = *req.BotChallengeInclude
+	}
+
 	// Preview URL toggle — owner or admin. Enabling re-checks the slug
 	// collision (see previewSlugConflict).
 	if req.TempURLEnabled != nil && *req.TempURLEnabled != domain.TempURLEnabled {
@@ -803,9 +813,6 @@ func (h *domainHandler) update(c *gin.Context) {
 		// (while bot detection is on) has the agent re-render jabali-bot-exempt.
 		if req.BotChallengeExempt != nil {
 			domain.BotChallengeExempt = *req.BotChallengeExempt
-		}
-		if req.BotChallengeInclude != nil {
-			domain.BotChallengeInclude = *req.BotChallengeInclude
 		}
 
 		if req.NginxRules != nil {

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import {
   PlusSquareOutlined,
   EyeOutlined,
+  SafetyOutlined,
   GlobalOutlined,
   MoreOutlined,
   SwapOutlined,
@@ -102,6 +103,7 @@ export type Domain = {
   is_enabled: boolean;
   temp_url_enabled?: boolean;
   temp_url?: string | null;
+  bot_challenge_include?: boolean;
   // GH #1175: >0 marks a reverse-proxy domain forwarding to this loopback port.
   reverse_proxy_port?: number;
   nginx_custom_directives: string;
@@ -343,6 +345,29 @@ export const UserDomainList = () => {
                           } catch (err) {
                             const e = err as { response?: { data?: { detail?: string; error?: string } } };
                             feedback.message.error(`Failed to toggle preview URL: ${e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message}`);
+                          }
+                        },
+                      },
+                      {
+                        key: "bot-challenge",
+                        label: r.bot_challenge_include
+                          ? "Disable bot-detection challenge"
+                          : "Enable bot-detection challenge",
+                        icon: <SafetyOutlined />,
+                        onClick: async () => {
+                          try {
+                            await apiClient.patch(`/domains/${r.id}`, {
+                              bot_challenge_include: !r.bot_challenge_include,
+                            });
+                            feedback.message.success(
+                              r.bot_challenge_include
+                                ? "Bot-detection challenge disabled for this site"
+                                : "Bot-detection challenge enabled — active within a minute if the server is in Selected-domains mode",
+                            );
+                            qc.invalidateQueries({ queryKey: ["list", "domains"] });
+                          } catch (err) {
+                            const e = err as { response?: { data?: { detail?: string; error?: string } } };
+                            feedback.message.error(`Failed to toggle bot challenge: ${e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message}`);
                           }
                         },
                       },


### PR DESCRIPTION
## What

Completes the CrowdSec 1.8 bot-detection arc: a **domain owner can opt their own site into the challenge** (`bot_challenge_include`), not just an admin.

Tenant Domains list → per-domain **Enable/Disable bot-detection challenge** action.

## Why it's safe

Opting **in** only adds protection. So — unlike the opt-**out** (`bot_challenge_exempt`, which stays **admin-only**, because a tenant disabling the admin's challenge would weaken the server posture) — it's safe for the owner to set. In the domain update handler `bot_challenge_include` moves out of the admin-only block into the owner-or-admin section; the existing forbidden gate already ensures a non-admin can only PATCH domains they own, so a tenant can only flip it on their own sites.

Nothing a tenant sets turns the feature on server-wide — enabling bot detection and choosing scope stay admin-only. The tenant include is effective only in the server-wide **Selected domains** scope; inert otherwise (the toggle's success message says so).

## Scope

- Backend: one flag moved from admin-only to owner-or-admin.
- UI: a direct-PATCH toggle mirroring the preview-URL action; reads `bot_challenge_include` from the list response (`domainListRow` embeds the model).
- **No** migration / agent / appseccfg change — reuses the shipped include mechanism (reconciler writes the include-hosts file → agent `refresh_exempt` reloads). Only *who may set the flag* changed, so no box drill needed.

`go build`/`vet` + domain api tests + `tsc -b` green.

Refs #1463, #1464, #1465.
