### PR TITLE
feat(backups): tenant self-service Restore-from-Upload (files/db/mail) (GH #1408)

### DIFF
--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -37,6 +37,46 @@ const restoreLockPath = "/var/lib/jabali-backups/.restore.lock"
 // (Gitea #463).
 var restoreDBNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`)
 
+// restoreEnforcement gates which manifest-named resources an account restore may
+// touch. It exists for the TENANT self-service restore (GH #1408), where the
+// uploaded tar is untrusted: the panel passes the caller's OWNED database names
+// and mail domains, and the agent skips any db/mail stage naming something the
+// caller doesn't own — a crafted tar can't `mariadb jabali_panel < …` or inject
+// into another tenant's mailbox. Admin restores pass the zero value (Mode="",
+// nil lists) and stay unrestricted.
+//
+// Semantics of the lists: nil = unrestricted; non-nil (EVEN EMPTY) = enforce
+// (empty → every stage of that kind is skipped). Mode=="tenant" additionally
+// drops docker (not gateable per-account here) and is the flag the panel keys
+// its fail-closed version check on.
+type restoreEnforcement struct {
+	Mode               string
+	AllowedDBNames     []string
+	AllowedMailDomains []string
+}
+
+func (e restoreEnforcement) enforceDB() bool   { return e.AllowedDBNames != nil }
+func (e restoreEnforcement) enforceMail() bool { return e.AllowedMailDomains != nil }
+
+func (e restoreEnforcement) dbAllowed(name string) bool {
+	for _, d := range e.AllowedDBNames {
+		if d == name { // exact — DB names are case-sensitive on Linux MariaDB/PG
+			return true
+		}
+	}
+	return false
+}
+
+func (e restoreEnforcement) mailDomainAllowed(domain string) bool {
+	domain = strings.ToLower(domain)
+	for _, d := range e.AllowedMailDomains {
+		if strings.ToLower(d) == domain {
+			return true
+		}
+	}
+	return false
+}
+
 type backupRestoreParams struct {
 	JobID              string `json:"job_id"`
 	ManifestSnapshotID string `json:"manifest_snapshot_id"`
@@ -203,7 +243,7 @@ func backupRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 	}
 	if apply {
 		stagingRoot := filepath.Join("/var/lib/jabali-backups/restore-staging", req.JobID)
-		applied, warnings := applyAccountRestore(ctx, stagingRoot, req.TargetUsername, manifest.User, manifest.Stages, out.Stages)
+		applied, warnings := applyAccountRestore(ctx, stagingRoot, req.TargetUsername, manifest.User, manifest.Stages, out.Stages, restoreEnforcement{})
 		out.Applied = applied
 		out.Warnings = warnings
 		// GH #1361: stage each FTP subaccount's captured /etc/shadow hash for
@@ -290,6 +330,7 @@ func applyAccountRestore(
 	manifestUser backup.ManifestUser,
 	manifestStages []backup.ManifestStage,
 	stageResults []backupRestoreStage,
+	enf restoreEnforcement,
 ) ([]string, []string) {
 	// Per-stage materialization gate, indexed — NOT keyed by stage Name.
 	// Docker and DB fan out one ManifestStage per app / per database, and
@@ -414,6 +455,14 @@ func applyAccountRestore(
 			applied = append(applied, fmt.Sprintf("home → /home/%s", username))
 
 		case backup.StageDocker:
+			// GH #1408: docker data lands in a GLOBAL docker-apps/<slug> dir keyed
+			// by the (untrusted) manifest slug, which we can't cheaply scope to the
+			// caller — so a tenant self-restore never applies docker (cut from
+			// tenant v1). Admin restores are unaffected (Mode="").
+			if enf.Mode == "tenant" {
+				warnings = append(warnings, "docker: not restored from a self-service upload (restore Docker apps via an admin)")
+				continue
+			}
 			if len(st.Items) == 0 {
 				warnings = append(warnings, "docker: manifest stage missing items[0] app slug")
 				continue
@@ -467,6 +516,15 @@ func applyAccountRestore(
 			if !restoreDBNameRe.MatchString(db) {
 				warnings = append(warnings,
 					fmt.Sprintf("db: manifest name %q rejected (not a valid identifier)", db))
+				continue
+			}
+			// GH #1408: a tenant self-restore may only load databases the caller
+			// owns — the untrusted manifest name is otherwise a global handle
+			// (`otheruser_db`, or even `jabali_panel`). Skip anything not on the
+			// panel-supplied owned list.
+			if enf.enforceDB() && !enf.dbAllowed(db) {
+				warnings = append(warnings,
+					fmt.Sprintf("db %q: not one of your databases — skipped (create it first, then restore)", db))
 				continue
 			}
 			// PG dump first — backup_databases.go writes "<db>.pgdump"
@@ -596,6 +654,24 @@ func applyAccountRestore(
 			if entries, err := os.ReadDir(mailTree); err != nil || len(entries) == 0 {
 				warnings = append(warnings, "mail: no message tree in snapshot — skip")
 				continue
+			}
+			// GH #1408: a tenant self-restore may only replay mailboxes for
+			// domains the caller owns. The tree is keyed <domain>/<local>, so drop
+			// every non-owned <domain> subdir from the (agent-owned) staging before
+			// import — a crafted tar otherwise injects messages into another
+			// tenant's mailbox via JMAP Email/import.
+			if enf.enforceMail() {
+				dirs, _ := os.ReadDir(mailTree)
+				for _, e := range dirs {
+					if e.IsDir() && !enf.mailDomainAllowed(e.Name()) {
+						_ = os.RemoveAll(filepath.Join(mailTree, e.Name()))
+						warnings = append(warnings, fmt.Sprintf("mail: domain %q is not yours — skipped", e.Name()))
+					}
+				}
+				if left, _ := os.ReadDir(mailTree); len(left) == 0 {
+					warnings = append(warnings, "mail: no mailboxes for your domains in this archive — skip")
+					continue
+				}
 			}
 			if !stalwartActive(ctx) {
 				warnings = append(warnings, "mail: Stalwart inactive — message import skipped")

--- a/panel-agent/internal/commands/backup_restore_enforcement_test.go
+++ b/panel-agent/internal/commands/backup_restore_enforcement_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRestoreEnforcement_Helpers(t *testing.T) {
+	// nil list = unrestricted; non-nil (even empty) = enforce.
+	if (restoreEnforcement{}).enforceDB() {
+		t.Error("nil AllowedDBNames must be unrestricted")
+	}
+	if !(restoreEnforcement{AllowedDBNames: []string{}}).enforceDB() {
+		t.Error("empty AllowedDBNames must enforce (own nothing)")
+	}
+	if !(restoreEnforcement{AllowedMailDomains: []string{}}).enforceMail() {
+		t.Error("empty AllowedMailDomains must enforce")
+	}
+
+	e := restoreEnforcement{AllowedDBNames: []string{"alice_blog"}, AllowedMailDomains: []string{"Alice.com"}}
+	if !e.dbAllowed("alice_blog") || e.dbAllowed("alice_Blog") || e.dbAllowed("jabali_panel") {
+		t.Error("dbAllowed must be an exact, case-sensitive match")
+	}
+	if !e.mailDomainAllowed("alice.com") || !e.mailDomainAllowed("ALICE.COM") {
+		t.Error("mailDomainAllowed must be case-insensitive")
+	}
+	if e.mailDomainAllowed("victim.com") {
+		t.Error("mailDomainAllowed must reject a non-owned domain")
+	}
+}
+
+func TestBackupRestoreFromTar_TenantRequiresAllowlists(t *testing.T) {
+	call := func(p map[string]any) error {
+		raw, _ := json.Marshal(p)
+		_, err := backupRestoreFromTarHandler(context.Background(), raw)
+		return err
+	}
+	// mode=tenant with a nil (missing) allowlist → refused BEFORE any restore work.
+	err := call(map[string]any{"mode": "tenant", "job_id": "x", "tar_path": "/x", "target_username": "alice"})
+	if err == nil || !strings.Contains(err.Error(), "mode=tenant requires") {
+		t.Fatalf("nil allowlist under tenant must be refused, got %v", err)
+	}
+	// mode=tenant WITH both lists (empty allowed) → passes the guard, fails later
+	// on the (bogus) job_id/tar_path, NOT on the allowlist guard.
+	err = call(map[string]any{
+		"mode": "tenant", "job_id": "x", "tar_path": "/x", "target_username": "alice",
+		"allowed_db_names": []string{}, "allowed_mail_domains": []string{},
+	})
+	if err != nil && strings.Contains(err.Error(), "mode=tenant requires") {
+		t.Fatalf("empty (present) allowlists must pass the guard, got %v", err)
+	}
+}
+
+func TestIntersectComponents(t *testing.T) {
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	allowed := []string{"home", "db", "mail"}
+	// Empty request = "all" → the allowed set (NOT empty, so it can't fall open).
+	if got := intersectComponents(nil, allowed); !eq(got, allowed) {
+		t.Errorf("empty request: got %v, want %v", got, allowed)
+	}
+	if got := intersectComponents([]string{"home", "docker", "db"}, allowed); !eq(got, []string{"home", "db"}) {
+		t.Errorf("subset: got %v, want [home db]", got)
+	}
+	if got := intersectComponents([]string{"docker", "dns"}, allowed); len(got) != 0 {
+		t.Errorf("only-disallowed: got %v, want empty", got)
+	}
+}

--- a/panel-agent/internal/commands/backup_restore_from_tar.go
+++ b/panel-agent/internal/commands/backup_restore_from_tar.go
@@ -42,6 +42,14 @@ type backupRestoreFromTarParams struct {
 	// ApplyStaged=false stages the extracted tree without touching the live
 	// system (recon), mirroring backup.restore.
 	ApplyStaged *bool `json:"apply_staged,omitempty"`
+	// GH #1408 tenant self-restore: when Mode=="tenant" the uploaded tar is
+	// untrusted, so the panel supplies the caller's OWNED resources and the
+	// agent skips anything else. AllowedDBNames / AllowedMailDomains: nil =
+	// unrestricted (admin); non-nil (even empty) = enforce. Mode=="tenant"
+	// REQUIRES both lists (fail-closed) and additionally drops docker.
+	Mode               string   `json:"mode,omitempty"`
+	AllowedDBNames     []string `json:"allowed_db_names,omitempty"`
+	AllowedMailDomains []string `json:"allowed_mail_domains,omitempty"`
 }
 
 type backupRestoreFromTarResult struct {
@@ -53,6 +61,11 @@ type backupRestoreFromTarResult struct {
 	Metadata       json.RawMessage      `json:"metadata,omitempty"`
 	StagingCleanup string               `json:"staging_cleanup,omitempty"`
 	BytesExtracted int64                `json:"bytes_extracted"`
+	// GH #1408 fail-closed ack: a tenant restore's panel handler REQUIRES these
+	// to be true. An agent predating the allowlist feature never sets them, so
+	// the panel rejects the restore rather than running it unrestricted.
+	DBAllowlistEnforced   bool `json:"db_allowlist_enforced"`
+	MailAllowlistEnforced bool `json:"mail_allowlist_enforced"`
 }
 
 func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -64,15 +77,38 @@ func backupRestoreFromTarHandler(ctx context.Context, raw json.RawMessage) (any,
 	if p.ApplyStaged != nil {
 		apply = *p.ApplyStaged
 	}
-	return restoreAccountFromTar(ctx, p.JobID, p.TarPath, p.TargetUsername, p.Components, apply)
+	enf := restoreEnforcement{
+		Mode:               p.Mode,
+		AllowedDBNames:     p.AllowedDBNames,
+		AllowedMailDomains: p.AllowedMailDomains,
+	}
+	// Belt-and-suspenders: a tenant restore MUST carry both allowlists (a nil
+	// list means "unrestricted", so a caller that forgot one would restore
+	// wide-open). Refuse rather than run partially-gated.
+	if enf.Mode == "tenant" && (enf.AllowedDBNames == nil || enf.AllowedMailDomains == nil) {
+		return nil, bkInvalidArg("mode=tenant requires allowed_db_names and allowed_mail_domains (may be empty, not null)")
+	}
+	return restoreAccountFromTar(ctx, p.JobID, p.TarPath, p.TargetUsername, p.Components, apply, enf)
 }
 
 // restoreAccountFromTar is the reusable core: extract an untrusted account backup
 // tar and apply it to targetUsername. Shared by the single-upload restore handler
 // and the full-server container restore (which calls it once per inner user tar).
-func restoreAccountFromTar(ctx context.Context, jobID, tarPath, targetUsername string, components []string, apply bool) (*backupRestoreFromTarResult, error) {
+func restoreAccountFromTar(ctx context.Context, jobID, tarPath, targetUsername string, components []string, apply bool, enf restoreEnforcement) (*backupRestoreFromTarResult, error) {
 	if !jobIDRE.MatchString(jobID) {
 		return nil, bkInvalidArg("job_id must be a 26-char ULID")
+	}
+	// GH #1408: a tenant self-restore is limited to the audited-safe components;
+	// docker/dns are never applied from an untrusted self-service upload.
+	if enf.Mode == "tenant" {
+		components = intersectComponents(components, []string{"home", "db", "mail"})
+		if len(components) == 0 {
+			// The caller asked only for components a self-service restore can't
+			// apply. An EMPTY list means "all" downstream (componentFilter), so
+			// substitute a sentinel that matches no stage — apply nothing rather
+			// than fall open to a full restore.
+			components = []string{"__none__"}
+		}
 	}
 	if !backupUsernameRE.MatchString(targetUsername) {
 		return nil, bkInvalidArg("target_username must match ^[a-z][a-z0-9_-]{0,31}$")
@@ -131,6 +167,10 @@ func restoreAccountFromTar(ctx context.Context, jobID, tarPath, targetUsername s
 	}
 
 	out := backupRestoreFromTarResult{JobID: jobID, User: manifest.User, BytesExtracted: written}
+	// Echo which allowlists this agent enforced so the panel's tenant handler can
+	// fail closed against an agent that predates the feature (it never sets these).
+	out.DBAllowlistEnforced = enf.enforceDB()
+	out.MailAllowlistEnforced = enf.enforceMail()
 
 	// v1 restores into the SAME username the backup was taken from — the home
 	// tree inside the archive is /home/<backup-user> and applyAccountRestore
@@ -170,7 +210,7 @@ func restoreAccountFromTar(ctx context.Context, jobID, tarPath, targetUsername s
 		return &out, nil
 	}
 
-	applied, warnings := applyAccountRestore(ctx, root, targetUsername, manifest.User, manifest.Stages, stageResults)
+	applied, warnings := applyAccountRestore(ctx, root, targetUsername, manifest.User, manifest.Stages, stageResults, enf)
 	out.Applied = applied
 	out.Warnings = append(out.Warnings, warnings...)
 
@@ -202,6 +242,27 @@ func componentFilter(components []string) map[string]bool {
 		return nil
 	}
 	return m
+}
+
+// intersectComponents restricts a requested component set to an allowed set. An
+// EMPTY request means "all", so it becomes exactly the allowed set (not empty) —
+// this is what keeps a tenant restore that asked for nothing-in-particular from
+// falling through to an unrestricted all-stages apply. GH #1408.
+func intersectComponents(requested, allowed []string) []string {
+	if len(requested) == 0 {
+		return allowed
+	}
+	allow := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		allow[a] = true
+	}
+	out := make([]string, 0, len(requested))
+	for _, r := range requested {
+		if allow[strings.TrimSpace(r)] {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // resolveExtractedRoot returns the per-stage staging root inside the extracted
@@ -254,6 +315,10 @@ type backupInspectUploadedTarParams struct {
 type backupInspectUploadedTarResult struct {
 	User       backup.ManifestUser `json:"user"`
 	Components []string            `json:"components"`
+	// AllowlistSupported is always true on an agent that has the GH #1408 tenant
+	// enforcement. The tenant restore handler gates on it BEFORE applying, so an
+	// older agent (which never sets it) can't run an unrestricted tenant restore.
+	AllowlistSupported bool `json:"allowlist_supported"`
 }
 
 func backupInspectUploadedTarHandler(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -288,7 +353,7 @@ func backupInspectUploadedTarHandler(ctx context.Context, raw json.RawMessage) (
 		comps = append(comps, st.Name)
 		seen[st.Name] = true
 	}
-	return backupInspectUploadedTarResult{User: manifest.User, Components: comps}, nil
+	return backupInspectUploadedTarResult{User: manifest.User, Components: comps, AllowlistSupported: true}, nil
 }
 
 func init() {

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -245,7 +245,7 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 			}
 			stageResults = append(stageResults, sr)
 		}
-		applied, warnings := applyAccountRestore(ctx, stagingRoot, p.TargetUsername, manifest.User, dbStages, stageResults)
+		applied, warnings := applyAccountRestore(ctx, stagingRoot, p.TargetUsername, manifest.User, dbStages, stageResults, restoreEnforcement{})
 		out.Applied = append(out.Applied, applied...)
 		out.Warnings = append(out.Warnings, warnings...)
 	}

--- a/panel-agent/internal/commands/system_fullbackup_restore.go
+++ b/panel-agent/internal/commands/system_fullbackup_restore.go
@@ -172,7 +172,7 @@ func systemFullbackupRestoreUploadedHandler(ctx context.Context, raw json.RawMes
 			out.Users = append(out.Users, fullRestoreUserResult{Username: e.Username, Error: "inner archive missing from container"})
 			continue
 		}
-		res, rerr := restoreAccountFromTar(ctx, randomULID(), inner, e.Username, nil, true)
+		res, rerr := restoreAccountFromTar(ctx, randomULID(), inner, e.Username, nil, true, restoreEnforcement{})
 		if rerr != nil {
 			msg := rerr.Error()
 			if ae, ok := rerr.(*agentwire.AgentError); ok && ae.Message != "" {

--- a/panel-api/internal/api/backup_restore_upload_tenant.go
+++ b/panel-api/internal/api/backup_restore_upload_tenant.go
@@ -1,0 +1,368 @@
+// Tenant self-service Restore-from-Upload (GH #1408, lxsdevcode). A tenant
+// uploads a backup archive of THEIR OWN account and restores it — the mirror of
+// the admin /admin/backups/restore-upload flow, but:
+//
+//   - owner-scoped: the target is ALWAYS the caller (never a chosen username);
+//   - the uploaded tar is UNTRUSTED (a lower-privilege actor), so the apply
+//     passes the caller's OWNED database names + mail domains as allowlists and
+//     the agent skips anything else (mode="tenant"); components are limited to
+//     files/db/mail (docker/dns are cut — they write manifest-keyed global state);
+//   - FAIL-CLOSED against an old agent: the apply first checks the agent reports
+//     `allowlist_supported` (via inspect, no extraction) and refuses to run
+//     otherwise, so a pre-feature agent can never apply an unrestricted restore;
+//   - no panel-row metadata rebuild (that path recreates domains/db rows from the
+//     untrusted bundle — a hijack vector; the caller's own rows already exist).
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func restoreUploadTenantTag(userID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-upload-tenant:" + userID))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func restoreUploadTenantPath(userID, uploadID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-upload-tenant-path:" + userID + ":" + uploadID))
+	return filepath.Join(restoreUploadDir, "rupt-"+restoreUploadTenantTag(userID)+"-"+hex.EncodeToString(sum[:])+".tar.zst")
+}
+
+func restoreUploadTenantOutcomePath(userID, uploadID string) string {
+	sum := sha256.Sum256([]byte("jabali-restore-upload-tenant-outcome:" + userID + ":" + uploadID))
+	return filepath.Join(restoreUploadDir, "ruot-"+restoreUploadTenantTag(userID)+"-"+hex.EncodeToString(sum[:])+".json")
+}
+
+func evictStaleTenantRestoreUploads(userID string) {
+	tag := restoreUploadTenantTag(userID)
+	cutoff := time.Now().Add(-restoreUploadTTL)
+	for _, pat := range []string{"rupt-" + tag + "-*.tar.zst", "ruot-" + tag + "-*.json"} {
+		matches, _ := filepath.Glob(filepath.Join(restoreUploadDir, pat))
+		for _, m := range matches {
+			if fi, err := os.Stat(m); err == nil && fi.ModTime().Before(cutoff) {
+				_ = os.Remove(m)
+			}
+		}
+	}
+}
+
+func (cfg MeBackupsHandlerConfig) allUserDomainNames(ctx context.Context, userID string) []string {
+	out := []string{} // NEVER nil — an empty (present) list means "enforce, owns none"
+	if cfg.Domains == nil {
+		return out
+	}
+	doms, _, err := cfg.Domains.ListByUserID(ctx, userID, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		return out
+	}
+	for _, d := range doms {
+		out = append(out, d.Name)
+	}
+	return out
+}
+
+func (h *meBackupHandler) restoreUploadUserID(c *gin.Context) (string, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil || claims.UserID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return "", false
+	}
+	return claims.UserID, true
+}
+
+// restoreUploadChunk: POST /me/backups/restore-upload?upload_id=&offset=[&final=1].
+// Owner-scoped mirror of the admin chunk reassembly; body-limit exempt.
+func (h *meBackupHandler) restoreUploadChunk(c *gin.Context) {
+	userID, ok := h.restoreUploadUserID(c)
+	if !ok {
+		return
+	}
+	uploadID := c.Query("upload_id")
+	if !uploadIDRE.MatchString(uploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	offset, err := strconv.ParseInt(c.Query("offset"), 10, 64)
+	if err != nil || offset < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_offset"})
+		return
+	}
+	if err := os.MkdirAll(restoreUploadDir, 0o750); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "staging_unavailable"})
+		return
+	}
+	evictStaleTenantRestoreUploads(userID)
+
+	path := restoreUploadTenantPath(userID, uploadID)
+	if offset == 0 {
+		if _, statErr := os.Stat(path); statErr != nil {
+			matches, _ := filepath.Glob(filepath.Join(restoreUploadDir, "rupt-"+restoreUploadTenantTag(userID)+"-*.tar.zst"))
+			if len(matches) >= maxInFlightRestoreTar {
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "too_many_uploads", "detail": "finish or wait for an in-flight restore upload"})
+				return
+			}
+		}
+	}
+	if offset >= maxRestoreUploadBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "archive_too_large"})
+		return
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "open_staging_failed"})
+		return
+	}
+	defer f.Close()
+	if _, err := f.Seek(offset, 0); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "seek_failed"})
+		return
+	}
+	remaining := maxRestoreUploadBytes - offset
+	written, werr := io.Copy(f, io.LimitReader(c.Request.Body, remaining))
+	if werr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "write_failed", "detail": werr.Error()})
+		return
+	}
+	if written == remaining { // exactly at the cap — reject if more bytes remain (silent-truncation guard)
+		var probe [1]byte
+		if n, _ := c.Request.Body.Read(probe[:]); n > 0 {
+			_ = os.Remove(path)
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "archive_too_large"})
+			return
+		}
+	}
+	if c.Query("final") == "1" {
+		size := offset + written
+		if fi, serr := f.Stat(); serr == nil {
+			size = fi.Size()
+		}
+		c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "size": size})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "written": written, "offset": offset + written})
+}
+
+// restoreUploadInspect returns the backup's user + restorable components (the UI
+// filters to files/db/mail on the tenant side).
+func (h *meBackupHandler) restoreUploadInspect(c *gin.Context) {
+	userID, ok := h.restoreUploadUserID(c)
+	if !ok {
+		return
+	}
+	var req restoreUploadInspectRequest
+	if err := c.ShouldBindJSON(&req); err != nil || !uploadIDRE.MatchString(req.UploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	path := restoreUploadTenantPath(userID, req.UploadID)
+	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "backup.inspect_uploaded_tar", map[string]string{"tar_path": path})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	c.Data(http.StatusOK, "application/json", raw)
+}
+
+type tenantRestoreUploadApplyRequest struct {
+	UploadID   string   `json:"upload_id"`
+	Components []string `json:"components,omitempty"`
+}
+
+// restoreUploadApply restores the uploaded archive into the CALLER's own account.
+// Detached (minutes-long) + 202 + status poll, like the admin path. Fails closed
+// on an agent that doesn't advertise allowlist support (checked before applying).
+func (h *meBackupHandler) restoreUploadApply(c *gin.Context) {
+	userID, ok := h.restoreUploadUserID(c)
+	if !ok {
+		return
+	}
+	ctx := c.Request.Context()
+	u, uerr := h.cfg.Users.FindByID(ctx, userID)
+	if uerr != nil || u == nil || u.Username == nil || *u.Username == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "user_lookup_failed"})
+		return
+	}
+	username := *u.Username
+
+	var req tenantRestoreUploadApplyRequest
+	if err := c.ShouldBindJSON(&req); err != nil || !uploadIDRE.MatchString(req.UploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	path := restoreUploadTenantPath(userID, req.UploadID)
+	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+
+	// FAIL-CLOSED capability gate: confirm the agent enforces the ownership
+	// allowlists BEFORE we let it touch the live system. inspect reads only the
+	// manifest (no extraction), so an old agent is refused with zero live change.
+	iraw, ierr := h.cfg.Agent.Call(ctx, "backup.inspect_uploaded_tar", map[string]string{"tar_path": path})
+	if ierr != nil {
+		respondAgentError(c, ierr)
+		return
+	}
+	var insp struct {
+		AllowlistSupported bool `json:"allowlist_supported"`
+	}
+	if json.Unmarshal(iraw, &insp) != nil || !insp.AllowlistSupported {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":  "agent_update_required",
+			"detail": "the server agent must be updated before self-service restore can run safely",
+		})
+		return
+	}
+
+	// Owned resources → allowlists (ALWAYS non-nil; an empty present list means
+	// "enforce, owns none" — the agent skips every db/mail stage).
+	allowedDBs := append([]string{}, h.cfg.allUserDatabases(ctx, userID)...)
+	allowedDBs = append(allowedDBs, h.cfg.allUserPostgresDatabases(ctx, userID)...)
+	allowedDomains := h.cfg.allUserDomainNames(ctx, userID)
+	components := intersectRestoreComponents(req.Components, []string{"home", "db", "mail"})
+
+	c.Set("audit_target", username)
+	c.Set("audit_target_type", "user")
+	evictStaleTenantRestoreUploads(userID)
+
+	outcomePath := restoreUploadTenantOutcomePath(userID, req.UploadID)
+	writeRestoreUploadOutcome(outcomePath, "restoring", nil, nil, "")
+	go h.runTenantUploadRestore(tenantUploadRestoreArgs{
+		path:           path,
+		outcomePath:    outcomePath,
+		username:       username,
+		components:     components,
+		allowedDBs:     allowedDBs,
+		allowedDomains: allowedDomains,
+	})
+	c.JSON(http.StatusAccepted, gin.H{"status": "restoring", "upload_id": req.UploadID})
+}
+
+type tenantUploadRestoreArgs struct {
+	path           string
+	outcomePath    string
+	username       string
+	components     []string
+	allowedDBs     []string
+	allowedDomains []string
+}
+
+func (h *meBackupHandler) runTenantUploadRestore(a tenantUploadRestoreArgs) {
+	ctx, cancel := context.WithTimeout(context.Background(), restoreJobTimeout)
+	defer cancel()
+
+	// Guarantee non-nil so the wire carries [] (enforce) not null (unrestricted);
+	// the agent's mode=tenant guard also rejects a nil list as belt-and-suspenders.
+	if a.allowedDBs == nil {
+		a.allowedDBs = []string{}
+	}
+	if a.allowedDomains == nil {
+		a.allowedDomains = []string{}
+	}
+	raw, err := h.cfg.Agent.Call(ctx, "backup.restore_from_tar", map[string]any{
+		"job_id":               ids.NewULID(),
+		"tar_path":             a.path,
+		"target_username":      a.username,
+		"components":           a.components,
+		"mode":                 "tenant",
+		"allowed_db_names":     a.allowedDBs,
+		"allowed_mail_domains": a.allowedDomains,
+	})
+	if err != nil {
+		writeRestoreUploadOutcome(a.outcomePath, "failed", nil, nil, restoreFailureDetail(err))
+		_ = os.Remove(a.path)
+		return
+	}
+	var result struct {
+		Applied               []string `json:"applied"`
+		Warnings              []string `json:"warnings"`
+		DBAllowlistEnforced   bool     `json:"db_allowlist_enforced"`
+		MailAllowlistEnforced bool     `json:"mail_allowlist_enforced"`
+	}
+	_ = json.Unmarshal(raw, &result)
+	// Belt-and-suspenders: the pre-apply inspect gate should have caught an old
+	// agent, but if the applied restore didn't report enforcement, treat it as a
+	// failure rather than trust an unrestricted run.
+	if !result.DBAllowlistEnforced || !result.MailAllowlistEnforced {
+		writeRestoreUploadOutcome(a.outcomePath, "failed", result.Applied, result.Warnings,
+			"restore did not confirm ownership enforcement — aborted")
+		_ = os.Remove(a.path)
+		return
+	}
+
+	// v1 deliberately does NOT rebuild panel metadata rows from the untrusted
+	// bundle (that path recreates domains/db rows from manifest data = a hijack
+	// vector). The caller's own rows already exist; the data restore is what a
+	// self-service restore needs.
+	_ = os.Remove(a.path)
+	writeRestoreUploadOutcome(a.outcomePath, "done", result.Applied, result.Warnings, "")
+}
+
+func (h *meBackupHandler) restoreUploadStatus(c *gin.Context) {
+	userID, ok := h.restoreUploadUserID(c)
+	if !ok {
+		return
+	}
+	uploadID := c.Query("upload_id")
+	if !uploadIDRE.MatchString(uploadID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_upload_id"})
+		return
+	}
+	o, err := readRestoreUploadOutcome(restoreUploadTenantOutcomePath(userID, uploadID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, o)
+}
+
+// intersectRestoreComponents restricts a requested component set to the allowed
+// set; an empty request ("all") becomes the allowed set (never empty → can't
+// fall through to an unrestricted apply).
+func intersectRestoreComponents(requested, allowed []string) []string {
+	if len(requested) == 0 {
+		return allowed
+	}
+	allow := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		allow[a] = true
+	}
+	out := make([]string, 0, len(requested))
+	for _, r := range requested {
+		if allow[r] {
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		return []string{"__none__"} // matches no stage — apply nothing
+	}
+	return out
+}

--- a/panel-api/internal/api/backup_restore_upload_tenant_test.go
+++ b/panel-api/internal/api/backup_restore_upload_tenant_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+// captureAgent records the last restore_from_tar params and returns a canned reply.
+type captureAgent struct {
+	reply       string
+	lastCommand string
+	lastParams  map[string]any
+}
+
+func (a *captureAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	a.lastCommand = cmd
+	if m, ok := params.(map[string]any); ok {
+		a.lastParams = m
+	}
+	return json.RawMessage(a.reply), nil
+}
+
+var _ agent.AgentInterface = (*captureAgent)(nil)
+
+func tenantRestoreHandler(ag agent.AgentInterface) *meBackupHandler {
+	return &meBackupHandler{cfg: MeBackupsHandlerConfig{Agent: ag}}
+}
+
+func TestRunTenantUploadRestore_FailsClosedWithoutAck(t *testing.T) {
+	dir := t.TempDir()
+	// Agent applied the restore but did NOT report enforcement (e.g. an old
+	// agent) → must be sealed as failed, never trusted.
+	ag := &captureAgent{reply: `{"applied":["home → /home/alice"],"warnings":[]}`}
+	oc := filepath.Join(dir, "outcome.json")
+	tenantRestoreHandler(ag).runTenantUploadRestore(tenantUploadRestoreArgs{
+		path: filepath.Join(dir, "archive.tar.zst"), outcomePath: oc, username: "alice",
+		allowedDBs: []string{}, allowedDomains: []string{},
+	})
+	o, err := readRestoreUploadOutcome(oc)
+	if err != nil {
+		t.Fatalf("read outcome: %v", err)
+	}
+	if o.Status != "failed" {
+		t.Fatalf("no enforcement ack must fail closed, got status %q", o.Status)
+	}
+}
+
+func TestRunTenantUploadRestore_DoneWithAck(t *testing.T) {
+	dir := t.TempDir()
+	ag := &captureAgent{reply: `{"applied":["home → /home/alice"],"warnings":["db \"x\": not one of your databases — skipped"],"db_allowlist_enforced":true,"mail_allowlist_enforced":true}`}
+	oc := filepath.Join(dir, "outcome.json")
+	tenantRestoreHandler(ag).runTenantUploadRestore(tenantUploadRestoreArgs{
+		path: filepath.Join(dir, "archive.tar.zst"), outcomePath: oc, username: "alice",
+		allowedDBs: []string{"alice_blog"}, allowedDomains: []string{"alice.com"},
+	})
+	o, err := readRestoreUploadOutcome(oc)
+	if err != nil {
+		t.Fatalf("read outcome: %v", err)
+	}
+	if o.Status != "done" {
+		t.Fatalf("enforced restore should be done, got %q (%s)", o.Status, o.Error)
+	}
+}
+
+func TestRunTenantUploadRestore_SendsModeAndNonNilAllowlists(t *testing.T) {
+	dir := t.TempDir()
+	ag := &captureAgent{reply: `{"db_allowlist_enforced":true,"mail_allowlist_enforced":true}`}
+	tenantRestoreHandler(ag).runTenantUploadRestore(tenantUploadRestoreArgs{
+		path: filepath.Join(dir, "a.tar.zst"), outcomePath: filepath.Join(dir, "o.json"),
+		username: "alice", allowedDBs: nil, allowedDomains: nil, // even nil in → non-nil on the wire
+	})
+	if ag.lastCommand != "backup.restore_from_tar" {
+		t.Fatalf("command = %q", ag.lastCommand)
+	}
+	if ag.lastParams["mode"] != "tenant" {
+		t.Errorf("mode = %v, want tenant", ag.lastParams["mode"])
+	}
+	for _, k := range []string{"allowed_db_names", "allowed_mail_domains"} {
+		v, ok := ag.lastParams[k]
+		if !ok || v == nil {
+			t.Errorf("%s must be present and non-nil on the wire (empty=enforce, null=unrestricted)", k)
+		}
+	}
+}
+
+func TestIntersectRestoreComponents(t *testing.T) {
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	allowed := []string{"home", "db", "mail"}
+	if got := intersectRestoreComponents(nil, allowed); !eq(got, allowed) {
+		t.Errorf("empty → allowed set, got %v", got)
+	}
+	if got := intersectRestoreComponents([]string{"home", "docker"}, allowed); !eq(got, []string{"home"}) {
+		t.Errorf("subset, got %v", got)
+	}
+	// Only-disallowed must NOT fall through to "all" (empty) — it applies nothing.
+	if got := intersectRestoreComponents([]string{"docker", "dns"}, allowed); !eq(got, []string{"__none__"}) {
+		t.Errorf("only-disallowed must map to the deny-all sentinel, got %v", got)
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1574,6 +1574,12 @@ func RegisterMeBackupRoutes(rg *gin.RouterGroup, cfg MeBackupsHandlerConfig) {
 	// dead during the restic materialize.
 	g.POST("/:id/download/prepare", h.downloadPrepare)
 	g.GET("/:id/download/prepare-status", h.downloadPrepareStatus)
+	// GH #1408: tenant self-service Restore-from-Upload (own account, untrusted
+	// tar → owned-DB/domain allowlists enforced by the agent).
+	g.POST("/restore-upload", h.restoreUploadChunk)
+	g.POST("/restore-upload/inspect", h.restoreUploadInspect)
+	g.POST("/restore-upload/apply", h.restoreUploadApply)
+	g.GET("/restore-upload/status", h.restoreUploadStatus)
 	g.DELETE("/:id", h.delete)
 	g.GET("/:id/manifest", h.manifest)
 	g.POST("/:id/restore", h.restoreSelective)

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3846,6 +3846,34 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /me/backups/restore-upload:
+    post:
+      tags: [Me]
+      summary: Upload a backup archive chunk to restore into your own account (GH #1408)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /me/backups/restore-upload/inspect:
+    post:
+      tags: [Me]
+      summary: Inspect an uploaded backup archive before restore (GH #1408)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /me/backups/restore-upload/apply:
+    post:
+      tags: [Me]
+      summary: Restore an uploaded archive into your own account (GH #1408)
+      security: [ { KratosSession: [] } ]
+      responses: { "202": { description: Accepted } }
+
+  /me/backups/restore-upload/status:
+    get:
+      tags: [Me]
+      summary: Poll a self-service restore-from-upload (GH #1408)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/backups/{id}/manifest:
     get:
       tags: [Me]

--- a/panel-api/internal/app/body_limit_exempt.go
+++ b/panel-api/internal/app/body_limit_exempt.go
@@ -30,6 +30,7 @@ var bodyLimitExemptRoutes = map[string]struct{}{
 	// The chunked backup-archive upload sends multi-MB chunks; without this the
 	// 1 MB global cap 413s every chunk before the handler's own LimitReader runs.
 	"POST /api/v1/admin/backups/restore-upload": {},
+	"POST /api/v1/me/backups/restore-upload":    {},
 	// GH #1184 admin File Manager — the SAME handlers as the tenant /files
 	// mount (which is exempt above), re-mounted under /admin/files, so they
 	// carry the same own caps and need the same exemptions (GH #1044).

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -490,6 +490,7 @@ export interface UploadedBackupInfo {
 export async function uploadBackupArchiveChunked(
   file: File,
   onProgress?: (p: RestoreUploadProgress) => void,
+  base = "/admin/backups", // GH #1408: "/me/backups" for tenant self-service restore
 ): Promise<string> {
   const chunkSize = RESTORE_CHUNK_SIZE;
   const totalChunks = Math.max(1, Math.ceil(file.size / chunkSize));
@@ -520,7 +521,7 @@ export async function uploadBackupArchiveChunked(
       ...(isLast ? { final: "1" } : {}),
     });
     await apiClient.post(
-      `/admin/backups/restore-upload?${params.toString()}`,
+      `${base}/restore-upload?${params.toString()}`,
       file.slice(start, end),
       {
         headers: { "Content-Type": "application/octet-stream" },
@@ -536,9 +537,10 @@ export async function uploadBackupArchiveChunked(
 
 export async function inspectUploadedBackup(
   uploadId: string,
+  base = "/admin/backups",
 ): Promise<UploadedBackupInfo> {
   const { data } = await apiClient.post<UploadedBackupInfo>(
-    "/admin/backups/restore-upload/inspect",
+    `${base}/restore-upload/inspect`,
     { upload_id: uploadId },
   );
   return data;
@@ -558,9 +560,10 @@ export async function applyUploadedBackupRestore(
   uploadId: string,
   targetUsername: string,
   components: string[],
+  base = "/admin/backups", // GH #1408: "/me/backups" forces target = the caller
 ): Promise<UploadedBackupRestoreResult> {
   await apiClient.post(
-    "/admin/backups/restore-upload/apply",
+    `${base}/restore-upload/apply`,
     { upload_id: uploadId, target_username: targetUsername, components },
   );
   const deadline = Date.now() + 65 * 60 * 1000; // matches the server's 60-min cap
@@ -569,7 +572,7 @@ export async function applyUploadedBackupRestore(
     let s: RestoreUploadStatus | null = null;
     try {
       const resp = await apiClient.get<RestoreUploadStatus>(
-        "/admin/backups/restore-upload/status",
+        `${base}/restore-upload/status`,
         { params: { upload_id: uploadId } },
       );
       s = resp.data;

--- a/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
@@ -37,11 +37,18 @@ const COMPONENT_LABELS: Record<string, string> = {
 interface Props {
   open: boolean;
   onClose: () => void;
+  // GH #1408: ownerMode drives the tenant self-service restore — target is the
+  // caller (no username field), the API is /me/backups, and only the audited
+  // components (files/db/mail) are offered.
+  ownerMode?: boolean;
 }
 
 type Phase = "pick" | "uploading" | "inspecting" | "ready" | "applying" | "done";
 
-export function RestoreFromUploadDrawer({ open, onClose }: Props) {
+const OWNER_COMPONENTS = ["home", "db", "mail"];
+
+export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
+  const base = ownerMode ? "/me/backups" : "/admin/backups";
   const [file, setFile] = useState<File | null>(null);
   const [phase, setPhase] = useState<Phase>("pick");
   const [pct, setPct] = useState(0);
@@ -72,14 +79,21 @@ export function RestoreFromUploadDrawer({ open, onClose }: Props) {
     setPhase("uploading");
     setPct(0);
     try {
-      const id = await uploadBackupArchiveChunked(file, (p) =>
-        setPct(Math.round(p.frac * 100)),
+      const id = await uploadBackupArchiveChunked(
+        file,
+        (p) => setPct(Math.round(p.frac * 100)),
+        base,
       );
       setUploadId(id);
       setPhase("inspecting");
-      const meta = await inspectUploadedBackup(id);
+      const meta = await inspectUploadedBackup(id, base);
       setInfo(meta);
-      setSelected(meta.components); // default: everything the archive holds
+      // Default selection = everything the archive holds, restricted to the
+      // audited-safe set in ownerMode (docker/dns aren't self-service).
+      const offered = ownerMode
+        ? meta.components.filter((c) => OWNER_COMPONENTS.includes(c))
+        : meta.components;
+      setSelected(offered);
       setTargetUser(meta.user.username); // v1: restore into the same username
       setPhase("ready");
     } catch (err) {
@@ -96,7 +110,7 @@ export function RestoreFromUploadDrawer({ open, onClose }: Props) {
     // empty "applying" state doesn't look like nothing happened (GH #1408).
     feedback.message.info("Restore started — running in the background");
     try {
-      const r = await applyUploadedBackupRestore(uploadId, targetUser, selected);
+      const r = await applyUploadedBackupRestore(uploadId, targetUser, selected, base);
       setResult(r);
       setPhase("done");
       const n = r.applied?.length ?? 0;
@@ -118,10 +132,21 @@ export function RestoreFromUploadDrawer({ open, onClose }: Props) {
     >
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-          Upload a backup archive you downloaded earlier (the per-account{" "}
-          <code>.tar</code>) and restore it into an existing user — useful for
-          disaster recovery or moving a user to a new server. Create the target
-          user first if it doesn&apos;t exist yet.
+          {ownerMode ? (
+            <>
+              Upload a backup archive you downloaded earlier (the{" "}
+              <code>.tar</code>) and restore it into <strong>your own account</strong>{" "}
+              — files, databases, and mail. Databases and mail domains you no
+              longer own are skipped; recreate a database first if you need it back.
+            </>
+          ) : (
+            <>
+              Upload a backup archive you downloaded earlier (the per-account{" "}
+              <code>.tar</code>) and restore it into an existing user — useful for
+              disaster recovery or moving a user to a new server. Create the target
+              user first if it doesn&apos;t exist yet.
+            </>
+          )}
         </Typography.Paragraph>
 
         <Alert
@@ -171,27 +196,32 @@ export function RestoreFromUploadDrawer({ open, onClose }: Props) {
               message={`Backup of ${info.user.username}`}
               description={info.user.email || undefined}
             />
-            <div>
-              <Typography.Text strong>Restore into user</Typography.Text>
-              <Input
-                value={targetUser}
-                onChange={(e) => setTargetUser(e.target.value.trim())}
-                placeholder="existing username"
-                style={{ marginTop: 4 }}
-                disabled={phase !== "ready"}
-              />
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                Must be an existing user. Restore into the same username the
-                backup came from.
-              </Typography.Text>
-            </div>
+            {!ownerMode && (
+              <div>
+                <Typography.Text strong>Restore into user</Typography.Text>
+                <Input
+                  value={targetUser}
+                  onChange={(e) => setTargetUser(e.target.value.trim())}
+                  placeholder="existing username"
+                  style={{ marginTop: 4 }}
+                  disabled={phase !== "ready"}
+                />
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Must be an existing user. Restore into the same username the
+                  backup came from.
+                </Typography.Text>
+              </div>
+            )}
             <div>
               <Typography.Text strong>Components</Typography.Text>
               <Checkbox.Group
                 value={selected}
                 onChange={(v) => setSelected(v as string[])}
                 style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 4 }}
-                options={info.components.map((c) => ({
+                options={(ownerMode
+                  ? info.components.filter((c) => OWNER_COMPONENTS.includes(c))
+                  : info.components
+                ).map((c) => ({
                   label: COMPONENT_LABELS[c] ?? c,
                   value: c,
                 }))}
@@ -219,7 +249,11 @@ export function RestoreFromUploadDrawer({ open, onClose }: Props) {
                 disabled={phase === "applying" || !targetUser || selected.length === 0}
                 onClick={apply}
               >
-                {phase === "applying" ? "Restoring…" : `Restore into ${targetUser || "user"}`}
+                {phase === "applying"
+                  ? "Restoring…"
+                  : ownerMode
+                    ? "Restore into my account"
+                    : `Restore into ${targetUser || "user"}`}
               </Button>
             )}
           </>

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -9,6 +9,7 @@ import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { shortDateTime } from "../../utils/datetime";
 import { backupTypeColor, backupTypeLabel } from "../../utils/backupType";
 import { RowActions } from "../../components/RowActions";
+import { RestoreFromUploadDrawer } from "../admin/backups/RestoreFromUploadDrawer";
 import { DeleteOutlined, DownloadOutlined, ReloadOutlined, SaveOutlined, WarningOutlined } from "@icons";
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -54,6 +55,7 @@ const statusColor = (status: string): string => {
 export const MyProfileBackupCard = () => {
   const { t } = useTranslation();
   const dl = useBackupDownloadPrepare("me"); // GH #1408: prepare-then-download
+  const [restoreUploadOpen, setRestoreUploadOpen] = useState(false); // GH #1408
   const screens = Grid.useBreakpoint();
   const [submitting, setSubmitting] = useState(false);
   const [restoreId, setRestoreId] = useState<string | null>(null);
@@ -165,6 +167,9 @@ export const MyProfileBackupCard = () => {
               options={destOptions}
             />
           )}
+          <Button onClick={() => setRestoreUploadOpen(true)}>
+            Restore from upload
+          </Button>
           <Button
             type="primary"
             loading={submitting}
@@ -318,6 +323,13 @@ export const MyProfileBackupCard = () => {
         open={restoreId !== null}
         onClose={() => setRestoreId(null)}
       />
+      {restoreUploadOpen && (
+        <RestoreFromUploadDrawer
+          ownerMode
+          open={restoreUploadOpen}
+          onClose={() => setRestoreUploadOpen(false)}
+        />
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
feat(backups): tenant self-service Restore-from-Upload (files/db/mail) (GH #1408)

A tenant can now restore their OWN account from a backup archive they upload:
Backups → Restore from upload → pick files/databases/mail → restore. The mirror
of the admin Restore-from-Upload, but the uploaded tar is UNTRUSTED (a
lower-privilege actor), so it's ownership-gated end to end.

Stage audit (why gating is needed): applyAccountRestore loads databases by the
MANIFEST's name (`mariadb <db> < …`) and imports the whole mail tree keyed by
<domain>/<local> — both global namespaces. A crafted tar could name
`otheruser_db` / `jabali_panel`, or inject into another tenant's mailbox. Docker
(global docker-apps/<slug>) and dns/metadata (rebuilds domain rows) are the same
class.

Agent (backup.restore_from_tar / applyAccountRestore): new mode="tenant" +
allowed_db_names + allowed_mail_domains. A list PRESENT (even empty) enforces;
absent = admin-unrestricted. In tenant mode a db not on the owned list is
skipped with a warning; non-owned <domain> mail subdirs are dropped from the
staging tree before import; docker/dns are cut; mode=tenant with a missing
allowlist is refused. The result echoes db_allowlist_enforced /
mail_allowlist_enforced, and backup.inspect_uploaded_tar now reports
allowlist_supported.

Panel (/me/backups/restore-upload*, owner-scoped, target = the caller): distinct
tenant staging namespace, body-limit exempt, per-tenant in-flight cap, 24h TTL,
no step-up. The apply is FAIL-CLOSED against an old agent: it checks
allowlist_supported via inspect (manifest only, no extraction) BEFORE applying,
so a pre-feature agent can never run an unrestricted restore — zero live change
if refused. It builds the caller's owned DB names (mariadb + postgres) and owned
domains as the allowlists (always non-nil on the wire), restricts components to
files/db/mail, and deliberately SKIPS the metadata-row rebuild (that path
recreates domains/db rows from the untrusted bundle = a hijack vector; the
caller's own rows already exist).

UI: the admin RestoreFromUploadDrawer gains an ownerMode (base=/me/backups, no
target-user field, files/db/mail only), surfaced on the tenant Backups card.

Cut / deferred (documented): docker + dns/metadata restore, and restore-into-a-
different-username, stay admin/CLI. New agent verb behaviour → fleet agent
redeploy on release.

Tests: agent enforcement (skip logic, mode=tenant guard, intersect fall-open,
inspect ack); panel fail-closed ack + non-nil allowlists + mode=tenant on the
wire + component fall-open guard. openapi + goldens updated.

Box drill: the db/mail SKIP runs on apply (recon returns before applyAccountRestore),
so a recon-only drill exercises only the acks/capability, not the skip. The
meaningful validation is a live apply=true on a DISPOSABLE account with an
allowlist excluding the backup's db/mail — asserting those are skipped (not
loaded), home applies, and the acks come back true. The enforcement logic is
unit-tested; recommend this apply-drill (needs the new agent on the box) before
fleet promotion.
