### PR TITLE
fix(domains): hide the DNS row action when the DNS module is off (GH #1419)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -38,6 +38,7 @@ import { DomainRedirectsButton } from "../../DomainRedirectsButton";
 import { DomainCacheButton } from "../../../components/DomainCacheButton";
 import { DomainIndexButton } from "../../DomainIndexButton";
 import { DomainInfoButton } from "../../DomainInfoButton";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 
 type ActiveModal = {
   domain: Domain;
@@ -185,6 +186,9 @@ export const DomainList = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
+  // GH #1419: hide the DNS row action when the DNS module is off (the page only
+  // 403s). Default-on while caps load, matching the sidebar's dns gate.
+  const { data: caps } = useServerCapabilities();
   const [activeModal, setActiveModal] = useState<ActiveModal>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -389,12 +393,16 @@ export const DomainList = () => {
                         label: "Edit",
                         onClick: () => navigate(`/jabali-admin/domains/edit/${r.id}`),
                       },
-                      {
-                        key: "dns",
-                        icon: <GlobalOutlined />,
-                        label: "DNS",
-                        onClick: () => navigate(`/jabali-admin/domains/${r.id}/dns`),
-                      },
+                      ...(caps?.dns_enabled !== false
+                        ? [
+                            {
+                              key: "dns",
+                              icon: <GlobalOutlined />,
+                              label: "DNS",
+                              onClick: () => navigate(`/jabali-admin/domains/${r.id}/dns`),
+                            },
+                          ]
+                        : []),
                       {
                         key: "info",
                         icon: <InfoCircleOutlined />,

--- a/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
@@ -1,0 +1,95 @@
+// UserDomainList.test.tsx — GH #1419. The Domains list Actions menu showed a
+// "DNS" entry even when the DNS module is off, leading to a page that only
+// redirects + 403s. It must be hidden, gated on the shared server-capabilities
+// dns flag (the same signal the sidebar uses). Real AntD table + dropdown run.
+import { App } from "antd";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UserDomainList } from "./UserDomainList";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { patch: vi.fn(), get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("../../../hooks/useQueries", () => ({
+  useDeleteMutation: () => ({ mutateAsync: vi.fn() }),
+  useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+const domainRow = {
+  id: "d1",
+  name: "site.tld",
+  is_enabled: true,
+  doc_root: "/home/alice/site.tld",
+  destination: "",
+  source: "",
+  type: "",
+  temp_url: "",
+  temp_url_enabled: false,
+  bot_challenge_include: false,
+  ssl_state: "active",
+  bytes_30d: 0,
+};
+
+vi.mock("../../../hooks/useTableURL", () => ({
+  useTableURL: () => ({
+    items: [domainRow],
+    total: 1,
+    isLoading: false,
+    params: { page: 1, pageSize: 20, q: "", sort: "name", order: "asc" },
+    setParams: vi.fn(),
+  }),
+}));
+
+let dnsEnabled = true;
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: { dns_enabled: dnsEnabled } }),
+}));
+
+const openRowMenu = async () => {
+  const moreBtn = await screen.findByRole("button", { name: /more/i }, { timeout: 5000 });
+  fireEvent.click(moreBtn);
+};
+
+beforeEach(() => {
+  dnsEnabled = true;
+});
+
+describe("UserDomainList DNS action gating (GH #1419)", () => {
+  it("shows the DNS action when the DNS module is enabled", async () => {
+    render(
+      <MemoryRouter>
+        <App>
+          <UserDomainList />
+        </App>
+      </MemoryRouter>,
+    );
+    await openRowMenu();
+    expect(await screen.findByText("DNS")).toBeInTheDocument();
+  });
+
+  it("hides the DNS action when the DNS module is disabled", async () => {
+    dnsEnabled = false;
+    render(
+      <MemoryRouter>
+        <App>
+          <UserDomainList />
+        </App>
+      </MemoryRouter>,
+    );
+    await openRowMenu();
+    // Another always-present action confirms the menu opened.
+    expect(await screen.findByText("Redirects")).toBeInTheDocument();
+    expect(screen.queryByText("DNS")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -273,12 +273,18 @@ export const UserDomainList = () => {
                   trigger={["click"]}
                   menu={{
                     items: [
-                      {
-                        key: "dns",
-                        label: "DNS",
-                        icon: <GlobalOutlined />,
-                        onClick: () => navigate(`/jabali-panel/domains/${r.id}/dns`),
-                      },
+                      // GH #1419: hide DNS when the DNS module is off — the page
+                      // only 403s. Default-on while caps load (sidebar gate).
+                      ...(caps?.dns_enabled !== false
+                        ? [
+                            {
+                              key: "dns",
+                              label: "DNS",
+                              icon: <GlobalOutlined />,
+                              onClick: () => navigate(`/jabali-panel/domains/${r.id}/dns`),
+                            },
+                          ]
+                        : []),
                       {
                         key: "redirects",
                         label: "Redirects",


### PR DESCRIPTION
## What

The Domains list **Actions** menu showed a **DNS** entry even when the DNS module is disabled (`server_settings.dns_enabled = 0`, GH #353). Clicking it dead-ended (GH #1419, reporter lxsdevcode):

- regular user → redirected to the first page + "module not installed" notice;
- admin → the DNS page loaded but showed *"Failed to load DNS data: This module is disabled on this server (Server Settings → Modules)."*

## Fix

Gate the DNS row action on the shared `useServerCapabilities().dns_enabled` — the same signal the sidebar already uses (default-on while caps load) — in **both** the user Domains list (`UserDomainList`) and the admin Domains list (`DomainList`). UI-only: the DNS pages already 403 server-side; this just stops exposing an unreachable entry point.

The admin `DomainList` gate is the identical tsc-checked conditional; behavior is locked by the user-list render test (opens the real Actions dropdown, asserts DNS present when enabled / absent when disabled).

## Not in scope (flagged, not fixed)

- **Admin deep-link**: admin routes lack the `CapabilityRoute` gating the user shell has, so an admin who types `/jabali-admin/domains/:id/dns` still lands on the erroring page. The reporter reached it via the now-hidden action, so the report is satisfied; admin route-gating is a separate follow-up.
- **Admin user-overview quick-links** (`AdminUserOverview` `USER_PANEL_CARDS`) show DNS, Python Apps and API Tokens regardless of their module flags — the whole grid needs capability filtering, a separate change.

## Verification

`tsc -b` + eslint clean; new `UserDomainList.test.tsx` (dropdown-open, DNS on/off) green; domains-area vitest green (14 tests). No box drill — a boolean gate on a flag the sidebar already exercises in production.

**Rollout: panel-only** (embedded SPA) — lands on the next panel update, no agent redeploy.

Tracking against GH #1419.
