### PR TITLE
feat(mail): mail-only delete — keep the web domain (GH #1387)

### DIFF
--- a/panel-agent/internal/commands/ssl_mail_delete.go
+++ b/panel-agent/internal/commands/ssl_mail_delete.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+// ssl.mail.delete — GH #1387 mail-only domain delete.
+//
+// Removes the per-domain mail TLS lineage (mail.<domain>) that ssl.mail.issue
+// created under /etc/letsencrypt/live/. Reuses cleanupCertbotLineage (GH #738):
+// `certbot delete --cert-name`, with a renewal-conf-removal floor when certbot
+// is absent or the lineage is half-broken. Removing the renewal conf is the
+// important part — a dangling conf pointing at deleted live files makes
+// `certbot renew` abort box-wide (the #738 failure), so mail-delete MUST take
+// the lineage down cleanly rather than leaving an auto-renewing orphan.
+//
+// Best-effort + idempotent: a lineage that was never issued (no renewal conf)
+// is a clean no-op, so re-running the mail-delete is safe.
+//
+// ORDER CONTRACT: the panel removes the per-domain mail vhost
+// (webmail.vhost_remove) BEFORE calling this, so no nginx `ssl_certificate`
+// directive still points at the lineage when its files disappear and the next
+// `nginx -t` / reload stays green (the cert/vhost delete-parity scar, #754).
+type sslMailDeleteParams struct {
+	Domain string `json:"domain"`
+	// LineagePath is the mail_certificates.lineage_path the panel stored at
+	// issue time. certbot names a lineage after its primary domain
+	// (mail.<domain>) but can suffix it on re-issue (mail.<domain>-0001), so
+	// the stored dir's basename is the authoritative cert-name when present.
+	LineagePath string `json:"lineage_path,omitempty"`
+}
+
+type sslMailDeleteResponse struct {
+	Ok       bool   `json:"ok"`
+	CertName string `json:"cert_name"`
+}
+
+func sslMailDeleteHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p sslMailDeleteParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+	if p.Domain == "" {
+		return nil, fmt.Errorf("domain is required")
+	}
+	// Guard the exec arg + the renewal-conf path against traversal even though
+	// the panel already validated the domain (defense in depth: cleanupCertbot-
+	// Lineage builds a filepath from the cert-name and passes it to certbot).
+	if err := validateDomainNameForShell(p.Domain); err != nil {
+		return nil, fmt.Errorf("invalid domain: %w", err)
+	}
+
+	certName := "mail." + p.Domain
+	if p.LineagePath != "" {
+		if b := filepath.Base(p.LineagePath); b != "" && b != "." && b != "/" {
+			certName = b
+		}
+	}
+
+	cleanupCertbotLineage(ctx, sslLERoot, certName)
+	return sslMailDeleteResponse{Ok: true, CertName: certName}, nil
+}
+
+func init() {
+	Default.Register("ssl.mail.delete", sslMailDeleteHandler)
+}

