### PR TITLE
fix(backup): complete manual admin + /me backup metadata wiring (JAB-359)

### DIFF
--- a/panel-api/internal/api/backup_metadata_parity_test.go
+++ b/panel-api/internal/api/backup_metadata_parity_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupmetadata"
+)
+
+// TestBackupMetadataAdaptersInLockstep guards JAB-359: both manual-backup
+// handler configs (admin BackupHandlerConfig + tenant MeBackupsHandlerConfig)
+// must declare every metadata section field that backupmetadata.Deps — the
+// single producer they both feed — consumes. If a schema-v2 section is added to
+// the builder but not mirrored onto an adapter config, that adapter's manual
+// backup would silently omit the section (the exact JAB-312/JAB-359 gap that
+// dropped egress policies/requests and, on /me, most of the set).
+//
+// The producer is the source of truth; KratosClient/Log are wiring, not
+// sections, so they're excluded.
+func TestBackupMetadataAdaptersInLockstep(t *testing.T) {
+	skip := map[string]bool{"KratosClient": true, "Log": true}
+
+	builder := reflect.TypeOf(backupmetadata.Deps{})
+	adapters := map[string]reflect.Type{
+		"BackupHandlerConfig":    reflect.TypeOf(BackupHandlerConfig{}),
+		"MeBackupsHandlerConfig": reflect.TypeOf(MeBackupsHandlerConfig{}),
+	}
+
+	for i := 0; i < builder.NumField(); i++ {
+		f := builder.Field(i)
+		if skip[f.Name] {
+			continue
+		}
+		for name, typ := range adapters {
+			if _, ok := typ.FieldByName(f.Name); !ok {
+				t.Errorf("%s is missing metadata section field %q declared on backupmetadata.Deps — its manual backup bundle would omit that section", name, f.Name)
+			}
+		}
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1155,6 +1155,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				CronJobs:       deps.CronJobs,
 				FtpAccounts:    deps.FtpAccounts,
 				LimitOverrides: deps.LimitOverrides,
+				// JAB-359: the last two schema-v2 sections; without them the admin
+				// manual backup bundle omitted egress policies/requests.
+				EgressPolicies: deps.UserEgressPolicies,
+				EgressRequests: deps.UserEgressRequests,
 				KratosClient:   deps.KratosClient,
 				Log:            deps.Log,
 				SSOKey:         deps.SSOKey,
@@ -1176,6 +1180,22 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				FtpAccounts:    deps.FtpAccounts,
 				DNSZones:       deps.DNSZones,
 				DNSRecords:     deps.DNSRecords,
+				// JAB-359: /me manual self-backup had the same schema-v2 wiring gap
+				// as the admin handler — a tenant's manual backup produced an
+				// incomplete bundle. Wire the full metadata repo set the builder
+				// consumes (matches BackupHandlerConfig + the scheduler).
+				SSLCerts:       deps.SSLCerts,
+				PHPPools:       deps.PHPPools,
+				PHPPoolIni:     deps.PHPPoolIniOverrides,
+				Forwarders:     deps.Forwarders,
+				Autoresponders: deps.Autoresponders,
+				MailboxShares:  deps.MailboxShares,
+				DNSSECKeys:     deps.DNSSECKeys,
+				SSHKeys:        deps.SSHKeys,
+				CronJobs:       deps.CronJobs,
+				LimitOverrides: deps.LimitOverrides,
+				EgressPolicies: deps.UserEgressPolicies,
+				EgressRequests: deps.UserEgressRequests,
 				// GH #454 Step 4: tenant scheduled-backup card. Schedules +
 				// Settings (the admin-owned cron time) gate the /me/backup-schedule
 				// routes; absent, the card's endpoints simply aren't mounted.


### PR DESCRIPTION
## JAB-359 — manual-backup metadata completeness (residual from JAB-312)

The schema-v2 metadata builder (`backupmetadata.Deps`) and both handler configs already carried every section, and both `buildAccountMetadata` calls pass the full set — but **app.go under-wired the configs** from the app deps bundle, so two manual-backup paths produced incomplete bundles. (Scheduled backups were already complete — the scheduler wires the full repo set.)

- **Admin manual backup** (`BackupHandlerConfig`) omitted `EgressPolicies` / `EgressRequests` — the wiring stopped at `LimitOverrides`.
- **Tenant `/me` self-backup** (`MeBackupsHandlerConfig`) was missing most of the schema-v2 set (SSLCerts, PHPPools, PHPPoolIni, Forwarders, Autoresponders, MailboxShares, DNSSECKeys, SSHKeys, CronJobs, LimitOverrides, Egress) — a badly incomplete bundle.

Fix: wire the full builder-consumed repo set into both handler registrations so a manual bundle matches the scheduler's. Restore does not apply these sections → **manual-backup metadata completeness only** (as the ticket scopes it).

### Test
A reflection test (`TestBackupMetadataAdaptersInLockstep`) asserts both manual handler configs declare every section field `backupmetadata.Deps` produces, so a future schema-v2 section can't be silently dropped by one adapter — enforcing the existing "handlers stay in lockstep with the scheduler" contract. The wiring fix itself is build- + diff-verified (pure DI; no live surface).

### Test plan
- [x] parity test + `go vet` + full `internal/api` + `internal/app` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)