### PR TITLE
feat(files): upload cancel, live speed, and direct upload over a bare IP (GH #1410)

### DIFF
--- a/panel-ui/src/shells/user/files/UploadDrawer.tsx
+++ b/panel-ui/src/shells/user/files/UploadDrawer.tsx
@@ -32,7 +32,7 @@ import { AxiosError } from "axios";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { getIdentity } from "../../../identity";
 import { UPLOAD_CHUNK_BYTES, UPLOAD_SINGLE_SHOT_MAX } from "../../../apiClient";
-import { tenantFilesApi, type FilesApi } from "./filesApi";
+import { isIPHost, tenantFilesApi, type FilesApi } from "./filesApi";
 import type { UploadOpts } from "./filesApi";
 
 export interface UploadDrawerHandle {
@@ -44,7 +44,7 @@ export interface UploadDrawerHandle {
   enqueue: (file: File, relDir?: string) => void;
 }
 
-type UploadStatus = "queued" | "uploading" | "success" | "error";
+type UploadStatus = "queued" | "uploading" | "success" | "error" | "cancelled";
 
 interface UploadItem {
   id: string;
@@ -54,6 +54,9 @@ interface UploadItem {
   relDir?: string;
   status: UploadStatus;
   progress: number;
+  // GH #1410: smoothed upload speed in bytes/sec while uploading (undefined
+  // before the first sample).
+  speed?: number;
   errorMessage?: string;
 }
 
@@ -110,6 +113,13 @@ function isAlreadyExists(err: unknown): boolean {
   return false;
 }
 
+// GH #1410: axios throws a CanceledError when an AbortSignal fires. Detect it by
+// code/name so a user cancel reads as "cancelled", not an upload error.
+function isCanceled(err: unknown): boolean {
+  const e = err as { code?: string; name?: string } | undefined;
+  return e?.code === "ERR_CANCELED" || e?.name === "CanceledError";
+}
+
 // makeRenamedName turns "photo.jpg" into "photo (1).jpg" for "keep both".
 function makeRenamedName(name: string, n: number): string {
   const dot = name.lastIndexOf(".");
@@ -146,6 +156,21 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
   // queue of items waiting to be processed; ref so the worker loop sees
   // the latest set without re-running on every state change
   const queueRef = useRef<UploadItem[]>([]);
+  // GH #1410: cancel support. One AbortController per in-flight item + a set of
+  // ids cancelled before they started (so a queued item that's already been
+  // shifted into the worker still bails). Kept in refs so aborting never waits
+  // on a re-render.
+  const controllers = useRef<Map<string, AbortController>>(new Map());
+  const cancelledIds = useRef<Set<string>>(new Set());
+  // GH #1410: per-item speed sampler (last timestamp + bytes + smoothed value).
+  const speedRef = useRef<Map<string, { t: number; bytes: number; ema: number }>>(new Map());
+  // GH #1410: reached by a bare IP → no Cloudflare/proxy body cap in the path,
+  // so large files can upload as one direct request instead of chunking.
+  const isDirectHost = useMemo(
+    () => (typeof window !== "undefined" ? isIPHost(window.location.hostname) : false),
+    [],
+  );
+  const effectiveSingleShot = isDirectHost ? maxBytes : SINGLE_MULTIPART_CEILING;
   // Collision prompt (GH #188). conflictItem drives the modal; the worker
   // loop awaits the user's decision via the promise stashed in the ref.
   const [conflictItem, setConflictItem] = useState<UploadItem | null>(null);
@@ -179,6 +204,36 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
 
   const runOne = useCallback(
     async (item: UploadItem) => {
+      // Cancelled while still queued (before we got here) — nothing to do.
+      if (cancelledIds.current.has(item.id)) {
+        updateItem(item.id, { status: "cancelled" });
+        return;
+      }
+      const controller = new AbortController();
+      controllers.current.set(item.id, controller);
+      speedRef.current.set(item.id, { t: performance.now(), bytes: 0, ema: 0 });
+      let lastUpdate = 0;
+      // Progress callback: derive a smoothed speed from the fraction delta and
+      // throttle the state writes so a fast upload doesn't re-render the list on
+      // every progress event.
+      const onp = (frac: number) => {
+        const now = performance.now();
+        const loaded = frac * item.file.size;
+        const s = speedRef.current.get(item.id);
+        if (s) {
+          const dt = (now - s.t) / 1000;
+          if (dt >= 0.2) {
+            const inst = Math.max(0, (loaded - s.bytes) / dt);
+            s.ema = s.ema > 0 ? s.ema * 0.7 + inst * 0.3 : inst;
+            s.t = now;
+            s.bytes = loaded;
+          }
+        }
+        if (now - lastUpdate >= 300 || frac >= 1) {
+          lastUpdate = now;
+          updateItem(item.id, { progress: frac, speed: s?.ema });
+        }
+      };
       try {
         if (item.file.size > maxBytes) {
           throw new Error(`exceeds the ${formatBytes(maxBytes)} upload limit`);
@@ -188,27 +243,40 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
         const destDir = item.relDir
           ? `${currentPath.replace(/\/+$/, "")}/${item.relDir}`
           : currentPath;
+        // doUpload always injects the signal so the retry loop below can't drop
+        // it. Over a bare IP a big file goes as one direct request (effective-
+        // SingleShot = the server limit); over a domain it chunks past 90 MB.
         const doUpload = (opts?: UploadOpts) => {
-          const onp = (frac: number) => updateItem(item.id, { progress: frac });
-          return item.file.size <= SINGLE_MULTIPART_CEILING
-            ? api.upload(destDir, item.file, onp, opts)
-            : api.uploadChunked(destDir, item.file, CHUNK_SIZE, onp, opts);
+          const merged: UploadOpts = { ...opts, signal: controller.signal };
+          return item.file.size <= effectiveSingleShot
+            ? api.upload(destDir, item.file, onp, merged)
+            : api.uploadChunked(destDir, item.file, CHUNK_SIZE, onp, merged);
         };
         let mode: "ask" | "overwrite" | "rename" = alwaysOverwriteRef.current
           ? "overwrite"
           : "ask";
         let renameN = 0;
         for (let guard = 0; guard < 1002; guard++) {
+          // A cancel can land between iterations (e.g. during the conflict
+          // prompt, when no request is in flight for abort() to interrupt).
+          if (controller.signal.aborted) {
+            updateItem(item.id, { status: "cancelled" });
+            return;
+          }
           let opts: UploadOpts | undefined;
           if (mode === "overwrite") opts = { overwrite: true };
           else if (mode === "rename")
             opts = { name: makeRenamedName(item.file.name, ++renameN) };
-          updateItem(item.id, { status: "uploading", progress: 0 });
+          updateItem(item.id, { status: "uploading", progress: 0, speed: undefined });
           try {
             await doUpload(opts);
-            updateItem(item.id, { status: "success", progress: 1 });
+            updateItem(item.id, { status: "success", progress: 1, speed: undefined });
             return;
           } catch (err) {
+            if (isCanceled(err)) {
+              updateItem(item.id, { status: "cancelled" });
+              return;
+            }
             if (!isAlreadyExists(err)) throw err;
             if (mode === "rename") continue; // try the next (n) silently
             if (mode === "overwrite") throw err; // overwrite shouldn't collide
@@ -233,14 +301,39 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
           errorMessage: "Too many name collisions",
         });
       } catch (err) {
-        updateItem(item.id, {
-          status: "error",
-          errorMessage: errMessage(err),
-        });
+        if (isCanceled(err)) {
+          updateItem(item.id, { status: "cancelled" });
+        } else {
+          updateItem(item.id, { status: "error", errorMessage: errMessage(err) });
+        }
+      } finally {
+        controllers.current.delete(item.id);
+        speedRef.current.delete(item.id);
+        cancelledIds.current.delete(item.id);
       }
     },
-    [currentPath, updateItem, askConflict, maxBytes],
+    [currentPath, updateItem, askConflict, maxBytes, effectiveSingleShot],
   );
+
+  // GH #1410: cancel a queued or in-flight upload. A still-queued item is just
+  // dropped from the queue (it never runs, so no cancelledIds entry to leak).
+  // One already picked up by the worker is flagged + its request aborted; runOne
+  // clears the flag in its finally.
+  const cancelItem = useCallback((id: string) => {
+    const wasQueued = queueRef.current.some((q) => q.id === id);
+    queueRef.current = queueRef.current.filter((q) => q.id !== id);
+    if (!wasQueued) {
+      cancelledIds.current.add(id);
+      controllers.current.get(id)?.abort();
+    }
+    setItems((prev) =>
+      prev.map((it) =>
+        it.id === id && (it.status === "queued" || it.status === "uploading")
+          ? { ...it, status: "cancelled", speed: undefined }
+          : it,
+      ),
+    );
+  }, []);
 
   const processQueue = useCallback(async () => {
     if (running) return;
@@ -295,8 +388,12 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
 
   const totalProgress = useMemo(() => {
     if (items.length === 0) return 0;
+    // A settled item (uploaded / failed / cancelled) counts as fully accounted
+    // for, so a cancelled upload can't pin the batch bar below 100% forever.
+    const settled = (s: UploadStatus) =>
+      s === "success" || s === "error" || s === "cancelled";
     const sum = items.reduce(
-      (acc, it) => acc + (it.status === "success" ? 1 : it.progress),
+      (acc, it) => acc + (settled(it.status) ? 1 : it.progress),
       0,
     );
     return sum / items.length;
@@ -304,10 +401,16 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
 
   const completedCount = items.filter((it) => it.status === "success").length;
   const errorCount = items.filter((it) => it.status === "error").length;
+  const cancelledCount = items.filter((it) => it.status === "cancelled").length;
 
   const clearCompleted = () => {
     setItems((prev) =>
-      prev.filter((it) => it.status !== "success" && it.status !== "error"),
+      prev.filter(
+        (it) =>
+          it.status !== "success" &&
+          it.status !== "error" &&
+          it.status !== "cancelled",
+      ),
     );
   };
 
@@ -328,9 +431,10 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
             <Typography.Text type="secondary">
               {completedCount}/{items.length} done
               {errorCount > 0 ? ` · ${errorCount} failed` : ""}
+              {cancelledCount > 0 ? ` · ${cancelledCount} cancelled` : ""}
             </Typography.Text>
             <Space>
-              {(completedCount > 0 || errorCount > 0) && (
+              {(completedCount > 0 || errorCount > 0 || cancelledCount > 0) && (
                 <Button onClick={clearCompleted} disabled={running}>
                   Clear completed
                 </Button>
@@ -350,8 +454,10 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
             Click or drag files here to upload
           </p>
           <p className="ant-upload-hint">
-            Multiple files supported. Files over {formatBytes(SINGLE_MULTIPART_CEILING)} use
-            chunked upload with resume on disconnect.
+            Multiple files supported.{" "}
+            {isDirectHost
+              ? `Direct upload, up to ${formatBytes(maxBytes)}.`
+              : `Files over ${formatBytes(SINGLE_MULTIPART_CEILING)} use chunked upload with resume on disconnect.`}
           </p>
         </Upload.Dragger>
 
@@ -383,14 +489,29 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
                   </Typography.Text>
                 </Space>
                 {it.status === "queued" && (
-                  <Typography.Text type="secondary">Queued</Typography.Text>
+                  <Space style={{ width: "100%", justifyContent: "space-between" }}>
+                    <Typography.Text type="secondary">Queued</Typography.Text>
+                    <Button size="small" type="link" danger onClick={() => cancelItem(it.id)}>
+                      Cancel
+                    </Button>
+                  </Space>
                 )}
                 {it.status === "uploading" && (
-                  <Progress
-                    percent={Math.round(it.progress * 100)}
-                    size="small"
-                    status="active"
-                  />
+                  <>
+                    <Progress
+                      percent={Math.round(it.progress * 100)}
+                      size="small"
+                      status="active"
+                    />
+                    <Space style={{ width: "100%", justifyContent: "space-between" }}>
+                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                        {it.speed && it.speed > 0 ? `${formatBytes(it.speed)}/s` : " "}
+                      </Typography.Text>
+                      <Button size="small" type="link" danger onClick={() => cancelItem(it.id)}>
+                        Cancel
+                      </Button>
+                    </Space>
+                  </>
                 )}
                 {it.status === "success" && (
                   <Typography.Text type="success">
@@ -401,6 +522,9 @@ export const UploadDrawer = forwardRef<UploadDrawerHandle, UploadDrawerProps>(fu
                   <Typography.Text type="danger">
                     <CloseCircleFilled /> {it.errorMessage}
                   </Typography.Text>
+                )}
+                {it.status === "cancelled" && (
+                  <Typography.Text type="secondary">Cancelled</Typography.Text>
                 )}
               </Space>
             </List.Item>

--- a/panel-ui/src/shells/user/files/filesApi.ts
+++ b/panel-ui/src/shells/user/files/filesApi.ts
@@ -74,6 +74,20 @@ export interface UploadOpts {
   // name overrides the destination filename (used for "keep both" auto-rename
   // on a collision). Defaults to the File's own name.
   name?: string;
+  // GH #1410: abort an in-flight upload (Cancel button). Forwarded to axios;
+  // aborting throws a CanceledError the caller treats as "cancelled".
+  signal?: AbortSignal;
+}
+
+// GH #1410: is the panel being reached by a bare IP rather than a domain? Then
+// there's no Cloudflare/reverse-proxy body cap in the path (CF can't be reached
+// without an SNI hostname), so a big upload can go as one direct request instead
+// of being chunked to dodge a cap that isn't there. Strips IPv6 brackets first.
+export function isIPHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, "");
+  if (h === "localhost") return true;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(h)) return true; // IPv4
+  return h.includes(":"); // bracket-stripped IPv6 literal
 }
 
 export async function filesUpload(
@@ -94,6 +108,7 @@ export async function filesUpload(
     // default request timeout — a large file (or a slow uplink) legitimately
     // takes longer than 60s and was failing with "timeout of 15000ms exceeded".
     timeout: 0,
+    signal: opts?.signal,
     onUploadProgress: (e) => {
       if (!onProgress) return;
       const total = e.total ?? file.size;
@@ -179,13 +194,26 @@ export async function filesUploadChunked(
       ...(isLast ? { final: "1" } : {}),
       ...(isLast && opts?.overwrite ? { overwrite: "true" } : {}),
     });
+    const chunkStart = offset;
     await apiClient.post(`${base}/upload-chunk?${params.toString()}`, blob, {
       headers: { "Content-Type": "application/octet-stream" },
       timeout: 0, // GH #1410: a slow chunk mustn't hit the client request timeout
+      signal: opts?.signal,
+      // GH #1410: report progress WITHIN the chunk, not just at its boundary —
+      // at 80 MB chunks a boundary-only bar jumps ~13% at a time and the speed
+      // read-out would only refresh every several seconds.
+      onUploadProgress: (e) => {
+        if (onProgress && file.size > 0) {
+          onProgress(Math.min(1, (chunkStart + e.loaded) / file.size));
+        }
+      },
     });
     offset = end;
-    if (onProgress) onProgress(file.size > 0 ? offset / file.size : 1);
   } while (offset < file.size);
+  // The within-chunk onUploadProgress above drives the live bar + speed; one
+  // final tick guarantees 100% (and covers a zero-byte file, which fires no
+  // upload-progress events) without a per-boundary sample dragging the EMA down.
+  if (onProgress) onProgress(1);
   // Success — forget the resume key.
   clearResumeId(resumeKey);
 }

--- a/panel-ui/src/shells/user/files/filesApi.upload.test.ts
+++ b/panel-ui/src/shells/user/files/filesApi.upload.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { apiClient, UPLOAD_CHUNK_BYTES, UPLOAD_SINGLE_SHOT_MAX } from "../../../apiClient";
-import { filesUploadChunked } from "./filesApi";
+import { filesUploadChunked, isIPHost } from "./filesApi";
 
 type Sent = { offset: number; final: boolean; len: number };
 
@@ -38,6 +38,15 @@ describe("GH #1410 — File Manager upload chunking", () => {
   it("uses the same 80 MB chunk size as the DB restore", () => {
     expect(UPLOAD_CHUNK_BYTES).toBe(80 * 1024 * 1024);
     expect(UPLOAD_SINGLE_SHOT_MAX).toBe(90 * 1024 * 1024);
+  });
+
+  it("isIPHost detects bare IPs (direct upload) vs domains (chunked)", () => {
+    expect(isIPHost("1.2.3.4")).toBe(true);
+    expect(isIPHost("127.0.0.1")).toBe(true);
+    expect(isIPHost("[2001:db8::1]")).toBe(true); // location.hostname brackets IPv6
+    expect(isIPHost("localhost")).toBe(true);
+    expect(isIPHost("example.com")).toBe(false);
+    expect(isIPHost("panel.example.com")).toBe(false);
   });
 
   it("splits a file into contiguous chunks, flagging only the last final", async () => {
@@ -74,6 +83,44 @@ describe("GH #1410 — File Manager upload chunking", () => {
     // Starts clean from 0, does not send a bad offset.
     expect(sent.map((s) => s.offset)).toEqual([0, 4, 8]);
     expect(localStorage.getItem("jabali:upload:/home/a|f.bin|10|1")).not.toBe("stale-uuid");
+  });
+
+  it("stops the chunk loop when the abort signal is already fired", async () => {
+    let posts = 0;
+    vi.spyOn(apiClient, "post").mockImplementation((async (_u: string, _b: unknown, cfg: { signal?: AbortSignal }) => {
+      if (cfg?.signal?.aborted) {
+        const e = new Error("canceled") as Error & { code?: string };
+        e.code = "ERR_CANCELED";
+        throw e;
+      }
+      posts++;
+      return { data: {} };
+    }) as never);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      filesUploadChunked("/home/a", mkFile(10), 4, undefined, { signal: ctrl.signal }),
+    ).rejects.toMatchObject({ code: "ERR_CANCELED" });
+    expect(posts).toBe(0);
+  });
+
+  it("stops after the in-flight chunk when aborted mid-upload", async () => {
+    let posts = 0;
+    const ctrl = new AbortController();
+    vi.spyOn(apiClient, "post").mockImplementation((async (_u: string, _b: unknown, cfg: { signal?: AbortSignal }) => {
+      if (cfg?.signal?.aborted) {
+        const e = new Error("canceled") as Error & { code?: string };
+        e.code = "ERR_CANCELED";
+        throw e;
+      }
+      posts++;
+      if (posts === 1) ctrl.abort(); // cancel after the first chunk lands
+      return { data: {} };
+    }) as never);
+    await expect(
+      filesUploadChunked("/home/a", mkFile(10), 4, undefined, { signal: ctrl.signal }),
+    ).rejects.toMatchObject({ code: "ERR_CANCELED" });
+    expect(posts).toBe(1); // only the first of three chunks went out
   });
 
   it("finalises a fully-staged resume by sending the final marker", async () => {


### PR DESCRIPTION
feat(files): upload cancel, live speed, and direct upload over a bare IP (GH #1410)

Finishes lxsdevcode's File Manager upload follow-ups (the 80 MB chunk size landed
earlier; these were the remaining three):

Cancel — each queued/uploading row has a Cancel button. An AbortController per
item is threaded through UploadOpts.signal into both the single and chunked
upload paths; aborting reads as "cancelled" (not an error). doUpload always
injects the signal so the collision-retry loop can't drop it, and the loop
re-checks signal.aborted between iterations so a cancel during the overwrite/
keep-both prompt (when no request is in flight) still stops it. The resume key
is deliberately KEPT on cancel: there's no client staging-delete endpoint and
staging files are capped per user, so re-adding the file resumes into the same
slot instead of orphaning one and restarting from zero.

Live speed — the chunk POST now reports progress WITHIN the chunk
(onUploadProgress), not just at each 80 MB boundary, so the bar and a smoothed
bytes/sec read-out update continuously. Progress state writes are throttled
(~300 ms) so a fast upload doesn't thrash the list.

Direct upload over a bare IP — when the panel is reached by an IP literal
(isIPHost: IPv4 / bracket-stripped IPv6 / localhost) there's no Cloudflare or
reverse-proxy body cap in the path (CF needs an SNI hostname), so a large file
uploads as one direct request up to the server's configured limit instead of
being chunked. Over a domain the chunk-past-90 MB path is unchanged. The
effective single-shot ceiling is computed locally — the shared
UPLOAD_SINGLE_SHOT_MAX (which also drives the DB restore threshold) is untouched.
The dragger hint switches to match. Tradeoff: a single direct POST has no resume,
so a dropped large upload over IP restarts from zero.

UI-only — no server change (the /files/upload* routes are already body-limit
exempt), no new route, no agent verb. Tests: signal stops the chunk loop
(pre-aborted + mid-flight) and the isIPHost matrix.

Note: isDirectHost is evaluated once per drawer mount, so a tab left open
across a hostname change picks up the new value on the next open (nobody will
realistically hit this).
