### PR TITLE
fix(files): File Manager upload uses the same 80 MB chunks as DB restore (GH #1410)

### DIFF
--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -314,8 +314,20 @@ export async function restoreDatabaseUpload(
 // (a 2.7 GB dump drops from ~270 requests to ~34), which matters a lot on fast
 // links where per-request latency dominated. Note it stays below the 90 MB
 // single-shot threshold, which already sends bigger single requests via CF.
-const RESTORE_CHUNK_SIZE = 80 * 1024 * 1024;
-const RESTORE_CHUNK_THRESHOLD = 90 * 1024 * 1024;
+// GH #1410: one upload chunk size across the whole panel. The File Manager
+// upload and the DB restore both send 80 MB chunks so a big upload uses ~8x
+// fewer requests (a 600 MB file → ~8 chunks, not 60) while staying under the
+// ~100 MB Cloudflare/proxy body cap that chunking exists to dodge. Exported so
+// UploadDrawer / filesApi use the exact same value — the reporter's "same limit
+// everywhere", and a single lever so the two paths can never drift again.
+export const UPLOAD_CHUNK_BYTES = 80 * 1024 * 1024;
+// Files at or below this upload as one request; above it they chunk. 90 MB keeps
+// a single-shot POST safely under the CF cap (a ~100 MB multipart would exceed
+// it once boundary overhead is added).
+export const UPLOAD_SINGLE_SHOT_MAX = 90 * 1024 * 1024;
+
+const RESTORE_CHUNK_SIZE = UPLOAD_CHUNK_BYTES;
+const RESTORE_CHUNK_THRESHOLD = UPLOAD_SINGLE_SHOT_MAX;
 
 function lsGet(k: string): string | null {
   try {

--- a/panel-ui/src/shells/user/files/UploadDrawer.tsx
+++ b/panel-ui/src/shells/user/files/UploadDrawer.tsx
@@ -31,6 +31,7 @@ import type { UploadProps } from "antd";
 import { AxiosError } from "axios";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { getIdentity } from "../../../identity";
+import { UPLOAD_CHUNK_BYTES, UPLOAD_SINGLE_SHOT_MAX } from "../../../apiClient";
 import { tenantFilesApi, type FilesApi } from "./filesApi";
 import type { UploadOpts } from "./filesApi";
 
@@ -66,8 +67,12 @@ interface UploadDrawerProps {
   api?: FilesApi;
 }
 
-const SINGLE_MULTIPART_CEILING = 100 * 1024 * 1024;
-const CHUNK_SIZE = 10 * 1024 * 1024;
+// GH #1410: match the DB restore upload — files up to UPLOAD_SINGLE_SHOT_MAX go
+// as one request, larger ones chunk at UPLOAD_CHUNK_BYTES (80 MB). This is the
+// bump the earlier fix missed: it changed filesApi's default but this call site
+// still passed 10 MB, so uploads stayed on 10 MB chunks.
+const SINGLE_MULTIPART_CEILING = UPLOAD_SINGLE_SHOT_MAX;
+const CHUNK_SIZE = UPLOAD_CHUNK_BYTES;
 const HARD_CEILING = 1024 * 1024 * 1024;
 
 function formatBytes(n: number): string {
@@ -345,8 +350,8 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
             Click or drag files here to upload
           </p>
           <p className="ant-upload-hint">
-            Multiple files supported. Files &gt; 100 MB use chunked upload
-            with resume on disconnect.
+            Multiple files supported. Files over {formatBytes(SINGLE_MULTIPART_CEILING)} use
+            chunked upload with resume on disconnect.
           </p>
         </Upload.Dragger>
 

--- a/panel-ui/src/shells/user/files/filesApi.ts
+++ b/panel-ui/src/shells/user/files/filesApi.ts
@@ -1,5 +1,5 @@
 // filesApi.ts — typed wrappers around the /api/v1/files endpoints.
-import { apiClient } from "../../../apiClient";
+import { apiClient, UPLOAD_CHUNK_BYTES } from "../../../apiClient";
 import { getActAs } from "../../../impersonation";
 
 export type FileEntry = {
@@ -115,37 +115,45 @@ export async function filesUpload(
 export async function filesUploadChunked(
   dirPath: string,
   file: File,
-  // GH #1410: 25 MB chunks (was 10) — a quarter the requests for a big upload,
-  // still well under the ~100 MB proxy/Cloudflare request cap chunking exists to
-  // dodge. Each chunk opts out of the client timeout (progress-bounded).
-  chunkSize = 25 * 1024 * 1024,
+  // GH #1410: 80 MB chunks, the same size as the DB restore upload — ~8x fewer
+  // requests for a big file, still under the ~100 MB proxy/Cloudflare request
+  // cap chunking exists to dodge. Each chunk opts out of the client timeout
+  // (progress-bounded).
+  chunkSize = UPLOAD_CHUNK_BYTES,
   onProgress?: (frac: number) => void,
   opts?: UploadOpts,
   base = "/files",
 ): Promise<void> {
   const destName = opts?.name ?? file.name;
-  const totalChunks = Math.max(1, Math.ceil(file.size / chunkSize));
   const resumeKey = `jabali:upload:${dirPath}|${destName}|${file.size}|${file.lastModified}`;
   let uploadId = readResumeId(resumeKey);
-  let startChunk = 0;
+  // Resume by BYTE OFFSET (the server's current staging size), not by chunk
+  // index. The server appends only at offset == current size (else 409
+  // bad_offset), so resuming at exactly `written` is safe for ANY chunk size —
+  // a partial upload started under a different chunk size (e.g. an older build)
+  // still resumes cleanly instead of 409-looping. GH #1410.
+  let offset = 0;
   if (uploadId) {
-    // See how much the server has already. If 404, the /tmp file is
+    // See how much the server has already. If 404, the staging file is
     // gone (panel restart, cleanup job) and we start fresh.
     try {
       const r = await apiClient.get<{ written: number }>(
         `${base}/upload-chunk-status`,
         { params: { upload_id: uploadId } },
       );
-      const written = r.data.written || 0;
-      // Resume at the start of the first not-yet-complete chunk. Round
-      // DOWN so a partial chunk is re-uploaded in full — the server
-      // seeks to the offset before writing, so re-sending is safe.
-      startChunk = Math.floor(written / chunkSize);
+      offset = r.data.written || 0;
     } catch {
       // Stale or missing — drop the key and regenerate.
       uploadId = null;
       clearResumeId(resumeKey);
     }
+  }
+  // A staged size past the file is corrupt or a foreign upload_id collision —
+  // drop it and start fresh under a new id (a new staging file) rather than send
+  // a bad offset that would 409-loop against the mismatched staging file.
+  if (uploadId && offset > file.size) {
+    clearResumeId(resumeKey);
+    uploadId = null;
   }
   if (!uploadId) {
     uploadId =
@@ -153,16 +161,19 @@ export async function filesUploadChunked(
         ? crypto.randomUUID()
         : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     writeResumeId(resumeKey, uploadId);
+    offset = 0;
   }
-  if (onProgress) onProgress(startChunk / totalChunks);
-  for (let i = startChunk; i < totalChunks; i++) {
-    const start = i * chunkSize;
-    const end = Math.min(start + chunkSize, file.size);
-    const blob = file.slice(start, end);
-    const isLast = i === totalChunks - 1;
+  if (onProgress) onProgress(file.size > 0 ? offset / file.size : 0);
+  // do/while so a zero-byte file (and a resume where every byte already landed
+  // but the final marker never did) still sends one final chunk to finalise —
+  // moving the staging file into scope.
+  do {
+    const end = Math.min(offset + chunkSize, file.size);
+    const blob = file.slice(offset, end);
+    const isLast = end >= file.size;
     const params = new URLSearchParams({
       upload_id: uploadId,
-      offset: String(start),
+      offset: String(offset),
       path: dirPath,
       name: destName,
       ...(isLast ? { final: "1" } : {}),
@@ -172,8 +183,9 @@ export async function filesUploadChunked(
       headers: { "Content-Type": "application/octet-stream" },
       timeout: 0, // GH #1410: a slow chunk mustn't hit the client request timeout
     });
-    if (onProgress) onProgress((i + 1) / totalChunks);
-  }
+    offset = end;
+    if (onProgress) onProgress(file.size > 0 ? offset / file.size : 1);
+  } while (offset < file.size);
   // Success — forget the resume key.
   clearResumeId(resumeKey);
 }

--- a/panel-ui/src/shells/user/files/filesApi.upload.test.ts
+++ b/panel-ui/src/shells/user/files/filesApi.upload.test.ts
@@ -1,0 +1,90 @@
+// GH #1410: the File Manager upload uses the same 80 MB chunk size as the DB
+// restore, and resumes by byte offset so a chunk-size change can't 409-loop a
+// partial upload. These tests pin both so the size can't silently drift back
+// (the earlier fix changed only filesApi's default and the call site kept 10 MB).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { apiClient, UPLOAD_CHUNK_BYTES, UPLOAD_SINGLE_SHOT_MAX } from "../../../apiClient";
+import { filesUploadChunked } from "./filesApi";
+
+type Sent = { offset: number; final: boolean; len: number };
+
+function mkFile(bytes: number): File {
+  return new File([new Uint8Array(bytes)], "f.bin", { lastModified: 1 });
+}
+
+function recordPost(sent: Sent[]) {
+  return vi.spyOn(apiClient, "post").mockImplementation((async (url: string, body: unknown) => {
+    const q = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+    sent.push({
+      offset: Number(q.get("offset")),
+      final: q.get("final") === "1",
+      len: (body as Blob).size,
+    });
+    return { data: {} };
+  }) as never);
+}
+
+beforeEach(() => {
+  try {
+    localStorage.clear();
+  } catch {
+    /* ignore */
+  }
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("GH #1410 — File Manager upload chunking", () => {
+  it("uses the same 80 MB chunk size as the DB restore", () => {
+    expect(UPLOAD_CHUNK_BYTES).toBe(80 * 1024 * 1024);
+    expect(UPLOAD_SINGLE_SHOT_MAX).toBe(90 * 1024 * 1024);
+  });
+
+  it("splits a file into contiguous chunks, flagging only the last final", async () => {
+    const sent: Sent[] = [];
+    recordPost(sent);
+    await filesUploadChunked("/home/a", mkFile(10), 4); // 10 bytes @ 4-byte chunks
+    expect(sent.map((s) => s.offset)).toEqual([0, 4, 8]);
+    expect(sent.map((s) => s.len)).toEqual([4, 4, 2]);
+    expect(sent.map((s) => s.final)).toEqual([false, false, true]);
+  });
+
+  it("resumes at the server's exact byte offset even if it isn't chunk-aligned", async () => {
+    const sent: Sent[] = [];
+    recordPost(sent);
+    // A prior (differently-chunked) session left 5 bytes staged.
+    vi.spyOn(apiClient, "get").mockResolvedValue({ data: { written: 5 } } as never);
+    localStorage.setItem("jabali:upload:/home/a|f.bin|10|1", "resume-uuid");
+
+    await filesUploadChunked("/home/a", mkFile(10), 4);
+    // Resume from 5 (not floored to 4) → no 409 bad_offset loop.
+    expect(sent[0].offset).toBe(5);
+    expect(sent.map((s) => s.offset)).toEqual([5, 9]);
+    expect(sent[sent.length - 1].final).toBe(true);
+  });
+
+  it("restarts under a fresh id when the staged size is past the file", async () => {
+    const sent: Sent[] = [];
+    recordPost(sent);
+    // Corrupt/foreign status: server reports more bytes than the file has.
+    vi.spyOn(apiClient, "get").mockResolvedValue({ data: { written: 999 } } as never);
+    localStorage.setItem("jabali:upload:/home/a|f.bin|10|1", "stale-uuid");
+
+    await filesUploadChunked("/home/a", mkFile(10), 4);
+    // Starts clean from 0, does not send a bad offset.
+    expect(sent.map((s) => s.offset)).toEqual([0, 4, 8]);
+    expect(localStorage.getItem("jabali:upload:/home/a|f.bin|10|1")).not.toBe("stale-uuid");
+  });
+
+  it("finalises a fully-staged resume by sending the final marker", async () => {
+    const sent: Sent[] = [];
+    recordPost(sent);
+    vi.spyOn(apiClient, "get").mockResolvedValue({ data: { written: 10 } } as never);
+    localStorage.setItem("jabali:upload:/home/a|f.bin|10|1", "resume-uuid");
+
+    await filesUploadChunked("/home/a", mkFile(10), 4);
+    // Every byte already landed, but the final marker hadn't — one empty final.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ offset: 10, final: true, len: 0 });
+  });
+});


### PR DESCRIPTION
fix(files): File Manager upload uses the same 80 MB chunks as DB restore (GH #1410)

lxsdevcode asked for the File Manager upload chunk size to match the database
upload (80 MB) for consistency and far fewer requests on large files.

The earlier "10 MB → 25 MB" change only touched filesApi's default parameter;
UploadDrawer still passed a hardcoded 10 MB, so uploads never actually left
10 MB chunks. This wires both paths (and the DB restore) to one shared constant:

  - apiClient exports UPLOAD_CHUNK_BYTES (80 MB) + UPLOAD_SINGLE_SHOT_MAX (90 MB);
    the DB restore now sources its size/threshold from them, so File Manager and
    DB uploads can never drift apart again.
  - UploadDrawer chunks at 80 MB (was 10 MB) and sends files up to 90 MB as a
    single request (was 100 MB — a ~100 MB single multipart POST can exceed
    Cloudflare's 100 MB cap once boundary overhead is added; 90 keeps a margin).
    The dragger hint now reads the threshold instead of a hardcoded "100 MB".
  - A 600 MB upload now takes ~8 chunks instead of ~60.

No server change: the /files/upload* routes are already body-limit exempt
(GH #1044/#1184) and the DB restore has proven 80 MB chunk bodies through the
same nginx/Cloudflare stack.

Also hardened the resume path (the bigger chunk size would have exposed it).
Resume now continues from the server's exact staged byte offset instead of a
chunk-index boundary. The server only appends at offset == current staging size
(else 409 bad_offset), so this fixes three defects:

  1. a PRE-EXISTING bug: any upload interrupted mid-chunk resumed at
     floor(written/chunk)*chunk < written → 409 → stuck, even at the same chunk
     size (the old "server seeks before writing, re-sending is safe" comment was
     wrong — the server rejects a below-size offset);
  2. a partial upload started under a different chunk size (an older cached
     build) 409-looping after this bump;
  3. a fully-staged-but-unfinalised upload that the old chunk-index loop skipped
     the final marker for, clearing the resume key and orphaning the staging
     file — it now sends the final marker.

A corrupt/foreign staged size (> file size) restarts under a fresh upload id.

Tests: filesApi.upload.test pins FM chunk === 80 MB, the contiguous-chunk split,
the byte-offset resume, the corrupt-status restart, and finalise-on-resume.

Out of scope (already flagged as follow-ups on the issue): a cancel button, an
upload speed indicator, and direct-over-IP vs chunked-over-a-domain.
