### PR TITLE
feat(php): per-version OPcache / JIT controls (GH #1332)

### DIFF
--- a/panel-agent/internal/commands/php_pool_apply.go
+++ b/panel-agent/internal/commands/php_pool_apply.go
@@ -126,6 +126,15 @@ var adminValueAllowlist = map[string]bool{
 	"max_input_vars":      true,
 	"max_input_time":      true,
 	"date.timezone":       true,
+	// GH #1332 OPcache / JIT controls (per-pool = per-user,version). Values
+	// are clamped/validated by the panel endpoint before they reach here; this
+	// allowlist is the final gate on the directive NAMES. opcache.jit takes a
+	// CRTO string ("tracing"/"function"/"off"); the others are byte/int sizes.
+	"opcache.memory_consumption":    true,
+	"opcache.max_accelerated_files": true,
+	"opcache.revalidate_freq":       true,
+	"opcache.jit":                   true,
+	"opcache.jit_buffer_size":       true,
 }
 
 // adminFlagAllowlist is the set of allowed php_admin_flag directives.
@@ -133,6 +142,9 @@ var adminFlagAllowlist = map[string]bool{
 	"display_errors": true,
 	"log_errors":     true,
 	"file_uploads":   true,
+	// GH #1332 OPcache on/off + timestamp validation (per-pool).
+	"opcache.enable":              true,
+	"opcache.validate_timestamps": true,
 }
 
 // defaultDisableFunctions is the GH #401 command-exec lockdown: the safe,

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3913,6 +3913,19 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/php-opcache:
+    get:
+      tags: [Me]
+      summary: Get OPcache/JIT settings for a PHP version
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Me]
+      summary: Set OPcache/JIT settings for a PHP version (restarts that pool's FPM master)
+      security: [ { KratosSession: [] } ]
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: OK } }
+
   /me/php-extensions:
     get:
       tags: [Me]

