### PR TITLE
fix(mail): Mail Domains list + drill polish (GH #1387)

### DIFF
--- a/panel-api/internal/api/me_mail_domains.go
+++ b/panel-api/internal/api/me_mail_domains.go
@@ -53,17 +53,16 @@ type mailDomainRow struct {
 	MailBytes    int64  `json:"mail_bytes"`
 	Sent30d      int64  `json:"sent_30d"`
 	Received30d  int64  `json:"received_30d"`
-	// EmailEnabled drives the Status column and the Enable/Disable row action
-	// (GH #1387 follow-up). The list now includes mail-DISABLED owned domains
-	// too, so a tenant can turn mail ON for a domain from here — a mail-off row
-	// simply carries email_enabled=false and (usually) zero counts.
+	// EmailEnabled is always true for listed rows (GH #1387, johnnyq 2026-09-01:
+	// the list shows only mail-active domains). Kept on the wire so the UI can
+	// still reason about mail state without a second fetch.
 	EmailEnabled bool `json:"email_enabled"`
 	// SSLState is the domain's computed cert state (off/pending/active_le/
 	// self_signed/failed — DomainRepository.computeSSLState), surfaced for the
 	// SSL column. Omitted when empty so the UI renders "Off".
 	SSLState string `json:"ssl_state,omitempty"`
-	// IsQuotaSuspended marks a bandwidth-suspended domain; the Status column
-	// shows "Suspended" for it regardless of the mail flag.
+	// IsQuotaSuspended marks a bandwidth-suspended (mail-active) domain; the UI
+	// badges it "Suspended" so the tenant sees why mail may be paused.
 	IsQuotaSuspended bool `json:"is_quota_suspended"`
 	// Queue is the count of queued messages touching this domain (as sender or
 	// recipient). nil = unknown (agent unavailable) — omitted from JSON so the
@@ -123,12 +122,15 @@ func (h *meMailDomainsHandler) list(c *gin.Context) {
 		}
 	}
 
-	// GH #1387 follow-up: list ALL owned domains, not just mail-enabled ones, so
-	// the Status column reads Enabled/Disabled and the Enable action has a row to
-	// act on. Counts/traffic for a mail-off domain are naturally zero.
+	// GH #1387 (johnnyq, 2026-09-01): list ONLY domains where mail is active. A
+	// mail-off domain is a Domains-page concern (enable mail there); this page is
+	// the tenant's mailbox home and shows only domains that actually have mail.
 	out := []mailDomainRow{}
 	for i := range domains {
 		d := &domains[i]
+		if !d.EmailEnabled {
+			continue
+		}
 		a := byDomainID[d.ID]
 		t := byName[d.Name]
 		out = append(out, mailDomainRow{

--- a/panel-api/internal/api/me_mail_domains_test.go
+++ b/panel-api/internal/api/me_mail_domains_test.go
@@ -82,13 +82,15 @@ func setupMailDomainsRouter(t *testing.T, userID string, cfg MeMailDomainsConfig
 }
 
 func TestMailDomains_AggregatesAndScopes(t *testing.T) {
-	// u1 owns a.test (mail on) + b.test (mail OFF). u2 owns c.test (mail on).
-	// GH #1387 follow-up: a mail-OFF domain is now LISTED too (email_enabled=false)
-	// so the Status column + Enable action have a row to act on.
+	// u1 owns a.test (mail on) + b.test (mail on, quota-suspended) + off.test
+	// (mail OFF). u2 owns c.test (mail on).
+	// GH #1387 (johnnyq, 2026-09-01): the list shows ONLY domains where mail is
+	// active — a mail-OFF domain (off.test) is excluded, not shown as "Disabled".
 	cfg := MeMailDomainsConfig{
 		Domains: mdDomainRepo{ds: []models.Domain{
 			{ID: "da", UserID: "u1", Name: "a.test", EmailEnabled: true, SSLState: "active_le"},
-			{ID: "db", UserID: "u1", Name: "b.test", EmailEnabled: false, IsQuotaSuspended: true},
+			{ID: "db", UserID: "u1", Name: "b.test", EmailEnabled: true, IsQuotaSuspended: true},
+			{ID: "dd", UserID: "u1", Name: "off.test", EmailEnabled: false},
 			{ID: "dc", UserID: "u2", Name: "c.test", EmailEnabled: true},
 		}},
 		Mailboxes: mdMailboxRepo{mbs: []repository.MailboxWithDomain{
@@ -120,7 +122,7 @@ func TestMailDomains_AggregatesAndScopes(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(resp.Data) != 2 || resp.Total != 2 {
-		t.Fatalf("want both a.test + b.test (mail-off now listed), got %+v", resp.Data)
+		t.Fatalf("want only a.test + b.test (mail-active); off.test excluded, got %+v", resp.Data)
 	}
 	byName := map[string]mailDomainRow{}
 	for _, r := range resp.Data {
@@ -150,13 +152,16 @@ func TestMailDomains_AggregatesAndScopes(t *testing.T) {
 	}
 	b, ok := byName["b.test"]
 	if !ok {
-		t.Fatalf("b.test (mail-off) must be listed now: %+v", resp.Data)
+		t.Fatalf("b.test (mail on) must be listed: %+v", resp.Data)
 	}
-	if b.EmailEnabled {
-		t.Fatalf("b.test email_enabled = true, want false")
+	if !b.EmailEnabled {
+		t.Fatalf("b.test email_enabled = false, want true")
 	}
 	if !b.IsQuotaSuspended {
-		t.Fatalf("b.test is_quota_suspended = false, want true")
+		t.Fatalf("b.test is_quota_suspended = false, want true (suspended active domain still surfaces its state)")
+	}
+	if _, listed := byName["off.test"]; listed {
+		t.Fatalf("off.test (mail off) must be EXCLUDED from the mail-active list: %+v", resp.Data)
 	}
 }
 

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1546,6 +1546,7 @@
   "createmailboxwizardmodal": {
     "a_send_only_mailbox_can_authenticate_for_smt": "A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials, so each system has its own account to revoke or rotate.",
     "add_to_groups": "Add to groups",
+    "adding_to_domain": "Adding a mailbox to",
     "aliases_optional": "Aliases (optional)",
     "alice_smith": "Alice Smith",
     "create_mailbox": "Create mailbox",

--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.test.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.test.tsx
@@ -38,6 +38,7 @@ const DOMAINS = [
 function renderModal(opts: {
   open?: boolean;
   domains?: typeof DOMAINS;
+  lockDomain?: boolean;
   onCancel?: () => void;
   onCreated?: (resp: { id: string; email: string }) => void;
 } = {}) {
@@ -47,6 +48,7 @@ function renderModal(opts: {
       <CreateMailboxWizardModal
         open={opts.open ?? true}
         domains={opts.domains ?? DOMAINS}
+        lockDomain={opts.lockDomain}
         onCancel={opts.onCancel ?? (() => {})}
         // Lift the response type to satisfy the wizard's prop; tests
         // only verify the fields they care about.
@@ -86,6 +88,42 @@ describe("CreateMailboxWizardModal — step gating", () => {
     await screen.findByLabelText(/email address/i);
     expect(screen.getByLabelText(/^Password$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/quota/i)).toBeInTheDocument();
+  });
+});
+
+describe("CreateMailboxWizardModal — GH #1387 lockDomain (drill-down)", () => {
+  it("hides the Domain picker, pre-fills the domain, and reveals account fields", async () => {
+    renderModal({ domains: [DOMAINS[0]], lockDomain: true });
+
+    // No Domain select — the drill already scoped to one domain.
+    expect(screen.queryByLabelText(/^Domain$/i)).toBeNull();
+    // A hint tells the user where the mailbox lands.
+    await screen.findByText(/adding a mailbox to/i);
+    // Exact match targets the hint's <strong>first.test</strong>, not the
+    // email field's "@first.test" addon.
+    expect(screen.getByText("first.test")).toBeInTheDocument();
+    // Account fields materialise immediately (step-2), no picking needed.
+    await screen.findByLabelText(/email address/i);
+  });
+
+  it("posts to the locked domain without a pick step", async () => {
+    mocked.post.mockResolvedValueOnce({
+      data: { id: "mb1", email: "bob@first.test", quota_bytes: 1 << 30 },
+    });
+    const onCreated = vi.fn();
+    renderModal({ domains: [DOMAINS[0]], lockDomain: true, onCreated });
+
+    fireEvent.change(await screen.findByLabelText(/email address/i), {
+      target: { value: "bob" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create mailbox/i }));
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith(
+        "/domains/dom1/mailboxes",
+        expect.objectContaining({ local_part: "bob" }),
+      ),
+    );
   });
 });
 

--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
@@ -57,6 +57,10 @@ type DomainOption = { id: string; name: string };
 type Props = {
   open: boolean;
   domains: DomainOption[];
+  // GH #1387 (johnnyq): when the wizard is opened from a single domain's
+  // Mail Domains drill-down the target is already known, so don't ask for it.
+  // lockDomain pre-fills domains[0] and hides the Domain picker.
+  lockDomain?: boolean;
   onCancel: () => void;
   onCreated: (resp: CreateMailboxResponse) => void;
 };
@@ -77,11 +81,15 @@ type FormValues = {
 export const CreateMailboxWizardModal = ({
   open,
   domains,
+  lockDomain,
   onCancel,
   onCreated,
 }: Props) => {
   const { t } = useTranslation();
   const [form] = Form.useForm<FormValues>();
+  // When locked, the domain is fixed to the only entry; it seeds the form so
+  // step-2 (account fields) materialises immediately without a picker step.
+  const lockedDomainId = lockDomain && domains.length > 0 ? domains[0].id : undefined;
   const createMutation = useCreateMailbox();
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
@@ -187,19 +195,33 @@ export const CreateMailboxWizardModal = ({
 
   const accountTab = (
     <>
-      <Form.Item
-        label={t("createmailboxwizardmodal.domain")}
-        name="domain_id"
-        rules={[{ required: true, message: "Pick a domain" }]}
-        tooltip={t("createmailboxwizardmodal.only_domains_with_email_enabled_appear_here")}
-      >
-        <Select
-          showSearch
-          optionFilterProp="label"
-          placeholder={t("createmailboxwizardmodal.select_a_domain")}
-          options={domains.map((d) => ({ value: d.id, label: d.name }))}
-        />
-      </Form.Item>
+      {lockDomain ? (
+        <>
+          {/* Domain already chosen by the drill-down — carry it in a hidden
+              field and just tell the user where the mailbox lands. */}
+          <Form.Item name="domain_id" hidden noStyle>
+            <Input />
+          </Form.Item>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+            {t("createmailboxwizardmodal.adding_to_domain", "Adding a mailbox to")}{" "}
+            <Typography.Text strong>{domains[0]?.name}</Typography.Text>.
+          </Typography.Paragraph>
+        </>
+      ) : (
+        <Form.Item
+          label={t("createmailboxwizardmodal.domain")}
+          name="domain_id"
+          rules={[{ required: true, message: "Pick a domain" }]}
+          tooltip={t("createmailboxwizardmodal.only_domains_with_email_enabled_appear_here")}
+        >
+          <Select
+            showSearch
+            optionFilterProp="label"
+            placeholder={t("createmailboxwizardmodal.select_a_domain")}
+            options={domains.map((d) => ({ value: d.id, label: d.name }))}
+          />
+        </Form.Item>
+      )}
 
       {chosenDomain && (
         <>
@@ -358,7 +380,7 @@ export const CreateMailboxWizardModal = ({
       <Form
         form={form}
         layout="vertical"
-        initialValues={{ quota_mib: QUOTA_DEFAULT_BYTES / 1024 / 1024 }}
+        initialValues={{ quota_mib: QUOTA_DEFAULT_BYTES / 1024 / 1024, domain_id: lockedDomainId }}
       >
         <Tabs
           defaultActiveKey="account"

--- a/panel-ui/src/shells/user/mail/MailDomainPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainPage.tsx
@@ -4,11 +4,12 @@
 // error, never another tenant's data). The account/domain tabs reuse the mail
 // tab components in their single-domain mode. Logs + Statistics scoping and the
 // retirement of the flat Mail page are a follow-up (PR-B).
-import { Alert, Breadcrumb, Button, Card, Skeleton, Space, Typography } from "antd";
+import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
 import { MailOutlined, PlusOutlined } from "@icons";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { useOneQuery } from "../../../hooks/useQueries";
 import type { Domain } from "../domains/UserDomainList";
 import { MailboxesTab } from "./tabs/MailboxesTab";
@@ -57,6 +58,21 @@ export const MailDomainPage = () => {
   const activeKey: TabKey = (TAB_KEYS as readonly string[]).includes(tab ?? "")
     ? (tab as TabKey)
     : DEFAULT_TAB;
+
+  // GH #1387 (johnnyq): the shell already renders ONE breadcrumb (RouteBreadcrumb,
+  // GH #455). Override it with the 3-level entity trail instead of rendering a
+  // second inline <Breadcrumb> — the drill used to show two trails with two
+  // different last crumbs (the raw :domainId vs the domain name).
+  const domainName = domainQ.data?.name;
+  useSetBreadcrumbs(
+    domainName
+      ? [
+          { title: "Dashboard", href: "/jabali-panel/dashboard" },
+          { title: "Mail Domains", href: "/jabali-panel/mail-domains" },
+          { title: domainName },
+        ]
+      : null,
+  );
 
   const back = () => navigate("/jabali-panel/mail-domains");
 
@@ -109,19 +125,6 @@ export const MailDomainPage = () => {
 
   return (
     <div style={{ padding: "20px" }}>
-      {/* GH #1387 follow-up: 3-level trail Dashboard / Mail Domains / <domain>. */}
-      <Breadcrumb
-        style={{ marginBottom: 8 }}
-        items={[
-          {
-            title: <a onClick={() => navigate("/jabali-panel/dashboard")}>Dashboard</a>,
-          },
-          {
-            title: <a onClick={back}>Mail Domains</a>,
-          },
-          { title: domain.name },
-        ]}
-      />
       <Space
         wrap
         align="center"
@@ -130,9 +133,13 @@ export const MailDomainPage = () => {
         <Typography.Title level={3} style={{ margin: 0 }}>
           <MailOutlined /> {domain.name}
         </Typography.Title>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setShowCreateMailbox(true)}>
-          New Mailbox
-        </Button>
+        {/* GH #1387 (johnnyq): New Mailbox belongs to the Accounts (mailboxes)
+            view only — not the Mail Domains list, and not the settings tabs. */}
+        {activeKey === "mailboxes" && (
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setShowCreateMailbox(true)}>
+            New Mailbox
+          </Button>
+        )}
       </Space>
 
       <Card
@@ -147,6 +154,7 @@ export const MailDomainPage = () => {
         <CreateMailboxWizardModal
           open={showCreateMailbox}
           domains={[{ id: domain.id, name: domain.name }]}
+          lockDomain
           onCancel={() => setShowCreateMailbox(false)}
           onCreated={() => setShowCreateMailbox(false)}
         />

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -1,7 +1,8 @@
-// GH #1387 follow-up (johnnyq): the Mail Domains list gained a Status column,
-// an SSL column, and a per-row Enable/Disable mail action. The list now shows
-// ALL owned domains (so a mail-off domain can be enabled in place) — the toggle
-// reuses POST/DELETE /domains/:id/email.
+// GH #1387 (johnnyq, 2026-09-01): the Mail Domains list shows ONLY mail-active
+// domains — the earlier "list every owned domain + a Status column + an Enable
+// action" is reverted. What remains: SSL badge + a per-row Disable action
+// (DELETE /domains/:id/email). Creating a mailbox happens inside a domain's
+// drill-down, so there is no New Mailbox button on this list.
 import { App } from "antd";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -22,6 +23,9 @@ const mocked = apiClient as unknown as {
   delete: ReturnType<typeof vi.fn>;
 };
 
+// The API only ever returns mail-active domains now, so every row here is
+// mail-on. susp.test is a mail-on domain that is also bandwidth-suspended — it
+// still lists (mail is active), the Status column that used to badge it is gone.
 const ROWS = [
   {
     id: "d-on",
@@ -33,17 +37,6 @@ const ROWS = [
     queue: 0,
     email_enabled: true,
     ssl_state: "active_le",
-    is_quota_suspended: false,
-  },
-  {
-    id: "d-off",
-    name: "off.test",
-    mailbox_count: 0,
-    mail_bytes: 0,
-    sent_30d: 0,
-    received_30d: 0,
-    email_enabled: false,
-    ssl_state: "off",
     is_quota_suspended: false,
   },
   {
@@ -97,34 +90,25 @@ beforeEach(() => {
   mocked.delete.mockReset().mockResolvedValue({ data: {} });
 });
 
-describe("GH #1387 — MailDomainsPage status + actions", () => {
-  it("lists all owned domains with Status and SSL badges", async () => {
+describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
+  it("lists mail-active domains with SSL badges, no Status column, no Enable/New Mailbox", async () => {
     renderPage();
     await waitFor(() => expect(mocked.get).toHaveBeenCalledWith("/me/mail-domains"));
-    // All three rows render (mail-off domain is listed too).
     await screen.findByText("on.test");
-    await screen.findByText("off.test");
     await screen.findByText("susp.test");
-    // Status badges: Enabled / Disabled / Suspended.
-    expect(screen.getByText("Disabled")).toBeInTheDocument();
-    expect(screen.getByText("Suspended")).toBeInTheDocument();
-    expect(screen.getAllByText("Enabled").length).toBeGreaterThanOrEqual(1);
-    // SSL badge for the LE domain.
+    // SSL badge for the LE domain still renders.
     expect(screen.getByText("Let's Encrypt")).toBeInTheDocument();
+    // Status column is gone: no Enabled/Disabled/Suspended badges.
+    expect(screen.queryByText("Enabled")).not.toBeInTheDocument();
+    expect(screen.queryByText("Disabled")).not.toBeInTheDocument();
+    expect(screen.queryByText("Suspended")).not.toBeInTheDocument();
+    // No Enable action (all listed domains are already active) and no
+    // list-level New Mailbox button (creation lives in the drill-down).
+    expect(screen.queryByRole("button", { name: "Enable" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /New Mailbox/i })).not.toBeInTheDocument();
   });
 
-  it("enables mail on a mail-off domain via POST /domains/:id/email", async () => {
-    renderPage();
-    const offRow = (await screen.findByText("off.test")).closest("tr") as HTMLElement;
-    const enableBtn = within(offRow).getByRole("button", { name: "Enable" });
-    await openAndConfirm(enableBtn, "Enable");
-    await waitFor(() =>
-      expect(mocked.post).toHaveBeenCalledWith("/domains/d-off/email"),
-    );
-    expect(mocked.delete).not.toHaveBeenCalled();
-  });
-
-  it("disables mail on a mail-on domain via DELETE /domains/:id/email", async () => {
+  it("disables mail on a domain via DELETE /domains/:id/email", async () => {
     renderPage();
     const onRow = (await screen.findByText("on.test")).closest("tr") as HTMLElement;
     const disableBtn = within(onRow).getByRole("button", { name: "Disable" });

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -1,12 +1,12 @@
 // MailDomainsPage — GH #1387. The tenant's Mail entry point: every domain they
-// own, with at-a-glance mail info (mailbox count, storage, 30-day sent/received,
-// queue), an SSL badge and a mail Status, plus a per-row Enable/Disable action.
+// own that HAS mail active, with at-a-glance info (mailbox count, storage,
+// 30-day sent/received, queue), an SSL badge, and a per-row Disable action.
 //
-// GH #1387 follow-up (johnnyq): columns sort, SSL + Status columns, and the
-// Enable/Disable action. To make "Enable" meaningful the list now shows ALL
-// owned domains (not just mail-enabled ones); a mail-off row carries
-// email_enabled=false and can be turned on in place. Enable/Disable reuse the
-// existing owner-scoped POST/DELETE /domains/:id/email endpoints.
+// GH #1387 (johnnyq, 2026-09-01): the list shows ONLY mail-active domains (the
+// earlier "show every owned domain + a Status column + Enable action" is
+// reverted). Enabling mail on a domain is a Domains-page action; creating a
+// mailbox happens inside a domain's drill-down, not here. Disable reuses the
+// existing owner-scoped DELETE /domains/:id/email endpoint.
 import {
   Button,
   Card,
@@ -15,19 +15,16 @@ import {
   Spin,
   Table,
   Tag,
-  Tooltip,
   Typography,
   type TableColumnsType,
 } from "antd";
-import { PlusOutlined } from "@icons";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useListQuery } from "../../../hooks/useQueries";
 import { humanBytes } from "../../../utils/bytes";
 import { getSSLTagColor, getSSLTagLabel } from "../../../utils/sslState";
 import { apiClient } from "../../../apiClient";
 import { feedback } from "../../../lib/feedback";
-import { CreateMailboxWizardModal } from "./CreateMailboxWizardModal";
 
 interface MailDomainRow {
   id: string;
@@ -51,38 +48,22 @@ const numOrNull = (n: number | null | undefined): number =>
 
 export function MailDomainsPage() {
   const navigate = useNavigate();
-  const [showCreate, setShowCreate] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
   const rows = query.items;
-  // Only mail-ENABLED domains can host a new mailbox, so the create wizard is
-  // scoped to those even though the table also lists mail-off domains.
-  const createDomains = useMemo(
-    () => rows.filter((r) => r.email_enabled).map((r) => ({ id: r.id, name: r.name })),
-    [rows],
-  );
 
-  const toggleMail = async (row: MailDomainRow) => {
-    const enable = !row.email_enabled;
+  // Every listed domain is mail-active, so the only mail-state action here is
+  // Disable (soft — keeps mailboxes, re-enable from the Domains page restores
+  // service). It reuses the owner-scoped DELETE /domains/:id/email endpoint.
+  const disableMail = async (row: MailDomainRow) => {
     setBusyId(row.id);
     try {
-      if (enable) {
-        const resp = await apiClient.post<{ warnings?: string[] }>(
-          `/domains/${row.id}/email`,
-        );
-        feedback.message.success(`Mail enabled for ${row.name}`);
-        const warnings = resp.data?.warnings ?? [];
-        if (warnings.length > 0) {
-          feedback.message.warning(warnings[0]);
-        }
-      } else {
-        await apiClient.delete(`/domains/${row.id}/email`);
-        feedback.message.success(`Mail disabled for ${row.name}`);
-      }
+      await apiClient.delete(`/domains/${row.id}/email`);
+      feedback.message.success(`Mail disabled for ${row.name}`);
       await query.refetch();
     } catch (err) {
       feedback.message.error(
-        err instanceof Error ? err.message : "Could not change mail status",
+        err instanceof Error ? err.message : "Could not disable mail",
       );
     } finally {
       setBusyId(null);
@@ -99,21 +80,6 @@ export function MailDomainsPage() {
       render: (name: string, row) => (
         <a onClick={() => navigate(`/jabali-panel/mail-domains/${row.id}`)}>{name}</a>
       ),
-    },
-    {
-      title: "Status",
-      key: "status",
-      sorter: (a, b) => Number(a.email_enabled) - Number(b.email_enabled),
-      render: (_v, row) =>
-        row.is_quota_suspended ? (
-          <Tooltip title="Suspended by bandwidth quota — this is the domain's state, not its mail setting">
-            <Tag color="red">Suspended</Tag>
-          </Tooltip>
-        ) : row.email_enabled ? (
-          <Tag color="green">Enabled</Tag>
-        ) : (
-          <Tag>Disabled</Tag>
-        ),
     },
     {
       title: "SSL",
@@ -169,56 +135,35 @@ export function MailDomainsPage() {
     {
       title: "Actions",
       key: "actions",
-      render: (_v, row) =>
-        row.email_enabled ? (
-          <Popconfirm
-            title={`Disable mail for ${row.name}?`}
-            description="Incoming mail stops and the managed mail DNS records are removed. Mailboxes are kept — re-enabling restores service."
-            okText="Disable"
-            okButtonProps={{ danger: true }}
-            onConfirm={() => toggleMail(row)}
-          >
-            <Button size="small" danger loading={busyId === row.id}>
-              Disable
-            </Button>
-          </Popconfirm>
-        ) : (
-          <Popconfirm
-            title={`Enable mail for ${row.name}?`}
-            description="Sets up DKIM and publishes the recommended mail DNS records for this domain."
-            okText="Enable"
-            onConfirm={() => toggleMail(row)}
-          >
-            <Button size="small" loading={busyId === row.id}>
-              Enable
-            </Button>
-          </Popconfirm>
-        ),
+      render: (_v, row) => (
+        <Popconfirm
+          title={`Disable mail for ${row.name}?`}
+          description="Incoming mail stops and the managed mail DNS records are removed. Mailboxes are kept — re-enabling from the Domains page restores service."
+          okText="Disable"
+          okButtonProps={{ danger: true }}
+          onConfirm={() => disableMail(row)}
+        >
+          <Button size="small" danger loading={busyId === row.id}>
+            Disable
+          </Button>
+        </Popconfirm>
+      ),
     },
   ];
 
   return (
-    <Card
-      title="Mail Domains"
-      extra={
-        <Button
-          type="primary"
-          icon={<PlusOutlined />}
-          disabled={createDomains.length === 0}
-          onClick={() => setShowCreate(true)}
-        >
-          New Mailbox
-        </Button>
-      }
-    >
+    <Card title="Mail Domains">
       <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
-        Your domains and their mail at a glance. Select a domain to manage its
-        accounts, or enable mail on a domain that doesn&apos;t have it yet.
+        Domains with mail active, at a glance. Select a domain to manage its
+        accounts and add mailboxes.
       </Typography.Paragraph>
       {query.isLoading ? (
         <Spin />
       ) : rows.length === 0 ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No domains yet." />
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No domains have mail active yet. Enable mail on a domain from the Domains page."
+        />
       ) : (
         <Table<MailDomainRow>
           rowKey="id"
@@ -226,14 +171,6 @@ export function MailDomainsPage() {
           columns={columns}
           pagination={false}
           scroll={{ x: "max-content" }}
-        />
-      )}
-      {showCreate && (
-        <CreateMailboxWizardModal
-          open={showCreate}
-          domains={createDomains}
-          onCancel={() => setShowCreate(false)}
-          onCreated={() => setShowCreate(false)}
         />
       )}
     </Card>


### PR DESCRIPTION
## GH #1387 — Mail Domains list + drill polish (items 1–4)

Addresses the first four items from johnnyq's 2026-09-01 feedback on the Mail Domains restructure. **Item 5 (mail-only Delete) is destructive and ships as a separate PR.**

### 1. One breadcrumb in the drill-down
The user shell already renders a single route-derived breadcrumb (`RouteBreadcrumb`, GH #455). `MailDomainPage` was *also* rendering an inline `<Breadcrumb>`, so the Mailboxes view showed **two** trails with two different last crumbs (the raw `:domainId` vs the domain name). Fix: drop the inline breadcrumb and override the shell trail via `useSetBreadcrumbs` → `Dashboard / Mail Domains / <domain>`.

### 2. New Mailbox only in the Accounts view
Removed the **New Mailbox** button (and the create wizard) from the Mail Domains **list**. In the drill it now renders only on the **Accounts** tab, not on the settings tabs.

### 3. Don't ask for the domain inside a domain
New `lockDomain` prop on `CreateMailboxWizardModal`: when the wizard is opened from a single domain's drill-down it pre-fills that domain and **hides the picker**, so the account fields appear immediately instead of a redundant "pick a domain" step.

### 4. Show only mail-active domains
Reverts the earlier "list every owned domain + Status column + Enable action". `GET /me/mail-domains` now filters to `email_enabled`; the list drops the **Status** column and the **Enable** action, keeping a per-row **Disable** (soft — mailboxes kept, re-enable from the Domains page restores service). Enabling mail on a domain stays a Domains-page action.

### Tests
- `me_mail_domains_test.go` — flipped to assert a mail-off domain is **excluded**; keeps suspended-domain coverage on a mail-on row.
- `MailDomainsPage.test.tsx` — rewritten: no Status/Enable, no list New Mailbox, Disable still hits `DELETE /domains/:id/email`.
- `CreateMailboxWizardModal.test.tsx` — new `lockDomain` cases (picker hidden, domain pre-filled, posts to the locked domain).

### Verification
- panel-api: `go vet`, `go build ./...`, `go test ./internal/api -run TestMailDomains` ✅
- panel-ui: `tsc -b` ✅, `vitest run src/shells/user/mail` → 11 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
