### PR TITLE
fix(mail): skip mailbox creation + hide Email surfaces when the mail module is off (GH #1417)

### DIFF
--- a/panel-api/internal/reconciler/sendmail_cred_reconcile.go
+++ b/panel-api/internal/reconciler/sendmail_cred_reconcile.go
@@ -46,6 +46,14 @@ func (r *Reconciler) reconcileSendmailCreds(ctx context.Context) {
 	if err != nil || srv == nil || srv.Hostname == "" {
 		return
 	}
+	// GH #1417: the noreply@ relay mailbox is a mail-module artifact. When the
+	// mail module is disabled there is no Stalwart to authenticate against, and
+	// the mailbox only causes confusion — it surfaces under Email in Disk Usage
+	// and links to a mailbox page the tenant can't reach. Skip creating it so a
+	// mail-less install grows no system mailboxes.
+	if !srv.MailEnabled {
+		return
+	}
 	mailHost := models.PanelMailHostname(srv.Hostname)
 
 	domains, _, err := r.domains.List(ctx, repository.ListOptions{Limit: 10000})

--- a/panel-api/internal/reconciler/sendmail_cred_reconcile_test.go
+++ b/panel-api/internal/reconciler/sendmail_cred_reconcile_test.go
@@ -112,7 +112,7 @@ func sendmailTestReconciler(agent *fakeSendmailAgent, mailboxes *fakeSendmailMai
 			// has no OS counterpart (testserver E2E found the warn-loop).
 			"u3": {ID: "u3", Username: strPtr("user_01krhrna2zmp"), IsAdmin: true},
 		}},
-		serverSettings: &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: "panel.example.tld"}},
+		serverSettings: &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: "panel.example.tld", MailEnabled: true}},
 		agent:          agent,
 		mailboxes:      mailboxes,
 		sendmailSSOKey: &key,
@@ -318,6 +318,31 @@ func TestReconcileSendmailCreds_BothNamesHumanSkips(t *testing.T) {
 	r.reconcileSendmailCreds(ctx)
 	if len(agent.calls) != 0 {
 		t.Fatal("skipped domain must stay quiet on later ticks")
+	}
+}
+
+func TestReconcileSendmailCreds_SkippedWhenMailModuleDisabled(t *testing.T) {
+	// GH #1417: with the mail module off there is no Stalwart to authenticate
+	// against, so the reconciler must create no noreply@ relay mailboxes (they
+	// would otherwise surface under Email in Disk Usage and link to a page the
+	// tenant can't reach).
+	agent := &fakeSendmailAgent{}
+	mailboxes := &fakeSendmailMailboxRepo{
+		byEmail:     map[string]*models.Mailbox{},
+		domainNames: map[string]string{"d1": "site.tld"},
+	}
+	r := sendmailTestReconciler(agent, mailboxes, []models.Domain{
+		{ID: "d1", Name: "site.tld", UserID: "u1", EmailEnabled: true},
+	})
+	r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: "panel.example.tld", MailEnabled: false}}
+
+	r.reconcileSendmailCreds(context.Background())
+
+	if len(mailboxes.created) != 0 {
+		t.Fatalf("mail module disabled: no relay mailbox may be created (created=%d)", len(mailboxes.created))
+	}
+	if len(agent.calls) != 0 {
+		t.Fatalf("mail module disabled: no agent calls expected, got %v", agent.calls)
 	}
 }
 

