### PR TITLE
fix(mail): collapse Mail Domains row actions into a ⋯ dropdown (GH #1387)

### DIFF
--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -71,17 +71,11 @@ function renderPage() {
   );
 }
 
-// The row trigger and the Popconfirm OK share the same label. Open the confirm
-// from the given (row-scoped) trigger, then click the OK — it's portaled to
-// document.body, so it's the LAST button carrying that label in DOM order.
-async function openAndConfirm(trigger: HTMLElement, label: string) {
-  const before = screen.getAllByRole("button", { name: label }).length;
-  fireEvent.click(trigger);
-  await waitFor(() =>
-    expect(screen.getAllByRole("button", { name: label }).length).toBe(before + 1),
-  );
-  const all = screen.getAllByRole("button", { name: label });
-  fireEvent.click(all[all.length - 1]);
+// GH #1387: actions live behind a per-row "⋯" dropdown. Open it and click the
+// named menu item.
+async function openRowMenu(onRow: HTMLElement, item: string) {
+  fireEvent.click(within(onRow).getByRole("button", { name: /Actions for/i }));
+  fireEvent.click(await screen.findByRole("menuitem", { name: item }));
 }
 
 beforeEach(() => {
@@ -108,21 +102,31 @@ describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
     expect(screen.queryByRole("button", { name: /New Mailbox/i })).not.toBeInTheDocument();
   });
 
-  it("disables mail on a domain via DELETE /domains/:id/email", async () => {
+  it("actions collapse into a ⋯ menu (no inline Disable/Delete buttons)", async () => {
     renderPage();
     const onRow = (await screen.findByText("on.test")).closest("tr") as HTMLElement;
-    const disableBtn = within(onRow).getByRole("button", { name: "Disable" });
-    await openAndConfirm(disableBtn, "Disable");
+    // No visible action buttons in the row until the menu is opened.
+    expect(within(onRow).queryByRole("button", { name: "Disable" })).not.toBeInTheDocument();
+    expect(within(onRow).queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+    within(onRow).getByRole("button", { name: /Actions for/i }); // the ⋯ trigger exists
+  });
+
+  it("disables mail via the ⋯ menu → confirm → DELETE /domains/:id/email", async () => {
+    renderPage();
+    const onRow = (await screen.findByText("on.test")).closest("tr") as HTMLElement;
+    await openRowMenu(onRow, "Disable");
+    // A confirm modal pops (okText "Disable"); confirm it.
+    fireEvent.click(await screen.findByRole("button", { name: "Disable" }));
     await waitFor(() =>
       expect(mocked.delete).toHaveBeenCalledWith("/domains/d-on/email"),
     );
     expect(mocked.post).not.toHaveBeenCalled();
   });
 
-  it("deletes mail only after type-to-confirm → POST /domains/:id/email/purge", async () => {
+  it("deletes mail via the ⋯ menu → type-to-confirm → POST /domains/:id/email/purge", async () => {
     renderPage();
     const onRow = (await screen.findByText("on.test")).closest("tr") as HTMLElement;
-    fireEvent.click(within(onRow).getByRole("button", { name: "Delete" }));
+    await openRowMenu(onRow, "Delete");
 
     // Modal opens; the destructive confirm is disabled until the name matches.
     const okBtn = await screen.findByRole("button", { name: /Delete mail/i });

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -13,17 +13,17 @@ import {
   Alert,
   Button,
   Card,
+  Dropdown,
   Empty,
   Input,
   Modal,
-  Popconfirm,
-  Space,
   Spin,
   Table,
   Tag,
   Typography,
   type TableColumnsType,
 } from "antd";
+import { DeleteOutlined, MoreOutlined, PoweroffOutlined } from "@icons";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useListQuery } from "../../../hooks/useQueries";
@@ -78,6 +78,17 @@ export function MailDomainsPage() {
     } finally {
       setBusyId(null);
     }
+  };
+
+  const confirmDisable = (row: MailDomainRow) => {
+    feedback.modal.confirm({
+      title: `Disable mail for ${row.name}?`,
+      content:
+        "Incoming mail stops and the managed mail DNS records are removed. Mailboxes are kept — re-enabling from the Domains page restores service.",
+      okText: "Disable",
+      okButtonProps: { danger: true },
+      onOk: () => disableMail(row),
+    });
   };
 
   // Delete = the destructive mail-only teardown (POST /domains/:id/email/purge).
@@ -169,30 +180,41 @@ export function MailDomainsPage() {
     {
       title: "Actions",
       key: "actions",
+      // GH #1387 (johnnyq): collapse Disable + Delete into one "⋯" menu so the
+      // row stays compact. Disable confirms via a modal (a Popconfirm can't
+      // anchor cleanly inside a dropdown); Delete opens the type-to-confirm modal.
       render: (_v, row) => (
-        <Space size="small">
-          <Popconfirm
-            title={`Disable mail for ${row.name}?`}
-            description="Incoming mail stops and the managed mail DNS records are removed. Mailboxes are kept — re-enabling from the Domains page restores service."
-            okText="Disable"
-            okButtonProps={{ danger: true }}
-            onConfirm={() => disableMail(row)}
-          >
-            <Button size="small" danger loading={busyId === row.id}>
-              Disable
-            </Button>
-          </Popconfirm>
+        <Dropdown
+          trigger={["click"]}
+          menu={{
+            items: [
+              {
+                key: "disable",
+                icon: <PoweroffOutlined />,
+                danger: true,
+                label: "Disable",
+                onClick: () => confirmDisable(row),
+              },
+              {
+                key: "delete",
+                icon: <DeleteOutlined />,
+                danger: true,
+                label: "Delete",
+                onClick: () => {
+                  setConfirmText("");
+                  setDeleteRow(row);
+                },
+              },
+            ],
+          }}
+        >
           <Button
             size="small"
-            danger
-            onClick={() => {
-              setConfirmText("");
-              setDeleteRow(row);
-            }}
-          >
-            Delete
-          </Button>
-        </Space>
+            icon={<MoreOutlined />}
+            loading={busyId === row.id}
+            aria-label={`Actions for ${row.name}`}
+          />
+        </Dropdown>
       ),
     },
   ];


### PR DESCRIPTION
fix(mail): collapse Mail Domains row actions into a ⋯ dropdown (GH #1387)

johnnyq's follow-up after the mail-only Delete landed: wrap the per-row Disable
and Delete actions into a single "⋯" dropdown so the Actions column stays
compact instead of showing two danger buttons per row.

The Actions cell is now a MoreOutlined (⋯) button whose menu holds:
  - Disable — confirms via a modal (a Popconfirm can't anchor cleanly inside a
    dropdown menu), then DELETE /domains/:id/email as before;
  - Delete — opens the existing type-to-confirm modal (POST .../email/purge).

Behaviour and endpoints are unchanged; this is purely how the two actions are
presented. Test updated to drive the actions through the ⋯ menu.