--- a/panel-api/internal/api/php_pool_opcache.go
+++ b/panel-api/internal/api/php_pool_opcache.go
@@ -1,0 +1,286 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// OPcache / JIT controls (GH #1332). Per-pool = per (user, PHP version): a
+// pool's OPcache SHM is shared by every domain the user runs on that version,
+// so these settings are version-scoped, exactly like the Performance tuning.
+// Stored as php_pool_ini_overrides (rendered php_admin_value/flag), which the
+// agent already applies via php.pool.apply — no new pool columns.
+//
+// A change to OPcache SHM sizing / JIT only takes effect at FPM MASTER start; a
+// graceful USR2 reload (what php.pool.apply does on a same-version change) keeps
+// the old SHM. So the PUT chains php.opcache.reset (a master RESTART) after the
+// apply, so "Disable OPcache" / a new JIT buffer are observable immediately.
+
+const (
+	dirOpcacheEnable        = "opcache.enable"
+	dirOpcacheValidateTS    = "opcache.validate_timestamps"
+	dirOpcacheMemory        = "opcache.memory_consumption"
+	dirOpcacheMaxFiles      = "opcache.max_accelerated_files"
+	dirOpcacheRevalFreq     = "opcache.revalidate_freq"
+	dirOpcacheJit           = "opcache.jit"
+	dirOpcacheJitBufferSize = "opcache.jit_buffer_size"
+)
+
+// Clamp bounds — flat caps for v1 (per-package caps a future knob, mirroring
+// the FPM clampToPackageCap philosophy). jit_buffer_size + memory_consumption
+// allocate real memory per master, so bounding them protects the fleet's small
+// (2 GB) boxes (the kswapd-deathspiral class).
+const (
+	opMemoryMinMB = 8
+	opMemoryMaxMB = 512
+	opFilesMin    = 100
+	opFilesMax    = 1000000
+	opRevalMaxSec = 3600
+	opJitBufMinMB = 8
+	opJitBufMaxMB = 256
+	opcacheJitOn  = "tracing" // the only "on" CRTO we expose; tenants never see the integer flags
+	opcacheJitOff = "off"
+)
+
+// opcacheSettings is the curated, nullable view. A nil field means "no
+// override — use the server default"; the UI shows the default as a placeholder
+// (the item-5 preset-transparency lesson: distinguish set from default).
+type opcacheSettings struct {
+	PHPVersion          string  `json:"php_version"`
+	Enable              *bool   `json:"enable"`
+	ValidateTimestamps  *bool   `json:"validate_timestamps"`
+	MemoryConsumptionMB *uint32 `json:"memory_consumption_mb"`
+	MaxAcceleratedFiles *uint32 `json:"max_accelerated_files"`
+	RevalidateFreq      *uint32 `json:"revalidate_freq"`
+	JitEnabled          *bool   `json:"jit_enabled"`
+	JitBufferSizeMB     *uint32 `json:"jit_buffer_size_mb"`
+}
+
+// getOpcache returns the caller's OPcache/JIT overrides for a PHP version.
+func (h *phpUserTuningHandler) getOpcache(c *gin.Context) {
+	user, pkg := h.ownerPackage(c)
+	if user == nil || pkg == nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	pool, ok := h.userPool(c, user.ID, c.Query("php_version"))
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, h.readOpcache(c, pool))
+}
+
+func (h *phpUserTuningHandler) readOpcache(c *gin.Context, pool *models.PHPPool) opcacheSettings {
+	s := opcacheSettings{PHPVersion: pool.PHPVersion}
+	rows, err := h.cfg.PHPPoolIniOverrides.ListByPool(c.Request.Context(), pool.ID)
+	if err != nil {
+		return s
+	}
+	for i := range rows {
+		switch rows[i].Directive {
+		case dirOpcacheEnable:
+			s.Enable = boolPtr(strings.EqualFold(rows[i].Value, "on"))
+		case dirOpcacheValidateTS:
+			s.ValidateTimestamps = boolPtr(strings.EqualFold(rows[i].Value, "on"))
+		case dirOpcacheMemory:
+			s.MemoryConsumptionMB = uint32PtrFromStr(rows[i].Value)
+		case dirOpcacheMaxFiles:
+			s.MaxAcceleratedFiles = uint32PtrFromStr(rows[i].Value)
+		case dirOpcacheRevalFreq:
+			s.RevalidateFreq = uint32PtrFromStr(rows[i].Value)
+		case dirOpcacheJit:
+			s.JitEnabled = boolPtr(rows[i].Value != opcacheJitOff && rows[i].Value != "")
+		case dirOpcacheJitBufferSize:
+			// stored as "<N>M" → report N.
+			v := rows[i].Value
+			if len(v) > 0 && (v[len(v)-1] == 'M' || v[len(v)-1] == 'm') {
+				v = v[:len(v)-1]
+			}
+			s.JitBufferSizeMB = uint32PtrFromStr(v)
+		}
+	}
+	return s
+}
+
+type setOpcacheRequest struct {
+	PHPVersion          string  `json:"php_version"`
+	Enable              *bool   `json:"enable"`
+	ValidateTimestamps  *bool   `json:"validate_timestamps"`
+	MemoryConsumptionMB *uint32 `json:"memory_consumption_mb"`
+	MaxAcceleratedFiles *uint32 `json:"max_accelerated_files"`
+	RevalidateFreq      *uint32 `json:"revalidate_freq"`
+	JitEnabled          *bool   `json:"jit_enabled"`
+	JitBufferSizeMB     *uint32 `json:"jit_buffer_size_mb"`
+}
+
+// setOpcache validates+clamps, writes the override rows (or deletes them when a
+// field is unset → server default), re-applies the pool, and restarts its
+// master so OPcache/JIT changes take effect immediately.
+func (h *phpUserTuningHandler) setOpcache(c *gin.Context) {
+	user, pkg := h.ownerPackage(c)
+	if user == nil || pkg == nil || !pkg.FpmUserCanEdit {
+		c.JSON(http.StatusForbidden, gin.H{"error": "fpm_editing_not_allowed"})
+		return
+	}
+	var req setOpcacheRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_json"})
+		return
+	}
+	if req.MemoryConsumptionMB != nil && (*req.MemoryConsumptionMB < opMemoryMinMB || *req.MemoryConsumptionMB > opMemoryMaxMB) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_memory", "detail": "opcache.memory_consumption must be 8–512 MB"})
+		return
+	}
+	if req.MaxAcceleratedFiles != nil && (*req.MaxAcceleratedFiles < opFilesMin || *req.MaxAcceleratedFiles > opFilesMax) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_max_files", "detail": "opcache.max_accelerated_files must be 100–1000000"})
+		return
+	}
+	if req.RevalidateFreq != nil && *req.RevalidateFreq > opRevalMaxSec {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_reval_freq", "detail": "opcache.revalidate_freq must be 0–3600 s"})
+		return
+	}
+	if req.JitBufferSizeMB != nil && (*req.JitBufferSizeMB < opJitBufMinMB || *req.JitBufferSizeMB > opJitBufMaxMB) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_jit_buffer", "detail": "opcache.jit_buffer_size must be 8–256 MB"})
+		return
+	}
+
+	pool, ok := h.userPool(c, user.ID, req.PHPVersion)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pool_not_found"})
+		return
+	}
+
+	// Map struct → directive rows (upsert on set, delete on unset).
+	apply := func(dir string, set bool, value, kind string) bool {
+		if set {
+			return h.upsertOverride(c, pool.ID, dir, value, kind) == nil
+		}
+		return h.deleteOverride(c, pool.ID, dir) == nil
+	}
+	okAll := true
+	okAll = apply(dirOpcacheEnable, req.Enable != nil, onOff(req.Enable), "flag") && okAll
+	okAll = apply(dirOpcacheValidateTS, req.ValidateTimestamps != nil, onOff(req.ValidateTimestamps), "flag") && okAll
+	okAll = apply(dirOpcacheMemory, req.MemoryConsumptionMB != nil, u32str(req.MemoryConsumptionMB), "value") && okAll
+	okAll = apply(dirOpcacheMaxFiles, req.MaxAcceleratedFiles != nil, u32str(req.MaxAcceleratedFiles), "value") && okAll
+	okAll = apply(dirOpcacheRevalFreq, req.RevalidateFreq != nil, u32str(req.RevalidateFreq), "value") && okAll
+	// JIT: two controls, three directives. Enabled → opcache.jit=tracing (+
+	// buffer); disabled → opcache.jit=off and the buffer override is dropped.
+	if req.JitEnabled != nil {
+		if *req.JitEnabled {
+			okAll = h.upsertOverride(c, pool.ID, dirOpcacheJit, opcacheJitOn, "value") == nil && okAll
+		} else {
+			okAll = h.upsertOverride(c, pool.ID, dirOpcacheJit, opcacheJitOff, "value") == nil && okAll
+		}
+	} else {
+		okAll = h.deleteOverride(c, pool.ID, dirOpcacheJit) == nil && okAll
+	}
+	if req.JitBufferSizeMB != nil {
+		okAll = h.upsertOverride(c, pool.ID, dirOpcacheJitBufferSize, u32str(req.JitBufferSizeMB)+"M", "value") == nil && okAll
+	} else {
+		okAll = h.deleteOverride(c, pool.ID, dirOpcacheJitBufferSize) == nil && okAll
+	}
+	if !okAll {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "override_write_failed"})
+		return
+	}
+
+	// Apply the pool (renders the overrides + reloads) SYNCHRONOUSLY so the
+	// conf is on disk before the restart below re-reads it.
+	pool.Status = "pending"
+	_ = h.cfg.PHPPools.Update(c.Request.Context(), pool)
+	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	if fresh, err := h.cfg.PHPPools.FindByID(c.Request.Context(), pool.ID); err == nil && fresh != nil && fresh.Status == "error" {
+		detail := ""
+		if fresh.LastError != nil {
+			detail = *fresh.LastError
+		}
+		c.JSON(http.StatusBadGateway, gin.H{"error": "pool_apply_failed", "detail": detail})
+		return
+	}
+
+	// Restart the master so OPcache SHM / JIT changes take effect (a graceful
+	// reload would keep the old SHM). Reuses the item-10 reset verb.
+	username := ""
+	if user.Username != nil {
+		username = *user.Username
+	}
+	isDefault := true
+	if list, err := h.cfg.PHPPools.ListByUserID(c.Request.Context(), user.ID); err == nil && len(list) > 0 {
+		isDefault = list[0].ID == pool.ID
+	}
+	slug := models.PoolSlug(username, pool.PHPVersion, isDefault)
+	c.Set("audit_target", "php_opcache:"+slug)
+	if _, err := h.cfg.Agent.Call(c.Request.Context(), "php.opcache.reset", map[string]any{
+		"username": username, "slug": slug,
+	}); err != nil {
+		respondAgentErr(c, "opcache_restart_failed", err)
+		return
+	}
+	c.JSON(http.StatusOK, h.readOpcache(c, pool))
+}
+
+// upsertOverride writes (or replaces) one directive override on a pool.
+func (h *phpUserTuningHandler) upsertOverride(c *gin.Context, poolID, directive, value, kind string) error {
+	ctx := c.Request.Context()
+	rows, err := h.cfg.PHPPoolIniOverrides.ListByPool(ctx, poolID)
+	if err != nil {
+		return err
+	}
+	for i := range rows {
+		if rows[i].Directive == directive {
+			rows[i].Value = value
+			rows[i].Kind = kind
+			return h.cfg.PHPPoolIniOverrides.Update(ctx, &rows[i])
+		}
+	}
+	return h.cfg.PHPPoolIniOverrides.Create(ctx, &models.PHPPoolIniOverride{
+		ID: ids.NewULID(), PoolID: poolID, Directive: directive, Value: value, Kind: kind,
+	})
+}
+
+// deleteOverride removes a directive override (→ server default). No-op if absent.
+func (h *phpUserTuningHandler) deleteOverride(c *gin.Context, poolID, directive string) error {
+	ctx := c.Request.Context()
+	rows, err := h.cfg.PHPPoolIniOverrides.ListByPool(ctx, poolID)
+	if err != nil {
+		return err
+	}
+	for i := range rows {
+		if rows[i].Directive == directive {
+			return h.cfg.PHPPoolIniOverrides.Delete(ctx, rows[i].ID)
+		}
+	}
+	return nil
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// onOff renders a php_admin_flag value. The agent requires lowercase
+// "on"/"off" (php_pool_apply.go rejects anything else).
+func onOff(b *bool) string {
+	if b != nil && *b {
+		return "on"
+	}
+	return "off"
+}
+func u32str(v *uint32) string {
+	if v == nil {
+		return "0"
+	}
+	return strconv.FormatUint(uint64(*v), 10)
+}
+func uint32PtrFromStr(s string) *uint32 {
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return nil
+	}
+	v := uint32(n)
+	return &v
+}

