### PR TITLE
fix(mail): per-domain/per-user Sent stats miss authenticated user mail (GH #1416)

### DIFF
--- a/install/stalwart/apply-plan.json.tmpl
+++ b/install/stalwart/apply-plan.json.tmpl
@@ -159,6 +159,7 @@
         "eventsPolicy": "include",
         "events": {
           "queue.message-queued": true,
+          "queue.authenticated-message-queued": true,
           "delivery.completed": true,
           "delivery.failed": true
         }

--- a/panel-agent/internal/commands/mail_logs_query.go
+++ b/panel-agent/internal/commands/mail_logs_query.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -46,8 +47,14 @@ import (
 const (
 	mailLogPrefix         = "delivery"
 	mailLogEventQueued    = "(queue.message-queued)"
-	mailLogEventCompleted = "(delivery.completed)"
-	mailLogEventFailed    = "(delivery.failed)"
+	// mailLogEventAuthQueued is the queue event Stalwart emits for an
+	// AUTHENTICATED submission — i.e. a tenant sending mail (GH #1416).
+	// Inbound relay produces queue.message-queued; a user send produces this
+	// distinct event, so it must be treated as a queued line too or per-domain
+	// "Sent" (and the Mail > Logs outbound rows) never see a single user send.
+	mailLogEventAuthQueued = "(queue.authenticated-message-queued)"
+	mailLogEventCompleted  = "(delivery.completed)"
+	mailLogEventFailed     = "(delivery.failed)"
 	// mailLogMaxScan bounds memory: at most this many matching lines are
 	// parsed across all log files before filtering. Newest files are read
 	// first, so the cap drops only the oldest history.
@@ -109,7 +116,8 @@ type parsedMailLine struct {
 // tracer line. Returns ok=false for any non-message line (lifecycle events,
 // blank lines) so callers can skip them.
 func parseMailLogLine(line string) (parsedMailLine, bool) {
-	queued := strings.Contains(line, mailLogEventQueued)
+	queued := strings.Contains(line, mailLogEventQueued) ||
+		strings.Contains(line, mailLogEventAuthQueued)
 	if !queued &&
 		!strings.Contains(line, mailLogEventCompleted) &&
 		!strings.Contains(line, mailLogEventFailed) {
@@ -384,6 +392,26 @@ func containsDomain(addr, domain string) bool {
 // ensureDeliveryTracer creates the #jabali-delivery-log Stalwart Log tracer if
 // no tracer with prefix "delivery" exists. Mirrors install/stalwart/
 // apply-plan.json.tmpl. Idempotent + change-gated (reloads only on create).
+// deliveryTracerEvents is the include-only event set the delivery Log tracer
+// must carry. queue.message-queued is inbound relay + local delivery;
+// queue.authenticated-message-queued (GH #1416) is a tenant sending mail — a
+// distinct Stalwart event, so without it per-domain "Sent" and the Mail > Logs
+// outbound rows never see a single user send.
+func deliveryTracerEvents() map[string]any {
+	return map[string]any{
+		"queue.message-queued":               true,
+		"queue.authenticated-message-queued": true,
+		"delivery.completed":                 true,
+		"delivery.failed":                    true,
+	}
+}
+
+// deliveryTracerBackfillOnce bounds the GH #1416 event back-fill — which ends
+// in a settings reload — to a single attempt per agent process. Belt against a
+// tracer whose `events` can't be read back in the shape we expect: without it,
+// a false "missing the event" read would reload on EVERY mail.logs_query.
+var deliveryTracerBackfillOnce sync.Once
+
 func ensureDeliveryTracer(ctx context.Context) error {
 	var qr jmapQueryResult
 	if err := jmapCall(ctx, "x:Tracer/query", map[string]any{}, &qr); err != nil {
@@ -394,13 +422,31 @@ func ensureDeliveryTracer(ctx context.Context) error {
 		if err := jmapCall(ctx, "x:Tracer/get", map[string]any{"ids": qr.IDs}, &gr); err != nil {
 			return fmt.Errorf("tracer get: %w", err)
 		}
-		for _, raw := range gr.List {
+		for i, raw := range gr.List {
 			var t struct {
-				Prefix string `json:"prefix"`
+				ID     string          `json:"id"`
+				Prefix string          `json:"prefix"`
+				Events map[string]bool `json:"events"`
 			}
-			if json.Unmarshal(raw, &t) == nil && t.Prefix == "delivery" {
-				return nil // already provisioned
+			if json.Unmarshal(raw, &t) != nil || t.Prefix != "delivery" {
+				continue
 			}
+			// Already carries the authenticated-send event — nothing to do.
+			if t.Events["queue.authenticated-message-queued"] {
+				return nil
+			}
+			// GH #1416: a tracer provisioned before authenticated sends were
+			// tracked is stranded by the old "already provisioned → return" path.
+			// Patch the event set in place (once per process — see the Once).
+			id := t.ID
+			if id == "" && i < len(qr.IDs) {
+				id = qr.IDs[i]
+			}
+			var patchErr error
+			deliveryTracerBackfillOnce.Do(func() {
+				patchErr = patchDeliveryTracerEvents(ctx, id)
+			})
+			return patchErr
 		}
 	}
 	args := map[string]any{"create": map[string]any{"jabali-delivery-log": map[string]any{
@@ -408,11 +454,7 @@ func ensureDeliveryTracer(ctx context.Context) error {
 		"path": mailLogDir, "prefix": mailLogPrefix, "rotate": "daily",
 		"ansi": false, "multiline": false, "lossy": false,
 		"eventsPolicy": "include",
-		"events": map[string]any{
-			"queue.message-queued": true,
-			"delivery.completed":   true,
-			"delivery.failed":      true,
-		},
+		"events":       deliveryTracerEvents(),
 	}}}
 	var res jmapSetResult
 	if err := jmapCall(ctx, "x:Tracer/set", args, &res); err != nil {
@@ -420,6 +462,26 @@ func ensureDeliveryTracer(ctx context.Context) error {
 	}
 	if reason, bad := res.NotCreated["jabali-delivery-log"]; bad {
 		return fmt.Errorf("tracer create refused: %s", string(reason))
+	}
+	return reloadStalwartSettings(ctx)
+}
+
+// patchDeliveryTracerEvents rewrites an existing delivery tracer's include-only
+// event set to the current desired set (GH #1416 back-fill) and reloads.
+func patchDeliveryTracerEvents(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("delivery tracer missing id, cannot patch events")
+	}
+	upd := map[string]any{"update": map[string]any{id: map[string]any{
+		"eventsPolicy": "include",
+		"events":       deliveryTracerEvents(),
+	}}}
+	var res jmapSetResult
+	if err := jmapCall(ctx, "x:Tracer/set", upd, &res); err != nil {
+		return fmt.Errorf("tracer update events: %w", err)
+	}
+	if reason, bad := res.NotUpdated[id]; bad {
+		return fmt.Errorf("tracer update refused: %s", string(reason))
 	}
 	return reloadStalwartSettings(ctx)
 }

--- a/panel-agent/internal/commands/mail_logs_query_test.go
+++ b/panel-agent/internal/commands/mail_logs_query_test.go
@@ -15,6 +15,11 @@ const sampleMultiRcpt = `2026-06-19T23:00:00Z INFO Queued message for delivery (
 
 const sampleCompleted = `2026-06-19T22:11:43Z INFO Delivery completed (delivery.completed) queueId = 313790779361329152, queueName = "local", from = "probe7@jabali.site", to = ["shuki@jabali.site"], size = 1662, total = 1, elapsed = 0ms`
 
+// sampleAuthQueued is a tenant SEND — an authenticated submission, which fires
+// queue.authenticated-message-queued (verified against Stalwart 0.16.15), not
+// the plain queue.message-queued an inbound relay produces (GH #1416).
+const sampleAuthQueued = `2026-09-04T01:12:00Z INFO Queued message for delivery (queue.authenticated-message-queued) listenerId = "smtp", localPort = 587, remoteIp = 127.0.0.1, queueId = 327583827553682432, from = "u@jabali.site", to = ["ext@remote.example"], size = 900`
+
 func TestParseMailLogLine_Queued(t *testing.T) {
 	pl, ok := parseMailLogLine(sampleQueued)
 	if !ok {
@@ -34,6 +39,30 @@ func TestParseMailLogLine_Queued(t *testing.T) {
 	}
 	if len(pl.recipients) != 1 || pl.recipients[0] != "shuki@jabali.site" {
 		t.Errorf("recipients = %v", pl.recipients)
+	}
+}
+
+func TestParseMailLogLine_AuthenticatedQueued(t *testing.T) {
+	// GH #1416: the authenticated-submission event must parse as a queued line
+	// so a tenant's outbound shows in Mail > Logs and feeds per-domain "Sent".
+	pl, ok := parseMailLogLine(sampleAuthQueued)
+	if !ok {
+		t.Fatal("expected queue.authenticated-message-queued line to parse")
+	}
+	if !pl.queued {
+		t.Error("authenticated queued line must report queued=true")
+	}
+	if pl.rank != 0 {
+		t.Errorf("rank = %d, want 0 (queued)", pl.rank)
+	}
+	if pl.entry.From != "u@jabali.site" {
+		t.Errorf("from = %q", pl.entry.From)
+	}
+	if len(pl.recipients) != 1 || pl.recipients[0] != "ext@remote.example" {
+		t.Errorf("recipients = %v", pl.recipients)
+	}
+	if pl.queueID != "327583827553682432" {
+		t.Errorf("queueID = %q", pl.queueID)
 	}
 }
 

--- a/panel-agent/internal/commands/mail_stats_domain_test.go
+++ b/panel-agent/internal/commands/mail_stats_domain_test.go
@@ -67,6 +67,38 @@ func TestMailStatsDomain_AttributesSentReceivedDeliveredFailed(t *testing.T) {
 	}
 }
 
+func TestMailStatsDomain_CountsAuthenticatedSubmissionAsSent(t *testing.T) {
+	// GH #1416: a tenant sending mail authenticates, so Stalwart emits
+	// queue.authenticated-message-queued — a DIFFERENT event from the plain
+	// queue.message-queued that inbound relay produces. The delivery tracer +
+	// parser only knew the plain event, so per-domain/per-user "Sent" never
+	// counted a single real user send (while the global prometheus "Sent" card
+	// did). These authenticated lines must be attributed exactly like a queued
+	// line: sent for a local From domain, received for a local recipient.
+	now := time.Now().UTC()
+	ts := now.Add(-1 * time.Hour)
+	lines := strings.Join([]string{
+		// authenticated outbound to remote: sent for a.test only.
+		dline(ts, "queue.authenticated-message-queued", "u@a.test", []string{"x@remote.example"}, "20"),
+		// authenticated local -> local: sent for a.test + received for b.test.
+		dline(ts, "queue.authenticated-message-queued", "u@a.test", []string{"v@b.test"}, "21"),
+	}, "\n") + "\n"
+	withMailLogDir(t, "delivery.now", lines)
+
+	got := runDomainSample(t, now.Add(-2*time.Hour), []string{"a.test", "b.test"})
+	if got["sent|a.test"] != 2 {
+		t.Errorf("sent|a.test = %d, want 2 (both authenticated submissions); all: %v", got["sent|a.test"], got)
+	}
+	if got["received|b.test"] != 1 {
+		t.Errorf("received|b.test = %d, want 1 (qid 21 local recipient); all: %v", got["received|b.test"], got)
+	}
+	for k := range got {
+		if strings.Contains(k, "remote.example") {
+			t.Errorf("remote domain leaked into counts: %s", k)
+		}
+	}
+}
+
 func TestMailStatsDomain_DedupesMultiRecipientSameDomain(t *testing.T) {
 	now := time.Now().UTC()
 	ts := now.Add(-30 * time.Minute)


### PR DESCRIPTION
## What

Per-domain and per-user **Sent** mail stats stayed at 0 while the global (admin) **Sent** card kept incrementing (GH #1416, reporter johnnyq). "Possibly Fail too" — see scope-out below.

## Root cause — a Stalwart event the pipeline never knew about

The two "Sent" numbers come from **different sources**:

- Global **Sent** card → prometheus counter `queue_authenticated_message_queued`.
- Per-domain **Sent** → derived from the delivery-log tracer, whose include-filter (and the agent parser + sampler) only knew `queue.message-queued`.

A tenant sending mail **authenticates**, so Stalwart emits a *distinct* event — **`queue.authenticated-message-queued`** — which the delivery tracer never captured. Inbound relay (plain `queue.message-queued`) kept feeding Received/Delivered, so only Sent looked broken. The same gap hid tenants' outbound from **Mail → Logs**.

Confirmed against Stalwart 0.16.15: `Message::queued_event()` (crates/smtp/src/queue/mod.rs) selects the event *type* by flags (`FROM_AUTHENTICATED → AuthenticatedMessageQueued … else MessageQueued`); the single emission (queue/spool.rs) logs identical `QueueId` / `From` (= return-path) / `To` / `Size` fields for every variant — so the authenticated line is byte-compatible with the parser's existing regexes.

## Fix (agent-side only — panel aggregation + UI were already correct)

- `parseMailLogLine` treats `queue.authenticated-message-queued` as a queued line → the sampler attributes it to the local **From** domain as "sent", and Mail → Logs shows outbound.
- The delivery tracer's include-filter gains the event in two places:
  - the install apply-plan (fresh boxes), and
  - **`ensureDeliveryTracer`**, which now *patches an existing tracer in place* instead of early-returning "already provisioned". Without this self-heal every existing box stays blind forever (the install-gate scar class). The back-fill (which ends in a settings reload) is bounded to once per agent process.

No API/schema/UI/openapi change.

## Box-drilled on the test server (Stalwart 0.16.15)

- Live delivery tracer **before**: `{queue.message-queued, delivery.completed, delivery.failed}` — reproduces the bug on a real box.
- One `mail.logs_query` (new agent) → tracer **after**: additionally carries `queue.authenticated-message-queued`. Second call idempotent (events read-back detects it; no re-patch).
- A real authenticated-send line injected into the delivery log scored **sent=1** for its local From domain through the deployed agent binary.
- Old agent binary restored afterward.

## Not in scope (deliberate; flagged, not silent)

- **Outbound bounces**: a `delivery.failed` to a *remote* recipient still attributes to the external domain, so a sender's per-domain **Failed** excludes their own bounces. Making "Failed" sender-centric changes what the column means (Delivered/Failed are currently recipient-centric) — worth a follow-up, not folded in here. This is the "possibly Fail too" the reporter saw.
- **Auto-generated mail** (`queue.autogenerated-queued`: forwards, vacation replies) is not counted as a user "Sent".

## Rollout note

Counts accrue **going forward** only — the delivery log never held past sends, so there is no historical backfill. Needs the agent update on each server (same fleet-redeploy standing item as #1408; one deploy covers both).

## Test plan

- [x] `panel-agent`: `go build ./...`, `go vet ./...`, full `internal/commands` suite green
- [x] New tests: `TestMailStatsDomain_CountsAuthenticatedSubmissionAsSent`, `TestParseMailLogLine_AuthenticatedQueued` (RED→GREEN)
- [x] apply-plan template renders to valid JSON with the new event
- [x] Box drill on the test server (tracer self-heal + sampler on the deployed binary)

Tracking against GH #1416.