--- a/panel-ui/src/shells/user/UserDashboard.test.tsx
+++ b/panel-ui/src/shells/user/UserDashboard.test.tsx
@@ -1,0 +1,63 @@
+// UserDashboard.test.tsx — GH #1417. With the mail module disabled the
+// dashboard must not surface Email pieces: the "Recent mailboxes" card and the
+// "Mailboxes" stat tile both link to /mail/mailboxes, which redirects to an
+// inaccessible page. Same server-capabilities gate the sidebar + Disk Usage use.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+vi.mock("../../hooks/useQueries", () => ({
+  useListQuery: () => ({ items: [], total: 0, isLoading: false }),
+}));
+vi.mock("@tanstack/react-query", async (orig) => ({
+  ...(await orig<typeof import("@tanstack/react-query")>()),
+  useQueries: () => [],
+}));
+vi.mock("../../identity", () => ({ getIdentity: () => Promise.resolve(null) }));
+vi.mock("./MyProfileUsageCard", () => ({ MyProfileUsageCard: () => null }));
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: vi.fn(async () => ({ data: { data: [], total: 0 } })) },
+}));
+
+let mailEnabled = true;
+vi.mock("../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: { mail_enabled: mailEnabled } }),
+}));
+
+import { UserDashboard } from "./UserDashboard";
+
+function renderDash() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <UserDashboard />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("UserDashboard mail-module gating (GH #1417)", () => {
+  beforeEach(() => {
+    mailEnabled = true;
+  });
+
+  it("shows the mailboxes card + stat tile when mail is enabled", async () => {
+    renderDash();
+    await waitFor(() => expect(screen.getByText("userdashboard.recent_mailboxes")).toBeInTheDocument());
+    expect(screen.getByText("userdashboard.mailboxes")).toBeInTheDocument();
+  });
+
+  it("hides the mailboxes card + stat tile when the mail module is disabled", async () => {
+    mailEnabled = false;
+    renderDash();
+    // Domains always renders — anchor on it, then assert the mail pieces are gone.
+    await waitFor(() => expect(screen.getByText("userdashboard.recent_domains")).toBeInTheDocument());
+    expect(screen.queryByText("userdashboard.recent_mailboxes")).not.toBeInTheDocument();
+    expect(screen.queryByText("userdashboard.mailboxes")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/UserDashboard.tsx
+++ b/panel-ui/src/shells/user/UserDashboard.tsx
@@ -71,13 +71,19 @@ export function UserDashboard() {
     resource: "domains",
     params: { pageSize: RECENT_LIMIT, sort: "created_at", order: "desc" },
   });
+  const { data: caps } = useServerCapabilities();
+  // GH #1417: with the mail module off, hide the mailbox surfaces below AND
+  // skip their per-domain fetches — a domain that kept email_enabled from
+  // before the module was disabled would otherwise 403-fan-out in the
+  // background. Default-on while caps load, matching the sidebar's mail gate.
+  const mailEnabled = caps?.mail_enabled !== false;
   const allDomainsForMail = useListQuery<DomainRow>({
     resource: "domains",
     params: { pageSize: 200, sort: "name", order: "asc" },
   });
   const emailDomains = useMemo(
-    () => allDomainsForMail.items.filter((d) => d.email_enabled),
-    [allDomainsForMail.items],
+    () => (mailEnabled ? allDomainsForMail.items.filter((d) => d.email_enabled) : []),
+    [allDomainsForMail.items, mailEnabled],
   );
   const mailboxResults = useQueries({
     queries: emailDomains.map((d) => ({
@@ -119,7 +125,6 @@ export function UserDashboard() {
     resource: "databases",
     params: { pageSize: RECENT_LIMIT, sort: "created_at", order: "desc" },
   });
-  const { data: caps } = useServerCapabilities();
 
   const items = [
     {
@@ -281,16 +286,18 @@ export function UserDashboard() {
             to="/jabali-panel/domains"
           />
         </Col>
-        <Col xs={24} sm={12} md={6}>
-          <StatCard
-            label={t("userdashboard.mailboxes")}
-            value={formatCount(mailboxTotal)}
-            icon={<MailOutlined />}
-            iconBg="rgba(250, 140, 22, 0.14)"
-            iconColor="#fa8c16"
-            to="/jabali-panel/mail/mailboxes"
-          />
-        </Col>
+        {mailEnabled && (
+          <Col xs={24} sm={12} md={6}>
+            <StatCard
+              label={t("userdashboard.mailboxes")}
+              value={formatCount(mailboxTotal)}
+              icon={<MailOutlined />}
+              iconBg="rgba(250, 140, 22, 0.14)"
+              iconColor="#fa8c16"
+              to="/jabali-panel/mail/mailboxes"
+            />
+          </Col>
+        )}
         <Col xs={24} sm={12} md={6}>
           <StatCard
             label={t("userdashboard.applications")}
@@ -322,7 +329,7 @@ export function UserDashboard() {
       <Masonry
         columns={{ xs: 1, sm: 1, md: 1, lg: 2 }}
         gutter={16}
-        items={items}
+        items={mailEnabled ? items : items.filter((it) => it.key !== "mailboxes")}
       />
     </Space>
   );

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.test.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.test.tsx
@@ -1,0 +1,74 @@
+// DiskUsagePage.test.tsx — GH #1417. When the mail module is disabled the panel
+// must not surface Email-related pieces on the Disk Usage page: the "Email"
+// stat card, the "Email Mailboxes" breakdown, and its "View all mailboxes" link
+// (which would redirect to a page the tenant can't reach). Gated on the shared
+// server-capabilities mail flag, the same signal the sidebar uses.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mailEnabled = true;
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: { mail_enabled: mailEnabled } }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const diskUsage = {
+  computed_at: "2026-09-04T00:00:00Z",
+  total_bytes: 1000,
+  quota_bytes: 0,
+  files: { bytes: 100, items: [] },
+  email: { bytes: 50, items: [{ name: "noreply@site.tld", bytes: 50 }] },
+  databases: { bytes: 200, items: [] },
+};
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: {
+    get: vi.fn(async (url: string) => {
+      // The Files & Folders tree auto-fetches the browse endpoint on mount.
+      if (url.startsWith("/me/disk-usage/files")) {
+        return { data: { path: "~", total: 0, entries: [] } };
+      }
+      return { data: diskUsage };
+    }),
+  },
+}));
+
+import { DiskUsagePage } from "./DiskUsagePage";
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <DiskUsagePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DiskUsagePage mail-module gating (GH #1417)", () => {
+  beforeEach(() => {
+    mailEnabled = true;
+  });
+
+  it("shows the Email Mailboxes section + View all mailboxes link when mail is enabled", async () => {
+    renderPage();
+    expect(await screen.findByText("Email Mailboxes")).toBeInTheDocument();
+    expect(screen.getByText("View all mailboxes")).toBeInTheDocument();
+  });
+
+  it("hides the Email section + link when the mail module is disabled", async () => {
+    mailEnabled = false;
+    renderPage();
+    // "Storage Quota Usage" always renders once loaded — unique, unlike
+    // "Databases" (stat card + section both use it) — so wait on it.
+    expect(await screen.findByText("Storage Quota Usage")).toBeInTheDocument();
+    expect(screen.queryByText("Email Mailboxes")).not.toBeInTheDocument();
+    expect(screen.queryByText("View all mailboxes")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
@@ -14,6 +14,7 @@ import { DatabaseOutlined, ExportOutlined, FileOutlined, FolderOutlined, MailOut
 
 import { apiClient } from "../../../apiClient";
 import { StatCard } from "../../../components/StatCard";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 
 interface UsageItem {
   name: string;
@@ -168,6 +169,11 @@ export function DiskUsagePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
+  // GH #1417: hide the Email stat card + Mailboxes breakdown (and its "View all
+  // mailboxes" link, which would 403-redirect) when the mail module is off.
+  // Default-on while the capability loads, matching the sidebar's mail gate.
+  const { data: caps } = useServerCapabilities();
+  const mailEnabled = caps?.mail_enabled !== false;
   const { data, isLoading, error } = useQuery<DiskUsage>({
     queryKey: ["me-disk-usage"],
     queryFn: async () => {
@@ -224,13 +230,17 @@ export function DiskUsagePage() {
       iconColor: COLORS.blue,
       icon: <FileOutlined />,
     },
-    {
-      label: "Email",
-      value: fmtBytes(data.email.bytes),
-      subtitle: pctOf(data.email.bytes),
-      iconColor: COLORS.green,
-      icon: <MailOutlined />,
-    },
+    ...(mailEnabled
+      ? [
+          {
+            label: "Email",
+            value: fmtBytes(data.email.bytes),
+            subtitle: pctOf(data.email.bytes),
+            iconColor: COLORS.green,
+            icon: <MailOutlined />,
+          },
+        ]
+      : []),
     {
       label: "Databases",
       value: fmtBytes(data.databases.bytes),
@@ -289,17 +299,21 @@ export function DiskUsagePage() {
       emptyText: "No files",
       viewAll: { label: "View all files", to: "/jabali-panel/files" },
     },
-    {
-      key: "email",
-      title: "Email Mailboxes",
-      icon: <MailOutlined />,
-      iconColor: COLORS.green,
-      cat: data.email,
-      cols: emailCols,
-      emptyText: "No email usage yet",
-      emptyHint: "Your mailboxes are currently empty.",
-      viewAll: { label: "View all mailboxes", to: "/jabali-panel/mail/mailboxes" },
-    },
+    ...(mailEnabled
+      ? [
+          {
+            key: "email",
+            title: "Email Mailboxes",
+            icon: <MailOutlined />,
+            iconColor: COLORS.green,
+            cat: data.email,
+            cols: emailCols,
+            emptyText: "No email usage yet",
+            emptyHint: "Your mailboxes are currently empty.",
+            viewAll: { label: "View all mailboxes", to: "/jabali-panel/mail/mailboxes" },
+          },
+        ]
+      : []),
     {
       key: "databases",
       title: "Databases",


### PR DESCRIPTION
## What

With the **mail module disabled** (`server_settings.mail_enabled = 0`, GH #353) the panel still created a default `noreply@<domain>` mailbox for every domain, and still surfaced Email-related pieces that link to the mail pages a tenant can't reach (GH #1417, reporter lxsdevcode):

- the mailbox showed under **Email Mailboxes** in Disk Usage;
- the **View all mailboxes** link appeared there (and on the dashboard);
- clicking it redirected to the menu + a "no access to module" notice.

## Fix

**Backend** — `reconcileSendmailCreds` now returns early when the mail module is off. The `noreply@` relay is a mail-module artifact: with no Stalwart to authenticate against it only causes confusion. It's the *only* relay-mailbox creator (grep-confirmed), so one gate covers every entry point. The shared test helper now sets `MailEnabled: true` (the production DB default) and a new test locks the disabled-skip.

**UI** — gated on the shared `useServerCapabilities().mail_enabled`, the same signal the sidebar and the domain drawer already use (default-on while it loads):

- **Disk Usage**: hide the "Email" stat card and the "Email Mailboxes" breakdown (with its "View all mailboxes" link).
- **Dashboard**: hide the "Recent mailboxes" card and the "Mailboxes" stat tile, and skip their per-domain mailbox fetches *at the source* — a domain that kept `email_enabled` from before the module was disabled would otherwise 403-fan-out in the background.

## Scope notes

- **Existing `noreply@` mailboxes are not removed.** The fix prevents creation and hides every surface, so on a box that already has the mailbox it disappears from view but the (inert) DB row stays — destructive cleanup of already-created system mailboxes remains a manual/operator action.
- On an enabled-then-disabled box, existing mail bytes still count toward "Total Used" even with the Email card hidden. Trivial, left as-is.
- The domain create/edit drawer already gated its email field on the same capability — unchanged.

## Verification

Unit-verified on both sides (reconciler disabled-skip; Disk Usage + Dashboard gating render tests), `tsc -b` + eslint clean, full panel-ui vitest green (361 tests). No box drill: this is a boolean gate on a flag the sidebar already exercises in production — nothing runtime/wire-format-risky.

**Rollout: panel-only.** The reconciler and the embedded SPA ship in the panel binary, so this lands on the next panel update — no agent redeploy needed (unlike #1408/#1416).

## Test plan

- [x] `go build ./...`, `go vet`, `internal/reconciler` tests green (incl. `TestReconcileSendmailCreds_SkippedWhenMailModuleDisabled`)
- [x] New UI tests: `DiskUsagePage.test.tsx`, `UserDashboard.test.tsx` (both mail-on and mail-off)
- [x] `tsc -b`, eslint, full vitest suite (79 files / 361 tests) green

Tracking against GH #1417.