--- a/panel-agent/internal/commands/ssl_mail_delete_test.go
+++ b/panel-agent/internal/commands/ssl_mail_delete_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func callSSLMailDelete(t *testing.T, p sslMailDeleteParams) (sslMailDeleteResponse, error) {
+	t.Helper()
+	raw, _ := json.Marshal(p)
+	got, err := sslMailDeleteHandler(context.Background(), raw)
+	if err != nil {
+		return sslMailDeleteResponse{}, err
+	}
+	resp, ok := got.(sslMailDeleteResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", got)
+	}
+	return resp, nil
+}
+
+// The lineage never exists in the test environment (sslLERoot=/etc/letsencrypt),
+// so cleanupCertbotLineage is a clean no-op and we assert the handler's cert-name
+// derivation + validation rather than the certbot side (covered by the box drill
+// and cleanupCertbotLineage's own GH #738 tests).
+func TestSSLMailDelete_CertNameFromDomain(t *testing.T) {
+	resp, err := callSSLMailDelete(t, sslMailDeleteParams{Domain: "foo.test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Ok || resp.CertName != "mail.foo.test" {
+		t.Fatalf("got %+v, want ok=true cert_name=mail.foo.test", resp)
+	}
+}
+
+func TestSSLMailDelete_CertNameFromLineageBasename(t *testing.T) {
+	// A re-issued lineage is suffixed; the stored dir's basename wins.
+	resp, err := callSSLMailDelete(t, sslMailDeleteParams{
+		Domain:      "foo.test",
+		LineagePath: "/etc/letsencrypt/live/mail.foo.test-0001",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.CertName != "mail.foo.test-0001" {
+		t.Fatalf("cert_name = %q, want mail.foo.test-0001", resp.CertName)
+	}
+}
+
+func TestSSLMailDelete_RejectsBadInput(t *testing.T) {
+	for _, d := range []string{"", "../etc/passwd", "a b.test", "foo.test;rm -rf"} {
+		if _, err := sslMailDeleteHandler(context.Background(), mustJSON(t, sslMailDeleteParams{Domain: d})); err == nil {
+			t.Errorf("domain %q: expected error, got nil", d)
+		}
+	}
+}

--- a/panel-api/internal/api/domain_mail_purge.go
+++ b/panel-api/internal/api/domain_mail_purge.go
@@ -1,0 +1,301 @@
+// Mail-only domain delete (GH #1387, johnnyq 2026-09-01).
+//
+// POST /domains/:id/email/purge tears down the MAIL SERVICE for a domain while
+// keeping the web domain, its DNS zone, its website cert, and its docroot:
+//
+//   - destroys every Stalwart account under the domain (its mailboxes)
+//   - de-registers the domain in Stalwart + clears email_enabled
+//   - removes the managed mail DNS (M6 autoconfig set + the mail-specific
+//     bootstrap rows: mail A/AAAA, apex MX→mail, SPF, DMARC) — apex A/AAAA,
+//     www, NS, and any user-edited row survive
+//   - removes the per-domain mail vhost (mail./autoconfig./autodiscover.)
+//   - deletes the mail TLS lineage (mail.<domain>) + its mail_certificates row
+//
+// This is deliberately a DISTINCT route from DELETE /domains/:id/email (soft
+// disable): the distance between "turn mail off, keep everything" and "delete
+// every mailbox" must never be a single flipped flag. The caller must echo the
+// domain name in confirm_domain (mirrors the UI's type-to-confirm).
+//
+// Ordering is agent-authoritative first, DB after, and every step idempotent so
+// a retry converges on a half-torn-down domain. purge_accounts is the hard gate
+// (it must run while the domain is still registered in Stalwart); once it
+// succeeds the teardown is committed and the rest is best-effort with warnings —
+// the mail-cert reconciler and the DNS/vhost reconcilers re-converge on residue.
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type DomainMailPurgeHandlerConfig struct {
+	Domains        repository.DomainRepository
+	Mailboxes      repository.MailboxRepository
+	MailCerts      repository.MailCertificateRepository
+	Agent          agent.AgentInterface
+	DNSZones       repository.DNSZoneRepository
+	DNSRecords     repository.DNSRecordRepository
+	ServerSettings repository.ServerSettingsRepository
+}
+
+// RegisterDomainMailPurgeRoutes mounts POST /domains/:id/email/purge. Sibling of
+// the enable/disable routes; owner-or-admin, like them.
+func RegisterDomainMailPurgeRoutes(g *gin.RouterGroup, cfg DomainMailPurgeHandlerConfig) {
+	if cfg.Domains == nil {
+		return
+	}
+	h := &domainMailPurgeHandler{cfg: cfg}
+	g.POST("/domains/:id/email/purge", h.purge)
+}
+
+type domainMailPurgeHandler struct{ cfg DomainMailPurgeHandlerConfig }
+
+type domainMailPurgeRequest struct {
+	// ConfirmDomain must equal the domain name (case-insensitive) — a
+	// server-side echo of the UI's type-to-confirm so a stray POST can't wipe
+	// a domain's mail.
+	ConfirmDomain string `json:"confirm_domain"`
+}
+
+type domainMailPurgeResponse struct {
+	DomainID         string   `json:"domain_id"`
+	DomainName       string   `json:"domain_name"`
+	MailboxesDeleted int      `json:"mailboxes_deleted"`
+	Warnings         []string `json:"warnings,omitempty"`
+}
+
+const domainMailPurgeAgentTimeout = 60 * time.Second
+
+func (h *domainMailPurgeHandler) purge(c *gin.Context) {
+	ctx := c.Request.Context()
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	dom, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if !claims.IsAdmin && dom.UserID != claims.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	var req domainMailPurgeRequest
+	_ = c.ShouldBindJSON(&req)
+	if !strings.EqualFold(strings.TrimSpace(req.ConfirmDomain), dom.Name) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":  "confirm_mismatch",
+			"detail": "confirm_domain must equal the domain name",
+		})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "agent_unconfigured"})
+		return
+	}
+
+	// Once we start the teardown it must run to completion regardless of the
+	// client hanging up: purge_accounts destroys Stalwart accounts, and a
+	// cancelled ctx aborting steps 2–6 would leave email_enabled=1, half-deleted
+	// rows, and an auto-renewing cert with nobody signalled to retry. Decouple
+	// from request cancellation (per-step timeouts below still bound it).
+	ctx = context.WithoutCancel(ctx)
+
+	var warnings []string
+
+	// 1. HARD GATE — destroy every Stalwart account under the domain, BY DOMAIN
+	//    (catches orphaned accounts a row-driven loop would miss), while the
+	//    domain is still registered in Stalwart. On failure nothing DB-side has
+	//    been touched: return 502 and let the operator retry (it is idempotent).
+	pctx, cancel := context.WithTimeout(ctx, domainMailPurgeAgentTimeout)
+	_, perr := h.cfg.Agent.Call(pctx, "mail.domain.purge_accounts", map[string]any{"domain": dom.Name})
+	cancel()
+	if perr != nil {
+		respondAgentErr(c, "purge_accounts_failed", perr)
+		return
+	}
+
+	// 2. Delete the USER mailbox rows. The domain row STAYS (web domain kept), so
+	//    nothing FK-cascades — the rows must go explicitly (per-mailbox children
+	//    like forwarders/autoresponders/shares do cascade off mailboxes). The
+	//    hidden system relay (JAB-230 PHP mail() identity) is EXCLUDED: it is
+	//    infra ensured per-domain regardless of email_enabled by the sendmail-
+	//    cred reconciler, which re-converges its Stalwart account on its next
+	//    tick — deleting the row here would only churn it back.
+	deleted := 0
+	if h.cfg.Mailboxes != nil {
+		rows, _, lerr := h.cfg.Mailboxes.ListByDomainID(ctx, dom.ID, repository.ListOptions{ExcludeSystem: true})
+		if lerr != nil {
+			warnings = append(warnings, "could not enumerate mailboxes for row cleanup")
+		}
+		for i := range rows {
+			if derr := h.cfg.Mailboxes.Delete(ctx, rows[i].ID); derr != nil {
+				warnings = append(warnings, "mailbox row "+rows[i].LocalPart+" not removed")
+				continue
+			}
+			deleted++
+		}
+	}
+
+	// 3. De-register the domain in Stalwart + clear email_enabled. The agent
+	//    teardown is best-effort (the reconciler re-converges), but the flag is
+	//    always cleared — the accounts are gone, so the domain no longer has mail.
+	dctx, cancel2 := context.WithTimeout(ctx, domainEmailAgentTimeout)
+	_, derr := h.cfg.Agent.Call(dctx, "domain.email_disable", map[string]any{
+		"domain_id":   dom.ID,
+		"domain_name": dom.Name,
+	})
+	cancel2()
+	if derr != nil {
+		warnings = append(warnings, "Stalwart domain de-registration reported an error; the reconciler will retry")
+	}
+	if uerr := h.cfg.Domains.UpdateEmailState(ctx, dom.ID, repository.DomainEmailState{
+		Enabled:        false,
+		EmailEnabledAt: nil,
+	}); uerr != nil {
+		warnings = append(warnings, "email flag not cleared in the database")
+	}
+
+	// MTA-STS is gated on its OWN flag (mta_sts_enabled), not email_enabled, so
+	// clearing email alone would leave the policy + its _mta-sts TXT live for a
+	// domain that no longer has mail. Clear the flag; the MTA-STS reconciler's
+	// disable branch (!enabled && applied_id != 0) tears the policy + DNS down.
+	if dom.MTASTSEnabled {
+		if _, mErr := h.cfg.Domains.UpdateMTASTSEnabled(ctx, dom.ID, false); mErr != nil {
+			warnings = append(warnings, "MTA-STS not disabled; turn it off manually if it lingers")
+		}
+	}
+
+	// 4. Remove the managed mail DNS (M6 set + mail-specific bootstrap rows).
+	warnings = append(warnings, purgeMailDNS(ctx, h.cfg.DNSZones, h.cfg.DNSRecords, h.cfg.ServerSettings, dom.ID)...)
+
+	// 5. Remove the per-domain mail vhost so nginx stops referencing the mail
+	//    lineage BEFORE its files are deleted (cert/vhost delete-parity, #754).
+	vctx, cancel3 := context.WithTimeout(ctx, domainEmailAgentTimeout)
+	_, verr := h.cfg.Agent.Call(vctx, "webmail.vhost_remove", map[string]any{"domain_name": dom.Name})
+	cancel3()
+	if verr != nil {
+		warnings = append(warnings, "mail vhost not removed; remove it manually if it lingers")
+	}
+
+	// 6. Delete the mail TLS lineage (auto-renewing on disk) + its DB row. Skips
+	//    cleanly when the domain never opted into a mail cert.
+	if h.cfg.MailCerts != nil {
+		row, cerr := h.cfg.MailCerts.GetByDomain(ctx, dom.ID)
+		if cerr == nil && row != nil {
+			sctx, cancel4 := context.WithTimeout(ctx, domainEmailAgentTimeout)
+			_, serr := h.cfg.Agent.Call(sctx, "ssl.mail.delete", map[string]any{
+				"domain":       dom.Name,
+				"lineage_path": row.LineagePath,
+			})
+			cancel4()
+			if serr != nil {
+				warnings = append(warnings, "mail certificate files not removed on disk; delete the lineage manually")
+			}
+			if delErr := h.cfg.MailCerts.Delete(ctx, row.ID); delErr != nil {
+				warnings = append(warnings, "mail certificate record not removed")
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, domainMailPurgeResponse{
+		DomainID:         dom.ID,
+		DomainName:       dom.Name,
+		MailboxesDeleted: deleted,
+		Warnings:         warnings,
+	})
+}
+
+// purgeMailDNS removes the managed mail records for a domain: the M6 set
+// (autoconfig/autodiscover/SRV/TLS-RPT/DKIM/CAA, by managed_by marker) plus the
+// mail-specific bootstrap rows that still carry the panel's pristine content.
+// The zone itself and every non-mail or user-edited record survive. Best-effort:
+// returns human-readable warnings, never an error.
+func purgeMailDNS(
+	ctx context.Context,
+	zones repository.DNSZoneRepository,
+	records repository.DNSRecordRepository,
+	serverSettings repository.ServerSettingsRepository,
+	domainID string,
+) []string {
+	if zones == nil || records == nil {
+		return nil
+	}
+	zone, err := zones.FindByDomainID(ctx, domainID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return []string{"mail DNS cleanup skipped: could not read the domain's zone"}
+	}
+
+	// M6-managed set — scoped by managed_by="m6", can never hit a bootstrap or
+	// user row.
+	_ = records.DeleteByZoneIDAndManagedBy(ctx, zone.ID, dnscompile.EmailRecordsManagedBy)
+
+	existing, lerr := records.ListByZoneID(ctx, zone.ID)
+	if lerr != nil {
+		return []string{"mail DNS bootstrap cleanup skipped: could not list records"}
+	}
+	var srv *models.ServerSettings
+	if serverSettings != nil {
+		srv, _ = serverSettings.Get(ctx)
+	}
+	var warnings []string
+	for i := range existing {
+		r := &existing[i]
+		if !isPristineMailBootstrapRecord(r, zone.Name, srv) {
+			continue
+		}
+		if derr := records.Delete(ctx, r.ID); derr != nil {
+			warnings = append(warnings, "mail DNS record "+r.Name+" "+r.Type+" not removed")
+		}
+	}
+	return warnings
+}
+
+// isPristineMailBootstrapRecord reports whether r is one of the MAIL-specific
+// records BootstrapRecords writes (mail A/AAAA, apex MX→mail.<zone>, apex SPF,
+// _dmarc DMARC) AND still carries the panel's pristine content. It never matches:
+//   - a user-edited row (Managed=false),
+//   - a row owned by another pipeline (ManagedBy != nil — e.g. an m6 row, which
+//     step 4 already removed by marker),
+//   - the apex A/AAAA (the website IP), www, NS, or any other record.
+//
+// The exact-content gate means a customised SPF/DMARC, or a mail host record that
+// drifted from the current server IP, is left in place rather than deleted.
+func isPristineMailBootstrapRecord(r *models.DNSRecord, zoneName string, srv *models.ServerSettings) bool {
+	if !r.Managed || r.ManagedBy != nil {
+		return false
+	}
+	switch {
+	case r.Name == "mail" && r.Type == "A":
+		return srv != nil && srv.PublicIPv4 != "" && r.Content == srv.PublicIPv4
+	case r.Name == "mail" && r.Type == "AAAA":
+		return srv != nil && srv.PublicIPv6 != "" && r.Content == srv.PublicIPv6
+	case r.Name == "@" && r.Type == "MX":
+		return zoneName != "" && r.Priority == 10 && r.Content == "mail."+zoneName
+	case r.Name == "@" && r.Type == "TXT":
+		return srv != nil && hintMatches(r.Content, dnscompile.BuildSPFString(srv))
+	case r.Name == "_dmarc" && r.Type == "TXT":
+		return dnscompile.IsCanonicalDMARC(r.Content)
+	}
+	return false
+}

--- a/panel-api/internal/api/domain_mail_purge_test.go
+++ b/panel-api/internal/api/domain_mail_purge_test.go
@@ -1,0 +1,290 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- partial mocks (embed the interface, override only what purge touches) ---
+
+type mpMailboxRepo struct {
+	repository.MailboxRepository
+	byDomain map[string][]models.Mailbox
+	deleted  []string
+}
+
+func (m *mpMailboxRepo) ListByDomainID(_ context.Context, domainID string, opts repository.ListOptions) ([]models.Mailbox, int64, error) {
+	var out []models.Mailbox
+	for _, mb := range m.byDomain[domainID] {
+		if opts.ExcludeSystem && mb.System {
+			continue
+		}
+		out = append(out, mb)
+	}
+	return out, int64(len(out)), nil
+}
+func (m *mpMailboxRepo) Delete(_ context.Context, id string) error {
+	m.deleted = append(m.deleted, id)
+	return nil
+}
+
+type mpMailCertRepo struct {
+	repository.MailCertificateRepository
+	row     *models.MailCertificate
+	deleted []string
+}
+
+func (m *mpMailCertRepo) GetByDomain(_ context.Context, _ string) (*models.MailCertificate, error) {
+	if m.row == nil {
+		return nil, repository.ErrNotFound
+	}
+	return m.row, nil
+}
+func (m *mpMailCertRepo) Delete(_ context.Context, id string) error {
+	m.deleted = append(m.deleted, id)
+	return nil
+}
+
+// recording agent
+type mpAgent struct {
+	calls   []string
+	failCmd string
+}
+
+func (a *mpAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	a.calls = append(a.calls, cmd)
+	if a.failCmd != "" && cmd == a.failCmd {
+		return nil, errors.New("agent boom")
+	}
+	return json.RawMessage(`{"ok":true}`), nil
+}
+func (a *mpAgent) has(cmd string) bool {
+	for _, c := range a.calls {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+func (a *mpAgent) indexOf(cmd string) int {
+	for i, c := range a.calls {
+		if c == cmd {
+			return i
+		}
+	}
+	return -1
+}
+
+func purgeRouter(t *testing.T, userID string, isAdmin bool, cfg DomainMailPurgeHandlerConfig) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: isAdmin})
+		c.Next()
+	})
+	RegisterDomainMailPurgeRoutes(r.Group("/api/v1"), cfg)
+	return r
+}
+
+func doPurge(r *gin.Engine, domainID, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/domains/"+domainID+"/email/purge", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestMailPurge_ConfirmMismatchDoesNothing(t *testing.T) {
+	dr := newMockDomainRepo()
+	dr.Create(context.Background(), &models.Domain{ID: "d1", UserID: "u1", Name: "foo.test", EmailEnabled: true})
+	ag := &mpAgent{}
+	r := purgeRouter(t, "u1", false, DomainMailPurgeHandlerConfig{Domains: dr, Agent: ag})
+
+	w := doPurge(r, "d1", `{"confirm_domain":"WRONG.test"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("no agent calls expected on confirm mismatch, got %v", ag.calls)
+	}
+	if dr.domains["d1"].EmailEnabled != true {
+		t.Fatalf("email must stay enabled on a rejected purge")
+	}
+}
+
+func TestMailPurge_CrossTenantForbidden(t *testing.T) {
+	dr := newMockDomainRepo()
+	dr.Create(context.Background(), &models.Domain{ID: "d1", UserID: "owner", Name: "foo.test", EmailEnabled: true})
+	ag := &mpAgent{}
+	r := purgeRouter(t, "intruder", false, DomainMailPurgeHandlerConfig{Domains: dr, Agent: ag})
+
+	w := doPurge(r, "d1", `{"confirm_domain":"foo.test"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("no agent calls expected for a foreign domain, got %v", ag.calls)
+	}
+}
+
+func TestMailPurge_PurgeAccountsFailureAborts(t *testing.T) {
+	dr := newMockDomainRepo()
+	dr.Create(context.Background(), &models.Domain{ID: "d1", UserID: "u1", Name: "foo.test", EmailEnabled: true})
+	mb := &mpMailboxRepo{byDomain: map[string][]models.Mailbox{"d1": {{ID: "m1", LocalPart: "a"}}}}
+	ag := &mpAgent{failCmd: "mail.domain.purge_accounts"}
+	r := purgeRouter(t, "u1", false, DomainMailPurgeHandlerConfig{Domains: dr, Mailboxes: mb, Agent: ag})
+
+	w := doPurge(r, "d1", `{"confirm_domain":"foo.test"}`)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("want 502 when purge_accounts fails, got %d: %s", w.Code, w.Body.String())
+	}
+	// Hard gate: nothing DB-side touched, so the operator can retry.
+	if len(mb.deleted) != 0 {
+		t.Fatalf("no mailbox rows should be deleted when the gate fails, got %v", mb.deleted)
+	}
+	if dr.domains["d1"].EmailEnabled != true {
+		t.Fatalf("email must stay enabled when the gate fails")
+	}
+	if ag.has("domain.email_disable") || ag.has("ssl.mail.delete") {
+		t.Fatalf("no later teardown steps should run after the gate fails: %v", ag.calls)
+	}
+}
+
+func TestMailPurge_FullTeardown(t *testing.T) {
+	ctx := context.Background()
+	dr := newMockDomainRepo()
+	dr.Create(ctx, &models.Domain{ID: "d1", UserID: "u1", Name: "foo.test", EmailEnabled: true, MTASTSEnabled: true, MTASTSAppliedId: 3})
+	mb := &mpMailboxRepo{byDomain: map[string][]models.Mailbox{"d1": {
+		{ID: "m1", LocalPart: "a"}, {ID: "m2", LocalPart: "b"},
+		{ID: "relay", LocalPart: "jabali-relay", System: true}, // infra — must survive
+	}}}
+	mc := &mpMailCertRepo{row: &models.MailCertificate{ID: "c1", LineagePath: "/etc/letsencrypt/live/mail.foo.test"}}
+
+	zr := newMockDNSZoneRepo()
+	zr.Create(ctx, &models.DNSZone{ID: "z1", DomainID: "d1", Name: "foo.test"})
+	rr := newMockDNSRecordRepo()
+	srv := &models.ServerSettings{PublicIPv4: "1.2.3.4"}
+	m6 := dnscompile.EmailRecordsManagedBy
+	// Mail-specific bootstrap rows (pristine) — must be removed.
+	rr.Create(ctx, &models.DNSRecord{ID: "r-mailA", ZoneID: "z1", Name: "mail", Type: "A", Content: "1.2.3.4", Managed: true})
+	rr.Create(ctx, &models.DNSRecord{ID: "r-mx", ZoneID: "z1", Name: "@", Type: "MX", Content: "mail.foo.test", Priority: 10, Managed: true})
+	rr.Create(ctx, &models.DNSRecord{ID: "r-spf", ZoneID: "z1", Name: "@", Type: "TXT", Content: dnscompile.BuildSPFString(srv), Managed: true})
+	rr.Create(ctx, &models.DNSRecord{ID: "r-dmarc", ZoneID: "z1", Name: "_dmarc", Type: "TXT", Content: `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"`, Managed: true})
+	// M6-managed autoconfig — removed by marker.
+	rr.Create(ctx, &models.DNSRecord{ID: "r-ac", ZoneID: "z1", Name: "autoconfig", Type: "CNAME", Content: "mail.foo.test", Managed: true, ManagedBy: &m6})
+	// Survivors: apex A (website IP) + a user-edited TXT at apex.
+	rr.Create(ctx, &models.DNSRecord{ID: "r-apexA", ZoneID: "z1", Name: "@", Type: "A", Content: "1.2.3.4", Managed: true})
+	rr.Create(ctx, &models.DNSRecord{ID: "r-userTXT", ZoneID: "z1", Name: "@", Type: "TXT", Content: `"google-site-verification=abc"`, Managed: false})
+
+	ag := &mpAgent{}
+	r := purgeRouter(t, "u1", false, DomainMailPurgeHandlerConfig{
+		Domains: dr, Mailboxes: mb, MailCerts: mc, Agent: ag,
+		DNSZones: zr, DNSRecords: rr, ServerSettings: &mockServerSettingsRepo{getResult: srv},
+	})
+
+	w := doPurge(r, "d1", `{"confirm_domain":"foo.test"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp domainMailPurgeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.MailboxesDeleted != 2 {
+		t.Errorf("mailboxes_deleted = %d, want 2", resp.MailboxesDeleted)
+	}
+
+	// Agent orchestration + ordering.
+	for _, cmd := range []string{"mail.domain.purge_accounts", "domain.email_disable", "webmail.vhost_remove", "ssl.mail.delete"} {
+		if !ag.has(cmd) {
+			t.Errorf("expected agent call %s, got %v", cmd, ag.calls)
+		}
+	}
+	if ag.indexOf("mail.domain.purge_accounts") >= ag.indexOf("domain.email_disable") {
+		t.Errorf("purge_accounts must precede email_disable: %v", ag.calls)
+	}
+	if ag.indexOf("webmail.vhost_remove") >= ag.indexOf("ssl.mail.delete") {
+		t.Errorf("vhost_remove must precede ssl.mail.delete (cert/vhost parity): %v", ag.calls)
+	}
+
+	// DB side: only the two USER mailboxes deleted; the system relay survives
+	// (the sendmail-cred reconciler owns it).
+	if len(mb.deleted) != 2 {
+		t.Errorf("mailbox rows deleted = %v, want m1+m2 (relay excluded)", mb.deleted)
+	}
+	for _, id := range mb.deleted {
+		if id == "relay" {
+			t.Errorf("the system relay row must NOT be deleted by a mail purge")
+		}
+	}
+	if dr.domains["d1"].EmailEnabled {
+		t.Errorf("email_enabled must be cleared")
+	}
+	if dr.domains["d1"].MTASTSEnabled {
+		t.Errorf("mta_sts_enabled must be cleared so the reconciler tears the policy down")
+	}
+	if len(mc.deleted) != 1 || mc.deleted[0] != "c1" {
+		t.Errorf("mail cert row deleted = %v, want [c1]", mc.deleted)
+	}
+
+	// DNS: mail rows gone, web/user rows survive.
+	remaining := map[string]bool{}
+	recs, _ := rr.ListByZoneID(ctx, "z1")
+	for _, rec := range recs {
+		remaining[rec.ID] = true
+	}
+	for _, gone := range []string{"r-mailA", "r-mx", "r-spf", "r-dmarc", "r-ac"} {
+		if remaining[gone] {
+			t.Errorf("mail DNS record %s should have been removed", gone)
+		}
+	}
+	for _, kept := range []string{"r-apexA", "r-userTXT"} {
+		if !remaining[kept] {
+			t.Errorf("record %s (web/user) must survive the mail purge", kept)
+		}
+	}
+}
+
+func TestIsPristineMailBootstrapRecord(t *testing.T) {
+	srv := &models.ServerSettings{PublicIPv4: "1.2.3.4", PublicIPv6: "2001:db8::1"}
+	m6 := dnscompile.EmailRecordsManagedBy
+	mk := func(name, typ, content string, pri int, managed bool, mgr *string) *models.DNSRecord {
+		return &models.DNSRecord{Name: name, Type: typ, Content: content, Priority: pri, Managed: managed, ManagedBy: mgr}
+	}
+	cases := []struct {
+		name string
+		rec  *models.DNSRecord
+		want bool
+	}{
+		{"mail A pristine", mk("mail", "A", "1.2.3.4", 0, true, nil), true},
+		{"mail A drifted IP", mk("mail", "A", "9.9.9.9", 0, true, nil), false},
+		{"mail AAAA pristine", mk("mail", "AAAA", "2001:db8::1", 0, true, nil), true},
+		{"apex MX pristine", mk("@", "MX", "mail.foo.test", 10, true, nil), true},
+		{"apex MX wrong prio", mk("@", "MX", "mail.foo.test", 5, true, nil), false},
+		{"apex SPF pristine", mk("@", "TXT", dnscompile.BuildSPFString(srv), 0, true, nil), true},
+		{"apex user TXT", mk("@", "TXT", `"google-site-verification=x"`, 0, false, nil), false},
+		{"dmarc canonical", mk("_dmarc", "TXT", `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"`, 0, true, nil), true},
+		{"apex A (website) kept", mk("@", "A", "1.2.3.4", 0, true, nil), false},
+		{"m6-managed skipped", mk("autoconfig", "CNAME", "mail.foo.test", 0, true, &m6), false},
+		{"user-edited mail A kept", mk("mail", "A", "1.2.3.4", 0, false, nil), false},
+	}
+	for _, tc := range cases {
+		if got := isPristineMailBootstrapRecord(tc.rec, "foo.test", srv); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3081,6 +3081,14 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /domains/{id}/email/purge:
+    post:
+      tags: [Email]
+      summary: Delete the mail service for a domain (GH #1387; keeps the web domain + DNS zone)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
 
   # --- Files (auto) ---
 

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -811,6 +811,17 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				SSLCerts:       deps.SSLCerts,
 				SSLReconciler:  deps.Reconciler,
 			})
+			// GH #1387: mail-only domain delete (destructive teardown that keeps
+			// the web domain + DNS zone). Distinct route from the soft disable.
+			api.RegisterDomainMailPurgeRoutes(mailGroup, api.DomainMailPurgeHandlerConfig{
+				Domains:        deps.Domains,
+				Mailboxes:      deps.Mailboxes,
+				MailCerts:      deps.MailCerts,
+				Agent:          deps.Agent,
+				DNSZones:       deps.DNSZones,
+				DNSRecords:     deps.DNSRecords,
+				ServerSettings: deps.ServerSettings,
+			})
 		}
 		// M6.5 Email features: forwarders, autoresponders, catch-all, disclaimer,
 		// shared folders, logs. All sub-routes live in routes_m65.go and are

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -118,4 +118,31 @@ describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
     );
     expect(mocked.post).not.toHaveBeenCalled();
   });
