### PR TITLE
perf(mail): server-paginate the admin mailbox Directory (JAB-370)

### DIFF
--- a/panel-api/cmd/server/mailbox_cmd_test.go
+++ b/panel-api/cmd/server/mailbox_cmd_test.go
@@ -156,6 +156,9 @@ func (f *fakeMailboxRepo) ListAllWithDomain(_ context.Context) ([]repository.Mai
 func (f *fakeMailboxRepo) ListByOwnerWithDomain(_ context.Context, _ string) ([]repository.MailboxWithDomain, error) {
 	return nil, nil
 }
+func (f *fakeMailboxRepo) ListDirectoryPage(_ context.Context, _ repository.ListOptions, _ string) ([]repository.MailboxWithDomain, int64, error) {
+	return nil, 0, nil
+}
 
 func (f *fakeMailboxRepo) UpdateUsage(_ context.Context, _ string, _ uint64, _ time.Time) error {
 	return nil

--- a/panel-api/internal/api/mailboxes.go
+++ b/panel-api/internal/api/mailboxes.go
@@ -601,30 +601,48 @@ type adminMailboxResponse struct {
 	UserUsername string `json:"user_username"`
 }
 
-// listAllAdmin returns every mailbox on the server (admin-only) for the
+// listAllAdmin returns the server-wide mailbox directory (admin-only) for the
 // server-wide Mail tab. GET /api/v1/admin/mailboxes.
+//
+// The directory is server-paginated (JAB-370): at thousands of mailboxes the
+// old unbounded read + client-side paging pulled every row (and, before
+// #1301, every password hash) into the browser. It paginates only when the
+// client sends ?page / ?page_size, so the owner-scoped admin user-overview
+// read — which sends neither and consumes the whole array — keeps its
+// historical unbounded behaviour. System principals are excluded in SQL, so
+// the total and the page never disagree (GH #1056).
 func (h *mailboxHandler) listAllAdmin(c *gin.Context) {
 	ctx := c.Request.Context()
-	var rows []repository.MailboxWithDomain
-	var err error
+
 	// Admin owner-scope via ?user_id (#483).
+	var ownerUserID string
 	if uid := c.Query("user_id"); uid != "" {
 		if !ids.IsValidULID(uid) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user_id"})
 			return
 		}
-		rows, err = h.cfg.Mailboxes.ListByOwnerWithDomain(ctx, uid)
-	} else {
-		rows, err = h.cfg.Mailboxes.ListAllWithDomain(ctx)
+		ownerUserID = uid
 	}
+
+	// Paginate only when the client asks; otherwise Limit=0 → unbounded, the
+	// behaviour non-paginating callers (the admin user-overview) depend on.
+	paginated := c.Query("page") != "" || c.Query("page_size") != ""
+	page, pageSize, opts := parseListOptions(c, defaultMailboxesPageSize, maxMailboxesPageSize)
+	if !paginated {
+		opts.Offset, opts.Limit = 0, 0
+	}
+
+	rows, total, err := h.cfg.Mailboxes.ListDirectoryPage(ctx, opts, ownerUserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
 	out := make([]adminMailboxResponse, 0, len(rows))
 	for _, r := range rows {
+		// System rows are already excluded in SQL; the guard stays as a
+		// defence-in-depth belt in case the projection ever changes.
 		if r.Mailbox.System {
-			continue // GH #1056: the JAB-230 relay is infra, not a listed mailbox
+			continue
 		}
 		out = append(out, adminMailboxResponse{
 			mailboxResponse: toMailboxResponse(r.Mailbox),
@@ -633,7 +651,12 @@ func (h *mailboxHandler) listAllAdmin(c *gin.Context) {
 			UserUsername:    r.UserUsername,
 		})
 	}
-	c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
+	resp := gin.H{"data": out, "total": total}
+	if paginated {
+		resp["page"] = page
+		resp["page_size"] = pageSize
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 func toMailboxResponse(mb models.Mailbox) mailboxResponse {

--- a/panel-api/internal/api/mailboxes_directory_admin_test.go
+++ b/panel-api/internal/api/mailboxes_directory_admin_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// dirCaptureMbxRepo records what listAllAdmin forwards to ListDirectoryPage so
+// the handler tests can assert the paginate-only-when-asked contract and the
+// #483 owner scope without a real DB. Embeds the interface — only
+// ListDirectoryPage is exercised.
+type dirCaptureMbxRepo struct {
+	repository.MailboxRepository
+	gotOpts  repository.ListOptions
+	gotOwner string
+	rows     []repository.MailboxWithDomain
+	total    int64
+}
+
+func (r *dirCaptureMbxRepo) ListDirectoryPage(_ context.Context, opts repository.ListOptions, owner string) ([]repository.MailboxWithDomain, int64, error) {
+	r.gotOpts = opts
+	r.gotOwner = owner
+	return r.rows, r.total, nil
+}
+
+func newAdminMailboxTestCtx(target string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	return c, w
+}
+
+// TestListAllAdmin_Paginated: a request with ?page/?page_size forwards a bounded
+// ListOptions and echoes page/page_size in the envelope alongside the
+// authoritative server-side total.
+func TestListAllAdmin_Paginated(t *testing.T) {
+	fake := &dirCaptureMbxRepo{
+		rows: []repository.MailboxWithDomain{{
+			Mailbox:    models.Mailbox{ID: "mb1", EmailCached: "a@example.com"},
+			DomainName: "example.com", OwnerUserID: "u1", UserUsername: "bob",
+		}},
+		total: 137,
+	}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/admin/mailboxes?page=3&page_size=10&q=ali&sort=domain&order=desc")
+
+	h.listAllAdmin(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 10, fake.gotOpts.Limit)
+	require.Equal(t, 20, fake.gotOpts.Offset) // (3-1)*10
+	require.Equal(t, "ali", fake.gotOpts.Search)
+	require.Equal(t, "domain", fake.gotOpts.Sort)
+	require.Equal(t, "desc", fake.gotOpts.Order)
+	require.Empty(t, fake.gotOwner)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.EqualValues(t, 137, body["total"])
+	require.EqualValues(t, 3, body["page"])
+	require.EqualValues(t, 10, body["page_size"])
+	require.Len(t, body["data"], 1)
+}
+
+// TestListAllAdmin_UnboundedWhenNoPageParams: with neither page nor page_size,
+// the handler asks for an unbounded read (Limit 0) and omits page/page_size —
+// the historical shape the admin user-overview consumes.
+func TestListAllAdmin_UnboundedWhenNoPageParams(t *testing.T) {
+	fake := &dirCaptureMbxRepo{total: 0}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/admin/mailboxes")
+
+	h.listAllAdmin(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Zero(t, fake.gotOpts.Limit)
+	require.Zero(t, fake.gotOpts.Offset)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	_, hasPage := body["page"]
+	_, hasSize := body["page_size"]
+	require.False(t, hasPage, "unbounded response must not carry page")
+	require.False(t, hasSize, "unbounded response must not carry page_size")
+	require.Contains(t, body, "total")
+}
+
+// TestListAllAdmin_OwnerScope: a valid ?user_id is forwarded as the owner scope
+// (#483); the read stays unbounded because no page params are present.
+func TestListAllAdmin_OwnerScope(t *testing.T) {
+	const ulid = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+	fake := &dirCaptureMbxRepo{}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/admin/mailboxes?user_id=" + ulid)
+
+	h.listAllAdmin(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, ulid, fake.gotOwner)
+	require.Zero(t, fake.gotOpts.Limit)
+}
+
+// TestListAllAdmin_InvalidOwner: a malformed ?user_id is rejected 400 before any
+// repo call.
+func TestListAllAdmin_InvalidOwner(t *testing.T) {
+	fake := &dirCaptureMbxRepo{}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/admin/mailboxes?user_id=not-a-ulid")
+
+	h.listAllAdmin(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Empty(t, fake.gotOwner)
+	require.Zero(t, fake.gotOpts.Limit)
+}

--- a/panel-api/internal/api/webmail_sso_test.go
+++ b/panel-api/internal/api/webmail_sso_test.go
@@ -131,6 +131,9 @@ func (r *ssoFakeMailboxRepo) ListAllWithDomain(_ context.Context) ([]repository.
 func (r *ssoFakeMailboxRepo) ListByOwnerWithDomain(_ context.Context, _ string) ([]repository.MailboxWithDomain, error) {
 	return nil, nil
 }
+func (r *ssoFakeMailboxRepo) ListDirectoryPage(_ context.Context, _ repository.ListOptions, _ string) ([]repository.MailboxWithDomain, int64, error) {
+	return nil, 0, nil
+}
 func (r *ssoFakeMailboxRepo) UpdateDisabled(ctx context.Context, id string, disabled bool) error {
 	return nil
 }

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -31,6 +32,11 @@ type MailboxRepository interface {
 	// CountAll counts mailboxes without loading rows (see implementation).
 	CountAll(ctx context.Context) (int64, error)
 	ListByOwnerWithDomain(ctx context.Context, userID string) ([]MailboxWithDomain, error)
+	// ListDirectoryPage is the server-paginated, searchable, sortable admin
+	// mailbox directory read (JAB-370) behind GET /admin/mailboxes. See the
+	// implementation for the ownerUserID scope and the unbounded (Limit==0)
+	// backward-compatible mode.
+	ListDirectoryPage(ctx context.Context, opts ListOptions, ownerUserID string) ([]MailboxWithDomain, int64, error)
 	CountByDomainID(ctx context.Context, domainID string) (int64, error)
 	Create(ctx context.Context, mb *models.Mailbox) error
 	Delete(ctx context.Context, id string) error
@@ -198,6 +204,87 @@ func (r *mailboxRepo) ListByOwnerWithDomain(ctx context.Context, userID string) 
 		Order("m.email_cached ASC").
 		Scan(&rows).Error
 	return rows, err
+}
+
+// mailboxDirectorySortKeys maps the clean API sort keys the admin directory
+// accepts (?sort=email|name|domain|owner|usage|status|created_at) to the
+// table-qualified column the JOIN'd query orders by. mailboxes, domains and
+// users all carry created_at, so a bare `ORDER BY created_at` is MariaDB 1052
+// "ambiguous" — every entry must be qualified. An unknown key maps to "" so
+// the query falls back to its default order; the caller's raw string is never
+// interpolated into SQL (the qualified value is re-validated by the allowlist).
+var mailboxDirectorySortKeys = map[string]string{
+	"email":      "m.email_cached",
+	"name":       "m.display_name",
+	"domain":     "d.name",
+	"owner":      "u.username",
+	"usage":      "m.last_usage_bytes",
+	"status":     "m.is_disabled",
+	"created_at": "m.created_at",
+}
+
+// mailboxDirectoryCols is the search/sort allowlist applyListOptions enforces
+// for the admin directory. Search spans the cached address, display name,
+// domain name and owner username — the same four fields the old client-side
+// filter matched (the "email / name / domain / owner" search box). u.username
+// is on the LEFT JOIN, so its LIKE is NULL→false for owner-less rows, which is
+// the correct "no match" in the OR chain. Sort accepts only the qualified
+// columns mailboxDirectorySortKeys can produce. DefaultSort reproduces the
+// historical email-ascending order.
+var mailboxDirectoryCols = ListCols{
+	Search:      []string{"m.email_cached", "m.display_name", "d.name", "u.username"},
+	Sort:        []string{"m.email_cached", "m.display_name", "d.name", "u.username", "m.last_usage_bytes", "m.is_disabled", "m.created_at"},
+	DefaultSort: "m.email_cached",
+}
+
+// ListDirectoryPage returns one server-paginated, searchable, sortable page of
+// the admin mailbox directory joined with domain + owner (JAB-370). It replaces
+// the unbounded ListAllWithDomain read behind GET /admin/mailboxes so the page
+// never materialises every mailbox on the server.
+//
+//   - System principals (the JAB-230 relay) are excluded in SQL, so the COUNT
+//     total and the page rows agree — the old handler dropped them post-query
+//     in Go, which would leave a server page one row short (GH #1056).
+//   - ownerUserID, when non-empty, scopes the read to one owner (the admin
+//     owner-scoped view, #483).
+//   - opts.Limit == 0 (no page/page_size on the request) returns every matching
+//     row unbounded — the historical behaviour the admin user-overview read
+//     still relies on; only a client that asks for a page gets one.
+//   - Sort is translated from the caller's clean key to a qualified column and
+//     whitelist-validated; an unknown key falls back to email ASC.
+//
+// The projection is mailboxInventorySelect — no password_hash / password_enc.
+func (r *mailboxRepo) ListDirectoryPage(ctx context.Context, opts ListOptions, ownerUserID string) ([]MailboxWithDomain, int64, error) {
+	base := r.db.WithContext(ctx).
+		Table("mailboxes m").
+		Joins("JOIN domains d ON d.id = m.domain_id").
+		Joins("LEFT JOIN users u ON u.id = d.user_id").
+		Where("m.system = 0") // GH #1056: the JAB-230 relay is infra, never a listed mailbox
+	if ownerUserID != "" {
+		base = base.Where("d.user_id = ?", ownerUserID) // #483 owner scope
+	}
+
+	var total int64
+	countQ := applyListOptions(base.Session(&gorm.Session{}), ListOptions{Search: opts.Search}, mailboxDirectoryCols)
+	if err := countQ.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Translate the clean API sort key to a qualified column; default the
+	// direction to ASC (email A→Z) when the caller specified neither, matching
+	// the pre-pagination ListAllWithDomain order (mirrors ListByDomainID's
+	// desc-default trick above).
+	opts.Sort = mailboxDirectorySortKeys[strings.ToLower(strings.TrimSpace(opts.Sort))]
+	if opts.Sort == "" && opts.Order == "" {
+		opts.Order = "asc"
+	}
+
+	var rows []MailboxWithDomain
+	q := applyListOptions(base.Session(&gorm.Session{}), opts, mailboxDirectoryCols).Select(mailboxInventorySelect)
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+	return rows, total, nil
 }
 
 func (r *mailboxRepo) CountByDomainID(ctx context.Context, domainID string) (int64, error) {

--- a/panel-api/internal/repository/mailbox_repository_test.go
+++ b/panel-api/internal/repository/mailbox_repository_test.go
@@ -213,6 +213,132 @@ func TestMailboxRepository_ListByDomainID_ExcludeSystem(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// directoryCols is the column set ListDirectoryPage's projection scans into
+// (mailboxInventorySelect + the three joined aliases). Deliberately WITHOUT
+// password_hash / password_enc — the projection must never select them.
+var directoryCols = []string{
+	"id", "domain_id", "local_part", "email_cached", "display_name",
+	"quota_bytes", "is_disabled", "send_only", "system",
+	"last_usage_bytes", "last_usage_at", "created_at", "updated_at",
+	"domain_name", "owner_user_id", "user_username",
+}
+
+// TestMailboxRepository_ListDirectoryPage_Paginated is the JAB-370 happy path:
+// a bounded page carries the system=0 predicate in BOTH count and select (so
+// the total and the page agree), orders by the qualified email column ASC by
+// default, and applies LIMIT/OFFSET. The projection is the inventory allowlist
+// (mailbox_inventory_internal_test guards it against secret columns).
+func TestMailboxRepository_ListDirectoryPage_Paginated(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewMailboxRepository(db)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT count.* FROM .*mailboxes.*JOIN domains d.*LEFT JOIN users u.*WHERE m\\.system = 0").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(42))
+	// Qualified projection, qualified default ORDER BY, and LIMIT — a bare
+	// `ORDER BY created_at` would be MariaDB 1052 (three joined tables carry it).
+	mock.ExpectQuery("SELECT m\\.id, m\\.domain_id.*d\\.name AS domain_name.*FROM .*mailboxes.*WHERE m\\.system = 0.*ORDER BY m\\.email_cached ASC.*LIMIT").
+		WillReturnRows(sqlmock.NewRows(directoryCols).AddRow(
+			"mb1", "dom1", "alice", "alice@example.com", "Alice",
+			uint64(1<<30), false, false, false,
+			uint64(0), nil, now, now,
+			"example.com", "usr1", "bob",
+		))
+
+	rows, total, err := repo.ListDirectoryPage(context.Background(), ListOptions{Offset: 20, Limit: 20}, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(42), total)
+	require.Len(t, rows, 1)
+	require.Equal(t, "alice@example.com", rows[0].EmailCached)
+	require.Equal(t, "example.com", rows[0].DomainName)
+	require.Equal(t, "bob", rows[0].UserUsername)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestMailboxRepository_ListDirectoryPage_SearchAndOwner verifies the search
+// LIKE-ESCAPE chain (so "50%" isn't a wildcard) and the #483 owner scope both
+// reach the SQL, in both the count and the page query.
+func TestMailboxRepository_ListDirectoryPage_SearchAndOwner(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewMailboxRepository(db)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT count.* FROM .*mailboxes.*WHERE m\\.system = 0 AND d\\.user_id = \\? AND .*m\\.email_cached LIKE \\? ESCAPE.*u\\.username LIKE \\? ESCAPE.*").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery("SELECT m\\.id.*FROM .*mailboxes.*WHERE m\\.system = 0 AND d\\.user_id = \\? AND .*LIKE \\? ESCAPE.*ORDER BY.*LIMIT").
+		WillReturnRows(sqlmock.NewRows(directoryCols).AddRow(
+			"mb1", "dom1", "alice", "alice@example.com", "Alice",
+			uint64(1<<30), false, false, false,
+			uint64(0), nil, now, now,
+			"example.com", "usr1", "bob",
+		))
+
+	rows, total, err := repo.ListDirectoryPage(context.Background(), ListOptions{Limit: 20, Search: "alice"}, "usr1")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestMailboxRepository_ListDirectoryPage_BadSortFallsBack proves a hostile
+// ?sort= value is never interpolated: it is not in mailboxDirectorySortKeys,
+// so the order falls back to the qualified email column. The mock only matches
+// if the ORDER BY is exactly `m.email_cached` — an interpolated injection would
+// fail the expectation.
+func TestMailboxRepository_ListDirectoryPage_BadSortFallsBack(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewMailboxRepository(db)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT count.* FROM .*mailboxes.*WHERE m\\.system = 0").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery("SELECT m\\.id.*WHERE m\\.system = 0.*ORDER BY m\\.email_cached (?:ASC|DESC).*LIMIT").
+		WillReturnRows(sqlmock.NewRows(directoryCols).AddRow(
+			"mb1", "dom1", "alice", "alice@example.com", "Alice",
+			uint64(1<<30), false, false, false,
+			uint64(0), nil, now, now,
+			"example.com", "usr1", "bob",
+		))
+
+	rows, _, err := repo.ListDirectoryPage(context.Background(),
+		ListOptions{Limit: 20, Sort: "email_cached); DROP TABLE mailboxes;--", Order: "asc"}, "")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestMailboxRepository_ListDirectoryPage_Unbounded confirms Limit==0 (no
+// page/page_size on the request) emits no LIMIT — the historical unbounded
+// read the admin user-overview still depends on.
+func TestMailboxRepository_ListDirectoryPage_Unbounded(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewMailboxRepository(db)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT count.* FROM .*mailboxes.*WHERE m\\.system = 0").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(2))
+	// No LIMIT clause: sqlmock matches on a prefix, so we assert the ORDER BY
+	// is the final clause by anchoring the pattern to the end with `$`.
+	mock.ExpectQuery("ORDER BY m\\.email_cached ASC$").
+		WillReturnRows(sqlmock.NewRows(directoryCols).
+			AddRow("mb1", "dom1", "a", "a@example.com", "A", uint64(0), false, false, false, uint64(0), nil, now, now, "example.com", "u1", "x").
+			AddRow("mb2", "dom1", "b", "b@example.com", "B", uint64(0), false, false, false, uint64(0), nil, now, now, "example.com", "u1", "x"))
+
+	rows, total, err := repo.ListDirectoryPage(context.Background(), ListOptions{}, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+	require.Len(t, rows, 2)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestMailboxRepository_ExistsByDomainAndLocalPart(t *testing.T) {
 	db, mock, raw := newMockDB(t)
 	defer raw.Close()

--- a/panel-ui/src/hooks/useMailboxes.test.tsx
+++ b/panel-ui/src/hooks/useMailboxes.test.tsx
@@ -211,7 +211,9 @@ describe("useDeleteMailbox", () => {
     expect(mocked.delete).toHaveBeenCalledWith("/mailboxes/mb1");
     const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidatedKeys).toContainEqual(["list", "mailboxes", "dom1"]);
-    expect(invalidatedKeys).toContainEqual(["admin", "mailboxes"]);
+    // JAB-370: admin Mail tab is server-paginated (useTableURL); its key is
+    // ["list","admin/mailboxes",…] — prefix-invalidated on delete.
+    expect(invalidatedKeys).toContainEqual(["list", "admin/mailboxes"]);
     // JAB-333: a deleted mailbox also leaves the tenant screen's group-membership
     // and autoresponder panels — those shared keys must be invalidated too, or
     // they render a ghost row for the deleted mailbox until the next refetch.

--- a/panel-ui/src/hooks/useMailboxes.ts
+++ b/panel-ui/src/hooks/useMailboxes.ts
@@ -230,7 +230,11 @@ export function useCreateMailbox(): UseMutationResult<
     },
     onSuccess: (_data, { domainId }) => {
       qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
-      qc.invalidateQueries({ queryKey: ["admin", "mailboxes"] });
+      // JAB-370: the admin Mail tab is now server-paginated via
+      // useTableURL({ resource: "admin/mailboxes" }), keyed ["list",
+      // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
+      // delete / create refreshes the visible page.
+      qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
     },
   });
 }
@@ -247,7 +251,11 @@ export function useDeleteMailbox(): UseMutationResult<
     },
     onSuccess: (_data, { domainId }) => {
       qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
-      qc.invalidateQueries({ queryKey: ["admin", "mailboxes"] });
+      // JAB-370: the admin Mail tab is now server-paginated via
+      // useTableURL({ resource: "admin/mailboxes" }), keyed ["list",
+      // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
+      // delete / create refreshes the visible page.
+      qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
       // JAB-333: a deleted mailbox also disappears from the tenant screen's
       // group-membership and autoresponder panels — invalidate those shared
       // keys so they don't render a ghost row until the next refetch.
@@ -279,19 +287,11 @@ export interface AdminMailbox extends Mailbox {
   user_username: string;
 }
 
-// useAdminMailboxes lists every mailbox on the server (admin-only) for the
-// server-wide Mail tab.
-export function useAdminMailboxes(): UseQueryResult<AdminMailbox[]> {
-  return useQuery({
-    queryKey: ["admin", "mailboxes"],
-    queryFn: async () => {
-      const { data } = await apiClient.get<{ data?: AdminMailbox[] }>(
-        "/admin/mailboxes",
-      );
-      return data.data ?? [];
-    },
-  });
-}
+// The server-wide admin Mail tab lists mailboxes via useTableURL
+// ({ resource: "admin/mailboxes" }) so the directory is server-paginated
+// (JAB-370) — there is no bulk useAdminMailboxes hook. The AdminMailbox row
+// type below is still the shared shape for that page and the owner-scoped
+// AdminUserOverview read.
 
 // useUpdateMailbox is the general partial-update PATCH (GH #197 + admin
 // Mail tab): any provided field (display_name / quota_bytes / is_disabled)
@@ -324,7 +324,11 @@ export function useUpdateMailbox(): UseMutationResult<
         qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
       }
       qc.invalidateQueries({ queryKey: ["list", "mailboxes"] });
-      qc.invalidateQueries({ queryKey: ["admin", "mailboxes"] });
+      // JAB-370: the admin Mail tab is now server-paginated via
+      // useTableURL({ resource: "admin/mailboxes" }), keyed ["list",
+      // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
+      // delete / create refreshes the visible page.
+      qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
     },
   });
 }

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -1,6 +1,12 @@
 // AdminMailPage — server-wide mailbox management (admin). Lists every mailbox
 // across all domains with add / edit / reset-password / delete. Reuses the
 // per-domain create wizard + the shared EditMailboxModal (GH #197 companion).
+//
+// JAB-370: the directory is server-paginated / -searched / -sorted via
+// useTableURL({ resource: "admin/mailboxes" }) + SearchableTableStringQ. The
+// old client-side "load every mailbox then filter/sort/paginate in the browser"
+// path did not scale past a few thousand mailboxes (one unbounded query + a
+// large payload). Owner scope (?user_id, #483) is forwarded as an extra param.
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
@@ -9,23 +15,20 @@ import {
   Button,
   Empty,
   Form,
-  Input,
   Modal,
   Card,
-  Skeleton,
   Space,
   Table,
   Tag,
   Typography,
 } from "antd";
+import type { TableProps } from "antd";
 import { DeleteOutlined, EditOutlined, KeyOutlined, MailOutlined, PlusOutlined } from "@icons";
 
-import {
-  useAdminMailboxes,
-  useDeleteMailbox,
-  type AdminMailbox,
-} from "../../../hooks/useMailboxes";
+import { useDeleteMailbox, type AdminMailbox } from "../../../hooks/useMailboxes";
 import { useListQuery, useOneQuery } from "../../../hooks/useQueries";
+import { useTableURL } from "../../../hooks/useTableURL";
+import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { useSearchParams, Link } from "react-router";
 import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, ownerLabel, adminLinks } from "../../../components/admin/entityLinks";
@@ -47,9 +50,20 @@ import { RowActions } from "../../../components/RowActions";
 export function AdminMailPage() {
   const { t } = useTranslation();
   const { message } = App.useApp();
-  const { data: rows, isLoading } = useAdminMailboxes();
   const [searchParams, setSearchParams] = useSearchParams();
   const ownerId = searchParams.get("user_id") ?? undefined;
+
+  // Server-paginated directory. The owner filter is forwarded as an extra
+  // param (not URL-backed by useTableURL — the URL's ?user_id is owned by the
+  // owner-tag flow below), so switching owners re-keys the query and refetches.
+  const query = useTableURL<AdminMailbox>({
+    resource: "admin/mailboxes",
+    defaultSort: "email",
+    defaultOrder: "asc",
+    defaultPageSize: 25,
+    extraParams: ownerId ? { user_id: ownerId } : undefined,
+  });
+
   const ownerQ = useOneQuery<{ id: string; username?: string | null }>({
     resource: "users",
     id: ownerId,
@@ -79,21 +93,6 @@ export function AdminMailPage() {
   const [editTarget, setEditTarget] = useState<AdminMailbox | null>(null);
   const [resetTarget, setResetTarget] = useState<AdminMailbox | null>(null);
   const [resetForm] = Form.useForm<{ password?: string }>();
-  const [search, setSearch] = useState("");
-
-  const filtered = useMemo(() => {
-    let list = rows ?? [];
-    if (ownerId) list = list.filter((m) => m.owner_user_id === ownerId);
-    if (!search.trim()) return list;
-    const q = search.toLowerCase();
-    return list.filter(
-      (m) =>
-        m.email.toLowerCase().includes(q) ||
-        (m.display_name ?? "").toLowerCase().includes(q) ||
-        m.domain_name.toLowerCase().includes(q) ||
-        (m.user_username ?? "").toLowerCase().includes(q),
-    );
-  }, [rows, search, ownerId]);
 
   // Server-wide admin: a form modal collecting an OPTIONAL custom password. The
   // rotate → reveal-once → error core is the shared hook.
@@ -115,9 +114,26 @@ export function AdminMailPage() {
       : null,
   );
 
-  if (isLoading && !rows) return <Skeleton active paragraph={{ rows: 6 }} />;
-
   const ownerRef = ownerId ? { id: ownerId, username: ownerQ.data?.username } : undefined;
+
+  // Map AntD's per-column sort event onto the server sort/order params. Columns
+  // set `sorter: true` (no local comparator) so sorting is authoritative across
+  // ALL pages, not just the visible one; the repo whitelists the sort key.
+  const sortOrderFor = (key: string): "ascend" | "descend" | null =>
+    query.params.sort === key ? (query.params.order === "asc" ? "ascend" : "descend") : null;
+
+  const handleTableChange: TableProps<AdminMailbox>["onChange"] = (pag, _filters, sorter, extra) => {
+    if (extra.action === "sort") {
+      const s = Array.isArray(sorter) ? sorter[0] : sorter;
+      if (s?.order && s.columnKey) {
+        query.setParams({ sort: String(s.columnKey), order: s.order === "ascend" ? "asc" : "desc", page: 1 });
+      } else {
+        query.setParams({ sort: undefined, order: undefined, page: 1 });
+      }
+    } else if (extra.action === "paginate" && pag) {
+      query.setParams({ page: pag.current, pageSize: pag.pageSize });
+    }
+  };
 
   return (
     <>
@@ -161,105 +177,112 @@ export function AdminMailPage() {
       {tab === "groups" && <AdminGroupsTab />}
       {tab === "stats" && <MailStatsTab />}
       {tab === "mailboxes" && (
-      <>
-        <Space style={{ width: "100%", justifyContent: "flex-start", marginBottom: 16 }} wrap>
-          <Input.Search
-            placeholder={t("adminmailpage.search_email_name_domain_owner")}
-            allowClear
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            style={{ maxWidth: 320 }}
-          />
-        </Space>
-
-        <Table<AdminMailbox>
-          scroll={{ x: "max-content" }}
+        <SearchableTableStringQ<AdminMailbox>
           rowKey="id"
-          dataSource={filtered}
-          loading={isLoading}
-          pagination={{ defaultPageSize: 25, showSizeChanger: true }}
+          loading={query.isLoading}
+          dataSource={query.items}
+          initialSearch={query.params.q}
+          searchPlaceholder={t("adminmailpage.search_email_name_domain_owner")}
+          onSearchChange={(q) => query.setParams({ q, page: 1 })}
+          onChange={handleTableChange}
+          pagination={{
+            current: query.params.page,
+            pageSize: query.params.pageSize,
+            total: query.total,
+            showSizeChanger: true,
+          }}
           locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminmailpage.no_mailboxes")} /> }}
-          columns={[
-            {
-              title: "Email",
-              dataIndex: "email",
-              defaultSortOrder: "ascend",
-              sorter: (a, b) => a.email.localeCompare(b.email),
-              render: (v: string) => (
-                <Typography.Text style={{ fontFamily: "monospace" }}>{v}</Typography.Text>
-              ),
-            },
-            {
-              title: "Name",
-              dataIndex: "display_name",
-              ellipsis: true,
-              sorter: (a, b) => (a.display_name ?? "").localeCompare(b.display_name ?? ""),
-              render: (v: string) =>
-                v ? v : <Typography.Text type="secondary">—</Typography.Text>,
-            },
-            {
-              title: "Domain",
-              dataIndex: "domain_name",
-              sorter: (a, b) => a.domain_name.localeCompare(b.domain_name),
-            },
-            {
-              title: "Owner",
-              dataIndex: "user_username",
-              sorter: (a, b) => (a.user_username ?? "").localeCompare(b.user_username ?? ""),
-              render: (v: string, row) =>
-                v ? (
-                  <Link to={adminLinks.user(row.owner_user_id)}>{v}</Link>
-                ) : (
-                  <Typography.Text type="secondary">—</Typography.Text>
-                ),
-            },
-            {
-              title: "Usage / Quota",
-              dataIndex: "quota_bytes",
-              width: 200,
-              // GH #1358: sort by space USED (what the column shows), not the
-              // quota limit — the old sorter made "sort by usage" a no-op.
-              sorter: (a, b) => (a.last_usage_bytes ?? 0) - (b.last_usage_bytes ?? 0),
-              render: (_quota: number, row) => renderMailboxQuota(row),
-            },
-            {
-              title: "Status",
-              dataIndex: "is_disabled",
-              width: 100,
-              sorter: (a, b) => Number(a.is_disabled) - Number(b.is_disabled),
-              render: (disabled: boolean) => renderMailboxStatus(disabled),
-            },
-            {
-              title: "Actions",
-              key: "actions",
-              render: (_, row) => (
-                <RowActions
-                  actions={[
-                    { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: webmail.isLaunching(row.id), onClick: () => webmail.launch(row.id) },
-                    { key: "edit", label: "Edit mailbox", icon: <EditOutlined />, onClick: () => setEditTarget(row) },
-                    { key: "reset", label: "Reset password", icon: <KeyOutlined />, onClick: () => { resetForm.resetFields(); setResetTarget(row); } },
-                    {
-                      key: "delete",
-                      label: "Delete",
-                      icon: <DeleteOutlined />,
-                      danger: true,
-                      onClick: async () => {
-                        try {
-                          await deleteMutation.mutateAsync({ id: row.id, domainId: row.domain_id });
-                          message.success("Mailbox deleted");
-                        } catch {
-                          message.error("Failed to delete");
-                        }
-                      },
-                      confirm: { title: `Delete ${row.email}?`, description: "All mail in this mailbox will be removed. This cannot be undone.", okText: "Delete" },
+        >
+          <Table.Column<AdminMailbox>
+            title="Email"
+            dataIndex="email"
+            key="email"
+            sorter
+            sortOrder={sortOrderFor("email")}
+            render={(v: string) => (
+              <Typography.Text style={{ fontFamily: "monospace" }}>{v}</Typography.Text>
+            )}
+          />
+          <Table.Column<AdminMailbox>
+            title="Name"
+            dataIndex="display_name"
+            key="name"
+            ellipsis
+            sorter
+            sortOrder={sortOrderFor("name")}
+            render={(v: string) =>
+              v ? v : <Typography.Text type="secondary">—</Typography.Text>
+            }
+          />
+          <Table.Column<AdminMailbox>
+            title="Domain"
+            dataIndex="domain_name"
+            key="domain"
+            sorter
+            sortOrder={sortOrderFor("domain")}
+          />
+          <Table.Column<AdminMailbox>
+            title="Owner"
+            dataIndex="user_username"
+            key="owner"
+            sorter
+            sortOrder={sortOrderFor("owner")}
+            render={(v: string, row: AdminMailbox) =>
+              v ? (
+                <Link to={adminLinks.user(row.owner_user_id)}>{v}</Link>
+              ) : (
+                <Typography.Text type="secondary">—</Typography.Text>
+              )
+            }
+          />
+          <Table.Column<AdminMailbox>
+            title="Usage / Quota"
+            key="usage"
+            width={200}
+            // GH #1358: sort by space USED (what the column shows), not the
+            // quota limit — server sort maps "usage" → m.last_usage_bytes.
+            sorter
+            sortOrder={sortOrderFor("usage")}
+            render={(_: unknown, row: AdminMailbox) => renderMailboxQuota(row)}
+          />
+          <Table.Column<AdminMailbox>
+            title="Status"
+            dataIndex="is_disabled"
+            key="status"
+            width={100}
+            sorter
+            sortOrder={sortOrderFor("status")}
+            render={(disabled: boolean) => renderMailboxStatus(disabled)}
+          />
+          <Table.Column<AdminMailbox>
+            title="Actions"
+            key="actions"
+            render={(_: unknown, row: AdminMailbox) => (
+              <RowActions
+                actions={[
+                  { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: webmail.isLaunching(row.id), onClick: () => webmail.launch(row.id) },
+                  { key: "edit", label: "Edit mailbox", icon: <EditOutlined />, onClick: () => setEditTarget(row) },
+                  { key: "reset", label: "Reset password", icon: <KeyOutlined />, onClick: () => { resetForm.resetFields(); setResetTarget(row); } },
+                  {
+                    key: "delete",
+                    label: "Delete",
+                    icon: <DeleteOutlined />,
+                    danger: true,
+                    onClick: async () => {
+                      try {
+                        await deleteMutation.mutateAsync({ id: row.id, domainId: row.domain_id });
+                        message.success("Mailbox deleted");
+                      } catch {
+                        message.error("Failed to delete");
+                      }
                     },
-                  ]}
-                />
-              ),
-            },
-          ]}
-        />
-      </>
+                    confirm: { title: `Delete ${row.email}?`, description: "All mail in this mailbox will be removed. This cannot be undone.", okText: "Delete" },
+                  },
+                ]}
+              />
+            )}
+          />
+        </SearchableTableStringQ>
       )}
       </Card>
 


### PR DESCRIPTION
## JAB-370 — server-paginate the admin mailbox Directory

`GET /admin/mailboxes` loaded **every** mailbox on the server in one unbounded
query and paged / searched / sorted them in the browser. Past a few thousand
mailboxes that is a single large query plus a heavy payload on an admin page.
This moves pagination, search and sort to the server.

This is the **Directory** slice of JAB-370. The module-parent stays **open**: the
tenant-facing Workspace / Recent / Selection projections are separate slices
(owner-scoped SQL is the isolation-critical part — kept out of this perf slice).

### Backend
- **`ListDirectoryPage(opts, ownerUserID)`** — one `COUNT` + one page via the
  shared `applyListOptions` (parameterised, escaped `LIKE`; sort allowlist).
- **All columns qualified.** `mailboxes`, `domains` and `users` all carry
  `created_at`, so a bare `ORDER BY created_at` is MariaDB 1052 "ambiguous". The
  clean API sort key (`email|name|domain|owner|usage|status|created_at`) is
  translated to a qualified column through a whitelist map; an unknown key falls
  back to `email ASC` and the caller's raw string never reaches the SQL.
- **System rows excluded in SQL** (both the COUNT and the page), so the total and
  the returned rows agree (GH #1056). The old handler dropped them Go-side, which
  on a server page would leave it one row short of `page_size`.
- **Search matches the same four fields** the old client filter did: email,
  display name, domain, owner.
- **`ListAllWithDomain` kept unchanged** — the mailbox usage ticker and the
  automation mail summary still legitimately need the full scan.

### Handler — backward compatible
- `listAllAdmin` **paginates only when the client sends `page`/`page_size`**. With
  neither it returns an unbounded set (`Limit=0`), so the owner-scoped admin
  **user-overview** read (`AdminUserOverview`, which consumes the whole array)
  keeps its historical behaviour. The `?user_id` owner scope (#483) is unchanged.
- Envelope carries `page`/`page_size` only in the paginated branch.

### Frontend
- `AdminMailPage` moves from `useAdminMailboxes` (load-all) to
  `useTableURL({ resource: "admin/mailboxes" })` + `SearchableTableStringQ`:
  server pagination, debounced server search, and **server sort across all pages**
  (columns are `sorter: true`, mapped to the API sort key). Owner filter is
  forwarded as an extra param.
- The mailbox mutations invalidated the now-dead `["admin","mailboxes"]` key;
  they now invalidate `["list","admin/mailboxes"]`, so an edit / delete / create
  refreshes the visible page.

### Tests
- Repo (sqlmock): `system = 0` in **both** count and page, `LIMIT/OFFSET`,
  `LIKE … ESCAPE`, owner scope, a hostile `?sort=` → `email` fallback (proves no
  interpolation), and unbounded when `Limit=0`.
- Handler: paginate-only-when-asked, unbounded response shape, owner forward,
  invalid `user_id` → 400.
- The generated SQL was **DryRun-verified end to end** (GORM renders the real SQL
  — every column qualified, `LIMIT ? OFFSET ?` parameterised). No live `EXPLAIN`
  (no DB MCP in this session); every construct except `m.system = 0` and the
  qualified `ORDER BY` already runs in production via `ListAllWithDomain` /
  `applyListOptions`. No migration, agent verb, or reconciler — no box deploy.

### Needs a human look
- No authed browser visual pass was possible from this session. The **server-mode
  table interaction** — sort cycle (asc/desc/none), page-size changer, owner tag +
  search — is the piece worth a manual check.
- No admin-mail E2E spec existed; none added (the logic is covered by the
  handler + repo tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
