### PR TITLE
refactor(mail): share the mailbox password-reset action across the 3 inventories (JAB-333)

### DIFF
--- a/panel-ui/src/components/mail/mailboxInventory.test.tsx
+++ b/panel-ui/src/components/mail/mailboxInventory.test.tsx
@@ -20,11 +20,16 @@ vi.mock("../../lib/feedback", () => ({
 
 import { apiClient } from "../../apiClient";
 import { feedback } from "../../lib/feedback";
-import { formatMailboxBytes, useMailboxWebmail } from "./mailboxInventory";
+import {
+  formatMailboxBytes,
+  useMailboxPasswordReset,
+  useMailboxWebmail,
+} from "./mailboxInventory";
 
 const post = apiClient.post as unknown as ReturnType<typeof vi.fn>;
 const warn = feedback.message.warning as unknown as ReturnType<typeof vi.fn>;
 const err = feedback.message.error as unknown as ReturnType<typeof vi.fn>;
+const success = feedback.message.success as unknown as ReturnType<typeof vi.fn>;
 
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -124,6 +129,69 @@ describe("useMailboxWebmail", () => {
 
     await waitFor(() => expect(err).toHaveBeenCalledWith("boom"));
     openSpy.mockRestore();
+  });
+});
+
+describe("useMailboxPasswordReset", () => {
+  beforeEach(() => success.mockReset());
+
+  it("reveals a SERVER-GENERATED password exactly once (no toast)", async () => {
+    // No custom password → server returns one to reveal.
+    post.mockResolvedValue({ data: { password: "GEN-pw-123" } });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxPasswordReset(), { wrapper });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.rotate({ id: "mb-1", email: "a@ex.com", title: "T" });
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.reveal).toEqual({ email: "a@ex.com", password: "GEN-pw-123", title: "T" });
+    // A revealed one-shot password must NOT also fire a toast (it would imply
+    // the caller can ignore the modal).
+    expect(success).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith("/mailboxes/mb-1/rotate-password", { new_password: "" });
+  });
+
+  it("does NOT reveal when a custom password was accepted (toast only)", async () => {
+    post.mockResolvedValue({ data: {} }); // custom pw → nothing to reveal
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxPasswordReset(), { wrapper });
+
+    await act(async () => {
+      await result.current.rotate({ id: "mb-1", email: "a@ex.com", newPassword: "hunter2" });
+    });
+
+    expect(result.current.reveal).toBeNull();
+    expect(success).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith("/mailboxes/mb-1/rotate-password", { new_password: "hunter2" });
+  });
+
+  it("surfaces the server error and returns false on failure (no reveal)", async () => {
+    post.mockRejectedValue({ response: { data: { error: "rate limited" } } });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxPasswordReset(), { wrapper });
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.rotate({ id: "mb-1", email: "a@ex.com" });
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.reveal).toBeNull();
+    expect(err).toHaveBeenCalledWith("rate limited");
+  });
+
+  it("revealPassword feeds another action (create) into the same modal", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMailboxPasswordReset(), { wrapper });
+
+    act(() => result.current.revealPassword({ email: "new@ex.com", password: "P", title: "New" }));
+    expect(result.current.reveal).toEqual({ email: "new@ex.com", password: "P", title: "New" });
+
+    act(() => result.current.clearReveal());
+    expect(result.current.reveal).toBeNull();
   });
 });
 

--- a/panel-ui/src/components/mail/mailboxInventory.tsx
+++ b/panel-ui/src/components/mail/mailboxInventory.tsx
@@ -5,15 +5,21 @@
 //   - user/mail/tabs/MailboxesTab.tsx       (tenant, cross-domain)
 //   - admin/domains/DomainMailboxesSection.tsx (per-domain)
 //