--- a/panel-api/internal/api/php_pool_opcache_test.go
+++ b/panel-api/internal/api/php_pool_opcache_test.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// statefulOverrideRepo is an in-memory PHPPoolIniOverride store so the opcache
+// mapping can be verified via readback (the shared no-op mock can't).
+type statefulOverrideRepo struct {
+	rows map[string]*models.PHPPoolIniOverride // id -> row
+	seq  int
+}
+
+func newStatefulOverrideRepo() *statefulOverrideRepo {
+	return &statefulOverrideRepo{rows: map[string]*models.PHPPoolIniOverride{}}
+}
+func (r *statefulOverrideRepo) Create(_ context.Context, o *models.PHPPoolIniOverride) error {
+	r.seq++
+	cp := *o
+	r.rows[o.ID] = &cp
+	return nil
+}
+func (r *statefulOverrideRepo) FindByID(_ context.Context, id string) (*models.PHPPoolIniOverride, error) {
+	return r.rows[id], nil
+}
+func (r *statefulOverrideRepo) ListByPool(_ context.Context, poolID string) ([]models.PHPPoolIniOverride, error) {
+	var out []models.PHPPoolIniOverride
+	for _, v := range r.rows {
+		if v.PoolID == poolID {
+			out = append(out, *v)
+		}
+	}
+	return out, nil
+}
+func (r *statefulOverrideRepo) Update(_ context.Context, o *models.PHPPoolIniOverride) error {
+	if _, ok := r.rows[o.ID]; ok {
+		cp := *o
+		r.rows[o.ID] = &cp
+	}
+	return nil
+}
+func (r *statefulOverrideRepo) Delete(_ context.Context, id string) error {
+	delete(r.rows, id)
+	return nil
+}
+func (r *statefulOverrideRepo) byDirective(poolID, dir string) (models.PHPPoolIniOverride, bool) {
+	for _, v := range r.rows {
+		if v.PoolID == poolID && v.Directive == dir {
+			return *v, true
+		}
+	}
+	return models.PHPPoolIniOverride{}, false
+}
+
+func setupOpcacheRouter(t *testing.T, ov *statefulOverrideRepo, calls *[]string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"}); c.Next() })
+	pkgID := "pkg1"
+	uname := "alice"
+	users := &mockUserRepo{users: map[string]*models.User{"u1": {ID: "u1", PackageID: &pkgID, Username: &uname}}}
+	packages := &mockPackageRepo{packages: map[string]*models.HostingPackage{"pkg1": {ID: "pkg1", FpmUserCanEdit: true}}}
+	pr := newMockPHPPoolRepo()
+	pr.Create(context.Background(), &models.PHPPool{ID: "p1", UserID: "u1", PHPVersion: "8.4"})
+	RegisterPHPUserTuningRoutes(r.Group("/api/v1"), PHPUserTuningHandlerConfig{
+		Agent: &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+			if calls != nil {
+				*calls = append(*calls, cmd)
+			}
+			if cmd == "php.version.list" {
+				return json.RawMessage(`{"versions":["8.4"]}`), nil
+			}
+			return json.RawMessage(`{}`), nil
+		}},
+		Users: users, Packages: packages, PHPPools: pr,
+		PHPPoolIniOverrides: ov, Modes: mockModesRepo{},
+	})
+	return r
+}
+
+func putOpcache(t *testing.T, r *gin.Engine, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/me/php-opcache", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestOpcache_SetMapsDirectivesAndRestarts(t *testing.T) {
+	ov := newStatefulOverrideRepo()
+	var calls []string
+	r := setupOpcacheRouter(t, ov, &calls)
+
+	w := putOpcache(t, r, `{"php_version":"8.4","enable":false,"jit_enabled":true,"jit_buffer_size_mb":64,"memory_consumption_mb":128}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	// Directive rows written correctly.
+	if o, ok := ov.byDirective("p1", dirOpcacheEnable); !ok || o.Kind != "flag" || o.Value != "off" {
+		t.Errorf("opcache.enable: %+v ok=%v", o, ok)
+	}
+	if o, ok := ov.byDirective("p1", dirOpcacheJit); !ok || o.Value != "tracing" {
+		t.Errorf("opcache.jit: %+v ok=%v", o, ok)
+	}
+	if o, ok := ov.byDirective("p1", dirOpcacheJitBufferSize); !ok || o.Value != "64M" {
+		t.Errorf("opcache.jit_buffer_size: %+v ok=%v", o, ok)
+	}
+	if o, ok := ov.byDirective("p1", dirOpcacheMemory); !ok || o.Value != "128" {
+		t.Errorf("opcache.memory_consumption: %+v ok=%v", o, ok)
+	}
+	// The master restart (php.opcache.reset) must be chained after the apply so
+	// OPcache/JIT changes take effect (reload keeps the SHM).
+	var sawApply, sawReset bool
+	for _, c := range calls {
+		if c == "php.pool.apply" {
+			sawApply = true
+		}
+		if c == "php.opcache.reset" {
+			sawReset = true
+		}
+	}
+	if !sawApply || !sawReset {
+		t.Errorf("expected php.pool.apply AND php.opcache.reset, got %v", calls)
+	}
+}
+
+func TestOpcache_GetReadsBack(t *testing.T) {
+	ov := newStatefulOverrideRepo()
+	r := setupOpcacheRouter(t, ov, nil)
+	if w := putOpcache(t, r, `{"php_version":"8.4","enable":true,"jit_enabled":true,"jit_buffer_size_mb":32}`); w.Code != http.StatusOK {
+		t.Fatalf("set failed: %d %s", w.Code, w.Body.String())
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/php-opcache?php_version=8.4", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	var got opcacheSettings
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Enable == nil || !*got.Enable {
+		t.Errorf("enable readback: %+v", got.Enable)
+	}
+	if got.JitEnabled == nil || !*got.JitEnabled {
+		t.Errorf("jit_enabled readback: %+v", got.JitEnabled)
+	}
+	if got.JitBufferSizeMB == nil || *got.JitBufferSizeMB != 32 {
+		t.Errorf("jit_buffer readback: %+v", got.JitBufferSizeMB)
+	}
+}
+
+func TestOpcache_ClampsRejectOutOfRange(t *testing.T) {
+	r := setupOpcacheRouter(t, newStatefulOverrideRepo(), nil)
+	for _, body := range []string{
+		`{"php_version":"8.4","memory_consumption_mb":5000}`,
+		`{"php_version":"8.4","jit_buffer_size_mb":9999}`,
+		`{"php_version":"8.4","revalidate_freq":99999}`,
+	} {
+		if w := putOpcache(t, r, body); w.Code != http.StatusBadRequest {
+			t.Errorf("want 400 for %s, got %d", body, w.Code)
+		}
+	}
+}
+
+func TestOpcache_UnsetFieldDeletesOverride(t *testing.T) {
+	ov := newStatefulOverrideRepo()
+	r := setupOpcacheRouter(t, ov, nil)
+	if w := putOpcache(t, r, `{"php_version":"8.4","enable":false}`); w.Code != http.StatusOK {
+		t.Fatalf("set: %d", w.Code)
+	}
+	if _, ok := ov.byDirective("p1", dirOpcacheEnable); !ok {
+		t.Fatal("expected opcache.enable row after set")
+	}
+	// A PUT without enable clears it back to server default.
+	if w := putOpcache(t, r, `{"php_version":"8.4"}`); w.Code != http.StatusOK {
+		t.Fatalf("clear: %d", w.Code)
+	}
+	if _, ok := ov.byDirective("p1", dirOpcacheEnable); ok {
+		t.Error("opcache.enable override must be deleted when field omitted")
+	}
+}

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -61,6 +61,9 @@ func RegisterPHPUserTuningRoutes(g *gin.RouterGroup, cfg PHPUserTuningHandlerCon
 	g.PUT("/me/php-pool-tuning", h.setTuning)
 	// GH #1332 item 10: reset a version's OPcache (restarts that pool's master).
 	g.POST("/me/php-opcache/reset", h.resetOpcache)
+	// GH #1332 OPcache / JIT per-version controls.
+	g.GET("/me/php-opcache", h.getOpcache)
+	g.PUT("/me/php-opcache", h.setOpcache)
 }
 
 // poolTuningRow is one of the caller's PHP pools, with its current per-version

--- a/panel-ui/src/shells/user/php-settings/UserPHPOpcacheCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPOpcacheCard.tsx
@@ -1,0 +1,177 @@
+// UserPHPOpcacheCard — GH #1332 OPcache / JIT controls. Per-version (per FPM
+// pool), like the Performance card: a pool's OPcache SHM is shared by every
+// domain on that PHP version. Each control is tri-state — "Pool default" leaves
+// no override (server default), On/Off (or a size) writes one. Saving restarts
+// the version's FPM master so the change takes effect (a graceful reload keeps
+// the old SHM), so Reset lives here too.
+import { Alert, Button, Card, Select, Space, Spin, Typography } from "antd";
+import { feedback } from "../../../lib/feedback";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { apiClient } from "../../../apiClient";
+
+type PoolRow = { php_version: string; is_default: boolean };
+type Tuning = { pools: PoolRow[] };
+
+type Opcache = {
+  php_version: string;
+  enable: boolean | null;
+  validate_timestamps: boolean | null;
+  memory_consumption_mb: number | null;
+  max_accelerated_files: number | null;
+  revalidate_freq: number | null;
+  jit_enabled: boolean | null;
+  jit_buffer_size_mb: number | null;
+};
+
+// Tri-state bool select: "Pool default" (null) / On / Off.
+const boolOpts = [
+  { label: "Pool default", value: "" },
+  { label: "On", value: "on" },
+  { label: "Off", value: "off" },
+];
+const toBool = (v: string): boolean | null => (v === "on" ? true : v === "off" ? false : null);
+const fromBool = (b: boolean | null): string => (b === true ? "on" : b === false ? "off" : "");
+
+const numOpts = (vals: number[], suffix = "") => [
+  { label: "Pool default", value: -1 },
+  ...vals.map((v) => ({ label: `${v}${suffix}`, value: v })),
+];
+const toNum = (v: number): number | null => (v < 0 ? null : v);
+const fromNum = (n: number | null): number => (n == null ? -1 : n);
+
+export const UserPHPOpcacheCard = () => {
+  const qc = useQueryClient();
+  const [version, setVersion] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [form, setForm] = useState<Opcache | null>(null);
+
+  const { data: tuning } = useQuery<Tuning>({
+    queryKey: ["me-php-pool-tuning"],
+    queryFn: async () => (await apiClient.get<Tuning>("/me/php-pool-tuning")).data,
+  });
+  const pools = tuning?.pools ?? [];
+  useEffect(() => {
+    if (!version && pools.length > 0) {
+      setVersion((pools.find((p) => p.is_default) ?? pools[0]).php_version);
+    }
+  }, [pools, version]);
+
+  const { data, isLoading } = useQuery<Opcache>({
+    queryKey: ["me-php-opcache", version],
+    enabled: !!version,
+    queryFn: async () =>
+      (await apiClient.get<Opcache>(`/me/php-opcache?php_version=${encodeURIComponent(version)}`)).data,
+  });
+  useEffect(() => {
+    if (data) setForm(data);
+  }, [data]);
+
+  const patch = (p: Partial<Opcache>) => setForm((f) => (f ? { ...f, ...p } : f));
+
+  const save = async () => {
+    if (!form) return;
+    setSaving(true);
+    try {
+      await apiClient.put("/me/php-opcache", { ...form, php_version: version });
+      feedback.message.success(`OPcache/JIT saved — FPM restarted for PHP ${version}`);
+      qc.invalidateQueries({ queryKey: ["me-php-opcache", version] });
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to save OPcache settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = async () => {
+    setResetting(true);
+    try {
+      await apiClient.post("/me/php-opcache/reset", { php_version: version });
+      feedback.message.success(`OPcache reset (FPM restarted for PHP ${version})`);
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to reset OPcache");
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  const Row = ({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 240 }}>
+      <Typography.Text strong>{label}</Typography.Text>
+      {children}
+      {hint && <Typography.Text type="secondary" style={{ fontSize: 12 }}>{hint}</Typography.Text>}
+    </div>
+  );
+
+  return (
+    <Card title="OPcache & JIT" size="small">
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Per PHP version — these apply to every site you run on the selected
+          version (OPcache is shared per FPM pool). Saving restarts that
+          version&apos;s FPM master so the change takes effect.
+        </Typography.Paragraph>
+
+        <div>
+          <Typography.Text strong>PHP version: </Typography.Text>
+          <Select
+            style={{ minWidth: 200 }}
+            value={version || undefined}
+            onChange={setVersion}
+            options={pools.map((p) => ({
+              value: p.php_version,
+              label: p.is_default ? `${p.php_version} (default)` : p.php_version,
+            }))}
+          />
+        </div>
+
+        {isLoading || !form ? (
+          <Spin />
+        ) : (
+          <>
+            <Space wrap size="large" align="start">
+              <Row label="OPcache">
+                <Select style={{ width: 160 }} value={fromBool(form.enable)} onChange={(v) => patch({ enable: toBool(v) })} options={boolOpts} />
+              </Row>
+              <Row label="JIT">
+                <Select style={{ width: 160 }} value={fromBool(form.jit_enabled)} onChange={(v) => patch({ jit_enabled: toBool(v) })} options={boolOpts} />
+              </Row>
+              <Row label="JIT buffer size">
+                <Select style={{ width: 160 }} value={fromNum(form.jit_buffer_size_mb)} onChange={(v) => patch({ jit_buffer_size_mb: toNum(v) })} options={numOpts([8, 16, 32, 64, 128, 256], " MB")} />
+              </Row>
+              <Row label="Memory">
+                <Select style={{ width: 160 }} value={fromNum(form.memory_consumption_mb)} onChange={(v) => patch({ memory_consumption_mb: toNum(v) })} options={numOpts([64, 128, 192, 256, 512], " MB")} />
+              </Row>
+              <Row label="Max accelerated files">
+                <Select style={{ width: 160 }} value={fromNum(form.max_accelerated_files)} onChange={(v) => patch({ max_accelerated_files: toNum(v) })} options={numOpts([10000, 20000, 50000, 100000])} />
+              </Row>
+              <Row label="Revalidate freq" hint="How often OPcache checks files for changes (with timestamp validation on).">
+                <Select style={{ width: 160 }} value={fromNum(form.revalidate_freq)} onChange={(v) => patch({ revalidate_freq: toNum(v) })} options={numOpts([0, 2, 5, 30, 60], " s")} />
+              </Row>
+              <Row label="Validate timestamps">
+                <Select style={{ width: 160 }} value={fromBool(form.validate_timestamps)} onChange={(v) => patch({ validate_timestamps: toBool(v) })} options={boolOpts} />
+              </Row>
+            </Space>
+
+            {form.validate_timestamps === false && (
+              <Alert
+                type="warning"
+                showIcon
+                message="Timestamp validation is off"
+                description="Changes to your PHP files won't take effect until OPcache is reset. Use the Reset button after each deploy."
+              />
+            )}
+
+            <Space>
+              <Button type="primary" loading={saving} onClick={save}>Save</Button>
+              <Button loading={resetting} onClick={reset}>Reset OPcache</Button>
+            </Space>
+          </>
+        )}
+      </Space>
+    </Card>
+  );
+};

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
+import { UserPHPOpcacheCard } from "./UserPHPOpcacheCard";
 import { DomainEnvVarsCard } from "./DomainEnvVarsCard";
 import { PHPExtensionsCard } from "./PHPExtensionsCard";
 import { PHPXdebugCard } from "./PHPXdebugCard";
@@ -747,6 +748,11 @@ export function UserPHPSettingsPage() {
               key: "perf",
               label: "Performance",
               children: <UserPHPPerformanceCard />,
+            },
+            {
+              key: "opcache",
+              label: "OPcache & JIT",
+              children: <UserPHPOpcacheCard />,
             },
             {
               key: "env",


### PR DESCRIPTION
## What

Adds the **OPcache & JIT** controls the reporter asked for on the per-domain PHP Settings page (Reset already shipped as item 10). A new tab, per PHP version (per FPM pool — a pool's OPcache SHM is shared by every domain on that version, so it's version-scoped like the Performance card):

- Enable / disable **OPcache**
- Enable / disable **JIT** + JIT buffer size
- `opcache.memory_consumption`, `max_accelerated_files`, `revalidate_freq`, `validate_timestamps`
- the existing **Reset OPcache**, moved adjacent

## Design

Stored as `php_pool_ini_overrides` (rendered `php_admin_value`/`flag`) — the agent already applies these via `php.pool.apply`, so **no new pool columns, no migration**. Each control is tri-state: "Pool default" writes no override → server default. The agent allowlist gains the `opcache.*` directive names (the final gate).

## Safety

- **Clamps** server-side (memory 8–512 MB, jit_buffer 8–256 MB, max_files 100–1000000, revalidate 0–3600 s) — jit_buffer + memory allocate real memory per master, so bounding them protects the small (2 GB) fleet boxes.
- **JIT** = two controls, three directives: enabled → `opcache.jit=tracing` + buffer; tenants never see the raw CRTO integers.
- **Restart, not reload.** OPcache SHM / JIT only take effect at FPM master start, and `php.pool.apply` does a graceful USR2 reload (keeps the old SHM) on a same-version change — so the PUT chains `php.opcache.reset` (a master restart) after the apply.
- `validate_timestamps=Off` ships with a UI warning ("changes to your PHP files won't apply until OPcache is reset") next to Reset.

## Tested — drilled on .60

`php.pool.apply` renders the opcache directives into the pool conf (`php_admin_flag[opcache.enable]=off`, `php_admin_value[opcache.jit]=tracing`, …), `php-fpm -t` **validates** the result, and the tenant override **wins** over the JAB-200 template defaults (FPM last-wins). The drill caught a real bug: the agent requires lowercase `on`/`off` flag values — the endpoint now emits them.

Unit tests: directive mapping + readback, clamp rejection, unset→delete (server default), apply→restart chain. `go build`/`vet`/exec-seam + openapi conformance + `tsc -b` green.

## Scope note

Per-(user,version), not per-domain: a pool's OPcache SHM is shared by every domain on that version, so per-domain isn't physically possible within one pool (same as the item-3 resource-limits conversation).

## Deferred

The admin-side per-domain PHP settings page (the other, larger request in this issue) stays parked — not dropped.

Refs GH #1332.
