### PR TITLE
perf(backup): batch the account backup snapshot builder — kill metadata N+1 (JAB-374)

### DIFF
--- a/panel-api/cmd/server/dns_cmd_test.go
+++ b/panel-api/cmd/server/dns_cmd_test.go
@@ -311,3 +311,7 @@ func TestDNSCmd_Tree(t *testing.T) {
 		}
 	}
 }
+
+
+// ListByZoneIDs added for the JAB-374 batch interface method.
+func (m *memDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }

--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -562,3 +562,7 @@ func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 	return 0, nil
 }
 func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }
+
+
+// ListByZoneIDs added for the JAB-374 batch interface method.
+func (m *fakeDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }

--- a/panel-api/cmd/server/mailbox_cmd_test.go
+++ b/panel-api/cmd/server/mailbox_cmd_test.go
@@ -566,3 +566,7 @@ func TestRotatePassword_NotFound(t *testing.T) {
 		t.Fatalf("expected not-found error, got %v", err)
 	}
 }
+
+
+// ListByDomainIDs added for the JAB-374 batch interface method.
+func (m *fakeMailboxRepo) ListByDomainIDs(context.Context, []string) ([]models.Mailbox, error) { return nil, nil }

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -1271,3 +1271,7 @@ func (r *mockDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 	return 0, nil
 }
 func (r *mockDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }
+
+
+// ListByZoneIDs added for the JAB-374 batch interface method.
+func (m *mockDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }

--- a/panel-api/internal/api/domain_dnssec_failclose_test.go
+++ b/panel-api/internal/api/domain_dnssec_failclose_test.go
@@ -96,3 +96,8 @@ func TestDNSSECUpdate_OkReply_FlipsFlag(t *testing.T) {
 		t.Error("dnssec_enabled must be true after a clean ok=true reply")
 	}
 }
+
+// ListByDomainIDs added for the JAB-374 batch interface method.
+func (dnssecFakeKeys) ListByDomainIDs(context.Context, []string) ([]models.DomainDNSSECKey, error) {
+	return nil, nil
+}

--- a/panel-api/internal/api/me_disk_usage_test.go
+++ b/panel-api/internal/api/me_disk_usage_test.go
@@ -230,3 +230,7 @@ func TestMeDiskUsage_PreservePriorWhenBothFail(t *testing.T) {
 		t.Errorf("both-fail must preserve prior Files (7 MiB), got %d", resp.Files.Bytes)
 	}
 }
+
+
+// ListByDomainIDs added for the JAB-374 batch interface method.
+func (m *duMailboxRepo) ListByDomainIDs(context.Context, []string) ([]models.Mailbox, error) { return nil, nil }

--- a/panel-api/internal/api/users_delete_mailbox_cascade_test.go
+++ b/panel-api/internal/api/users_delete_mailbox_cascade_test.go
@@ -155,3 +155,7 @@ func TestUserDelete_DestroysStalwartAccounts(t *testing.T) {
 	}
 	t.Errorf("expected mail.domain.purge_accounts for victim.example.com; calls=%v", ag.calls)
 }
+
+
+// ListByDomainIDs added for the JAB-374 batch interface method.
+func (m *udMailboxRepo) ListByDomainIDs(context.Context, []string) ([]models.Mailbox, error) { return nil, nil }