-// Adapters still own their data source and their role-specific columns/actions
-// (admin owner filter, tenant groups + autoresponders, domain enable-email +
-// create wizard). This module owns only what MUST stay identical: the quota /
-// status presentation and the safe webmail launcher (JAB-354).
+// Adapters still own their data source and their role-specific columns and the
+// SHAPE of the trigger (admin owner filter, tenant groups + autoresponders,
+// domain enable-email + create wizard; a one-click rotate button vs a form
+// modal with an optional custom password). This module owns what MUST stay
+// identical: the quota / status presentation, the safe webmail launcher
+// (JAB-354), and the password reset → reveal-once → toast/error core
+// (useMailboxPasswordReset), so a one-shot generated password is surfaced
+// through a single tested path no matter which surface produced it.
 
+import { useCallback, useState } from "react";
 import { Progress, Tag, Tooltip } from "antd";
 
-import { useMintMailboxSSO } from "../../hooks/useMailboxes";
+import { useMintMailboxSSO, useRotateMailboxPassword } from "../../hooks/useMailboxes";
 import { feedback } from "../../lib/feedback";
+import { DatabaseUserPasswordModal } from "../DatabaseUserPasswordModal";
 
 // ---- byte formatting ----------------------------------------------------
 
@@ -138,4 +144,104 @@ export function useMailboxWebmail() {
     // Per-row pending flag for the action's spinner.
     isLaunching: (id: string) => sso.isPending && sso.variables?.id === id,
   };
