### PR TITLE
fix(databases): custom DB-user grants crash the Databases page (GH #1415)

### DIFF
--- a/panel-api/internal/models/database_user_grant.go
+++ b/panel-api/internal/models/database_user_grant.go
@@ -7,7 +7,10 @@ type DatabaseUserGrant struct {
 	ID             string `gorm:"type:char(26);primaryKey" json:"id"`
 	DatabaseID     string `gorm:"type:char(26);not null" json:"database_id"`
 	DatabaseUserID string `gorm:"type:char(26);not null" json:"database_user_id"`
-	GrantLevel     string `gorm:"type:enum('rw','ro');not null" json:"grant_level"`
+	// 'custom' was added by migration 000025 — keep this tag in sync with
+	// the live enum so it documents the real column (a custom privilege
+	// set that is neither exactly ALL nor SELECT stores as "custom").
+	GrantLevel     string `gorm:"type:enum('rw','ro','custom');not null" json:"grant_level"`
 	Privileges     string `gorm:"type:varchar(255);not null;default:'ALL'" json:"privileges"`
 	CreatedAt      time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt      time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`

--- a/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
+++ b/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
@@ -24,14 +24,9 @@ import { useTableURL } from "../../../hooks/useTableURL";
 import { sorterToParams } from "../../../utils/tableSorter";
 import { EngineTag } from "../../../components/EngineTag";
 import { DatabaseUserDrawer } from "./DatabaseUserDrawer";
+import { grantLabel, type Grant } from "./grantLabel";
 
-export type Grant = {
-  id: string;
-  database_id: string;
-  database_name: string;
-  grant_level: "rw" | "ro" | "custom";
-  privileges?: string;
-};
+export type { Grant };
 
 export type DatabaseUser = {
   id: string;
@@ -54,23 +49,6 @@ function placeholderForRotateBody(): string {
   let out = "";
   for (const b of bytes) out += alphabet[b % alphabet.length];
   return out;
-}
-
-function grantLabel(grant: Grant): string {
-  switch (grant.grant_level) {
-    case "rw":
-      return "Full Access";
-    case "ro":
-      return "Read only";
-    case "custom":
-      if (grant.privileges) {
-        const privs = grant.privileges.split(",").map((p) => p.trim());
-        return privs.length > 2 ? `${privs.slice(0, 2).join(", ")}…` : privs.join(", ");
-      }
-      return "Custom";
-    default:
-      return "Unknown";
-  }
 }
 
 export const DatabaseUsersList = () => {

--- a/panel-ui/src/shells/admin/database-users/grantLabel.test.ts
+++ b/panel-ui/src/shells/admin/database-users/grantLabel.test.ts
@@ -1,0 +1,55 @@
+// grantLabel.test.ts — GH #1415. The Databases page rendered one Tag per
+// grant, labelled by grantLabel(). The API serializes a grant's privileges
+// as a JSON array (Go []string), but the frontend Grant type declared it a
+// `string` and the "custom" branch called `.privileges.split(",")`. On any
+// grant saved with a custom privilege set (grant_level "custom" — e.g. a
+// tenant ticking individual permission boxes), split-on-an-array threw a
+// TypeError mid-render, which the error boundary caught as
+// "Something went wrong", taking the whole Databases page down.
+//
+// These lock the label logic against the ACTUAL wire shape (array).
+import { describe, expect, it } from "vitest";
+
+import { grantLabel, type Grant } from "./grantLabel";
+
+function grant(over: Partial<Grant>): Grant {
+  return {
+    id: "g1",
+    database_id: "d1",
+    database_name: "db1",
+    grant_level: "rw",
+    ...over,
+  };
+}
+
+describe("grantLabel", () => {
+  it("labels full access", () => {
+    expect(grantLabel(grant({ grant_level: "rw" }))).toBe("Full Access");
+  });
+
+  it("labels read only", () => {
+    expect(grantLabel(grant({ grant_level: "ro" }))).toBe("Read only");
+  });
+
+  it("renders a custom grant whose privileges arrive as an array (GH #1415)", () => {
+    // The exact shape the API sends for a custom set — an array, not a
+    // comma-joined string. Must not throw.
+    const g = grant({
+      grant_level: "custom",
+      privileges: ["SELECT", "INSERT", "UPDATE", "DELETE"],
+    });
+    expect(() => grantLabel(g)).not.toThrow();
+    expect(grantLabel(g)).toBe("SELECT, INSERT…");
+  });
+
+  it("joins a short custom set without truncation", () => {
+    expect(
+      grantLabel(grant({ grant_level: "custom", privileges: ["SELECT", "INSERT"] })),
+    ).toBe("SELECT, INSERT");
+  });
+
+  it("falls back to 'Custom' when a custom grant has no privileges", () => {
+    expect(grantLabel(grant({ grant_level: "custom", privileges: [] }))).toBe("Custom");
+    expect(grantLabel(grant({ grant_level: "custom" }))).toBe("Custom");
+  });
+});

--- a/panel-ui/src/shells/admin/database-users/grantLabel.ts
+++ b/panel-ui/src/shells/admin/database-users/grantLabel.ts
@@ -1,0 +1,35 @@
+// A single database-user grant and its human label.
+//
+// GH #1415: `privileges` is a JSON array (Go []string) on the wire. It was
+// once typed `string` here and grantLabel() called `.split(",")` on it,
+// which threw on every "custom" grant (a set that is neither exactly ALL
+// nor SELECT) and took the whole Databases page down via the error
+// boundary. Kept in its own module so the label logic stays unit-testable
+// without dragging in the AntD table.
+export type Grant = {
+  id: string;
+  database_id: string;
+  database_name: string;
+  grant_level: "rw" | "ro" | "custom";
+  privileges?: string[];
+};
+
+export function grantLabel(grant: Grant): string {
+  switch (grant.grant_level) {
+    case "rw":
+      return "Full Access";
+    case "ro":
+      return "Read only";
+    case "custom": {
+      const privs = (grant.privileges ?? [])
+        .map((p) => p.trim())
+        .filter(Boolean);
+      if (privs.length === 0) {
+        return "Custom";
+      }
+      return privs.length > 2 ? `${privs.slice(0, 2).join(", ")}…` : privs.join(", ");
+    }
+    default:
+      return "Unknown";
+  }
+}


### PR DESCRIPTION
## What

The tenant **Databases** page crashed to the "Something went wrong" error-boundary overlay after a database user was given a **custom** privilege set (GH #1415). Reload flashed the page then re-crashed, because the offending row is refetched every time.

## Root cause — a frontend/backend wire-contract mismatch

The page renders one Tag per database-user grant, labelled by `grantLabel()`. The API serializes a grant's `privileges` as a **JSON array** (Go `[]string`, across the list/add/update endpoints). The frontend `Grant` type declared `privileges` a **`string`** and the `"custom"` branch did:

```ts
const privs = grant.privileges.split(",")   // .split on an array → TypeError
```

A grant stores `grant_level = "custom"` whenever the privilege set is neither exactly `ALL` nor `SELECT` (migration `000025` widened the enum to include `custom`) — e.g. a user ticking individual permission checkboxes in **Add Access** instead of the *Full Access* / *Read only* presets. For those rows `split`-on-an-array threw mid-render → error boundary → whole page down.

Engine-agnostic: reported on PostgreSQL, but the crash is identical on MariaDB — it's purely the label code.

## Fix

- Type `privileges` as the array it actually is on the wire and build the label from the array directly (empty ⇒ `"Custom"`).
- Extracted `grantLabel` + the `Grant` type into their own module (`grantLabel.ts`) so the label logic is unit-testable without the AntD table.
- Locked it with a test that feeds the **exact array shape the API sends** — RED (`grant.privileges.split is not a function`) before, GREEN after. `tsc -b` now enforces the contract.
- Synced the stale GORM enum tag on the model (`enum('rw','ro')` → `enum('rw','ro','custom')`) with the live column.

No API or schema change.

## Not in scope (permissions ≠ the crash)

The reporter's *first* symptom was "insufficient permissions" for their migrated site. That is separate from the crash and **not** what this PR touches:
- On current `main`, `db.postgres.grant` already grants schema-level access (CREATE/USAGE on `public`, ALL on tables/sequences + default privileges — GH #1406), so re-saving the grant grants working access on an up-to-date agent.
- On PostgreSQL the **custom privilege checkboxes are inert** — per ADR-0091 the agent grants ALL regardless of which tokens are ticked. So a PG grant stored as `custom` is cosmetically misleading (the DB user actually has full access). Left as-is here; flagging for a possible follow-up.

## Non-blocking flags for follow-up (operator's call)

1. **`PATCH /database-user-grants/:id` drift**: `updateGrant` updates only the `privileges` column, never recomputes `grant_level` (a custom edit can leave a stale `rw`/`ro` level → wrong label, not a crash). Its MariaDB re-grant also sends `grant_level: req.GrantLevel`, which is empty when the request carried `privileges`. No UI caller exercises this path today. It also hand-rolls validation instead of reusing `CanonicalDBGrant`.
2. **Optional UX**: hide/disable the custom-privileges checkboxes in `AddGrantModal` when `engine === "postgres"`, since they're inert there and were the crash trigger.

## Test plan

- [x] `grantLabel.test.ts` — RED→GREEN, covers rw/ro/custom(array)/short-set/empty
- [x] `panel-ui`: `vitest` (database-users + databases suites) green, `tsc -b` clean, `eslint` clean
- [x] `panel-api`: `go build ./...`, `go vet`, grant repo + database_users tests green

Tracking against GH #1415.