+
+  it("deletes mail only after type-to-confirm → POST /domains/:id/email/purge", async () => {
+    renderPage();
+    const onRow = (await screen.findByText("on.test")).closest("tr") as HTMLElement;
+    fireEvent.click(within(onRow).getByRole("button", { name: "Delete" }));
+
+    // Modal opens; the destructive confirm is disabled until the name matches.
+    const okBtn = await screen.findByRole("button", { name: /Delete mail/i });
+    expect(okBtn).toBeDisabled();
+
+    const input = screen.getByPlaceholderText("on.test");
+    fireEvent.change(input, { target: { value: "wrong" } });
+    expect(screen.getByRole("button", { name: /Delete mail/i })).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "on.test" } });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Delete mail/i })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Delete mail/i }));
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/domains/d-on/email/purge", {
+        confirm_domain: "on.test",
+      }),
+    );
+    expect(mocked.delete).not.toHaveBeenCalled();
+  });
 });

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -6,12 +6,18 @@
 // earlier "show every owned domain + a Status column + Enable action" is
 // reverted). Enabling mail on a domain is a Domains-page action; creating a
 // mailbox happens inside a domain's drill-down, not here. Disable reuses the
-// existing owner-scoped DELETE /domains/:id/email endpoint.
+// existing owner-scoped DELETE /domains/:id/email endpoint. Delete is the
+// destructive mail-only teardown (POST /domains/:id/email/purge) — it removes
+// mailboxes + mail certs + mail DNS but keeps the website + DNS zone.
 import {
+  Alert,
   Button,
   Card,
   Empty,
+  Input,
+  Modal,
   Popconfirm,
+  Space,
   Spin,
   Table,
   Tag,
@@ -49,6 +55,10 @@ const numOrNull = (n: number | null | undefined): number =>
 export function MailDomainsPage() {
   const navigate = useNavigate();
   const [busyId, setBusyId] = useState<string | null>(null);
+  // Delete (mail purge) is type-to-confirm: the row being deleted + the typed
+  // domain name that must match before the destructive button enables.
+  const [deleteRow, setDeleteRow] = useState<MailDomainRow | null>(null);
+  const [confirmText, setConfirmText] = useState("");
   const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
   const rows = query.items;
 
@@ -64,6 +74,30 @@ export function MailDomainsPage() {
     } catch (err) {
       feedback.message.error(
         err instanceof Error ? err.message : "Could not disable mail",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  // Delete = the destructive mail-only teardown (POST /domains/:id/email/purge).
+  // The server also requires confirm_domain to equal the name, so a stray call
+  // can't wipe a domain's mail.
+  const purgeMail = async (row: MailDomainRow) => {
+    setBusyId(row.id);
+    try {
+      const resp = await apiClient.post<{ warnings?: string[] }>(
+        `/domains/${row.id}/email/purge`,
+        { confirm_domain: row.name },
+      );
+      feedback.message.success(`Mail deleted for ${row.name}`);
+      (resp.data?.warnings ?? []).forEach((w) => feedback.message.warning(w));
+      setDeleteRow(null);
+      setConfirmText("");
+      await query.refetch();
+    } catch (err) {
+      feedback.message.error(
+        err instanceof Error ? err.message : "Could not delete mail",
       );
     } finally {
       setBusyId(null);
@@ -136,17 +170,29 @@ export function MailDomainsPage() {
       title: "Actions",
       key: "actions",
       render: (_v, row) => (
-        <Popconfirm
-          title={`Disable mail for ${row.name}?`}
-          description="Incoming mail stops and the managed mail DNS records are removed. Mailboxes are kept — re-enabling from the Domains page restores service."
-          okText="Disable"
-          okButtonProps={{ danger: true }}
-          onConfirm={() => disableMail(row)}
-        >
-          <Button size="small" danger loading={busyId === row.id}>
-            Disable
+        <Space size="small">
+          <Popconfirm
+            title={`Disable mail for ${row.name}?`}
+            description="Incoming mail stops and the managed mail DNS records are removed. Mailboxes are kept — re-enabling from the Domains page restores service."
+            okText="Disable"
+            okButtonProps={{ danger: true }}
+            onConfirm={() => disableMail(row)}
+          >
+            <Button size="small" danger loading={busyId === row.id}>
+              Disable
+            </Button>
+          </Popconfirm>
+          <Button
+            size="small"
+            danger
+            onClick={() => {
+              setConfirmText("");
+              setDeleteRow(row);
+            }}
+          >
+            Delete
           </Button>
-        </Popconfirm>
+        </Space>
       ),
     },
   ];
@@ -173,6 +219,47 @@ export function MailDomainsPage() {
           scroll={{ x: "max-content" }}
         />
       )}
+
+      <Modal
+        open={!!deleteRow}
+        title={deleteRow ? `Delete mail for ${deleteRow.name}?` : "Delete mail"}
+        okText="Delete mail"
+        okButtonProps={{
+          danger: true,
+          loading: busyId === deleteRow?.id,
+          disabled: !deleteRow || confirmText.trim() !== deleteRow.name,
+        }}
+        onOk={() => deleteRow && purgeMail(deleteRow)}
+        onCancel={() => setDeleteRow(null)}
+        destroyOnClose
+      >
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="This permanently deletes the mail service for this domain"
+          description={
+            <ul style={{ margin: "8px 0 0", paddingLeft: 18 }}>
+              <li>All mailboxes in this domain and the mail they store</li>
+              <li>The mail TLS certificate (mail, autodiscover, autoconfig)</li>
+              <li>The managed mail DNS records (MX, SPF, DKIM, autodiscover…)</li>
+            </ul>
+          }
+        />
+        <Typography.Paragraph style={{ marginBottom: 8 }}>
+          The website, its DNS zone, and its certificate are kept. Type{" "}
+          <Typography.Text code>{deleteRow?.name}</Typography.Text> to confirm.
+        </Typography.Paragraph>
+        <Input
+          autoFocus
+          placeholder={deleteRow?.name}
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          onPressEnter={() => {
+            if (deleteRow && confirmText.trim() === deleteRow.name) purgeMail(deleteRow);
+          }}
+        />
+      </Modal>
     </Card>
   );
 }


### PR DESCRIPTION
## GH #1387 — mail-only Delete (item 5)

> **Base is `gh1387-mail-domain-ui-fixes` (PR #1471, items 1–4)**, so this diff shows only item 5. After PR #1471 squash-merges I'll rebase this onto `main` and retarget.

Adds the destructive **Delete** the reporter asked for on Mail Domains: it removes the *mail service* for a domain and **keeps the website + its DNS zone**.

### Endpoint
`POST /domains/:id/email/purge` — owner-or-admin, a **distinct route** from the soft `DELETE /domains/:id/email` (so mass mailbox deletion is never one flipped flag). The body must echo the domain name in `confirm_domain`; the UI gates the button behind a **type-to-confirm** modal.

### Teardown (agent-authoritative first, DB after, each step idempotent)
Everything after the gate runs under `context.WithoutCancel` so a client disconnect can't half-apply it.

1. **`mail.domain.purge_accounts`** — destroy every Stalwart account under the domain (by-domain → catches orphans) while it's still registered. **Hard gate**: on failure nothing DB-side is touched (502, retryable).
2. **Delete the panel mailbox rows** (domain row stays → no FK cascade). Per-mailbox children — forwarders, autoresponders, shares, group memberships, send delegations — `ON DELETE CASCADE` off `mailboxes`.
3. **`domain.email_disable`** + clear `email_enabled`; also clear `mta_sts_enabled` (gated on its own flag) so the MTA-STS reconciler tears the policy + its `_mta-sts` TXT down.
4. **Remove managed mail DNS**: the M6 set (by `managed_by` marker) + the mail-specific bootstrap rows (`mail` A/AAAA, apex `MX`→mail, SPF, DMARC) **only when they still hold the panel's pristine content** (exact-content, quote-tolerant). Apex A/AAAA, www, NS, and any user-edited row survive.
5. **`webmail.vhost_remove`** — drop the per-domain mail vhost so nginx stops referencing the mail lineage **before** its files go (cert/vhost delete-parity, #754).
6. **`ssl.mail.delete`** (new agent verb) — `certbot delete` the `mail.<domain>` lineage via the existing `cleanupCertbotLineage` (GH #738), then delete the `mail_certificates` row. An on-disk delete is **required** — the lineage lives under `/etc/letsencrypt` and auto-renews, so deleting only the DB row would leave a renewing orphan.

### Kept by design (documented survivors)
Web domain, DNS zone + apex/www/NS records, website cert, docroot, DKIM key material (ADR-0043), domain-scoped mail config (catch-all target, disclaimer), and any tenant-customised SPF/DMARC (they fail the exact-content gate). The orphaned Stalwart Certificate entry for the deleted lineage is harmless (the domain is de-registered) and left for a follow-up.

### Ops
New agent verb `ssl.mail.delete` → **fleet agent redeploy** on release. Route added to `openapi.yaml`.

### Tests
- panel-api: purge orchestration + step ordering, confirm/authz/hard-gate, MTA-STS flag clear, `isPristineMailBootstrapRecord` matrix
- panel-agent: `ssl.mail.delete` cert-name derivation + input validation, exec-seam
- panel-ui: type-to-confirm delete flow
- `go vet` / `go build ./...` / `tsc -b` clean; OpenAPI coverage + cli-reference goldens pass

### Validation
- **Unit/integration:** panel-api purge orchestration + step ordering, confirm/authz/hard-gate, MTA-STS flag clear, **system relay excluded** (JAB-230 infra the sendmail-cred reconciler owns), `isPristineMailBootstrapRecord` matrix; agent `ssl.mail.delete` cert-name derivation + input validation + exec-seam; UI type-to-confirm flow. `go vet` / `go build ./...` / `tsc -b` clean; OpenAPI coverage + cli-reference goldens pass.
- **Runtime interactions resolved in code:** `domain.email_disable` keeps the Stalwart Domain principal (only the panel JOIN blocks auth), so the relay re-converges; per-mailbox children (forwarders/autoresponders/shares/group-members/delegations) `ON DELETE CASCADE` off `mailboxes`; MTA-STS is a separate flag (cleared).
- **Env confirmed on .60 (read-only):** the real box matches the code's assumptions exactly — cert-name `mail.<domain>` with the `mail`/`autoconfig`/`autodiscover` SAN set, lineage at `/etc/letsencrypt/live/mail.<domain>` + renewal conf `mail.<domain>.conf`, mail vhost `<domain>-mail.conf`. `ssl.mail.delete` reuses the production-proven `cleanupCertbotLineage` (GH #738).
- **Destructive E2E deferred:** .60's panel-api is inactive and its own hostname is `mx.jabali-panel.com`; a full purge→re-enable against the `jabali.site` test domain needs panel-api up + a heavy manual restore. Recommend running it with panel-api up before fleet promotion (assertions: `certbot renew --dry-run` clean, `nginx -t` green, web domain intact, purge→re-enable recreates the relay, DNS converges in pdns).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
