### PR TITLE
fix(php): tidy the OPcache & JIT tab — grid layout + drop duplicate Reset (GH #1332)

### DIFF
--- a/panel-ui/src/shells/user/php-settings/UserPHPOpcacheCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPOpcacheCard.tsx
@@ -4,7 +4,7 @@
 // no override (server default), On/Off (or a size) writes one. Saving restarts
 // the version's FPM master so the change takes effect (a graceful reload keeps
 // the old SHM), so Reset lives here too.
-import { Alert, Button, Card, Select, Space, Spin, Typography } from "antd";
+import { Alert, Button, Card, Col, Row, Select, Space, Spin, Typography } from "antd";
 import { feedback } from "../../../lib/feedback";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -98,13 +98,18 @@ export const UserPHPOpcacheCard = () => {
     }
   };
 
-  const Row = ({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) => (
-    <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 240 }}>
+  // GH #1332 (lxsdevcode): lay the controls out in a responsive grid like the
+  // Resource Limits section — 3 per row on desktop, collapsing to 2 / 1 columns
+  // on narrower screens — instead of one scattered wrapping flex row.
+  const Field = ({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <Typography.Text strong>{label}</Typography.Text>
       {children}
       {hint && <Typography.Text type="secondary" style={{ fontSize: 12 }}>{hint}</Typography.Text>}
     </div>
   );
+  const col = { xs: 24, sm: 12, lg: 8 };
+  const sel = { width: "100%" as const };
 
   return (
     <Card title="OPcache & JIT" size="small">
@@ -132,29 +137,43 @@ export const UserPHPOpcacheCard = () => {
           <Spin />
         ) : (
           <>
-            <Space wrap size="large" align="start">
-              <Row label="OPcache">
-                <Select style={{ width: 160 }} value={fromBool(form.enable)} onChange={(v) => patch({ enable: toBool(v) })} options={boolOpts} />
-              </Row>
-              <Row label="JIT">
-                <Select style={{ width: 160 }} value={fromBool(form.jit_enabled)} onChange={(v) => patch({ jit_enabled: toBool(v) })} options={boolOpts} />
-              </Row>
-              <Row label="JIT buffer size">
-                <Select style={{ width: 160 }} value={fromNum(form.jit_buffer_size_mb)} onChange={(v) => patch({ jit_buffer_size_mb: toNum(v) })} options={numOpts([8, 16, 32, 64, 128, 256], " MB")} />
-              </Row>
-              <Row label="Memory">
-                <Select style={{ width: 160 }} value={fromNum(form.memory_consumption_mb)} onChange={(v) => patch({ memory_consumption_mb: toNum(v) })} options={numOpts([64, 128, 192, 256, 512], " MB")} />
-              </Row>
-              <Row label="Max accelerated files">
-                <Select style={{ width: 160 }} value={fromNum(form.max_accelerated_files)} onChange={(v) => patch({ max_accelerated_files: toNum(v) })} options={numOpts([10000, 20000, 50000, 100000])} />
-              </Row>
-              <Row label="Revalidate freq" hint="How often OPcache checks files for changes (with timestamp validation on).">
-                <Select style={{ width: 160 }} value={fromNum(form.revalidate_freq)} onChange={(v) => patch({ revalidate_freq: toNum(v) })} options={numOpts([0, 2, 5, 30, 60], " s")} />
-              </Row>
-              <Row label="Validate timestamps">
-                <Select style={{ width: 160 }} value={fromBool(form.validate_timestamps)} onChange={(v) => patch({ validate_timestamps: toBool(v) })} options={boolOpts} />
-              </Row>
-            </Space>
+            <Row gutter={[16, 16]}>
+              <Col {...col}>
+                <Field label="OPcache">
+                  <Select style={sel} value={fromBool(form.enable)} onChange={(v) => patch({ enable: toBool(v) })} options={boolOpts} />
+                </Field>
+              </Col>
+              <Col {...col}>
+                <Field label="JIT">
+                  <Select style={sel} value={fromBool(form.jit_enabled)} onChange={(v) => patch({ jit_enabled: toBool(v) })} options={boolOpts} />
+                </Field>
+              </Col>
+              <Col {...col}>
+                <Field label="JIT buffer size">
+                  <Select style={sel} value={fromNum(form.jit_buffer_size_mb)} onChange={(v) => patch({ jit_buffer_size_mb: toNum(v) })} options={numOpts([8, 16, 32, 64, 128, 256], " MB")} />
+                </Field>
+              </Col>
+              <Col {...col}>
+                <Field label="Memory">
+                  <Select style={sel} value={fromNum(form.memory_consumption_mb)} onChange={(v) => patch({ memory_consumption_mb: toNum(v) })} options={numOpts([64, 128, 192, 256, 512], " MB")} />
+                </Field>
+              </Col>
+              <Col {...col}>
+                <Field label="Max accelerated files">
+                  <Select style={sel} value={fromNum(form.max_accelerated_files)} onChange={(v) => patch({ max_accelerated_files: toNum(v) })} options={numOpts([10000, 20000, 50000, 100000])} />
+                </Field>
+              </Col>
+              <Col {...col}>
+                <Field label="Validate timestamps">
+                  <Select style={sel} value={fromBool(form.validate_timestamps)} onChange={(v) => patch({ validate_timestamps: toBool(v) })} options={boolOpts} />
+                </Field>
+              </Col>
+              <Col {...col}>
+                <Field label="Revalidate freq" hint="How often OPcache checks files for changes (with timestamp validation on).">
+                  <Select style={sel} value={fromNum(form.revalidate_freq)} onChange={(v) => patch({ revalidate_freq: toNum(v) })} options={numOpts([0, 2, 5, 30, 60], " s")} />
+                </Field>
+              </Col>
+            </Row>
 
             {form.validate_timestamps === false && (
               <Alert

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -137,7 +137,6 @@ export function UserPHPSettingsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
-  const [opcacheResetting, setOpcacheResetting] = useState(false);
   const [, setMe] = useState<Identity | null>(null);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
@@ -374,25 +373,6 @@ export function UserPHPSettingsPage() {
     </Space>
   );
 
-  // GH #1332 item 10: reset OPcache for the selected domain's PHP version.
-  // OPcache is shared per FPM pool (per version), so this affects every site
-  // the account runs on that version — stated in the confirm copy.
-  const onResetOpcache = async () => {
-    setOpcacheResetting(true);
-    try {
-      await apiClient.post("/me/php-opcache/reset", {
-        php_version: phpSettings?.php_version ?? undefined,
-      });
-      feedback.message.success("OPcache reset (FPM restarted for this PHP version)");
-    } catch (err) {
-      const e = err as { response?: { data?: { detail?: string; error?: string } } };
-      feedback.message.error(
-        e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to reset OPcache",
-      );
-    } finally {
-      setOpcacheResetting(false);
-    }
-  };
 
   return (
     // GH #1332 item 1: the page was clamped to 800px and centred, unlike every
@@ -507,14 +487,11 @@ export function UserPHPSettingsPage() {
                     />
                   </Form.Item>
 
-                  {/* GH #1332 items 7, 10, 15: quick actions for the selected domain. */}
+                  {/* GH #1332 items 7, 15: quick actions for the selected domain.
+                      Reset OPcache lives on the OPcache & JIT tab now (it is
+                      per-version / shared-pool, not per-domain) — removed here to
+                      avoid the same control in two places (lxsdevcode). */}
                   <Space wrap style={{ marginBottom: 8 }}>
-                    <Button
-                      loading={opcacheResetting}
-                      onClick={onResetOpcache}
-                    >
-                      Reset OPcache
-                    </Button>
                     <Button
                       type="link"
                       style={{ paddingInline: 0 }}
@@ -532,13 +509,6 @@ export function UserPHPSettingsPage() {
                       Scheduled tasks (Cron)
                     </Button>
                   </Space>
-                  <Typography.Paragraph
-                    type="secondary"
-                    style={{ fontSize: 12, marginTop: -4 }}
-                  >
-                    Resetting OPcache restarts PHP-FPM for this version and
-                    affects all your sites running it — handy after a deploy.
-                  </Typography.Paragraph>
 
                   <Typography.Title level={5} style={{ marginBottom: 0 }}>
                     Resource Limits


### PR DESCRIPTION
fix(php): tidy the OPcache & JIT tab — grid layout + drop the duplicate Reset (GH #1332)

lxsdevcode's feedback after testing the new OPcache & JIT tab:

1. Reset OPcache appeared in two places. The domain-level PHP Settings still had
   its own "Reset OPcache" button, now redundant with the Reset on the OPcache &
   JIT tab (OPcache is per PHP version / shared FPM pool, not per domain).
   Removed the domain-level button + its handler/state and the now-orphaned
   explanatory line; View error log and Scheduled tasks (Cron) stay.

2. The OPcache & JIT controls were a single scattered wrapping row. Laid them out
   in a responsive grid like Resource Limits — 3 controls per row on desktop
   (lg), 2 on tablets (sm), 1 on phones (xs), each select filling its column:

     [ OPcache ]   [ JIT ]        [ JIT buffer size ]
     [ Memory ]    [ Max files ]  [ Validate timestamps ]
     [ Revalidate freq ]

UI-only; the Reset action and the /me/php-opcache/reset endpoint are unchanged.

Note: the larger open request on this issue — an Admin-side per-domain PHP
Settings page (Admin → Domains → Edit) reusing the tenant components/API — is a
separate, bigger effort and is not part of this change.