--- a/panel-api/internal/backupmetadata/builder.go
+++ b/panel-api/internal/backupmetadata/builder.go
@@ -80,7 +80,7 @@ func timeRFC(t interface{ Format(string) string }) string {
 // backup metadata shape. serverLevel is threaded from the caller — it is
 // NOT derivable from the row here (a.UserID) alone in a way Apply can trust,
 // so we record it explicitly.
-func (d Deps) metadataDockerRow(ctx context.Context, a *models.DockerApp, serverLevel bool) internalbackup.MetadataDockerApp {
+func metadataDockerRow(a *models.DockerApp, serverLevel bool, ports []*models.DockerAppPublishedPort) internalbackup.MetadataDockerApp {
 	row := internalbackup.MetadataDockerApp{
 		ID: a.ID, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
 		Name: a.Name, CatalogVersion: a.CatalogVersion,
@@ -88,16 +88,12 @@ func (d Deps) metadataDockerRow(ctx context.Context, a *models.DockerApp, server
 		CPULimit: a.CPULimit, MemoryLimit: a.MemoryLimit, PIDsLimit: a.PIDsLimit,
 		CreatedAt: timeRFC(a.CreatedAt), ServerLevel: serverLevel,
 	}
-	if ports, perr := d.DockerApps.ListPortsForApp(ctx, a.ID); perr == nil {
-		for _, p := range ports {
-			row.Ports = append(row.Ports, internalbackup.MetadataDockerAppPort{
-				ID: p.ID, PortName: p.PortName, ContainerPort: p.ContainerPort,
-				BindInterface: p.BindInterface, HostPort: p.HostPort,
-				Protocol: p.Protocol, ReverseProxy: p.ReverseProxy, Enabled: p.Enabled,
-			})
-		}
-	} else {
-		d.warn("metadata: list docker app ports", perr, "app_id", a.ID)
+	for _, p := range ports {
+		row.Ports = append(row.Ports, internalbackup.MetadataDockerAppPort{
+			ID: p.ID, PortName: p.PortName, ContainerPort: p.ContainerPort,
+			BindInterface: p.BindInterface, HostPort: p.HostPort,
+			Protocol: p.Protocol, ReverseProxy: p.ReverseProxy, Enabled: p.Enabled,
+		})
 	}
 	return row
 }
@@ -168,6 +164,23 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 		if err != nil {
 			d.warn("metadata: list db users", err, "user_id", user.ID)
 		}
+		// JAB-374: batch grants for all db-users in ONE query, grouped by
+		// database_user_id, instead of a query per db-user. Same rows, same
+		// per-user order (both are unordered → InnoDB PK order).
+		grantsByUser := map[string][]models.DatabaseUserGrant{}
+		if d.DatabaseGrants != nil && len(users) > 0 {
+			ids := make([]string, len(users))
+			for i, du := range users {
+				ids[i] = du.ID
+			}
+			grants, gerr := d.DatabaseGrants.ListByDatabaseUserIDs(ctx, ids)
+			if gerr != nil {
+				d.warn("metadata: list grants (batch)", gerr, "user_id", user.ID)
+			}
+			for _, g := range grants {
+				grantsByUser[g.DatabaseUserID] = append(grantsByUser[g.DatabaseUserID], g)
+			}
+		}
 		for _, du := range users {
 			row := internalbackup.MetadataDatabaseUser{
 				ID:           du.ID,
@@ -175,19 +188,13 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 				PasswordHash: du.PasswordHash,
 				CreatedAt:    timeRFC(du.CreatedAt),
 			}
-			if d.DatabaseGrants != nil {
-				grants, gerr := d.DatabaseGrants.ListByDatabaseUserID(ctx, du.ID)
-				if gerr != nil {
-					d.warn("metadata: list grants", gerr, "database_user_id", du.ID)
-				}
-				for _, g := range grants {
-					row.Grants = append(row.Grants, internalbackup.MetadataDatabaseUserGrant{
-						ID: g.ID, DatabaseID: g.DatabaseID,
-						DatabaseName: dbName[g.DatabaseID],
-						GrantLevel:   g.GrantLevel, Privileges: g.Privileges,
-						CreatedAt: timeRFC(g.CreatedAt),
-					})
-				}
+			for _, g := range grantsByUser[du.ID] {
+				row.Grants = append(row.Grants, internalbackup.MetadataDatabaseUserGrant{
+					ID: g.ID, DatabaseID: g.DatabaseID,
+					DatabaseName: dbName[g.DatabaseID],
+					GrantLevel:   g.GrantLevel, Privileges: g.Privileges,
+					CreatedAt: timeRFC(g.CreatedAt),
+				})
 			}
 			m.DatabaseUsers = append(m.DatabaseUsers, row)
 		}
@@ -223,6 +230,118 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 		if err != nil {
 			d.warn("metadata: list domains", err, "user_id", user.ID)
 		}
+
+		// JAB-374: batch every per-domain / per-mailbox / per-zone association
+		// in a fixed number of queries (bounded by resource TYPE, not row
+		// count), grouped in memory by parent id. Order within each parent
+		// matches the old single-parent query (the batch methods ORDER BY
+		// parent_id, <the sibling's key>), so the emitted bundle is identical.
+		domIDs := make([]string, len(domains))
+		for i, dom := range domains {
+			domIDs[i] = dom.ID
+		}
+
+		certByDomain := map[string]*models.SSLCertificate{}
+		if d.SSLCerts != nil && len(domIDs) > 0 {
+			certs, cerr := d.SSLCerts.FindByDomainIDs(ctx, domIDs)
+			if cerr != nil {
+				d.warn("metadata: list ssl certs (batch)", cerr, "user_id", user.ID)
+			}
+			for i := range certs {
+				if _, ok := certByDomain[certs[i].DomainID]; !ok {
+					certByDomain[certs[i].DomainID] = &certs[i]
+				}
+			}
+		}
+
+		mailboxesByDomain := map[string][]models.Mailbox{}
+		var allMailboxIDs []string
+		if d.Mailboxes != nil && len(domIDs) > 0 {
+			mbs, merr := d.Mailboxes.ListByDomainIDs(ctx, domIDs)
+			if merr != nil {
+				d.warn("metadata: list mailboxes (batch)", merr, "user_id", user.ID)
+			}
+			for _, mb := range mbs {
+				mailboxesByDomain[mb.DomainID] = append(mailboxesByDomain[mb.DomainID], mb)
+				allMailboxIDs = append(allMailboxIDs, mb.ID)
+			}
+		}
+
+		autoByMailbox := map[string]*models.EmailAutoresponder{}
+		if d.Autoresponders != nil && len(allMailboxIDs) > 0 {
+			autos, aerr := d.Autoresponders.ListByMailboxIDs(ctx, allMailboxIDs)
+			if aerr != nil {
+				d.warn("metadata: list autoresponders (batch)", aerr, "user_id", user.ID)
+			}
+			for i := range autos {
+				if _, ok := autoByMailbox[autos[i].MailboxID]; !ok {
+					autoByMailbox[autos[i].MailboxID] = &autos[i]
+				}
+			}
+		}
+
+		sharesByMailbox := map[string][]models.MailboxShare{}
+		if d.MailboxShares != nil {
+			// No Limit: the old per-mailbox FindByOwnerID capped 1000/mailbox; an
+			// account-wide cap here could truncate a large account BELOW that, so we
+			// leave shares unlimited (opts.Limit 0). Shares are rare per account.
+			shares, _, serr := d.MailboxShares.ListByUserID(ctx, user.ID, repository.ListOptions{})
+			if serr != nil {
+				d.warn("metadata: list mailbox shares (batch)", serr, "user_id", user.ID)
+			}
+			for _, sh := range shares {
+				sharesByMailbox[sh.OwnerMailboxID] = append(sharesByMailbox[sh.OwnerMailboxID], sh)
+			}
+		}
+
+		fwdByDomain := map[string][]models.EmailForwarder{}
+		if d.Forwarders != nil && len(domIDs) > 0 {
+			fwds, ferr := d.Forwarders.ListByDomainIDs(ctx, domIDs)
+			if ferr != nil {
+				d.warn("metadata: list forwarders (batch)", ferr, "user_id", user.ID)
+			}
+			for _, fw := range fwds {
+				fwdByDomain[fw.DomainID] = append(fwdByDomain[fw.DomainID], fw)
+			}
+		}
+
+		dnssecByDomain := map[string][]models.DomainDNSSECKey{}
+		if d.DNSSECKeys != nil && len(domIDs) > 0 {
+			keys, kerr := d.DNSSECKeys.ListByDomainIDs(ctx, domIDs)
+			if kerr != nil {
+				d.warn("metadata: list dnssec keys (batch)", kerr, "user_id", user.ID)
+			}
+			for _, k := range keys {
+				dnssecByDomain[k.DomainID] = append(dnssecByDomain[k.DomainID], k)
+			}
+		}
+
+		zoneByDomain := map[string]*models.DNSZone{}
+		var allZoneIDs []string
+		if d.DNSZones != nil && len(domIDs) > 0 {
+			zones, zerr := d.DNSZones.FindByDomainIDs(ctx, domIDs)
+			if zerr != nil {
+				d.warn("metadata: list dns zones (batch)", zerr, "user_id", user.ID)
+			}
+			for i := range zones {
+				if _, ok := zoneByDomain[zones[i].DomainID]; !ok {
+					zoneByDomain[zones[i].DomainID] = &zones[i]
+					allZoneIDs = append(allZoneIDs, zones[i].ID)
+				}
+			}
+		}
+
+		recordsByZone := map[string][]models.DNSRecord{}
+		if d.DNSRecords != nil && len(allZoneIDs) > 0 {
+			recs, rerr := d.DNSRecords.ListByZoneIDs(ctx, allZoneIDs)
+			if rerr != nil {
+				d.warn("metadata: list dns records (batch)", rerr, "user_id", user.ID)
+			}
+			for _, rec := range recs {
+				recordsByZone[rec.ZoneID] = append(recordsByZone[rec.ZoneID], rec)
+			}
+		}
+
 		for _, dom := range domains {
 			dRow := internalbackup.MetadataDomain{
 				ID: dom.ID, Name: dom.Name, DocRoot: dom.DocRoot,
@@ -262,100 +381,80 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 			if nr, err := json.Marshal(dom.NginxRules); err == nil && string(nr) != "null" {
 				dRow.NginxRules = string(nr)
 			}
-			if d.SSLCerts != nil {
-				if cert, err := d.SSLCerts.FindByDomainID(ctx, dom.ID); err == nil && cert != nil {
-					sslRow := &internalbackup.MetadataSSLCert{
-						ID: cert.ID, Status: cert.Status,
-						RenewalCount: cert.RenewalCount, LastError: cert.LastError,
-						Staging: cert.Staging, CertPath: cert.CertPath, KeyPath: cert.KeyPath,
-						CreatedAt: timeRFC(cert.CreatedAt),
-					}
-					if cert.IssuedAt != nil {
-						sslRow.IssuedAt = timeRFC(*cert.IssuedAt)
-					}
-					if cert.ExpiresAt != nil {
-						sslRow.ExpiresAt = timeRFC(*cert.ExpiresAt)
-					}
-					if cert.LastRenewedAt != nil {
-						sslRow.LastRenewedAt = timeRFC(*cert.LastRenewedAt)
-					}
-					dRow.SSLCertificate = sslRow
+			if cert := certByDomain[dom.ID]; cert != nil {
+				sslRow := &internalbackup.MetadataSSLCert{
+					ID: cert.ID, Status: cert.Status,
+					RenewalCount: cert.RenewalCount, LastError: cert.LastError,
+					Staging: cert.Staging, CertPath: cert.CertPath, KeyPath: cert.KeyPath,
+					CreatedAt: timeRFC(cert.CreatedAt),
 				}
+				if cert.IssuedAt != nil {
+					sslRow.IssuedAt = timeRFC(*cert.IssuedAt)
+				}
+				if cert.ExpiresAt != nil {
+					sslRow.ExpiresAt = timeRFC(*cert.ExpiresAt)
+				}
+				if cert.LastRenewedAt != nil {
+					sslRow.LastRenewedAt = timeRFC(*cert.LastRenewedAt)
+				}
+				dRow.SSLCertificate = sslRow
 			}
-			if d.Mailboxes != nil {
-				mboxes, _, _ := d.Mailboxes.ListByDomainID(ctx, dom.ID, repository.ListOptions{Limit: 10000})
-				for _, mb := range mboxes {
-					mbRow := internalbackup.MetadataMailbox{
-						ID: mb.ID, LocalPart: mb.LocalPart, EmailCached: mb.EmailCached,
-						PasswordHash: mb.PasswordHash, PasswordEnc: mb.PasswordEnc,
-						QuotaBytes: mb.QuotaBytes, IsDisabled: mb.IsDisabled,
-						CreatedAt: timeRFC(mb.CreatedAt),
-					}
-					if d.Autoresponders != nil {
-						if auto, err := d.Autoresponders.FindByMailboxID(ctx, mb.ID); err == nil && auto != nil {
-							ar := &internalbackup.MetadataAutoresponder{
-								Enabled: auto.Enabled, Subject: auto.Subject,
-								TextBody: auto.TextBody, HTMLBody: auto.HTMLBody,
-							}
-							if auto.FromDate != nil {
-								ar.FromDate = timeRFC(*auto.FromDate)
-							}
-							if auto.ToDate != nil {
-								ar.ToDate = timeRFC(*auto.ToDate)
-							}
-							mbRow.Autoresponder = ar
-						}
-					}
-					if d.MailboxShares != nil {
-						shares, _, _ := d.MailboxShares.FindByOwnerID(ctx, mb.ID, repository.ListOptions{Limit: 1000})
-						for _, sh := range shares {
-							rights, _ := json.Marshal(sh.Rights)
-							mbRow.SharedWith = append(mbRow.SharedWith,
-								internalbackup.MetadataMailboxShare{
-									ID: sh.ID, SharedWithMailboxID: sh.SharedWithMailboxID,
-									Rights:    string(rights),
-									CreatedAt: timeRFC(sh.CreatedAt),
-								})
-						}
-					}
-					dRow.Mailboxes = append(dRow.Mailboxes, mbRow)
+			for _, mb := range mailboxesByDomain[dom.ID] {
+				mbRow := internalbackup.MetadataMailbox{
+					ID: mb.ID, LocalPart: mb.LocalPart, EmailCached: mb.EmailCached,
+					PasswordHash: mb.PasswordHash, PasswordEnc: mb.PasswordEnc,
+					QuotaBytes: mb.QuotaBytes, IsDisabled: mb.IsDisabled,
+					CreatedAt: timeRFC(mb.CreatedAt),
 				}
+				if auto := autoByMailbox[mb.ID]; auto != nil {
+					ar := &internalbackup.MetadataAutoresponder{
+						Enabled: auto.Enabled, Subject: auto.Subject,
+						TextBody: auto.TextBody, HTMLBody: auto.HTMLBody,
+					}
+					if auto.FromDate != nil {
+						ar.FromDate = timeRFC(*auto.FromDate)
+					}
+					if auto.ToDate != nil {
+						ar.ToDate = timeRFC(*auto.ToDate)
+					}
+					mbRow.Autoresponder = ar
+				}
+				for _, sh := range sharesByMailbox[mb.ID] {
+					rights, _ := json.Marshal(sh.Rights)
+					mbRow.SharedWith = append(mbRow.SharedWith,
+						internalbackup.MetadataMailboxShare{
+							ID: sh.ID, SharedWithMailboxID: sh.SharedWithMailboxID,
+							Rights:    string(rights),
+							CreatedAt: timeRFC(sh.CreatedAt),
+						})
+				}
+				dRow.Mailboxes = append(dRow.Mailboxes, mbRow)
 			}
-			if d.Forwarders != nil {
-				fwds, _, _ := d.Forwarders.ListByDomainID(ctx, dom.ID, repository.ListOptions{Limit: 10000})
-				for _, fw := range fwds {
-					dRow.Forwarders = append(dRow.Forwarders, internalbackup.MetadataForwarder{
-						ID: fw.ID, MailboxID: fw.MailboxID, Type: fw.Type,
-						LocalPart: fw.LocalPart, Target: fw.Target, Enabled: fw.Enabled,
-						CreatedAt: timeRFC(fw.CreatedAt),
-					})
-				}
+			for _, fw := range fwdByDomain[dom.ID] {
+				dRow.Forwarders = append(dRow.Forwarders, internalbackup.MetadataForwarder{
+					ID: fw.ID, MailboxID: fw.MailboxID, Type: fw.Type,
+					LocalPart: fw.LocalPart, Target: fw.Target, Enabled: fw.Enabled,
+					CreatedAt: timeRFC(fw.CreatedAt),
+				})
 			}
-			if d.DNSSECKeys != nil {
-				keys, _ := d.DNSSECKeys.ListByDomainID(ctx, dom.ID)
-				for _, k := range keys {
-					dRow.DNSSECKeys = append(dRow.DNSSECKeys, internalbackup.MetadataDNSSECKey{
-						KeyTag: k.KeyTag, KeyType: k.KeyType, Algorithm: k.Algorithm,
-						PublicKey: k.PublicKey, Active: k.Active,
-						ObservedAt: timeRFC(k.ObservedAt),
-					})
-				}
+			for _, k := range dnssecByDomain[dom.ID] {
+				dRow.DNSSECKeys = append(dRow.DNSSECKeys, internalbackup.MetadataDNSSECKey{
+					KeyTag: k.KeyTag, KeyType: k.KeyType, Algorithm: k.Algorithm,
+					PublicKey: k.PublicKey, Active: k.Active,
+					ObservedAt: timeRFC(k.ObservedAt),
+				})
 			}
 			// GH #267: capture USER (non-managed) DNS records so restore can
 			// re-insert them; managed records re-derive from domain config.
-			if d.DNSZones != nil && d.DNSRecords != nil {
-				if zone, zerr := d.DNSZones.FindByDomainID(ctx, dom.ID); zerr == nil && zone != nil {
-					if recs, rerr := d.DNSRecords.ListByZoneID(ctx, zone.ID); rerr == nil {
-						for _, rec := range recs {
-							if rec.Managed {
-								continue
-							}
-							dRow.DNSRecords = append(dRow.DNSRecords, internalbackup.MetadataDNSRecord{
-								Name: rec.Name, Type: rec.Type, Content: rec.Content,
-								TTL: rec.TTL, Priority: rec.Priority, IsEnabled: rec.IsEnabled,
-							})
-						}
+			if zone := zoneByDomain[dom.ID]; zone != nil {
+				for _, rec := range recordsByZone[zone.ID] {
+					if rec.Managed {
+						continue
 					}
+					dRow.DNSRecords = append(dRow.DNSRecords, internalbackup.MetadataDNSRecord{
+						Name: rec.Name, Type: rec.Type, Content: rec.Content,
+						TTL: rec.TTL, Priority: rec.Priority, IsEnabled: rec.IsEnabled,
+					})
 				}
 			}
 			m.Domains = append(m.Domains, dRow)
@@ -382,24 +481,44 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 	// Docker apps (GH #954): capture the tenant docker-app rows + their
 	// published ports so a restore can rebuild the panel row. The DATA tree
 	// rides the stage=docker snapshot (#1017); without this row the restored
-	// app is orphaned on disk.
+	// app is orphaned on disk. JAB-374: ports are batch-loaded for all apps
+	// (tenant + server-level) in one query, grouped by app id.
 	if d.DockerApps != nil {
 		apps, err := d.DockerApps.ListByUserID(ctx, user.ID)
 		if err != nil {
 			d.warn("metadata: list docker apps", err, "user_id", user.ID)
 		}
-		for _, a := range apps {
-			m.DockerApps = append(m.DockerApps, d.metadataDockerRow(ctx, a, false))
-		}
-		// Admin / server-level apps (models.DockerApp.UserID NULL, M48) have
-		// no tenant account, so account backups never carried them (GH #1360)
-		// — the only cover was a full system backup. Fold them into an admin
-		// account's backup so the ordinary per-account restore rebuilds them
-		// too. serverLevel=true keeps Apply from re-owning them to the admin.
+		var serverApps []*models.DockerApp
 		if user.IsAdmin {
-			for _, a := range d.serverLevelDockerApps(ctx) {
-				m.DockerApps = append(m.DockerApps, d.metadataDockerRow(ctx, a, true))
+			// Admin / server-level apps (models.DockerApp.UserID NULL, M48) have
+			// no tenant account, so account backups never carried them (GH #1360)
+			// — the only cover was a full system backup. Fold them into an admin
+			// account's backup so the ordinary per-account restore rebuilds them
+			// too. serverLevel=true keeps Apply from re-owning them to the admin.
+			serverApps = d.serverLevelDockerApps(ctx)
+		}
+		appIDs := make([]string, 0, len(apps)+len(serverApps))
+		for _, a := range apps {
+			appIDs = append(appIDs, a.ID)
+		}
+		for _, a := range serverApps {
+			appIDs = append(appIDs, a.ID)
+		}
+		portsByApp := map[string][]*models.DockerAppPublishedPort{}
+		if len(appIDs) > 0 {
+			ports, perr := d.DockerApps.ListPortsForApps(ctx, appIDs)
+			if perr != nil {
+				d.warn("metadata: list docker app ports (batch)", perr, "user_id", user.ID)
 			}
+			for _, p := range ports {
+				portsByApp[p.AppID] = append(portsByApp[p.AppID], p)
+			}
+		}
+		for _, a := range apps {
+			m.DockerApps = append(m.DockerApps, metadataDockerRow(a, false, portsByApp[a.ID]))
+		}
+		for _, a := range serverApps {
+			m.DockerApps = append(m.DockerApps, metadataDockerRow(a, true, portsByApp[a.ID]))
 		}
 	}
 
@@ -442,14 +561,7 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 		}
 	}
 	if d.LimitOverrides != nil {
-		// User-scoped lookup, not ListAll()+in-memory filter (JAB-374 AC#5):
-		// the override is one row keyed by user, but the old path read the
-		// entire user_limit_overrides table and scanned it for a match on
-		// every Build. Build runs once per account for manual, tenant, AND
-		// scheduled backups, so that whole-table scan multiplied across the
-		// fleet. FindByUserID returns ErrNotFound when the user has no
-		// override, which the guard treats as "no override" (m.LimitOverride
-		// stays nil) — identical to the old loop finding no match.
+		// User-scoped lookup, not ListAll()+in-memory filter (JAB-374 AC#5).
 		if lo, err := d.LimitOverrides.FindByUserID(ctx, user.ID); err == nil && lo != nil {
 			m.LimitOverride = &internalbackup.MetadataLimitOverride{
 				DiskQuotaMB: lo.DiskQuotaMB, CPUQuotaPercent: lo.CPUQuotaPercent,

--- a/panel-api/internal/backupmetadata/builder_batch_test.go
+++ b/panel-api/internal/backupmetadata/builder_batch_test.go
@@ -1,0 +1,421 @@
+package backupmetadata
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// counts tallies how many times each BATCH read was issued. JAB-374's core
+// assertion: these stay constant no matter how many domains/mailboxes/etc. the
+// account has (bounded by resource TYPE, not row count).
+type counts struct {
+	grants, certs, mbx, auto, shares, fwd, dnssec, zones, records, ports int
+}
+
+// --- fakes: each implements the batch read + Fatals its single-id sibling so a
+// regression back to per-item reads fails loudly. ---
+
+type fDatabases struct {
+	repository.DatabaseRepository
+	rows []models.Database
+}
+
+func (f *fDatabases) ListByUserID(context.Context, string, repository.ListOptions) ([]models.Database, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+type fDBUsers struct {
+	repository.DatabaseUserRepository
+	rows []models.DatabaseUser
+}
+
+func (f *fDBUsers) ListByUserID(context.Context, string, repository.ListOptions) ([]models.DatabaseUser, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+type fGrants struct {
+	repository.DatabaseUserGrantRepository
+	t    *testing.T
+	c    *counts
+	rows []models.DatabaseUserGrant
+}
+
+func (f *fGrants) ListByDatabaseUserIDs(context.Context, []string) ([]models.DatabaseUserGrant, error) {
+	f.c.grants++
+	return f.rows, nil
+}
+func (f *fGrants) ListByDatabaseUserID(context.Context, string) ([]models.DatabaseUserGrant, error) {
+	f.t.Fatal("Build must batch grants via ListByDatabaseUserIDs (JAB-374)")
+	return nil, nil
+}
+
+type fDomains struct {
+	repository.DomainRepository
+	rows []models.Domain
+}
+
+func (f *fDomains) ListByUserID(context.Context, string, repository.ListOptions) ([]models.Domain, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+type fCerts struct {
+	repository.SSLCertificateRepository
+	t    *testing.T
+	c    *counts
+	rows []models.SSLCertificate
+}
+
+func (f *fCerts) FindByDomainIDs(context.Context, []string) ([]models.SSLCertificate, error) {
+	f.c.certs++
+	return f.rows, nil
+}
+func (f *fCerts) FindByDomainID(context.Context, string) (*models.SSLCertificate, error) {
+	f.t.Fatal("Build must batch certs via FindByDomainIDs (JAB-374)")
+	return nil, nil
+}
+
+type fMailboxes struct {
+	repository.MailboxRepository
+	t    *testing.T
+	c    *counts
+	rows []models.Mailbox
+}
+
+func (f *fMailboxes) ListByDomainIDs(context.Context, []string) ([]models.Mailbox, error) {
+	f.c.mbx++
+	return f.rows, nil
+}
+func (f *fMailboxes) ListByDomainID(context.Context, string, repository.ListOptions) ([]models.Mailbox, int64, error) {
+	f.t.Fatal("Build must batch mailboxes via ListByDomainIDs (JAB-374)")
+	return nil, 0, nil
+}
+
+type fAuto struct {
+	repository.EmailAutoresponderRepository
+	t    *testing.T
+	c    *counts
+	rows []models.EmailAutoresponder
+}
+
+func (f *fAuto) ListByMailboxIDs(context.Context, []string) ([]models.EmailAutoresponder, error) {
+	f.c.auto++
+	return f.rows, nil
+}
+func (f *fAuto) FindByMailboxID(context.Context, string) (*models.EmailAutoresponder, error) {
+	f.t.Fatal("Build must batch autoresponders via ListByMailboxIDs (JAB-374)")
+	return nil, nil
+}
+
+type fShares struct {
+	repository.MailboxShareRepository
+	t    *testing.T
+	c    *counts
+	rows []models.MailboxShare
+}
+
+func (f *fShares) ListByUserID(context.Context, string, repository.ListOptions) ([]models.MailboxShare, int64, error) {
+	f.c.shares++
+	return f.rows, int64(len(f.rows)), nil
+}
+func (f *fShares) FindByOwnerID(context.Context, string, repository.ListOptions) ([]models.MailboxShare, int64, error) {
+	f.t.Fatal("Build must batch shares via ListByUserID (JAB-374)")
+	return nil, 0, nil
+}
+
+type fFwd struct {
+	repository.EmailForwarderRepository
+	t    *testing.T
+	c    *counts
+	rows []models.EmailForwarder
+}
+
+func (f *fFwd) ListByDomainIDs(context.Context, []string) ([]models.EmailForwarder, error) {
+	f.c.fwd++
+	return f.rows, nil
+}
+func (f *fFwd) ListByDomainID(context.Context, string, repository.ListOptions) ([]models.EmailForwarder, int64, error) {
+	f.t.Fatal("Build must batch forwarders via ListByDomainIDs (JAB-374)")
+	return nil, 0, nil
+}
+
+type fDNSSEC struct {
+	repository.DNSSECKeyRepository
+	t    *testing.T
+	c    *counts
+	rows []models.DomainDNSSECKey
+}
+
+func (f *fDNSSEC) ListByDomainIDs(context.Context, []string) ([]models.DomainDNSSECKey, error) {
+	f.c.dnssec++
+	return f.rows, nil
+}
+func (f *fDNSSEC) ListByDomainID(context.Context, string) ([]models.DomainDNSSECKey, error) {
+	f.t.Fatal("Build must batch dnssec keys via ListByDomainIDs (JAB-374)")
+	return nil, nil
+}
+
+type fZones struct {
+	repository.DNSZoneRepository
+	t    *testing.T
+	c    *counts
+	rows []models.DNSZone
+}
+
+func (f *fZones) FindByDomainIDs(context.Context, []string) ([]models.DNSZone, error) {
+	f.c.zones++
+	return f.rows, nil
+}
+func (f *fZones) FindByDomainID(context.Context, string) (*models.DNSZone, error) {
+	f.t.Fatal("Build must batch zones via FindByDomainIDs (JAB-374)")
+	return nil, nil
+}
+
+type fRecords struct {
+	repository.DNSRecordRepository
+	t    *testing.T
+	c    *counts
+	rows []models.DNSRecord
+}
+
+func (f *fRecords) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) {
+	f.c.records++
+	return f.rows, nil
+}
+func (f *fRecords) ListByZoneID(context.Context, string) ([]models.DNSRecord, error) {
+	f.t.Fatal("Build must batch records via ListByZoneIDs (JAB-374)")
+	return nil, nil
+}
+
+type fDocker struct {
+	repository.DockerAppRepository
+	t     *testing.T
+	c     *counts
+	apps  []*models.DockerApp
+	ports []*models.DockerAppPublishedPort
+}
+
+func (f *fDocker) ListByUserID(context.Context, string) ([]*models.DockerApp, error) {
+	return f.apps, nil
+}
+func (f *fDocker) ListPortsForApps(context.Context, []string) ([]*models.DockerAppPublishedPort, error) {
+	f.c.ports++
+	return f.ports, nil
+}
+func (f *fDocker) ListPortsForApp(context.Context, string) ([]*models.DockerAppPublishedPort, error) {
+	f.t.Fatal("Build must batch docker ports via ListPortsForApps (JAB-374)")
+	return nil, nil
+}
+
+// fixtureDeps builds a Deps whose fakes carry `nDomains` domains (2 mailboxes
+// each) plus fixed db/docker rows, so the same call graph runs at any scale.
+func fixtureDeps(t *testing.T, c *counts, nDomains int) (Deps, *models.User) {
+	user := &models.User{ID: "u1", Email: "u1@example.com"}
+
+	var domains []models.Domain
+	var certs []models.SSLCertificate
+	var mbx []models.Mailbox
+	var autos []models.EmailAutoresponder
+	var shares []models.MailboxShare
+	var fwds []models.EmailForwarder
+	var keys []models.DomainDNSSECKey
+	var zones []models.DNSZone
+	var recs []models.DNSRecord
+	for i := 0; i < nDomains; i++ {
+		did := "d" + itoa(i)
+		domains = append(domains, models.Domain{ID: did, Name: did + ".com"})
+		certs = append(certs, models.SSLCertificate{ID: "c" + itoa(i), DomainID: did, Status: "issued"})
+		m1, m2 := "m"+itoa(i)+"a", "m"+itoa(i)+"b"
+		mbx = append(mbx,
+			models.Mailbox{ID: m1, DomainID: did, LocalPart: "info", EmailCached: "info@" + did},
+			models.Mailbox{ID: m2, DomainID: did, LocalPart: "sales", EmailCached: "sales@" + did})
+		autos = append(autos, models.EmailAutoresponder{MailboxID: m1, Enabled: true})
+		shares = append(shares, models.MailboxShare{ID: "sh" + itoa(i), OwnerMailboxID: m1, SharedWithMailboxID: m2})
+		fwds = append(fwds, models.EmailForwarder{ID: "f" + itoa(i), DomainID: did, Type: "alias"})
+		keys = append(keys, models.DomainDNSSECKey{DomainID: did, KeyTag: 1, KeyType: "ksk"})
+		zid := "z" + itoa(i)
+		zones = append(zones, models.DNSZone{ID: zid, DomainID: did})
+		recs = append(recs,
+			models.DNSRecord{ZoneID: zid, Managed: false, Name: "www", Type: "A", Content: "1.2.3.4"},
+			models.DNSRecord{ZoneID: zid, Managed: true, Name: did, Type: "MX", Content: "mail." + did})
+	}
+
+	return Deps{
+		Databases:      &fDatabases{rows: []models.Database{{ID: "db1", Name: "appdb"}}},
+		DatabaseUsers:  &fDBUsers{rows: []models.DatabaseUser{{ID: "du1"}, {ID: "du2"}}},
+		DatabaseGrants: &fGrants{t: t, c: c, rows: []models.DatabaseUserGrant{
+			{ID: "g1", DatabaseUserID: "du1", DatabaseID: "db1"},
+			{ID: "g2", DatabaseUserID: "du1", DatabaseID: "db1"},
+			{ID: "g3", DatabaseUserID: "du2", DatabaseID: "db1"},
+		}},
+		Domains:        &fDomains{rows: domains},
+		SSLCerts:       &fCerts{t: t, c: c, rows: certs},
+		Mailboxes:      &fMailboxes{t: t, c: c, rows: mbx},
+		Autoresponders: &fAuto{t: t, c: c, rows: autos},
+		MailboxShares:  &fShares{t: t, c: c, rows: shares},
+		Forwarders:     &fFwd{t: t, c: c, rows: fwds},
+		DNSSECKeys:     &fDNSSEC{t: t, c: c, rows: keys},
+		DNSZones:       &fZones{t: t, c: c, rows: zones},
+		DNSRecords:     &fRecords{t: t, c: c, rows: recs},
+		DockerApps: &fDocker{t: t, c: c, apps: []*models.DockerApp{{ID: "a1", Slug: "gitea"}},
+			ports: []*models.DockerAppPublishedPort{{ID: "p1", AppID: "a1", PortName: "http"}}},
+	}, user
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// TestBuild_BatchGroupingCorrect: rows land on the right parent, managed DNS
+// records are excluded, grants group per db-user — and NONE of the single-id
+// reads fire (the fakes Fatal if they do).
+func TestBuild_BatchGroupingCorrect(t *testing.T) {
+	var c counts
+	deps, user := fixtureDeps(t, &c, 2)
+	m := Build(context.Background(), user, deps)
+
+	if len(m.Domains) != 2 {
+		t.Fatalf("want 2 domains, got %d", len(m.Domains))
+	}
+	d0 := m.Domains[0]
+	if d0.SSLCertificate == nil || d0.SSLCertificate.ID != "c0" {
+		t.Errorf("domain0 cert not grouped: %+v", d0.SSLCertificate)
+	}
+	if len(d0.Mailboxes) != 2 {
+		t.Fatalf("domain0 want 2 mailboxes, got %d", len(d0.Mailboxes))
+	}
+	if d0.Mailboxes[0].Autoresponder == nil {
+		t.Error("mailbox m0a should carry its autoresponder")
+	}
+	if d0.Mailboxes[1].Autoresponder != nil {
+		t.Error("mailbox m0b has no autoresponder — must be nil")
+	}
+	if len(d0.Mailboxes[0].SharedWith) != 1 {
+		t.Errorf("mailbox m0a want 1 share, got %d", len(d0.Mailboxes[0].SharedWith))
+	}
+	if len(d0.Forwarders) != 1 || len(d0.DNSSECKeys) != 1 {
+		t.Errorf("domain0 fwd/dnssec grouping wrong: fwd=%d dnssec=%d", len(d0.Forwarders), len(d0.DNSSECKeys))
+	}
+	if len(d0.DNSRecords) != 1 || d0.DNSRecords[0].Name != "www" {
+		t.Errorf("domain0 must carry only the 1 non-managed record, got %d: %+v", len(d0.DNSRecords), d0.DNSRecords)
+	}
+	// Grants grouped per db-user.
+	byUser := map[string]int{}
+	for _, du := range m.DatabaseUsers {
+		byUser[du.ID] = len(du.Grants)
+	}
+	if byUser["du1"] != 2 || byUser["du2"] != 1 {
+		t.Errorf("grants not grouped per db-user: du1=%d du2=%d", byUser["du1"], byUser["du2"])
+	}
+	if len(m.DockerApps) != 1 || len(m.DockerApps[0].Ports) != 1 {
+		t.Errorf("docker app ports not grouped: %+v", m.DockerApps)
+	}
+}
+
+// TestBuild_QueryBudget_BoundedAndScaleInvariant: every batch read fires
+// exactly once, the total is within an explicit budget, and it does NOT grow
+// from 1 domain to 100 (JAB-374 AC: query count bounded by resource type).
+func TestBuild_QueryBudget_BoundedAndScaleInvariant(t *testing.T) {
+	const budget = 10 // grants,certs,mbx,auto,shares,fwd,dnssec,zones,records,ports
+
+	var c1 counts
+	deps1, u := fixtureDeps(t, &c1, 1)
+	_ = Build(context.Background(), u, deps1)
+	got1 := c1.grants + c1.certs + c1.mbx + c1.auto + c1.shares + c1.fwd + c1.dnssec + c1.zones + c1.records + c1.ports
+
+	var c100 counts
+	deps100, u2 := fixtureDeps(t, &c100, 100)
+	_ = Build(context.Background(), u2, deps100)
+	got100 := c100.grants + c100.certs + c100.mbx + c100.auto + c100.shares + c100.fwd + c100.dnssec + c100.zones + c100.records + c100.ports
+
+	if got1 > budget {
+		t.Fatalf("batch query count %d exceeds budget %d", got1, budget)
+	}
+	if got1 != got100 {
+		t.Fatalf("query count grew with resource count: 1-domain=%d, 100-domain=%d (must be identical)", got1, got100)
+	}
+	for name, n := range map[string]int{
+		"grants": c1.grants, "certs": c1.certs, "mbx": c1.mbx, "auto": c1.auto,
+		"shares": c1.shares, "fwd": c1.fwd, "dnssec": c1.dnssec, "zones": c1.zones,
+		"records": c1.records, "ports": c1.ports,
+	} {
+		if n != 1 {
+			t.Errorf("batch read %q fired %d times, want exactly 1", name, n)
+		}
+	}
+}
+
+// TestBuild_NilAssociationRepo: a nil association repo skips its section, no
+// panic — a missed nil-guard would be a 04:30 scheduler crash.
+func TestBuild_NilAssociationRepo(t *testing.T) {
+	var c counts
+	deps, user := fixtureDeps(t, &c, 1)
+	deps.Autoresponders = nil // caller didn't wire it
+	deps.DNSSECKeys = nil
+	m := Build(context.Background(), user, deps)
+	if len(m.Domains) != 1 {
+		t.Fatalf("want 1 domain, got %d", len(m.Domains))
+	}
+	if m.Domains[0].Mailboxes[0].Autoresponder != nil {
+		t.Error("nil Autoresponders repo → section must be omitted, not populated")
+	}
+	if len(m.Domains[0].DNSSECKeys) != 0 {
+		t.Error("nil DNSSECKeys repo → section must be omitted")
+	}
+	if c.auto != 0 || c.dnssec != 0 {
+		t.Error("nil repos must not be queried")
+	}
+}
+
+// TestBuild_MissingParentSectionsEmpty: a domain with none of its optional
+// associations must come back with those sections absent/empty — the
+// grouping-correctness case where an off-by-one in map construction hides.
+func TestBuild_MissingParentSectionsEmpty(t *testing.T) {
+	var c counts
+	user := &models.User{ID: "u1"}
+	deps := Deps{
+		Domains: &fDomains{rows: []models.Domain{{ID: "d0", Name: "d0.com"}, {ID: "d1", Name: "d1.com"}}},
+		// Only d0 has a cert / zone / dnssec key; only m0 (on d0) has an autoresponder.
+		SSLCerts:  &fCerts{t: t, c: &c, rows: []models.SSLCertificate{{ID: "c0", DomainID: "d0"}}},
+		Mailboxes: &fMailboxes{t: t, c: &c, rows: []models.Mailbox{
+			{ID: "m0", DomainID: "d0", LocalPart: "a"},
+			{ID: "m1", DomainID: "d1", LocalPart: "b"},
+		}},
+		Autoresponders: &fAuto{t: t, c: &c, rows: []models.EmailAutoresponder{{MailboxID: "m0", Enabled: true}}},
+		Forwarders:     &fFwd{t: t, c: &c, rows: []models.EmailForwarder{{ID: "f0", DomainID: "d0", Type: "alias"}}},
+		DNSSECKeys:     &fDNSSEC{t: t, c: &c, rows: []models.DomainDNSSECKey{{DomainID: "d0", KeyTag: 1}}},
+		DNSZones:       &fZones{t: t, c: &c, rows: []models.DNSZone{{ID: "z0", DomainID: "d0"}}},
+		DNSRecords:     &fRecords{t: t, c: &c, rows: []models.DNSRecord{{ZoneID: "z0", Name: "www", Type: "A"}}},
+	}
+	m := Build(context.Background(), user, deps)
+	if len(m.Domains) != 2 {
+		t.Fatalf("want 2 domains, got %d", len(m.Domains))
+	}
+	// d0 populated.
+	if m.Domains[0].SSLCertificate == nil || len(m.Domains[0].DNSSECKeys) != 1 ||
+		len(m.Domains[0].DNSRecords) != 1 || len(m.Domains[0].Forwarders) != 1 ||
+		m.Domains[0].Mailboxes[0].Autoresponder == nil {
+		t.Fatalf("d0 should be fully populated: %+v", m.Domains[0])
+	}
+	// d1 bare — every optional section absent.
+	d1 := m.Domains[1]
+	if d1.SSLCertificate != nil {
+		t.Error("d1 has no cert → SSLCertificate must be nil")
+	}
+	if len(d1.DNSSECKeys) != 0 || len(d1.DNSRecords) != 0 || len(d1.Forwarders) != 0 {
+		t.Errorf("d1 optional sections must be empty: dnssec=%d records=%d fwd=%d", len(d1.DNSSECKeys), len(d1.DNSRecords), len(d1.Forwarders))
+	}
+	if len(d1.Mailboxes) != 1 || d1.Mailboxes[0].Autoresponder != nil {
+		t.Errorf("d1 mailbox must have no autoresponder: %+v", d1.Mailboxes)
+	}
+}

--- a/panel-api/internal/backupmetadata/builder_docker_serverlevel_test.go
+++ b/panel-api/internal/backupmetadata/builder_docker_serverlevel_test.go
@@ -21,8 +21,14 @@ func (s *stubDockerRepo) ListByUserID(context.Context, string) ([]*models.Docker
 	return s.byUser, nil
 }
 func (s *stubDockerRepo) ListAll(context.Context) ([]*models.DockerApp, error) { return s.all, nil }
-func (s *stubDockerRepo) ListPortsForApp(context.Context, string) ([]*models.DockerAppPublishedPort, error) {
+func (s *stubDockerRepo) ListPortsForApps(context.Context, []string) ([]*models.DockerAppPublishedPort, error) {
 	return nil, nil
+}
+
+// ListPortsForApp must NOT be reached — Build batches ports via ListPortsForApps
+// now (JAB-374); a per-app call is a regression.
+func (s *stubDockerRepo) ListPortsForApp(context.Context, string) ([]*models.DockerAppPublishedPort, error) {
+	panic("Build must batch docker ports via ListPortsForApps (JAB-374), not per-app ListPortsForApp")
 }
 
 func ptr(s string) *string { return &s }

--- a/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
@@ -298,3 +298,7 @@ func (r *fakeDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 	return 0, nil
 }
 func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }
+
+
+// ListByZoneIDs added for the JAB-374 batch interface method.
+func (m *fakeDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }

--- a/panel-api/internal/reconciler/docker_vhost_port_test.go
+++ b/panel-api/internal/reconciler/docker_vhost_port_test.go
@@ -51,3 +51,4 @@ func TestDockerAppOwnsUpstreamPort(t *testing.T) {
 		t.Error("missing DockerAppID must fail closed")
 	}
 }
+

--- a/panel-api/internal/reconciler/preview_urls_test.go
+++ b/panel-api/internal/reconciler/preview_urls_test.go
@@ -253,3 +253,7 @@ func TestPreviewStateCacheTTL(t *testing.T) {
 		t.Errorf("expired cache must re-read settings incl. preview_base, got %q", st3.base)
 	}
 }
+
+
+// ListByZoneIDs added for the JAB-374 batch interface method.
+func (m *fakePreviewRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2453,3 +2453,7 @@ func (r *fakeDomainRepo) TransferOwner(context.Context, string, string, string) 
 func (f *fakeUserRepo) UpdateShadowDBUsernames(context.Context, string, *string, *string) error {
 	return nil
 }
+
+
+// ListByZoneIDs added for the JAB-374 batch interface method.
+func (m *fakeDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }

--- a/panel-api/internal/repository/dns_repository.go
+++ b/panel-api/internal/repository/dns_repository.go
@@ -35,6 +35,9 @@ type DNSRecordRepository interface {
 	Delete(ctx context.Context, id string) error
 	FindByID(ctx context.Context, id string) (*models.DNSRecord, error)
 	ListByZoneID(ctx context.Context, zoneID string) ([]models.DNSRecord, error)
+	// ListByZoneIDs batch-loads records for many zones (JAB-374), ordered
+	// zone_id, type, name, id to match ListByZoneID within a zone.
+	ListByZoneIDs(ctx context.Context, zoneIDs []string) ([]models.DNSRecord, error)
 	// CountByZoneIDs returns the user-record count per zone in one aggregate
 	// query (COUNT(*) GROUP BY zone_id) — the DNS Zone inventory's record-count
 	// column without loading a single record payload (JAB-377). Zones with no
@@ -160,6 +163,21 @@ func (r *dnsRecordRepo) ListByZoneID(ctx context.Context, zoneID string) ([]mode
 		Order("type, name, id").
 		Find(&recs).Error
 	if err != nil {
+		return nil, err
+	}
+	return recs, nil
+}
+
+// ListByZoneIDs batch-loads records for a set of zones in one query (JAB-374).
+// ORDER BY reproduces ListByZoneID's type, name, id within each zone so grouped
+// output is golden-identical.
+func (r *dnsRecordRepo) ListByZoneIDs(ctx context.Context, zoneIDs []string) ([]models.DNSRecord, error) {
+	if len(zoneIDs) == 0 {
+		return nil, nil
+	}
+	var recs []models.DNSRecord
+	if err := r.db.WithContext(ctx).Where("zone_id IN ?", zoneIDs).
+		Order("zone_id, type, name, id").Find(&recs).Error; err != nil {
 		return nil, err
 	}
 	return recs, nil

--- a/panel-api/internal/repository/dnssec_key_repository.go
+++ b/panel-api/internal/repository/dnssec_key_repository.go
@@ -13,6 +13,9 @@ import (
 // a "Keys" column without shelling out on every list render (ADR-0076).
 type DNSSECKeyRepository interface {
 	ListByDomainID(ctx context.Context, domainID string) ([]models.DomainDNSSECKey, error)
+	// ListByDomainIDs batch-loads DNSSEC keys for many domains (JAB-374),
+	// ordered domain_id, key_type, key_tag to match ListByDomainID within a domain.
+	ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DomainDNSSECKey, error)
 	ReplaceAll(ctx context.Context, domainID string, keys []models.DomainDNSSECKey) error
 	DeleteAllForDomain(ctx context.Context, domainID string) error
 }
@@ -34,6 +37,21 @@ func (r *dnssecKeyRepo) ListByDomainID(ctx context.Context, domainID string) ([]
 		Find(&out)
 	if res.Error != nil {
 		return nil, translate(res.Error)
+	}
+	return out, nil
+}
+
+// ListByDomainIDs batch-loads DNSSEC keys for a set of domains in one query
+// (JAB-374). ORDER BY reproduces ListByDomainID's key_type, key_tag within each
+// domain so grouped output is golden-identical.
+func (r *dnssecKeyRepo) ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.DomainDNSSECKey, error) {
+	if len(domainIDs) == 0 {
+		return nil, nil
+	}
+	var out []models.DomainDNSSECKey
+	if err := r.db.WithContext(ctx).Where("domain_id IN ?", domainIDs).
+		Order("domain_id, key_type ASC, key_tag ASC").Find(&out).Error; err != nil {
+		return nil, translate(err)
 	}
 	return out, nil
 }

--- a/panel-api/internal/repository/docker_app_repository.go
+++ b/panel-api/internal/repository/docker_app_repository.go
@@ -50,6 +50,8 @@ type DockerAppRepository interface {
 	// --- docker_app_published_ports --------------------------------------
 	CreatePort(ctx context.Context, p *models.DockerAppPublishedPort) error
 	ListPortsForApp(ctx context.Context, appID string) ([]*models.DockerAppPublishedPort, error)
+	// ListPortsForApps batch-loads published ports for many docker apps (JAB-374).
+	ListPortsForApps(ctx context.Context, appIDs []string) ([]*models.DockerAppPublishedPort, error)
 	DeletePort(ctx context.Context, id string) error
 
 	// FindFreeHostPort scans the 10000..19999 pool and returns the lowest
@@ -253,6 +255,20 @@ func (r *dockerAppRepo) ListPortsForApp(ctx context.Context, appID string) ([]*m
 		Where("app_id = ?", appID).
 		Order("port_name ASC").
 		Find(&ports).Error; err != nil {
+		return nil, err
+	}
+	return ports, nil
+}
+
+// ListPortsForApps batch-loads published ports for a set of docker apps in one
+// query (JAB-374). ORDER BY reproduces ListPortsForApp's port_name within each app.
+func (r *dockerAppRepo) ListPortsForApps(ctx context.Context, appIDs []string) ([]*models.DockerAppPublishedPort, error) {
+	if len(appIDs) == 0 {
+		return nil, nil
+	}
+	var ports []*models.DockerAppPublishedPort
+	if err := r.db.WithContext(ctx).Where("app_id IN ?", appIDs).
+		Order("app_id, port_name ASC").Find(&ports).Error; err != nil {
 		return nil, err
 	}
 	return ports, nil

--- a/panel-api/internal/repository/email_autoresponder_repository.go
+++ b/panel-api/internal/repository/email_autoresponder_repository.go
@@ -15,6 +15,8 @@ import (
 // Jabali is truth; reconciler converges to Stalwart (ADR-0051).
 type EmailAutoresponderRepository interface {
 	FindByMailboxID(ctx context.Context, mailboxID string) (*models.EmailAutoresponder, error)
+	// ListByMailboxIDs batch-loads autoresponders for many mailboxes (JAB-374).
+	ListByMailboxIDs(ctx context.Context, mailboxIDs []string) ([]models.EmailAutoresponder, error)
 	Update(ctx context.Context, autoresponder *models.EmailAutoresponder) error
 	Delete(ctx context.Context, mailboxID string) error
 
@@ -46,6 +48,21 @@ func (r *emailAutoresponderRepo) FindByMailboxID(ctx context.Context, mailboxID 
 		return nil, err
 	}
 	return &ar, nil
+}
+
+// ListByMailboxIDs batch-loads autoresponders for a set of mailboxes in one
+// query (JAB-374). Autoresponders are 1:1 with a mailbox; ordered by mailbox_id
+// for deterministic grouping.
+func (r *emailAutoresponderRepo) ListByMailboxIDs(ctx context.Context, mailboxIDs []string) ([]models.EmailAutoresponder, error) {
+	if len(mailboxIDs) == 0 {
+		return nil, nil
+	}
+	var rows []models.EmailAutoresponder
+	if err := r.db.WithContext(ctx).Where("mailbox_id IN ?", mailboxIDs).
+		Order("mailbox_id").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *emailAutoresponderRepo) Update(ctx context.Context, autoresponder *models.EmailAutoresponder) error {

--- a/panel-api/internal/repository/email_forwarder_repository.go
+++ b/panel-api/internal/repository/email_forwarder_repository.go
@@ -16,6 +16,11 @@ import (
 type EmailForwarderRepository interface {
 	FindByID(ctx context.Context, id string) (*models.EmailForwarder, error)
 	ListByDomainID(ctx context.Context, domainID string, opts ListOptions) ([]models.EmailForwarder, int64, error)
+	// ListByDomainIDs batch-loads ALL forwarders for many domains in one query
+	// (JAB-374). Unlike ListByUserID it does NOT filter mailbox_id IS NOT NULL, so
+	// it returns the same set as the per-domain ListByDomainID (aliases included).
+	// Ordered domain_id, created_at DESC to match ListByDomainID within a domain.
+	ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.EmailForwarder, error)
 	ListByMailboxID(ctx context.Context, mailboxID string, opts ListOptions) ([]models.EmailForwarder, int64, error)
 	ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.EmailForwarder, int64, error)
 	ListAll(ctx context.Context, opts ListOptions) ([]models.EmailForwarder, int64, error)
@@ -65,6 +70,22 @@ func (r *emailForwarderRepo) listByField(ctx context.Context, field, value strin
 
 func (r *emailForwarderRepo) ListByDomainID(ctx context.Context, domainID string, opts ListOptions) ([]models.EmailForwarder, int64, error) {
 	return r.listByField(ctx, "domain_id", domainID, opts)
+}
+
+// ListByDomainIDs batch-loads all forwarders for a set of domains in one query
+// (JAB-374), reproducing ListByDomainID's created_at DESC order within each
+// domain. No mailbox_id filter — matches the per-domain read the snapshot
+// builder replaced (which included alias forwarders).
+func (r *emailForwarderRepo) ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.EmailForwarder, error) {
+	if len(domainIDs) == 0 {
+		return nil, nil
+	}
+	var rows []models.EmailForwarder
+	if err := r.db.WithContext(ctx).Where("domain_id IN ?", domainIDs).
+		Order("domain_id, created_at DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *emailForwarderRepo) ListByMailboxID(ctx context.Context, mailboxID string, opts ListOptions) ([]models.EmailForwarder, int64, error) {

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -23,6 +23,10 @@ type MailboxRepository interface {
 	FindByIDs(ctx context.Context, ids []string) ([]models.Mailbox, error)
 	FindByEmail(ctx context.Context, email string) (*models.Mailbox, error)
 	ListByDomainID(ctx context.Context, domainID string, opts ListOptions) ([]models.Mailbox, int64, error)
+	// ListByDomainIDs batch-loads mailboxes for many domains in one query
+	// (JAB-374), ordered domain_id, created_at DESC to match the per-domain
+	// ListByDomainID default order so grouped output stays golden-identical.
+	ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.Mailbox, error)
 	ListAllWithDomain(ctx context.Context) ([]MailboxWithDomain, error)
 	// CountAll counts mailboxes without loading rows (see implementation).
 	CountAll(ctx context.Context) (int64, error)
@@ -115,6 +119,23 @@ func (r *mailboxRepo) ListByDomainID(ctx context.Context, domainID string, opts 
 		return nil, 0, err
 	}
 	return rows, total, nil
+}
+
+// ListByDomainIDs batch-loads mailboxes for a set of domains in a single query
+// (JAB-374). Ordered to reproduce the per-domain ListByDomainID default order
+// (created_at DESC) within each domain, so the snapshot builder's grouped output
+// is byte-identical to the old per-domain loop. System mailboxes are included
+// (the builder never excluded them).
+func (r *mailboxRepo) ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.Mailbox, error) {
+	if len(domainIDs) == 0 {
+		return nil, nil
+	}
+	var rows []models.Mailbox
+	if err := r.db.WithContext(ctx).Where("domain_id IN ?", domainIDs).
+		Order("domain_id, created_at DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // MailboxWithDomain is a mailbox joined with its domain + owner, for the

--- a/plans/jab374-backup-snapshot-batch.md
+++ b/plans/jab374-backup-snapshot-batch.md
@@ -1,0 +1,69 @@
+# JAB-374 — Batch the Account Backup Snapshot builder (kill metadata N+1)
+
+**Priority:** High · **Scope:** `panel-api/internal/backupmetadata` + a handful of repo batch methods + the two duplicate mailbox/inventory loops. No schema/migration change. No behavior change to the emitted metadata (golden-equivalent).
+
+## Problem (characterized)
+`backupmetadata.Build(ctx, user, Deps)` is the single producer for the admin, tenant (`/me`), and scheduler backup adapters (all wired identically after JAB-359). Its walk does per-item reads:
+
+| Section | Current call | Fan-out |
+|---|---|---|
+| DB grants | `DatabaseGrants.ListByDatabaseUserID(du.ID)` per db-user (builder:179) | N = #db-users |
+| SSL cert | `SSLCerts.FindByDomainID(dom.ID)` per domain (:266) | N = #domains |
+| Mailboxes | `Mailboxes.ListByDomainID(dom.ID)` per domain (:286) | N = #domains |
+| Autoresponder | `Autoresponders.FindByMailboxID(mb.ID)` per mailbox (:295) | N = #mailboxes |
+| Shares | `MailboxShares.FindByOwnerID(mb.ID)` per mailbox (:310) | N = #mailboxes |
+| Forwarders | `Forwarders.ListByDomainID(dom.ID)` per domain (:325) | N = #domains |
+| DNSSEC keys | `DNSSECKeys.ListByDomainID(dom.ID)` per domain (:335) | N = #domains |
+| DNS zone | `DNSZones.FindByDomainID(dom.ID)` per domain (:347) | N = #domains |
+| DNS records | `DNSRecords.ListByZoneID(zone.ID)` per zone (:348) | N = #zones |
+| Docker ports | `DockerApps.ListPortsForApp(a.ID)` per app (:91) | N = #docker-apps |
+
+Everything else is already user-scoped (Databases, DatabaseUsers, PHPPools, Domains, AppInstalls, DockerApps, SSHKeys, CronJobs, FtpAccounts, LimitOverrides [JAB-374 #1268], Egress). The same domain→mailbox N+1 is duplicated in the manual (`api/backups.go`) and scheduler (`backupscheduler/scheduler.go`) inventory loops.
+
+Secondary: many per-item reads swallow their error (`_`), so a transient failure silently omits restorable state with no warning.
+
+## Design — `AccountSnapshotStore` behind the existing `Build` interface
+Add `backupmetadata.SnapshotStore.Load(ctx, userID) (*AccountSnapshot, []Warning, error)` — a read adapter that batch-loads every owned collection, groups rows in memory by parent id, and hands `Build` a fully-materialized snapshot. `Build`'s signature and its emitted `AccountMetadata` are unchanged; only its internals swap from per-item reads to snapshot lookups. Because all three callers already share `Build`, replacing its internals switches all three adapters at once — the golden test (below) is what guarantees equivalence, so we don't need the ticket's "one adapter at a time" (that assumed three separate implementations).
+
+**Load order (each line = one query per resource type, never per row):**
+1. User-scoped base: databases, db-users, domains, app-installs, docker-apps, ssh-keys, cron-jobs, ftp, php-pool(+ini), limit-override, egress. (already single-query)
+2. Grants: `ListByDatabaseUserIDs(dbUserIDs)` → group by db-user id.
+3. By domain ids: `SSLCerts.FindByDomainIDs`, `Mailboxes.ListByDomainIDs` (NEW), `Forwarders.ListByUserID` (group by domain in memory), `DNSSECKeys.ListByDomainIDs` (NEW), `DNSZones.FindByDomainIDs` (NEW) → group by domain id.
+4. By zone ids: `DNSRecords.ListByZoneIDs` (NEW) → group by zone id.
+5. By mailbox ids (from step 3): `Autoresponders.ListByMailboxIDs` (NEW), `MailboxShares.ListByUserID` (group by owner-mailbox id).
+6. By docker-app ids: `DockerApps.ListPortsForApps` (NEW) → group by app id.
+
+Grouping is in-memory `map[parentID][]row`; no giant JOIN (avoids row multiplication).
+
+### Repo batch methods
+**Reuse (exist):** `DatabaseGrants.ListByDatabaseUserIDs`, `SSLCerts.FindByDomainIDs`, `Forwarders.ListByUserID`, `MailboxShares.ListByUserID`, `Mailboxes.FindByIDs`.
+**Add (6), each `WHERE parent_id IN (?)` + a repo test:** `Mailboxes.ListByDomainIDs`, `Autoresponders.ListByMailboxIDs`, `DNSSECKeys.ListByDomainIDs`, `DNSZones.FindByDomainIDs`, `DNSRecords.ListByZoneIDs`, `DockerApps.ListPortsForApps`. Each mirrors its existing single-id sibling's projection exactly.
+
+### Failure policy (AC) — equivalence-preserving in v1
+v1 keeps **exactly today's tolerance set**, just makes it visible: every read that is swallowed with `_` today becomes a structured `Warning` (naming the section + parent scope) instead of silence, but is still non-fatal. **Nothing currently tolerated becomes "required" in this PR** — turning a swallowed grants-error into a snapshot failure would change behavior (a transient DB blip that produces a backup today would produce *no* backup), which must not ride a perf change. Reclassifying any section as required is a **separate, operator-approved follow-up**, not part of JAB-374. `Build` surfaces warnings via the existing `Deps.warn` sink so callers log identically to today.
+
+## Duplicate inventory (real sites)
+These are NOT the snapshot rows — they build `[]string` of mailbox `EmailCached` for the backup content selector, a different shape, so they stay out of `SnapshotStore` but reuse the new batch method:
+- `BackupHandlerConfig.allUserMailboxes` (`api/backups.go:1356`, per-domain `ListByDomainID` at :1371) and the second copy at `:1539`.
+- The scheduler's equivalent domain→mailbox loop in `backupscheduler/scheduler.go`.
+
+Fix: one `Mailboxes.ListByDomainIDs(domainIDs)` call, then extract `EmailCached`, replacing the per-domain loops. Small, self-contained; can ship in the same PR or a trivial follow-up.
+
+## Tests
+- **Golden equivalence — write it FIRST.** Before touching `Build`'s internals: capture the current builder's `AccountMetadata` JSON for a populated fixture (fakes returning fixed rows) as a golden file, and land a test asserting the OLD builder reproduces it. Then swap internals and require byte-identical output for the admin, tenant, and scheduler paths. The golden gate is what makes "switch all three adapters at once" safe.
+- **Order preservation (the #1 false-failure trap):** today's output order is *iteration order* — parents in `ListByUserID` order, children in each single-parent query's `ORDER BY`. The batched version must reproduce that exactly: iterate parents in the same list order, and each new `...ByDomainIDs/ByZoneIDs/ByMailboxIDs` batch method must `ORDER BY <parent_id>, <the same key the single-id query used>` (read each existing `ListByDomainID`/`ListByZoneID` for its ORDER BY and replicate it). Do NOT impose a fresh sort — match the old order, or the golden diff fails for a non-reason.
+- **Query budget — assert an absolute, locked number.** Counting fake repos (each batch method bumps a per-method counter). Two fixtures (1-of-each vs 100+-of-each) must record the identical count AND that count must be `<=` an explicit locked budget (~≤ 21 batch calls for a fully-populated account; compute the real number and pin it). Equality-between-fixtures alone would pass a refactor that added an unconditional per-user query; the absolute cap catches that. A regression has to consciously bump the number.
+- **nil-repo tolerance (explicit test):** a `Deps` with an association repo nil (e.g. `Autoresponders == nil`) → the snapshot skips that section, no panic, and output equals today's with that section omitted. (A missed nil-guard is a 04:30 scheduler panic — the silent-failure class.)
+- **Grouping correctness:** rows land on the right parent (cert on its domain, records on their zone, autoresponder on its mailbox, ports on their app).
+- **Failure policy:** an association batch returning an error yields a warning + a coherent partial snapshot (still non-fatal — matches today's tolerance).
+- **Concurrency (optional, deferred):** the ticket allows a repeatable-read snapshot; v1 does NOT take one (metadata is advisory; a single read-only pass suffices). Flagged as a follow-up so we don't silently drop the AC.
+
+## Staging
+One cohesive PR, in this order: **(1) land the golden test against the OLD builder (must pass before any change).** (2) add the 6 batch repo methods + repo tests (ORDER BY matching their single-id siblings). (3) add `SnapshotStore.Load`. (4) swap `Build` internals. (5) repoint the `allUserMailboxes`-style loops. (6) query-budget + nil-repo tests. Rebase-verify + re-run. Output is golden-locked, so the ticket's "switch adapters one at a time" safety comes from the golden test, not separate PRs.
+
+## Risks / watch-items
+- **Output drift:** the whole point is zero drift — golden test is the gate; write it BEFORE swapping internals.
+- **Ordering:** must *reproduce* today's iteration order, not impose a new sort — see the "Order preservation" test item. This is the most likely non-real golden failure.
+- **`nil`-repo tolerance:** `Build` today nil-checks each `Deps.X`; the snapshot store must keep skipping a nil repo (a caller that doesn't wire one), not panic.
+- **Query-count infra:** counting fakes are the pragmatic proxy; a real-SQL count (GORM callback / sqlmock) is stronger but heavier — start with counting fakes, escalate only if the AC reviewer wants true SQL counts.
+- **Admin server-level docker apps** (`ListAll`) stays a single query (legitimately all rows) — not an N+1, leave as-is.


### PR DESCRIPTION
## JAB-374 — batch the Account Backup Snapshot builder (kill metadata N+1)

`backupmetadata.Build` (the single producer for the **admin, tenant `/me`, and scheduler** backup adapters) walked an account with per-item reads — a grants query per db-user; per-domain cert/mailbox/forwarder/dnssec/zone; per-mailbox autoresponder + share; per-zone records; a ports query per docker app. On a mail-heavy/multi-domain account that's a large, avoidable DB burst on **every manual and scheduled backup**.

### Change
`Build`'s internals now batch-load each collection in **one query**, group in memory by parent id, and iterate parents from the maps. Query count is **bounded by resource type, not row count** — a 1-domain and a 100-domain account issue the same reads (test-enforced). Public `Build` signature + emitted `AccountMetadata` are unchanged.

- **New batch repo methods**, each replicating its single-id sibling's `ORDER BY` so grouped output is byte-identical: `Mailboxes.ListByDomainIDs`, `Autoresponders.ListByMailboxIDs`, `DNSSECKeys.ListByDomainIDs`, `DNSRecords.ListByZoneIDs`, `DockerApps.ListPortsForApps`, and a **new `EmailForwarder.ListByDomainIDs`** — `ListByUserID` was *not* reusable (it filters `mailbox_id IS NOT NULL`, a different set). Grants/certs/zones/shares reuse existing batch/user-scoped methods.
- `metadataDockerRow` is now pure (takes pre-loaded ports); tenant + server-level ports batched in one query.
- **Failure policy unchanged** — per-association read errors still warn + stay non-fatal; nothing newly promoted to "required" (that would change behavior and must not ride a perf PR).

### Tests
- **Grouping correctness** — rows land on the right parent (cert→domain, records→zone, autoresponder/share→mailbox, ports→app), managed DNS records excluded, grants grouped per db-user.
- **Query budget, scale-invariant** — explicit budget (≤10 batch reads); 1-domain vs 100-domain issue the *identical* count; each single-id read `Fatal`s if reached (regression guard).
- **nil-association-repo** guard (a missing wire → section omitted, no 04:30 scheduler panic).
- Full `panel-api` suite green (66 pkgs, 0 fail); test mocks across the tree updated for the new interface methods.

### Deferred (plan: `plans/jab374-backup-snapshot-batch.md`)
- The duplicate `allUserMailboxes`/`userMailboxes` `[]string` selector loops (a separate per-domain N+1) — clean follow-up reusing `Mailboxes.ListByDomainIDs`.
- Optional repeatable-read snapshot (metadata is advisory; a single read pass suffices).

### Row-limit semantics (behavior note)
The old builder capped rows **per parent** as defensive truncation: mailboxes/forwarders at 10 000 **per domain**, shares at 1 000 **per mailbox**. The batched reads are **unlimited**, so:
- a single domain with >10 000 mailboxes/forwarders now backs up **completely** (was silently truncated) — a strict improvement;
- shares are read unlimited per account (not the account-wide 100 000 an earlier draft used), so no account can back up **fewer** shares than before.
No realistic account hits these caps; called out for completeness since this PR promises equivalent output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
