### PR TITLE
feat(backups): background "Preparing…" for per-account download (GH #1408)

### DIFF
--- a/panel-api/internal/api/backup_download_prepare.go
+++ b/panel-api/internal/api/backup_download_prepare.go
@@ -1,0 +1,200 @@
+// Per-account backup download prep (GH #1408, lxsdevcode).
+//
+// A per-account download runs a restic materialize (minutes) before the first
+// byte streams, so the Download button looked dead the whole time. This adds a
+// background prepare-job — mirroring the full-server package flow:
+//
+//	POST .../download/prepare        → 202, detached materialize, writes a marker
+//	GET  .../download/prepare-status → poll { status: preparing|ready|failed }
+//	GET  .../download                → streamBackupArtifact reuses the warmed dir
+//
+// streamBackupArtifact consumes the ready marker itself (consumePreparedDir), so
+// the download skips the materialize instead of re-running it. Both the admin
+// (/admin/backups/:job_id/…) and tenant (/me/backups/:id/…) surfaces get it.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// downloadPrepMarkerDir is a package var (defaults to the panel-writable upload
+// staging dir) only so tests can redirect the marker to a tempdir — production
+// always uses restoreUploadDir.
+var downloadPrepMarkerDir = restoreUploadDir
+
+func downloadPrepMarkerPath(jobID string) string {
+	return filepath.Join(downloadPrepMarkerDir, "dlprep-"+jobID+".json")
+}
+
+type downloadPrepOutcome struct {
+	Status string `json:"status"` // preparing | ready | failed
+	TS     int64  `json:"ts"`
+	Path   string `json:"path,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func writeDownloadPrepOutcome(path string, o downloadPrepOutcome) {
+	o.TS = time.Now().Unix()
+	if len(o.Error) > 600 {
+		o.Error = o.Error[:600] + "…"
+	}
+	b, _ := json.Marshal(o)
+	writeOutcomeFile(path, b) // atomic swap, shared with #1323/#1408
+}
+
+// consumePreparedDir returns the materialized dir a prepare-job warmed for this
+// job (or "" if none / not ready / gone), and removes the marker so a later
+// download re-materializes fresh rather than trusting a stale path. Called by
+// streamBackupArtifact.
+func consumePreparedDir(jobID string) string {
+	marker := downloadPrepMarkerPath(jobID)
+	b, err := os.ReadFile(marker)
+	if err != nil {
+		return ""
+	}
+	var o downloadPrepOutcome
+	if json.Unmarshal(b, &o) != nil || o.Status != "ready" || o.Path == "" {
+		return ""
+	}
+	fi, serr := os.Stat(o.Path)
+	if serr != nil || !fi.IsDir() {
+		_ = os.Remove(marker) // dir already reaped — drop the stale marker
+		return ""
+	}
+	_ = os.Remove(marker)
+	return o.Path
+}
+
+// downloadJobPreparable reports whether a job can be downloaded/prepared (same
+// gate as streamBackupArtifact: a real snapshot from a succeeded/partial run).
+func downloadJobPreparable(job *models.BackupJob) (int, string) {
+	if job.Status != models.BackupJobStatusSucceeded && job.Status != models.BackupJobStatusPartial {
+		return http.StatusNotFound, "no_completed_snapshot"
+	}
+	if job.SnapshotID == "" {
+		return http.StatusUnprocessableEntity, "no_snapshot_id"
+	}
+	return 0, ""
+}
+
+// startDownloadPrepare kicks the detached materialize + records the outcome in
+// the job's marker. Idempotent-ish: a second prepare just re-materializes.
+func startDownloadPrepare(ag agent.AgentInterface, dests repository.BackupDestinationRepository, ssoKey *ssokey.Key, job *models.BackupJob) {
+	marker := downloadPrepMarkerPath(job.ID)
+	writeDownloadPrepOutcome(marker, downloadPrepOutcome{Status: "preparing"})
+	jobID, snapID := job.ID, job.SnapshotID
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
+		defer cancel()
+		dest, destParams := materializeDest(ctx, dests, job)
+		_ = backupwrapperhelpers.WithOptionalDestPassword(ctx, dest, ag, ssoKey, func(passwordFile string) error {
+			params := map[string]any{"job_id": jobID, "snapshot_id": snapID}
+			for k, v := range destParams {
+				params[k] = v
+			}
+			if passwordFile != "" {
+				params["password_file"] = passwordFile
+			}
+			raw, err := ag.Call(ctx, "backup.materialize", params)
+			if err != nil {
+				writeDownloadPrepOutcome(marker, downloadPrepOutcome{Status: "failed", Error: firstLineString(err.Error())})
+				return nil
+			}
+			var mat struct {
+				Path string `json:"path"`
+			}
+			if json.Unmarshal(raw, &mat) != nil || mat.Path == "" {
+				writeDownloadPrepOutcome(marker, downloadPrepOutcome{Status: "failed", Error: "agent reply parse"})
+				return nil
+			}
+			writeDownloadPrepOutcome(marker, downloadPrepOutcome{Status: "ready", Path: mat.Path})
+			return nil
+		})
+	}()
+}
+
+func serveDownloadPrepStatus(c *gin.Context, jobID string) {
+	b, err := os.ReadFile(downloadPrepMarkerPath(jobID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"status": "not_found"})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", b)
+}
+
+// --- admin surface ---
+
+func (h *backupHandler) downloadPrepare(c *gin.Context) {
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	job, err := h.cfg.Jobs.Get(c.Request.Context(), c.Param("job_id"))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	if code, msg := downloadJobPreparable(job); code != 0 {
+		c.JSON(code, gin.H{"error": msg})
+		return
+	}
+	startDownloadPrepare(h.cfg.Agent, h.cfg.Destinations, h.cfg.SSOKey, job)
+	c.JSON(http.StatusAccepted, gin.H{"status": "preparing", "job_id": job.ID})
+}
+
+func (h *backupHandler) downloadPrepareStatus(c *gin.Context) {
+	serveDownloadPrepStatus(c, c.Param("job_id"))
+}
+
+// --- tenant surface (owner-scoped) ---
+
+func (h *meBackupHandler) downloadPrepare(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	job, err := h.cfg.Jobs.Get(c.Request.Context(), c.Param("id"))
+	if err != nil || job.UserID != claims.UserID { // cross-user → 404
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	if code, msg := downloadJobPreparable(job); code != 0 {
+		c.JSON(code, gin.H{"error": msg})
+		return
+	}
+	startDownloadPrepare(h.cfg.Agent, h.cfg.Destinations, h.cfg.SSOKey, job)
+	c.JSON(http.StatusAccepted, gin.H{"status": "preparing", "job_id": job.ID})
+}
+
+func (h *meBackupHandler) downloadPrepareStatus(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+	job, err := h.cfg.Jobs.Get(c.Request.Context(), c.Param("id"))
+	if err != nil || job.UserID != claims.UserID {
+		c.JSON(http.StatusNotFound, gin.H{"status": "not_found"})
+		return
+	}
+	serveDownloadPrepStatus(c, job.ID)
+}

--- a/panel-api/internal/api/backup_download_prepare_test.go
+++ b/panel-api/internal/api/backup_download_prepare_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestDownloadJobPreparable(t *testing.T) {
+	cases := []struct {
+		name string
+		job  *models.BackupJob
+		code int
+	}{
+		{"succeeded+snapshot", &models.BackupJob{Status: models.BackupJobStatusSucceeded, SnapshotID: "s1"}, 0},
+		{"partial+snapshot", &models.BackupJob{Status: models.BackupJobStatusPartial, SnapshotID: "s1"}, 0},
+		{"queued", &models.BackupJob{Status: models.BackupJobStatusQueued, SnapshotID: "s1"}, http.StatusNotFound},
+		{"succeeded no snapshot", &models.BackupJob{Status: models.BackupJobStatusSucceeded}, http.StatusUnprocessableEntity},
+	}
+	for _, tc := range cases {
+		if code, _ := downloadJobPreparable(tc.job); code != tc.code {
+			t.Errorf("%s: got %d, want %d", tc.name, code, tc.code)
+		}
+	}
+}
+
+func TestConsumePreparedDir(t *testing.T) {
+	dir := t.TempDir()
+	old := downloadPrepMarkerDir
+	downloadPrepMarkerDir = dir
+	t.Cleanup(func() { downloadPrepMarkerDir = old })
+
+	write := func(jobID string, o downloadPrepOutcome) {
+		b, _ := json.Marshal(o)
+		if err := os.WriteFile(downloadPrepMarkerPath(jobID), b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// No marker → "".
+	if p := consumePreparedDir("nope"); p != "" {
+		t.Errorf("no marker: got %q, want empty", p)
+	}
+
+	// Ready with a real dir → returns it AND removes the marker (one-shot).
+	ready := filepath.Join(dir, "mat")
+	if err := os.Mkdir(ready, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	write("j1", downloadPrepOutcome{Status: "ready", Path: ready})
+	if p := consumePreparedDir("j1"); p != ready {
+		t.Errorf("ready: got %q, want %q", p, ready)
+	}
+	if _, err := os.Stat(downloadPrepMarkerPath("j1")); !os.IsNotExist(err) {
+		t.Error("marker should be removed after a successful consume")
+	}
+	// Second consume finds nothing.
+	if p := consumePreparedDir("j1"); p != "" {
+		t.Errorf("second consume: got %q, want empty", p)
+	}
+
+	// Still preparing → "" (marker kept for the next poll).
+	write("j2", downloadPrepOutcome{Status: "preparing"})
+	if p := consumePreparedDir("j2"); p != "" {
+		t.Errorf("preparing: got %q, want empty", p)
+	}
+	if _, err := os.Stat(downloadPrepMarkerPath("j2")); err != nil {
+		t.Error("a preparing marker must NOT be removed")
+	}
+
+	// Ready but the dir is gone → "" and the stale marker is dropped.
+	write("j3", downloadPrepOutcome{Status: "ready", Path: filepath.Join(dir, "gone")})
+	if p := consumePreparedDir("j3"); p != "" {
+		t.Errorf("stale ready: got %q, want empty", p)
+	}
+	if _, err := os.Stat(downloadPrepMarkerPath("j3")); !os.IsNotExist(err) {
+		t.Error("a stale ready marker should be removed")
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -123,6 +123,10 @@ func RegisterBackupRoutes(rg *gin.RouterGroup, cfg BackupHandlerConfig) {
 	admin.DELETE("/backups/:job_id", h.delete)
 	admin.GET("/backups/:job_id/status", h.status)
 	admin.GET("/backups/:job_id/download", h.download)
+	// GH #1408: background prepare so the Download button isn't dead during the
+	// restic materialize.
+	admin.POST("/backups/:job_id/download/prepare", h.downloadPrepare)
+	admin.GET("/backups/:job_id/download/prepare-status", h.downloadPrepareStatus)
 	admin.POST("/backups/:job_id/cancel", h.cancel)
 	admin.GET("/backups/:job_id/logs", h.logs)
 	admin.POST("/backups/restore", h.restore)
@@ -865,42 +869,49 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 	// deadlines just keeps the default.
 	_ = http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{})
 
-	matCtx, matCancel := context.WithTimeout(c.Request.Context(), 30*time.Minute)
-	defer matCancel()
-	// The snapshot lives in the job's DESTINATION repo. Forward repo_url +
-	// credentials so the agent opens that repo, not the local default at
-	// /var/lib/jabali-backups/repo (which has no snapshots and 404s with
-	// "no snapshots for job" — GH #462). destParams is nil for a truly-local
-	// backup, in which case the agent keeps its local default.
-	params := map[string]any{
-		"job_id":      job.ID,
-		"snapshot_id": job.SnapshotID,
-	}
-	for k, v := range destParams {
-		params[k] = v
-	}
-	raw, err := ag.Call(matCtx, "backup.materialize", params)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"status": "error", "error": "restic_restore_failed", "detail": err.Error(),
-		})
-		return
-	}
-	var mat struct {
-		Path string `json:"path"`
-	}
-	if err := json.Unmarshal(raw, &mat); err != nil || mat.Path == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "agent_reply_parse"})
-		return
-	}
+	// The materialized dir is cleaned up once the stream ends — whether we
+	// restored it inline below or a GH #1408 prepare-job warmed it first.
 	defer func() {
-		// Best-effort cleanup; a stale dir is recovered by the next
-		// download (handler RemoveAll's before re-restoring) or by a
-		// future cron sweeper.
 		cleanCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		_, _ = ag.Call(cleanCtx, "backup.materialize_cleanup", map[string]string{"job_id": job.ID})
 	}()
+
+	// GH #1408: reuse a prepare-job's already-restored dir so the download
+	// doesn't re-run the minutes-long restic materialize (which is what made the
+	// Download button look dead). Falls back to an inline materialize otherwise.
+	matPath := consumePreparedDir(job.ID)
+	if matPath == "" {
+		matCtx, matCancel := context.WithTimeout(c.Request.Context(), 30*time.Minute)
+		defer matCancel()
+		// The snapshot lives in the job's DESTINATION repo. Forward repo_url +
+		// credentials so the agent opens that repo, not the local default at
+		// /var/lib/jabali-backups/repo (which has no snapshots and 404s with
+		// "no snapshots for job" — GH #462). destParams is nil for a truly-local
+		// backup, in which case the agent keeps its local default.
+		params := map[string]any{
+			"job_id":      job.ID,
+			"snapshot_id": job.SnapshotID,
+		}
+		for k, v := range destParams {
+			params[k] = v
+		}
+		raw, err := ag.Call(matCtx, "backup.materialize", params)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"status": "error", "error": "restic_restore_failed", "detail": err.Error(),
+			})
+			return
+		}
+		var mat struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(raw, &mat); err != nil || mat.Path == "" {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "agent_reply_parse"})
+			return
+		}
+		matPath = mat.Path
+	}
 
 	// GH #462: choose the compressor by what's actually installed. A box that
 	// lacks the zstd binary (installed before zstd became a dependency, then
@@ -919,7 +930,7 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 	// so under enforce the download died with "zstd: Cannot exec". Two direct
 	// execs stay on the profile's tar + zstd allowlist and never touch a shell.
 	tarCmd := exec.CommandContext(c.Request.Context(), "tar", "-cf", "-",
-		"-C", filepath.Dir(mat.Path), filepath.Base(mat.Path))
+		"-C", filepath.Dir(matPath), filepath.Base(matPath))
 	var tarErr, zstdErr bytes.Buffer
 	tarCmd.Stderr = &tarErr
 
@@ -1559,6 +1570,10 @@ func RegisterMeBackupRoutes(rg *gin.RouterGroup, cfg MeBackupsHandlerConfig) {
 	g.POST("", h.create)
 	g.GET("", h.list)
 	g.GET("/:id/download", h.download)
+	// GH #1408: background prepare (owner-scoped) so the Download button isn't
+	// dead during the restic materialize.
+	g.POST("/:id/download/prepare", h.downloadPrepare)
+	g.GET("/:id/download/prepare-status", h.downloadPrepareStatus)
 	g.DELETE("/:id", h.delete)
 	g.GET("/:id/manifest", h.manifest)
 	g.POST("/:id/restore", h.restoreSelective)

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2523,6 +2523,22 @@ paths:
       parameters: [ { in: path, name: job_id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /admin/backups/{job_id}/download/prepare:
+    post:
+      tags: [Backups]
+      summary: Prepare a backup download in the background (GH #1408)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: job_id, required: true, schema: { type: string } } ]
+      responses: { "202": { description: Accepted } }
+
+  /admin/backups/{job_id}/download/prepare-status:
+    get:
+      tags: [Backups]
+      summary: Poll a backup download prepare job (GH #1408)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: job_id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
   /admin/backups/{job_id}/logs:
     get:
       tags: [Backups]
@@ -3810,6 +3826,22 @@ paths:
     get:
       tags: [Me]
       summary: Download backups
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
+  /me/backups/{id}/download/prepare:
+    post:
+      tags: [Me]
+      summary: Prepare a backup download in the background (GH #1408)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "202": { description: Accepted } }
+
+  /me/backups/{id}/download/prepare-status:
+    get:
+      tags: [Me]
+      summary: Poll a backup download prepare job (GH #1408)
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -3,7 +3,7 @@
 // expandable to per-user children). Manual creates render flat.
 import { Badge, Button, Card, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import { downloadUrl } from "../../../utils/download";
+import { useBackupDownloadPrepare } from "../../../utils/backupDownload";
 import { backupTypeColor, backupTypeLabel, runScopeSummary } from "../../../utils/backupType";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
@@ -147,6 +147,7 @@ const RunStatusSummary = ({ run }: { run: BackupRun }) => {
 };
 
 export const AdminBackupsPage = () => {
+  const dl = useBackupDownloadPrepare("admin"); // GH #1408: prepare-then-download
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [uploadRestoreOpen, setUploadRestoreOpen] = useState(false);
   const [packageRunId, setPackageRunId] = useState<string | null>(null);
@@ -283,9 +284,9 @@ export const AdminBackupsPage = () => {
       feedback.message.warning("Backup must complete before download");
       return;
     }
-    // GH #462: anchor-download, not window.location.href — navigating aborts the
-    // in-flight backups poll and shows a spurious "Network Failed" toast.
-    downloadUrl(`/api/v1/admin/backups/${row.id}/download`);
+    // GH #1408: prepare in the background (restic materialize takes minutes)
+    // then trigger the download, so the button isn't dead in the meantime.
+    dl.start(row.id);
   };
 
   const handleCancel = async (row: BackupJob) => {
@@ -417,7 +418,7 @@ export const AdminBackupsPage = () => {
                 // GH #502: Download is the most common action after a backup completes —
                 // make it the primary (first, visible) action; Log + the rest collapse
                 // into the overflow menu.
-                { key: "download", label: "Download", icon: <DownloadOutlined />, hidden: isRestoreKind(row.kind) || (row.status !== "succeeded" && row.status !== "partial"), onClick: () => handleDownload(row) },
+                { key: "download", label: dl.preparingId === row.id ? "Preparing…" : "Download", icon: <DownloadOutlined />, loading: dl.preparingId === row.id, disabled: dl.preparingId === row.id, hidden: isRestoreKind(row.kind) || (row.status !== "succeeded" && row.status !== "partial"), onClick: () => handleDownload(row) },
                 { key: "log", label: "Log", icon: <FileTextOutlined />, onClick: () => setLogJob(row) },
                 {
                   key: "restore",

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -3,10 +3,9 @@
 // when a row is succeeded. Mirrors AdminBackupsPage data shape but
 // scoped via /me/backups (auth-gated to caller's user_id).
 import { useTranslation } from "react-i18next";
-import { downloadUrl } from "../../utils/download";
+import { useBackupDownloadPrepare } from "../../utils/backupDownload";
 import { Button, Card, Grid, Input, Select, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
-import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
 import { backupTypeColor, backupTypeLabel } from "../../utils/backupType";
 import { RowActions } from "../../components/RowActions";
@@ -54,6 +53,7 @@ const statusColor = (status: string): string => {
 
 export const MyProfileBackupCard = () => {
   const { t } = useTranslation();
+  const dl = useBackupDownloadPrepare("me"); // GH #1408: prepare-then-download
   const screens = Grid.useBreakpoint();
   const [submitting, setSubmitting] = useState(false);
   const [restoreId, setRestoreId] = useState<string | null>(null);
@@ -259,7 +259,7 @@ export const MyProfileBackupCard = () => {
                   // succeeded-only (a partial account backup is not a safe restore
                   // source).
                   ...(!isRestoreRow(row) && (row.status === "succeeded" || row.status === "partial")
-                    ? [{ key: "download", label: "Download", icon: <DownloadOutlined />, onClick: () => { const act = getActAs(); downloadUrl(`/api/v1/me/backups/${row.id}/download${act ? `?act_as=${encodeURIComponent(act.id)}` : ""}`); } }]
+                    ? [{ key: "download", label: dl.preparingId === row.id ? "Preparing…" : "Download", icon: <DownloadOutlined />, loading: dl.preparingId === row.id, disabled: dl.preparingId === row.id, onClick: () => dl.start(row.id) }]
                     : []),
                   ...(!isRestoreRow(row) && row.status === "succeeded"
                     ? [{ key: "restore", label: "Restore", icon: <ReloadOutlined />, onClick: () => setRestoreId(row.id) }]

--- a/panel-ui/src/utils/backupDownload.ts
+++ b/panel-ui/src/utils/backupDownload.ts
@@ -1,0 +1,86 @@
+// GH #1408: a backup download runs a restic materialize (minutes) before the
+// first byte, so a plain <a download> left the button looking dead. This hook
+// drives the background prepare flow: POST prepare → poll prepare-status →
+// trigger the browser download once the archive is warmed. Used by both the
+// tenant (MyProfileBackupCard) and admin (AdminBackupsPage) Download actions.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { apiClient } from "../apiClient";
+import { downloadUrl } from "./download";
+import { getActAs } from "../impersonation";
+import { feedback } from "../lib/feedback";
+
+const POLL_MS = 2000;
+const MAX_POLLS = 900; // ~30 min ceiling, matching the server materialize budget
+
+export function useBackupDownloadPrepare(scope: "me" | "admin") {
+  const base = scope === "me" ? "/me/backups" : "/admin/backups";
+  const [preparingId, setPreparingId] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelled = useRef(false);
+
+  useEffect(
+    () => () => {
+      cancelled.current = true;
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const triggerDownload = useCallback(
+    (id: string) => {
+      const act = scope === "me" ? getActAs() : null;
+      downloadUrl(
+        `/api/v1${base}/${id}/download${act ? `?act_as=${encodeURIComponent(act.id)}` : ""}`,
+      );
+    },
+    [base, scope],
+  );
+
+  const start = useCallback(
+    async (id: string) => {
+      setPreparingId(id);
+      feedback.message.info("Preparing download…");
+      try {
+        await apiClient.post(`${base}/${id}/download/prepare`);
+      } catch {
+        setPreparingId(null);
+        feedback.message.error("Could not start the download");
+        return;
+      }
+      let polls = 0;
+      const poll = async () => {
+        if (cancelled.current) return;
+        polls += 1;
+        try {
+          const r = await apiClient.get<{ status: string; error?: string }>(
+            `${base}/${id}/download/prepare-status`,
+          );
+          if (r.data.status === "ready") {
+            setPreparingId(null);
+            feedback.message.success("Download ready");
+            triggerDownload(id);
+            return;
+          }
+          if (r.data.status === "failed") {
+            setPreparingId(null);
+            feedback.message.error(r.data.error || "Failed to prepare the download");
+            return;
+          }
+        } catch {
+          // A transient 404 before the marker lands (or a blip) — keep polling.
+        }
+        if (polls >= MAX_POLLS) {
+          setPreparingId(null);
+          feedback.message.error("Preparing the download timed out — try again");
+          return;
+        }
+        timer.current = setTimeout(poll, POLL_MS);
+      };
+      timer.current = setTimeout(poll, 1200);
+    },
+    [base, triggerDownload],
+  );
+
+  return { start, preparingId };
+}


### PR DESCRIPTION
feat(backups): background "Preparing…" for per-account download (GH #1408)

lxsdevcode: the per-account backup Download button looked dead — the GET runs a
restic materialize (minutes) before the first byte streams. This gives it the
same background treatment as the full-server package download:

  POST .../download/prepare        → 202, detached restic materialize, marker
  GET  .../download/prepare-status → poll { status: preparing|ready|failed }
  GET  .../download                → reuses the warmed dir (no re-materialize)

streamBackupArtifact now consumes a "ready" prepare marker (consumePreparedDir)
and skips the inline materialize, so the actual download streams immediately once
prepared; with no marker it materializes inline exactly as before (fully backward
compatible — a direct GET still works). The materialized dir is cleaned up after
the stream whichever path ran; a stale/abandoned prepare is self-healed (the
download stat-checks the dir and falls back to a fresh materialize).

Both surfaces: admin (/admin/backups/:job_id/download/*) and tenant
(/me/backups/:id/download/*, owner-scoped, cross-user → 404). The Download menu
action shows "Preparing…" with a spinner while the job runs, then triggers the
browser download on ready.

No agent change (reuses backup.materialize + materialize_cleanup); routes added
to openapi.yaml. Tests: the preparable gate + consumePreparedDir marker logic
(ready one-shot, stale-dir drop, preparing kept).
