### PR TITLE
feat(server-status): light Health projection for the admin header badge (JAB-373)

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4937,7 +4937,13 @@ paths:
     get:
       tags: [Server Status]
       summary: List server status
+      description: >-
+        view=health returns the light projection for the admin header badge:
+        it omits the expensive processes / software / user_slices slices while
+        keeping the synthesized alerts and the cheap host/services/network
+        slices those alerts derive from.
       security: [ { KratosSession: [] } ]
+      parameters: [ { in: query, name: view, required: false, schema: { type: string, enum: [health] } } ]
       responses: { "200": { description: OK } }
 
 

--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -106,6 +106,15 @@ type ServerStatusAlert struct {
 func (h *adminServerStatusHandler) get(c *gin.Context) {
 	ctx := c.Request.Context()
 	now := time.Now().UTC()
+	// JAB-373: the fixed Health projection. The admin header (mounted on EVERY
+	// admin page, polling every 30s) renders only the synthesized alerts, which
+	// derive solely from host/services/apparmor/nginx — NOT processes, software,
+	// or user_slices. `?view=health` skips those three expensive slices
+	// (system.processes walks every PID with a 200ms sample; software; user
+	// slices), so the header never pays for data it doesn't show. Full Adapters
+	// (Dashboard, Server Status page) omit the param and get everything; the
+	// per-slice cache dedupes the shared slices across both.
+	health := c.Query("view") == "health"
 
 	type slot struct {
 		name string
@@ -158,10 +167,14 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 	call("host", "system.info", nil, ttlHost)
 	call("cpu", "system.cpu_usage", nil, ttlCPU)
 	call("network", "system.network", nil, ttlNetwork)
-	call("processes", "system.processes", nil, ttlProcesses)
+	if !health {
+		call("processes", "system.processes", nil, ttlProcesses)
+	}
 	call("services", "system.service_details", nil, ttlServices)
-	call("user_slices", "system.user_slices", nil, ttlUserSlices)
-	call("software", "system.software", nil, ttlSoftware)
+	if !health {
+		call("user_slices", "system.user_slices", nil, ttlUserSlices)
+		call("software", "system.software", nil, ttlSoftware)
+	}
 	// nginx.status, NOT nginx.test: this envelope is polled every few
 	// seconds from any open admin tab, and `nginx -t` recompiles every
 	// vhost plus the whole CrowdSec AppSec/CRS rule set (~19s at >60% CPU
@@ -307,6 +320,14 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 // Threshold rules are intentionally conservative — Step 1 ships a
 // minimum that catches obvious failures; Step 4 will extend with
 // service-specific rules and a link to the relevant remediation page.
+//
+// INVARIANT (JAB-373 Health projection): alerts must derive ONLY from the
+// host, services, apparmor and nginx slices. The admin header badge fetches
+// `?view=health`, which OMITS the processes, software and user_slices slices
+// to stay cheap on every admin page. If you add an alert sourced from one of
+// those three (e.g. a zombie-process or pending-update alert), the header will
+// silently never show it — add it to the Health projection's slice set in
+// get() (server_status.go) too, or the badge and the full-page banner diverge.
 func synthesizeAlerts(results map[string]json.RawMessage, errMap map[string]string) []ServerStatusAlert {
 	// Init non-nil: a HEALTHY server produces no alerts, and a nil slice marshals
 	// as JSON `null`, not `[]` (feedback_go_nil_slice_json_null_spa_crash). The SPA

--- a/panel-api/internal/api/server_status_health_test.go
+++ b/panel-api/internal/api/server_status_health_test.go
@@ -1,0 +1,87 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+// JAB-373: the fixed Health projection (?view=health) — the admin header, mounted
+// on every admin page, renders only alerts (from host/services/apparmor/nginx),
+// so it must NOT pay for system.processes (walks every PID + a 200ms sample),
+// system.software, or system.user_slices. Every other slice still refreshes.
+func TestServerStatus_HealthProjectionSkipsExpensiveSlices(t *testing.T) {
+	mock := agent.NewMockClient().
+		On("system.info", map[string]any{"hostname": "t.local", "partitions": []any{}, "mem_total_kb": 1000, "mem_used_kb": 100}).
+		On("system.cpu_usage", map[string]any{"usage_percent": 1.0}).
+		On("system.network", map[string]any{"interfaces": []any{}}).
+		On("system.processes", map[string]any{"total": 200}).
+		On("system.service_details", map[string]any{"services": []any{}}).
+		On("system.user_slices", map[string]any{"slices": []any{}}).
+		On("system.software", map[string]any{"packages": []any{}}).
+		On("nginx.status", map[string]any{"active": "active"}).
+		On("security.apparmor.summary", map[string]any{"enabled": false})
+
+	r := newServerStatusRouter(mock, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/server-status?view=health", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	called := map[string]bool{}
+	for _, c := range mock.Calls() {
+		called[c.Command] = true
+	}
+	for _, cmd := range []string{"system.processes", "system.software", "system.user_slices"} {
+		assert.False(t, called[cmd], "health view must NOT invoke %s", cmd)
+	}
+	for _, cmd := range []string{"system.info", "system.cpu_usage", "system.network", "system.service_details", "nginx.status", "security.apparmor.summary"} {
+		assert.True(t, called[cmd], "health view must still invoke %s", cmd)
+	}
+
+	var env map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+	for _, k := range []string{"processes", "software", "user_slices"} {
+		_, ok := env[k]
+		assert.False(t, ok, "health envelope must omit %q", k)
+	}
+	// The header's inputs are present.
+	for _, k := range []string{"host", "services", "alerts"} {
+		_, ok := env[k]
+		assert.True(t, ok, "health envelope must keep %q", k)
+	}
+}
+
+// The full envelope (no view param) still fetches everything — the Health
+// projection must not change default behavior.
+func TestServerStatus_FullViewFetchesAllSlices(t *testing.T) {
+	mock := agent.NewMockClient().
+		On("system.info", map[string]any{"partitions": []any{}}).
+		On("system.cpu_usage", map[string]any{"usage_percent": 1.0}).
+		On("system.network", map[string]any{"interfaces": []any{}}).
+		On("system.processes", map[string]any{"total": 1}).
+		On("system.service_details", map[string]any{"services": []any{}}).
+		On("system.user_slices", map[string]any{"slices": []any{}}).
+		On("system.software", map[string]any{"packages": []any{}}).
+		On("nginx.status", map[string]any{"active": "active"}).
+		On("security.apparmor.summary", map[string]any{"enabled": false})
+
+	r := newServerStatusRouter(mock, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/server-status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	called := map[string]bool{}
+	for _, c := range mock.Calls() {
+		called[c.Command] = true
+	}
+	for _, cmd := range []string{"system.processes", "system.software", "system.user_slices"} {
+		assert.True(t, called[cmd], "full view must invoke %s", cmd)
+	}
+}

--- a/panel-ui/src/components/ServerHealthIndicator.tsx
+++ b/panel-ui/src/components/ServerHealthIndicator.tsx
@@ -3,13 +3,13 @@
 // full Server Status page. Hidden when status is "ok" (no exclamation
 // in the chrome for the steady state).
 //
-// Subscribes to the shared `["admin","server-status"]` query at a 30s
-// cadence rather than fetching on its own timer. This component mounts on
-// EVERY admin page, so a hand-rolled setInterval + raw apiClient.get meant
-// a second, uncached fan-out of the heavy aggregate stacked on top of
-// whatever the page itself was polling — and it kept firing in background
-// tabs left open overnight. React Query dedupes across observers and
-// pauses in background tabs (refetchIntervalInBackground: false).
+// Subscribes to the light Health projection (`?view=health`, JAB-373) via
+// useServerHealth at a 30s cadence rather than fetching on its own timer.
+// This component mounts on EVERY admin page, so it must be cheap: the Health
+// projection skips system.processes / software / user_slices (which the badge
+// never renders), and React Query dedupes across observers and pauses in
+// background tabs (refetchIntervalInBackground: false). The badge reads only
+// `alerts`, which the projection carries in full.
 // Endpoint is admin-gated; on the user shell this component MUST NOT
 // mount (caller in JabaliHeader checks isAdminShell).
 
@@ -17,7 +17,7 @@ import { useTranslation } from "react-i18next";
 import { Badge, Button, Tooltip } from "antd";
 import { ExclamationCircleOutlined, WarningOutlined } from "@icons";
 import { useNavigate } from "react-router";
-import { useServerStatus } from "../hooks/useServerStatus";
+import { useServerHealth } from "../hooks/useServerStatus";
 
 // poll cadence — matches NotificationBell. Keep <60s so an operator
 // who just fixed a disk doesn't stare at a stale red badge. A page with a
@@ -27,7 +27,7 @@ const POLL_MS = 30_000;
 export function ServerHealthIndicator(): JSX.Element | null {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { data } = useServerStatus({ refetchInterval: POLL_MS });
+  const { data } = useServerHealth({ refetchInterval: POLL_MS });
 
   const alerts = data?.alerts ?? [];
   // A fetch error leaves `data` at its last value, so the badge holds the

--- a/panel-ui/src/hooks/useServerStatus.ts
+++ b/panel-ui/src/hooks/useServerStatus.ts
@@ -170,3 +170,31 @@ export function useServerStatus(opts?: { enabled?: boolean; refetchInterval?: nu
     refetchIntervalInBackground: false,
   });
 }
+
+// useServerHealth — the light Health projection (JAB-373) for the admin
+// header badge. Hits /admin/server-status?view=health, which skips the three
+// expensive agent slices the header never renders (system.processes walks
+// every PID with a 200ms sample; software inventory; per-user cgroup slices).
+// The synthesized `alerts` — the only field the badge reads — derive solely
+// from host/services/apparmor/nginx, so the badge is byte-identical to the
+// full envelope for its purpose while costing a fraction of the agent work on
+// EVERY admin page it mounts on.
+//
+// A distinct query key (NOT the shared ["admin","server-status"]) is
+// deliberate: the Dashboard and Server Status page need the full envelope, so
+// they keep their own key. When both are mounted, the server's per-slice cache
+// (JAB-373 #1272 singleflight+TTL) already has host/services/etc warm from the
+// 5s full poll, so this projection returns them from cache and adds only one
+// light round-trip — never a second fan-out of the expensive slices.
+export function useServerHealth(opts?: { enabled?: boolean; refetchInterval?: number }) {
+  return useQuery<ServerStatusEnvelope>({
+    queryKey: ["admin", "server-health"],
+    queryFn: async () => {
+      const r = await apiClient.get<ServerStatusEnvelope>("/admin/server-status?view=health");
+      return r.data;
+    },
+    enabled: opts?.enabled ?? true,
+    refetchInterval: opts?.refetchInterval ?? 30000,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/panel-ui/tests/e2e/dashboard.spec.ts
+++ b/panel-ui/tests/e2e/dashboard.spec.ts
@@ -12,7 +12,7 @@ test.describe("admin dashboard", () => {
     await mockApi(page, { me: admin });
     // Stub the server-status envelope so the welcome card's hostname
     // line resolves to a deterministic value rather than "—".
-    await page.route("**/api/v1/admin/server-status", (route) =>
+    await page.route("**/api/v1/admin/server-status*", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/panel-ui/tests/e2e/server-status.spec.ts
+++ b/panel-ui/tests/e2e/server-status.spec.ts
@@ -98,7 +98,7 @@ test.describe("admin server status page", () => {
   test("renders all sections from one envelope", async ({ page }) => {
     await mockApi(page, { me: admin });
 
-    await page.route("**/api/v1/admin/server-status", (route) =>
+    await page.route("**/api/v1/admin/server-status*", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -141,7 +141,7 @@ test.describe("admin server status page", () => {
 
   test("dashboard deep-links into server status", async ({ page }) => {
     await mockApi(page, { me: admin });
-    await page.route("**/api/v1/admin/server-status", (route) =>
+    await page.route("**/api/v1/admin/server-status*", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",


### PR DESCRIPTION
## What

Adds a light **Health projection** (`GET /admin/server-status?view=health`) so the admin header badge stops paying for data it never shows. Completes the remaining JAB-373 acceptance criterion; the per-slice TTL cache + singleflight core already shipped in #1272.

## Why

`ServerHealthIndicator` (the header badge) mounts on **every** admin page and renders only the synthesized `alerts`. Those alerts derive solely from the **host / services / apparmor / nginx** slices. But the badge shared the full `["admin","server-status"]` query, so every admin page fanned out `system.processes` (walks every PID with a 200ms sample), the software inventory, and the per-user cgroup slices — purely to render a badge.

## How

- **panel-api** — `adminServerStatusHandler.get()` reads `?view=health` and skips the three expensive slices (`processes`, `software`, `user_slices`) for that view, keeping the cheap alert-feeding slices. The emitted envelope simply omits the skipped fields (they're `omitempty`). Alerts are byte-identical to the full view.
- Fenced the invariant at `synthesizeAlerts`: alerts must source **only** the kept slices, or the badge silently diverges from the full-page banner. Documented the `view` param in `openapi.yaml`.
- **panel-ui** — new `useServerHealth()` hook on a **distinct** query key (`["admin","server-health"]`) hitting `?view=health`; repointed `ServerHealthIndicator` at it. The Dashboard and Server Status page keep the full envelope on their own key.
- **e2e** — widened the two `page.route("**/api/v1/admin/server-status", …)` globs to `…server-status*` so the header's `?view=health` request is served the same mock.

## Why a distinct query key (and not a shared one)

The Dashboard and Server Status page **need** processes/software/user_slices, so they can't share a key with `?view=health` bolted on. When both a full page and the header are mounted, the server's per-slice cache (singleflight+TTL, #1272) already has the shared slices warm from the 5s full poll, so the Health projection returns them from cache and adds only **one light round-trip** — never a second fan-out of the expensive slices. Please don't "simplify" this back to a shared key: that reintroduces the per-page processes/software/user_slices cost the projection removes.

## Behavior change (called out deliberately)

Before, the badge and the full-page `AlertsBanner` always shared one query, so they were identical. Now they use two queries: while the Dashboard is open, the badge can lag the banner by up to its 30s poll interval. Acceptable — the badge is a summary, the banner is authoritative — but naming it so it doesn't read as an unnoticed side effect.

## Test plan

- [x] `go test ./internal/api/ -run ServerStatus` — green.
- [x] New `TestServerStatus_HealthProjectionSkipsExpensiveSlices`: asserts (via `MockClient.Calls()`) that `?view=health` never invokes `system.processes` / `software` / `user_slices`, still invokes host/cpu/network/services/nginx/apparmor, and the envelope omits the three while keeping `host`/`services`/`alerts`.
- [x] New `TestServerStatus_FullViewFetchesAllSlices`: the default (no param) view still fetches everything — no default-behavior regression.
- [x] `tsc -b` clean (panel-ui).
- [ ] CI E2E (`dashboard.spec`, `server-status.spec`) with widened route globs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
