### PR TITLE
fix(disk-usage): Files = actual du of the home dir, not the whole-UID quota (GH #1439)

### DIFF
--- a/panel-api/internal/api/me_disk_usage.go
+++ b/panel-api/internal/api/me_disk_usage.go
@@ -1,8 +1,11 @@
 // me_disk_usage.go — per-user disk-usage breakdown (cPanel-style), for the
 // tenant panel. Aggregates the three storage areas a hosting user occupies:
 //
-//   - Files     — the home directory, via the POSIX quota report
-//     (`user.limits.report`). Web content, logs, etc.
+//   - Files     — the home directory, via an actual `du` of /home/<user>
+//     (`files.du`), the same figure the FilesTree shows. Falls back to the
+//     POSIX quota report (`user.limits.report`) if du can't run. Web content,
+//     logs, etc. (The quota "used" counts every block the UID owns across the
+//     whole device, so it over-reports the home dir — GH #1439 — hence du.)
 //
 //   - Email     — sum of the user's mailboxes' last sampled usage
 //     (`mailboxes.last_usage_bytes`, kept fresh by the reconciler;
@@ -86,10 +89,11 @@ type DiskUsageItem = diskUsageItem
 type DiskUsageCategory = diskUsageCategory
 type DiskUsageResult = diskUsageResponse
 
-// ComputeDiskUsage runs the live per-user breakdown (home quota + cached
-// mailbox usage + db.size), the exact path POST /me/disk-usage/refresh uses.
+// ComputeDiskUsage runs the live per-user breakdown (home du + cached mailbox
+// usage + db.size), the exact path POST /me/disk-usage/refresh uses.
 func ComputeDiskUsage(ctx context.Context, cfg DiskUsageConfig, userID string) (DiskUsageResult, error) {
-	return (&meDiskUsageHandler{cfg: cfg}).compute(ctx, userID)
+	res, _, err := (&meDiskUsageHandler{cfg: cfg}).compute(ctx, userID)
+	return res, err
 }
 
 // diskUsageListLimit bounds the per-category enumeration. A single hosting
@@ -131,10 +135,23 @@ func (h *meDiskUsageHandler) refresh(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	resp, err := h.compute(ctx, claims.UserID)
+	resp, homeMeasured, err := h.compute(ctx, claims.UserID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user_not_found"})
 		return
+	}
+	// Never overwrite a real Files figure with 0 because BOTH the du and the
+	// quota calls failed this pass (agent hiccup). Keep the last known Files
+	// (and its Total contribution). A legitimately-empty home reports du=0 with
+	// homeMeasured=true, so it is NOT preserved — only the un-measured case is.
+	if !homeMeasured && h.cfg.Snapshots != nil {
+		if prev, perr := h.cfg.Snapshots.Get(ctx, claims.UserID); perr == nil && prev != nil {
+			var pr diskUsageResponse
+			if json.Unmarshal([]byte(prev.Payload), &pr) == nil && pr.Files.Bytes > 0 {
+				resp.Files = pr.Files
+				resp.TotalBytes = resp.Files.Bytes + resp.Email.Bytes + resp.Databases.Bytes
+			}
+		}
 	}
 	now := time.Now()
 	resp.ComputedAt = &now
@@ -146,11 +163,15 @@ func (h *meDiskUsageHandler) refresh(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// compute runs the live aggregation. Extracted from the old GET handler.
-func (h *meDiskUsageHandler) compute(ctx context.Context, userID string) (diskUsageResponse, error) {
+// compute runs the live aggregation. Extracted from the old GET handler. The
+// second return reports whether the home-directory figure was actually
+// measured this pass (either du or the quota report answered) — false means
+// both agent calls failed, and the caller must NOT persist a 0 over a real
+// prior value.
+func (h *meDiskUsageHandler) compute(ctx context.Context, userID string) (diskUsageResponse, bool, error) {
 	user, err := h.cfg.Users.FindByID(ctx, userID)
 	if err != nil || user == nil {
-		return diskUsageResponse{}, err
+		return diskUsageResponse{}, false, err
 	}
 	opts := repository.ListOptions{Limit: diskUsageListLimit}
 
@@ -160,12 +181,31 @@ func (h *meDiskUsageHandler) compute(ctx context.Context, userID string) (diskUs
 		Databases: diskUsageCategory{Items: []diskUsageItem{}},
 	}
 
-	// --- Files: home-directory quota report (admins have no Linux account) ---
-	if user.Username != nil && *user.Username != "" && h.cfg.Agent != nil && h.cfg.QuotaMount != "" {
-		used, limit := h.homeUsage(ctx, *user.Username)
-		resp.Files.Bytes = used
+	// --- Files: ACTUAL home-directory usage via du (admins have no Linux
+	// account, so the whole block is skipped for them → homeMeasured stays
+	// true, correctly reporting an empty Files). du is scoped to /home/<user>
+	// and matches both the "Home directory" label and the FilesTree beside it.
+	// The POSIX quota report counts every block the UID owns across the whole
+	// device — which over-reports the home dir (GH #1439: quota 484 MB vs du
+	// 354 MB on a real account) — so it is now only the FALLBACK when du can't
+	// run. QuotaBytes still comes from the quota report: it is the limit, the
+	// only source for it.
+	homeMeasured := true
+	if user.Username != nil && *user.Username != "" && h.cfg.Agent != nil {
+		quotaUsed, limit, quotaOK := h.homeUsage(ctx, *user.Username)
 		resp.QuotaBytes = limit
-		resp.Files.Items = append(resp.Files.Items, diskUsageItem{Name: "Home directory", Bytes: used})
+		du, duOK := h.homeDuBytes(ctx, userID, *user.Username)
+		var filesBytes uint64
+		switch {
+		case duOK:
+			filesBytes = du // primary: accurate home-subtree usage
+		case quotaOK:
+			filesBytes = quotaUsed // fallback: du timed out on a huge home
+		default:
+			homeMeasured = false // both failed — don't clobber the last value
+		}
+		resp.Files.Bytes = filesBytes
+		resp.Files.Items = append(resp.Files.Items, diskUsageItem{Name: "Home directory", Bytes: filesBytes})
 	}
 
 	// --- Email: sum cached mailbox usage across the user's domains ---
@@ -208,7 +248,7 @@ func (h *meDiskUsageHandler) compute(ctx context.Context, userID string) (diskUs
 	}
 
 	resp.TotalBytes = resp.Files.Bytes + resp.Email.Bytes + resp.Databases.Bytes
-	return resp, nil
+	return resp, homeMeasured, nil
 }
 
 // homeUsage returns (usedBytes, limitBytes) from the agent's quota report.
@@ -262,7 +302,14 @@ func (h *meDiskUsageHandler) filesTree(c *gin.Context) {
 	c.JSON(http.StatusOK, v)
 }
 
-func (h *meDiskUsageHandler) homeUsage(ctx context.Context, username string) (uint64, uint64) {
+// homeUsage returns (usedBytes, limitBytes, ok) from the agent's quota report.
+// ok is false on any agent/parse failure (or when QuotaMount is unset). The
+// used figure is now only the fallback for Files; limitBytes is the quota
+// limit (the sole source for QuotaBytes).
+func (h *meDiskUsageHandler) homeUsage(ctx context.Context, username string) (uint64, uint64, bool) {
+	if h.cfg.QuotaMount == "" {
+		return 0, 0, false
+	}
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(cctx, "user.limits.report", map[string]any{
@@ -270,7 +317,7 @@ func (h *meDiskUsageHandler) homeUsage(ctx context.Context, username string) (ui
 		"quota_mount": h.cfg.QuotaMount,
 	})
 	if err != nil {
-		return 0, 0
+		return 0, 0, false
 	}
 	var v struct {
 		Disk struct {
@@ -279,9 +326,36 @@ func (h *meDiskUsageHandler) homeUsage(ctx context.Context, username string) (ui
 		} `json:"disk"`
 	}
 	if json.Unmarshal(raw, &v) != nil {
-		return 0, 0
+		return 0, 0, false
 	}
-	return v.Disk.UsedKB * 1024, v.Disk.LimitKB * 1024
+	return v.Disk.UsedKB * 1024, v.Disk.LimitKB * 1024, true
+}
+
+// homeDuBytes returns (bytes, ok): the ACTUAL recursive disk usage of
+// /home/<user> via the same files.du (`du -B1 --max-depth=1`, GH #657-bounded)
+// the FilesTree uses, so the summary and the tree agree by construction. A
+// larger timeout than homeUsage (a full-home du can be slow); the refresh
+// endpoint is explicit and the CLI grants 90s, so 45s fits inside the 60s
+// axios ceiling (#1410). ok=false on timeout/error → the caller falls back to
+// the quota report.
+func (h *meDiskUsageHandler) homeDuBytes(ctx context.Context, userID, username string) (uint64, bool) {
+	cctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(cctx, "files.du", map[string]any{
+		"user_id":  userID,
+		"username": username,
+		"path":     "/home/" + username,
+	})
+	if err != nil {
+		return 0, false
+	}
+	var v struct {
+		Total int64 `json:"total"`
+	}
+	if json.Unmarshal(raw, &v) != nil || v.Total < 0 {
+		return 0, false
+	}
+	return uint64(v.Total), true
 }
 
 // dbSize returns a database's size in bytes (0 on any error).

--- a/panel-api/internal/api/me_disk_usage_test.go
+++ b/panel-api/internal/api/me_disk_usage_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -50,16 +51,47 @@ func (r *duDatabaseRepo) ListByUserID(context.Context, string, repository.ListOp
 	return r.dbs, int64(len(r.dbs)), nil
 }
 
-type duAgent struct{}
+// duAgent mocks the agent. Zero value: quota answers (used_kb 1024, limit
+// 10240), db.size answers 2048, and files.du ERRORS — so the summary falls
+// back to the quota figure (the pre-#1439 number). Set duOK to have files.du
+// answer duTotalBytes (the new primary path); set quotaErr to fail the quota
+// report too.
+type duAgent struct {
+	duOK         bool
+	duTotalBytes int64
+	quotaErr     bool
+}
 
-func (duAgent) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
+func (a duAgent) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
 	switch method {
 	case "user.limits.report":
+		if a.quotaErr {
+			return nil, fmt.Errorf("quota unavailable")
+		}
 		return json.Marshal(map[string]any{"disk": map[string]uint64{"used_kb": 1024, "limit_kb": 10240}})
+	case "files.du":
+		if !a.duOK {
+			return nil, fmt.Errorf("du timed out")
+		}
+		return json.Marshal(map[string]int64{"total": a.duTotalBytes})
 	case "db.size":
 		return json.Marshal(map[string]int64{"size_bytes": 2048})
 	}
 	return nil, fmt.Errorf("unexpected agent call %q", method)
+}
+
+// duSnapRepo is a minimal in-memory snapshot repo for the preserve test.
+type duSnapRepo struct {
+	repository.DiskUsageSnapshotRepository
+	snap *models.DiskUsageSnapshot
+}
+
+func (r *duSnapRepo) Get(context.Context, string) (*models.DiskUsageSnapshot, error) {
+	return r.snap, nil
+}
+func (r *duSnapRepo) Upsert(_ context.Context, userID, payload string, at time.Time) error {
+	r.snap = &models.DiskUsageSnapshot{UserID: userID, Payload: payload, ComputedAt: at}
+	return nil
 }
 
 func TestMeDiskUsage_Aggregates(t *testing.T) {
@@ -123,5 +155,78 @@ func TestMeDiskUsage_Aggregates(t *testing.T) {
 	want := uint64(1024*1024 + 3500 + 2048)
 	if resp.TotalBytes != want {
 		t.Errorf("total: want %d, got %d", want, resp.TotalBytes)
+	}
+}
+
+// duRefresh is a small harness: POST /refresh with the given agent + optional
+// snapshot repo, returning the decoded response.
+func duRefresh(t *testing.T, ag duAgent, snaps repository.DiskUsageSnapshotRepository) diskUsageResponse {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	uname := "alice"
+	cfg := DiskUsageConfig{
+		Users:      &duUserRepo{u: &models.User{ID: "u1", Username: &uname}},
+		Domains:    &duDomainRepo{},
+		Mailboxes:  &duMailboxRepo{},
+		Databases:  &duDatabaseRepo{},
+		Agent:      ag,
+		QuotaMount: "/home",
+		Snapshots:  snaps,
+	}
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"}); c.Next() })
+	RegisterMeDiskUsageRoutes(v1, cfg)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/me/disk-usage/refresh", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh: want 200, got %d %s", rec.Code, rec.Body.String())
+	}
+	var resp diskUsageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+// GH #1439: Files must be the ACTUAL du of the home dir, not the quota report
+// (which over-counts the whole-UID footprint across the device).
+func TestMeDiskUsage_FilesFromDu(t *testing.T) {
+	resp := duRefresh(t, duAgent{duOK: true, duTotalBytes: 5 * 1024 * 1024}, nil)
+	if resp.Files.Bytes != 5*1024*1024 {
+		t.Errorf("Files must be the du figure (5 MiB), got %d", resp.Files.Bytes)
+	}
+	// QuotaBytes still comes from the quota report's limit.
+	if resp.QuotaBytes != 10240*1024 {
+		t.Errorf("QuotaBytes must be the quota limit, got %d", resp.QuotaBytes)
+	}
+}
+
+func TestMeDiskUsage_FilesFallBackToQuotaWhenDuFails(t *testing.T) {
+	resp := duRefresh(t, duAgent{duOK: false}, nil) // du errors → quota used_kb
+	if resp.Files.Bytes != 1024*1024 {
+		t.Errorf("Files must fall back to quota used (1 MiB), got %d", resp.Files.Bytes)
+	}
+}
+
+// A truly-empty home (du=0, measured) must report 0 — NOT preserve a stale
+// prior value.
+func TestMeDiskUsage_EmptyHomeReportsZero(t *testing.T) {
+	prior, _ := json.Marshal(diskUsageResponse{Files: diskUsageCategory{Bytes: 9 * 1024 * 1024, Items: []diskUsageItem{}}})
+	snaps := &duSnapRepo{snap: &models.DiskUsageSnapshot{UserID: "u1", Payload: string(prior)}}
+	resp := duRefresh(t, duAgent{duOK: true, duTotalBytes: 0}, snaps)
+	if resp.Files.Bytes != 0 {
+		t.Errorf("empty home must report 0, got %d (must not preserve prior)", resp.Files.Bytes)
+	}
+}
+
+// When BOTH du and quota fail (agent hiccup), the last real Files figure must
+// be preserved rather than clobbered with 0.
+func TestMeDiskUsage_PreservePriorWhenBothFail(t *testing.T) {
+	prior, _ := json.Marshal(diskUsageResponse{Files: diskUsageCategory{Bytes: 7 * 1024 * 1024, Items: []diskUsageItem{{Name: "Home directory", Bytes: 7 * 1024 * 1024}}}})
+	snaps := &duSnapRepo{snap: &models.DiskUsageSnapshot{UserID: "u1", Payload: string(prior)}}
+	resp := duRefresh(t, duAgent{duOK: false, quotaErr: true}, snaps)
+	if resp.Files.Bytes != 7*1024*1024 {
+		t.Errorf("both-fail must preserve prior Files (7 MiB), got %d", resp.Files.Bytes)
 	}
 }

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
@@ -474,7 +474,8 @@ export function DiskUsagePage() {
       </Row>
 
       <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginTop: 12 }}>
-        Email usage is sampled periodically. PostgreSQL database sizes are not yet reported.
+        Email usage is sampled periodically; file and database sizes (both
+        MariaDB and PostgreSQL) are recomputed when you click Refresh.
       </Typography.Text>
     </div>
   );


### PR DESCRIPTION
## What

Fixes two things the reporter flagged on **Tenant → Disk Usage**:

1. **Files** figure didn't track the home directory.
2. The stale notice **"PostgreSQL database sizes are not yet reported"** — PG *is* sized now.

## Files — root cause + fix

The summary used the POSIX **quota report** (`user.limits.report` → `used_kb`), which counts every block the user's **UID owns across the whole device**, not the home subtree. So it over-reported and drifted from both the card's **"Home directory"** label and the **FilesTree** beside it (which does an actual `du`).

Reproduced on a real box:

| account | quota `used` | actual `du` |
|---|---|---|
| (large) | 484 MB | 354 MB |
| (small) | 100 KB | 24 KB |

Fix: **Files now uses the same `files.du` (`du -B1 --max-depth=1`, GH#657-bounded) the tree uses**, scoped to `/home/<user>` — the stat and the tree agree by construction and the number matches its label. The quota report is kept only as a **fallback** when `du` can't run; `QuotaBytes` still comes from it (it's the limit).

Robustness: `du` gets 45s (inside the 60s axios ceiling; the CLI grants 90s); on `du` error → quota `used`; if **both** fail (agent hiccup) the refresh **preserves the last real Files** rather than writing 0, while a legitimately-empty home (`du=0`, measured) still reports 0. `ComputeDiskUsage` (shared with the `jabali disk-usage` CLI, #568) carries the same behaviour.

## Notice

Removed the stale PG line (PG sized via `pg_database_size()` since #1005/#1012). Now: "Email usage is sampled periodically; file and database sizes (both MariaDB and PostgreSQL) are recomputed when you click Refresh."

## Tested — drilled on .60 via the real `ComputeDiskUsage` path

- Files == `du -sB1` of the home **exactly**
- wrote a 2 MB file → Files grew by 2 MB; removed it → Files back to original (this *is* the reporter's "not updated" complaint)

Unit tests: du-primary, du-fail→quota-fallback, empty-home→0, both-fail→preserve-prior. `go build`/`vet` + disk-usage tests + `tsc -b` green.

Refs GH #1439.