+}
+
+// ---- password reset action (JAB-333) ------------------------------------
+//
+// The three inventories each copied the same rotate flow: call the rotate
+// mutation, and if the server GENERATED the password (no custom one supplied)
+// reveal it exactly once via DatabaseUserPasswordModal, otherwise a success
+// toast. The trigger differs by surface and STAYS adapter-owned — a one-click
+// button (per-domain) or a form modal collecting an optional custom password
+// (admin, tenant) — but the reveal/toast/error core must stay identical: a
+// one-shot generated password dropped silently is a real support incident, and
+// that's exactly the kind of invariant that drifts across hand-copied screens.
+// Each surface calls `rotate(...)` and renders <MailboxPasswordRevealModal>.
+
+export interface MailboxReveal {
+  email: string;
+  password: string;
+  title: string;
+}
+
+// TODO(i18n): the success/error toast strings below are hardcoded English,
+// matching the (already-untranslated) strings this replaced across the three
+// surfaces. A future i18n sweep should route them through `t(...)`.
+export function useMailboxPasswordReset() {
+  const rotateMutation = useRotateMailboxPassword();
+  const [rotatingId, setRotatingId] = useState<string | null>(null);
+  const [reveal, setReveal] = useState<MailboxReveal | null>(null);
+
+  const rotate = useCallback(
+    async (args: {
+      id: string;
+      email: string;
+      newPassword?: string;
+      title?: string;
+    }): Promise<boolean> => {
+      setRotatingId(args.id);
+      try {
+        const resp = await rotateMutation.mutateAsync({
+          id: args.id,
+          new_password: args.newPassword?.trim() || undefined,
+        });
+        if (resp.password) {
+          setReveal({
+            email: args.email,
+            password: resp.password,
+            title: args.title ?? "New mailbox password",
+          });
+        } else {
+          // Custom password accepted — nothing to reveal.
+          feedback.message.success("Password rotated");
+        }
+        return true;
+      } catch (err) {
+        feedback.message.error(
+          (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+            "Failed to rotate password",
+        );
+        return false;
+      } finally {
+        setRotatingId(null);
+      }
+    },
+    [rotateMutation],
+  );
+
+  return {
+    rotate,
+    // Per-row pending flag for the trigger's spinner.
+    rotatingId,
+    // The pending mutation itself, for callers wanting `.isPending` on a form.
+    rotateMutation,
+    // The reveal-once state + its modal.
+    reveal,
+    clearReveal: useCallback(() => setReveal(null), []),
+    // Feed a server-generated password from ANOTHER action (e.g. the create
+    // wizard) into the same reveal-once modal, so a one-shot password is shown
+    // through one code path regardless of which action produced it.
+    revealPassword: useCallback((r: MailboxReveal) => setReveal(r), []),
+  };
+}
+
+// MailboxPasswordRevealModal renders the shared reveal-once modal from the
+// hook's `reveal` state. Render it once per surface; it is inert until a
+// generated password is captured.
+export function MailboxPasswordRevealModal({
+  reveal,
+  onClose,
+}: {
+  reveal: MailboxReveal | null;
+  onClose: () => void;
+}) {
+  return (
+    <DatabaseUserPasswordModal
+      open={reveal !== null}
+      username={reveal?.email ?? ""}
+      password={reveal?.password ?? ""}
+      title={reveal?.title}
+      onClose={onClose}
+    />
+  );
 }

--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -17,11 +17,12 @@ import {
   PlusOutlined,
 } from "@icons";
 
-import { DatabaseUserPasswordModal } from "../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../components/PasswordInput";
 import {
+  MailboxPasswordRevealModal,
   renderMailboxQuota,
   renderMailboxStatus,
+  useMailboxPasswordReset,
   useMailboxWebmail,
 } from "../../../components/mail/mailboxInventory";
 import {
@@ -30,7 +31,6 @@ import {
   useDomainEmail,
   useEnableDomainEmail,
   useMailboxes,
-  useRotateMailboxPassword,
   type Mailbox,
 } from "../../../hooks/useMailboxes";
 
@@ -80,7 +80,8 @@ export const DomainMailboxesSection = ({
 
   const createMutation = useCreateMailbox();
   const deleteMutation = useDeleteMailbox();
-  const rotateMutation = useRotateMailboxPassword();
+  const { rotate: rotatePassword, rotatingId, reveal, clearReveal, revealPassword } =
+    useMailboxPasswordReset();
   const webmail = useMailboxWebmail();
   // enableMutation is only used when the section lands in the
   // disabled state (auto-enable failed at domain.create time, or an
@@ -89,12 +90,6 @@ export const DomainMailboxesSection = ({
   const enableMutation = useEnableDomainEmail();
 
   const [createOpen, setCreateOpen] = useState(false);
-  const [passwordModal, setPasswordModal] = useState<{
-    email: string;
-    password: string;
-    title: string;
-  } | null>(null);
-  const [rotatingId, setRotatingId] = useState<string | null>(null);
   const [form] = Form.useForm<{
     domain_id: string;
     local_part: string;
@@ -154,28 +149,14 @@ export const DomainMailboxesSection = ({
     );
   }
 
-  const rotate = async (row: Mailbox) => {
-    setRotatingId(row.id);
-    try {
-      const resp = await rotateMutation.mutateAsync({ id: row.id });
-      if (resp.password) {
-        setPasswordModal({
-          email: row.email,
-          password: resp.password,
-          title: "New mailbox password (rotation)",
-        });
-      } else {
-        feedback.message.success("Password rotated");
-      }
-    } catch (err) {
-      const msg =
-        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
-        "Failed to rotate password";
-      feedback.message.error(msg);
-    } finally {
-      setRotatingId(null);
-    }
-  };
+  // Per-domain: one-click rotation (no custom-password form). The reveal-once /
+  // toast / error handling lives in the shared hook.
+  const rotate = (row: Mailbox) =>
+    rotatePassword({
+      id: row.id,
+      email: row.email,
+      title: "New mailbox password (rotation)",
+    });
 
   const onCreate = async () => {
     const values = await form.validateFields();
@@ -201,7 +182,7 @@ export const DomainMailboxesSection = ({
         onDomainCreated?.(targetDomainId);
       }
       if (resp.password) {
-        setPasswordModal({
+        revealPassword({
           email: resp.email,
           password: resp.password,
           title: "New mailbox password",
@@ -408,13 +389,7 @@ export const DomainMailboxesSection = ({
         </Form>
       </Modal>
 
-      <DatabaseUserPasswordModal
-        open={passwordModal !== null}
-        username={passwordModal?.email ?? ""}
-        password={passwordModal?.password ?? ""}
-        title={passwordModal?.title}
-        onClose={() => setPasswordModal(null)}
-      />
+      <MailboxPasswordRevealModal reveal={reveal} onClose={clearReveal} />
     </>
   );
 };

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -23,7 +23,6 @@ import { DeleteOutlined, EditOutlined, KeyOutlined, MailOutlined, PlusOutlined }
 import {
   useAdminMailboxes,
   useDeleteMailbox,
-  useRotateMailboxPassword,
   type AdminMailbox,
 } from "../../../hooks/useMailboxes";
 import { useListQuery, useOneQuery } from "../../../hooks/useQueries";
@@ -33,14 +32,15 @@ import { ownerResourceCrumbs, ownerLabel, adminLinks } from "../../../components
 import type { Domain } from "../../user/domains/UserDomainList";
 import { EditMailboxModal } from "../../../components/mail/EditMailboxModal";
 import {
+  MailboxPasswordRevealModal,
   renderMailboxQuota,
   renderMailboxStatus,
+  useMailboxPasswordReset,
   useMailboxWebmail,
 } from "../../../components/mail/mailboxInventory";
 import { AdminGroupsTab } from "./AdminGroupsTab";
 import { MailStatsTab } from "./MailStatsTab";
 import { CreateMailboxWizardModal } from "../../user/mail/CreateMailboxWizardModal";
-import { DatabaseUserPasswordModal } from "../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../components/PasswordInput";
 import { RowActions } from "../../../components/RowActions";
 
@@ -70,7 +70,8 @@ export function AdminMailPage() {
   );
 
   const deleteMutation = useDeleteMailbox();
-  const rotate = useRotateMailboxPassword();
+  const { rotate: rotatePassword, rotateMutation, reveal, clearReveal, revealPassword } =
+    useMailboxPasswordReset();
   const webmail = useMailboxWebmail();
 
   const [tab, setTab] = useTabParam<string>("mailboxes");
@@ -78,7 +79,6 @@ export function AdminMailPage() {
   const [editTarget, setEditTarget] = useState<AdminMailbox | null>(null);
   const [resetTarget, setResetTarget] = useState<AdminMailbox | null>(null);
   const [resetForm] = Form.useForm<{ password?: string }>();
-  const [revealed, setRevealed] = useState<{ email: string; password: string } | null>(null);
   const [search, setSearch] = useState("");
 
   const filtered = useMemo(() => {
@@ -95,25 +95,18 @@ export function AdminMailPage() {
     );
   }, [rows, search, ownerId]);
 
+  // Server-wide admin: a form modal collecting an OPTIONAL custom password. The
+  // rotate → reveal-once → error core is the shared hook.
   const submitReset = async () => {
     if (!resetTarget) return;
     const v = await resetForm.validateFields();
-    const custom = (v.password ?? "").trim();
-    try {
-      const resp = await rotate.mutateAsync({
-        id: resetTarget.id,
-        new_password: custom || undefined,
-      });
-      const target = resetTarget;
-      setResetTarget(null);
-      if (resp.password) {
-        setRevealed({ email: target.email, password: resp.password });
-      } else {
-        message.success("Password updated");
-      }
-    } catch {
-      message.error("Failed to reset password");
-    }
+    const ok = await rotatePassword({
+      id: resetTarget.id,
+      email: resetTarget.email,
+      newPassword: v.password,
+      title: t("adminmailpage.mailbox_password"),
+    });
+    if (ok) setResetTarget(null);
   };
 
   useSetBreadcrumbs(
@@ -277,7 +270,11 @@ export function AdminMailPage() {
         onCreated={(resp) => {
           setCreateOpen(false);
           if (resp.password) {
-            setRevealed({ email: resp.email, password: resp.password });
+            revealPassword({
+              email: resp.email,
+              password: resp.password,
+              title: t("adminmailpage.mailbox_password"),
+            });
           } else {
             message.success("Mailbox created");
           }
@@ -294,7 +291,7 @@ export function AdminMailPage() {
         open={resetTarget !== null}
         title={resetTarget ? `Reset password — ${resetTarget.email}` : "Reset password"}
         okText={t("adminmailpage.set_password")}
-        confirmLoading={rotate.isPending}
+        confirmLoading={rotateMutation.isPending}
         onOk={submitReset}
         onCancel={() => setResetTarget(null)}
         destroyOnClose
@@ -310,15 +307,7 @@ export function AdminMailPage() {
         </Form>
       </Modal>
 
-      {revealed && (
-        <DatabaseUserPasswordModal
-          open
-          username={revealed.email}
-          password={revealed.password}
-          title={t("adminmailpage.mailbox_password")}
-          onClose={() => setRevealed(null)}
-        />
-      )}
+      <MailboxPasswordRevealModal reveal={reveal} onClose={clearReveal} />
     </>
   );
 }

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -26,17 +26,17 @@ import { useForwarders } from "../../../../hooks/useForwarders";
 import { apiClient } from "../../../../apiClient";
 import {
   useDeleteMailbox,
-  useRotateMailboxPassword,
   type Mailbox,
 } from "../../../../hooks/useMailboxes";
 import {
+  MailboxPasswordRevealModal,
   renderMailboxQuota,
   renderMailboxStatus,
+  useMailboxPasswordReset,
   useMailboxWebmail,
 } from "../../../../components/mail/mailboxInventory";
 import { useListQuery } from "../../../../hooks/useQueries";
 import type { Domain } from "../../domains/UserDomainList";
-import { DatabaseUserPasswordModal } from "../../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../../components/PasswordInput";
 import { EditMailboxModal } from "../../../../components/mail/EditMailboxModal";
 import { MailSyncInfoModal } from "../../../../components/mail/MailSyncInfoModal";
@@ -157,12 +157,6 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   }, [forwarders]);
 
 
-  const [passwordModal, setPasswordModal] = useState<{
-    email: string;
-    password: string;
-    title: string;
-  } | null>(null);
-  const [rotatingId, setRotatingId] = useState<string | null>(null);
   const [resetTarget, setResetTarget] = useState<MailboxRow | null>(null);
   const [editTarget, setEditTarget] = useState<MailboxRow | null>(null);
   const [arTarget, setArTarget] = useState<MailboxRow | null>(null);
@@ -170,7 +164,7 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   const [resetForm] = Form.useForm<{ password?: string }>();
 
   const deleteMutation = useDeleteMailbox();
-  const rotateMutation = useRotateMailboxPassword();
+  const { rotate: rotatePassword, rotatingId, reveal, clearReveal } = useMailboxPasswordReset();
   const webmail = useMailboxWebmail();
 
   const openReset = (row: MailboxRow) => {
@@ -178,35 +172,19 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
     setResetTarget(row);
   };
 
+  // Tenant cross-domain: a form modal collecting an OPTIONAL custom password.
+  // The rotate → reveal-once (when the server generates one) → error handling is
+  // the shared hook; this adapter only owns the form trigger.
   const submitReset = async () => {
     if (!resetTarget) return;
     const values = await resetForm.validateFields();
-    const custom = (values.password ?? "").trim();
-    setRotatingId(resetTarget.id);
-    try {
-      const resp = await rotateMutation.mutateAsync({
-        id: resetTarget.id,
-        new_password: custom || undefined,
-      });
-      setResetTarget(null);
-      if (resp.password) {
-        // No custom password supplied -> server generated one; reveal once.
-        setPasswordModal({
-          email: resetTarget.email,
-          password: resp.password,
-          title: "New mailbox password (auto-generated)",
-        });
-      } else {
-        feedback.message.success("Password updated");
-      }
-    } catch (err) {
-      const msg =
-        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
-        "Failed to reset password";
-      feedback.message.error(msg);
-    } finally {
-      setRotatingId(null);
-    }
+    const ok = await rotatePassword({
+      id: resetTarget.id,
+      email: resetTarget.email,
+      newPassword: values.password,
+      title: "New mailbox password (auto-generated)",
+    });
+    if (ok) setResetTarget(null);
   };
 
   const loading = loadingDomains || mailboxResults.some((r) => r.isLoading);
@@ -489,15 +467,7 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
         </Form>
       </Modal>
 
-      {passwordModal && (
-        <DatabaseUserPasswordModal
-          open={true}
-          username={passwordModal.email}
-          password={passwordModal.password}
-          title={passwordModal.title}
-          onClose={() => setPasswordModal(null)}
-        />
-      )}
+      <MailboxPasswordRevealModal reveal={reveal} onClose={clearReveal} />
     </>
   );
 };


### PR DESCRIPTION
## What

Retires the hand-copied **mailbox password-reset action** across the three mailbox inventories, finishing the JAB-333 module de-dup started in #1317. The shared module already owned the row, quota/status, safe webmail launcher and the mutation hooks; the rotate → **reveal-once** → toast/error core was still copied into all three surfaces — the exact shape of drift this ticket exists to kill (a one-shot generated password dropped silently is a real support incident).

## How

- New `useMailboxPasswordReset()` + `<MailboxPasswordRevealModal>` in `components/mail/mailboxInventory.tsx` own the rotate/reveal/error core.
- **Each surface keeps its trigger UI unchanged** — per-domain: one-click button; admin + tenant: a form modal collecting an *optional* custom password. The parametrization is the trigger, not the shared core.
- The create-wizard reveal (admin + per-domain) reuses the same reveal-once modal via `revealPassword()`, so a generated password is shown through one tested path regardless of which action produced it.
- **Structural result:** all 3 surfaces now have **zero** `useRotateMailboxPassword` / `setRevealed` / `setPasswordModal`; the mutation is referenced in **exactly one file**. Net −120 lines despite the new hook.

## Scope — rotate only; delete deferred

This lands the **rotate + create-reveal** action. The **delete** action stays adapter-owned: its confirm style genuinely differs (tenant modal-confirm vs inline) and the mutation (`useDeleteMailbox`) is already shared, so a mechanical extraction there fights real UX divergence. Noted as remaining on JAB-333.

## Behavior — unchanged, except three declared consistency fixes

The reveal-once modal, the modal-close-on-success behavior, and every trigger UI are identical. Deliberately unified (called out so review isn't surprised):
- success toast → `"Password rotated"` (was `"Password updated"` on admin + tenant; per-domain already said "rotated").
- admin rotate error now surfaces the server `error` field (was a fixed `"Failed to reset password"`), matching the others.
- admin rotate toasts use the themed `feedback` singleton (GH #970) like the others, not antd `message` (create/other paths there still use `message`).

## Test plan

- [x] New unit test on the shared hook: reveal-once when the server generates a password, toast-only when a custom one is accepted, error surfaced + returns `false` on failure, `revealPassword` feeds the create path into the same modal.
- [x] `tsc -b` clean; full `vitest` 349/349.
- [x] Structural: rotate/reveal copies gone from all 3 surfaces; mutation in one file.
- [ ] **CI Playwright E2E** — this touches panel-ui; `tests/e2e/m6-email.spec.ts` drives the create reveal-once modal. Verified locally the modal is DOM-equivalent (always-mounted `open={reveal!==null}` + `destroyOnClose` ≡ the old `{revealed && …}`), but the E2E is the required gate — do not admin-merge over a cancelled/failed E2E on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
