### PR TITLE
feat(cron): allow python and node cron commands (GH #1435)

### DIFF
--- a/docs/site/user/cron-jobs.md
+++ b/docs/site/user/cron-jobs.md
@@ -19,15 +19,35 @@ Both are owned by you. The first time you add a cron job, systemd lingering is e
 
 ## Command allowlist
 
-The panel does not allow arbitrary shell commands. The allowlist includes:
+The panel does not allow arbitrary shell commands, and cron jobs run **outside**
+the SSH shell sandbox as your user — so the command must be one of a fixed set
+of interpreters running a file you own, with no shell features (no `cd`, `$HOME`,
+`|`, `;`, `&&`, backticks, redirects, or globbing). Use **absolute paths**
+instead of `cd`/`$HOME`.
 
-- `php` (with any args)
-- `wp` (WP-CLI; with any args)
-- `python` / `python3`
-- `node`
-- `curl` (limited to your domains)
+The allowlist:
 
-The allowlist is configurable by the operator; ask if you need a command not currently listed.
+- **`wp`** (WP-CLI) — requires `--path=<absolute-docroot>` instead of `cd`.
+  Example: `wp --path=/home/USER/domains/example.com/public_html cron event run --due-now`
+- **`php`** (or a pinned version, e.g. `php8.3`) — runs an **absolute `.php` file
+  inside one of your docroots**. Inline code (`-r`, `-R`, `-B`, `-E`) is not allowed.
+- **`python`** / **`python3`** / a pinned version (e.g. `python3.11`), or the
+  absolute path to a **virtualenv** interpreter — runs an **absolute `.py` file
+  inside your account** (home or a docroot). Inline/module execution (`-c`, `-m`,
+  reading from stdin) is not allowed. Django example:
+  `python3 /home/USER/site/manage.py runjobs` or, with a venv,
+  `/home/USER/venv/bin/python /home/USER/site/manage.py migrate` — note there is
+  no `cd`; give `manage.py`'s absolute path.
+- **`node`** / **`nodejs`** (or an absolute path to one, e.g. an nvm build) — runs
+  an **absolute `.js` / `.mjs` / `.cjs` file inside your account**. Inline code
+  (`-e`, `--eval`, `-p`, `--print`) is not allowed.
+- **`curl`** / **`wget`** — a plain GET to one of **your own domains** (a
+  self-domain HTTP trigger; the panel pins the target and hardens the request).
+
+A job may hold **several commands, one per line** — they run in order and stop
+if one fails. Blank lines and `#` comments (including a `#!/bin/bash` shebang
+line) are ignored, so you can paste a script's body, but every executable line
+must still match the allowlist above.
 
 ## Why systemd-user, not crontab
 

--- a/internal/cronvalidate/cron.go
+++ b/internal/cronvalidate/cron.go
@@ -131,7 +131,7 @@ func hasUnquotedMetachar(s string) bool {
 // All shell metacharacters are rejected unless inside quotes (and glob chars
 // are still rejected in pre-shlex scan). Returns a Command with parsed argv
 // on success, or a ValidationError with a code suitable for API responses.
-func ValidateCommand(raw string, ownedDocroots []string) (*Command, error) {
+func ValidateCommand(raw string, ownedDocroots []string, ownedHome string) (*Command, error) {
 	// Empty or whitespace-only
 	if strings.TrimSpace(raw) == "" {
 		return nil, &ValidationError{
@@ -209,15 +209,40 @@ func ValidateCommand(raw string, ownedDocroots []string) (*Command, error) {
 		// installed version never needs a path, and isVersionedPHP requires the
 		// token to start with "php", so a slash-bearing path never matches.
 		return validatePHPCommand(argv, ownedDocroots)
+	case isPythonBinary(binary):
+		// GH #1435: python / python3 / python<X.Y> (bare) or an absolute path to
+		// one (a virtualenv's bin/python, a pyenv build). Must run an absolute
+		// .py file the tenant owns — no `-c`/`-m` arbitrary code.
+		return validatePythonCommand(argv, scriptRoots(ownedDocroots, ownedHome))
+	case isNodeBinary(binary):
+		// GH #1435: node / nodejs (bare) or an absolute path to one. Must run an
+		// absolute .js/.mjs/.cjs file the tenant owns — no `-e`/`-p` inline code.
+		return validateNodeCommand(argv, scriptRoots(ownedDocroots, ownedHome))
 	default:
 		return nil, &ValidationError{
 			Code: ErrCodeBinaryNotAllowed,
 			Detail: fmt.Sprintf(
-				"first token must be 'wp', 'php', or 'php<X.Y>', got %q",
+				"first token must be 'wp', 'php', 'php<X.Y>', 'python[3][.Y]', or 'node', got %q",
 				binary,
 			),
 		}
 	}
+}
+
+// scriptRoots is the containment set for python/node scripts: the account's
+// docroots PLUS its home directory. Unlike wp/php (docroot-only), a Python or
+// Node project's entry file (manage.py, a script) usually lives under the home
+// but outside any web docroot, so the home is the right ownership boundary.
+// ownedHome may be "" (e.g. a context with no resolved account) — then only the
+// docroots apply.
+func scriptRoots(ownedDocroots []string, ownedHome string) []string {
+	if ownedHome == "" {
+		return ownedDocroots
+	}
+	roots := make([]string, 0, len(ownedDocroots)+1)
+	roots = append(roots, ownedDocroots...)
+	roots = append(roots, ownedHome)
+	return roots
 }
 
 // isVersionedPHP reports whether name is a versioned PHP CLI binary like
@@ -247,6 +272,184 @@ func isAllDigits(s string) bool {
 		}
 	}
 	return true
+}
+
+// baseName returns the last path element of name (the interpreter basename),
+// so an absolute interpreter path (a virtualenv's bin/python) is matched by the
+// same rules as a bare name.
+func baseName(name string) string {
+	if i := strings.LastIndexByte(name, '/'); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+// isPythonBinary reports whether name is an allowed Python interpreter:
+// bare `python`, `python3`, or versioned `python<X>`/`python<X.Y>` (e.g.
+// python3.11), or an absolute path whose basename is one of those (a
+// virtualenv or pyenv interpreter — GH #1435). This mirrors php's acceptance
+// of both a bare name and an absolute `/…/php` path.
+func isPythonBinary(name string) bool {
+	base := baseName(name)
+	return base == "python" || isVersionedPython(base)
+}
+
+// isVersionedPython reports whether name is `python<version>` where version is
+// digits with at most one dot (python3, python3.11, python2.7). Bare "python"
+// is handled separately by isPythonBinary.
+func isVersionedPython(name string) bool {
+	rest, ok := strings.CutPrefix(name, "python")
+	if !ok || rest == "" {
+		return false
+	}
+	if dot := strings.IndexByte(rest, '.'); dot >= 0 {
+		return dot > 0 && dot < len(rest)-1 && isAllDigits(rest[:dot]) && isAllDigits(rest[dot+1:])
+	}
+	return isAllDigits(rest)
+}
+
+// isNodeBinary reports whether name is `node` or `nodejs`, bare or as an
+// absolute path's basename (GH #1435).
+func isNodeBinary(name string) bool {
+	base := baseName(name)
+	return base == "node" || base == "nodejs"
+}
+
+// pythonStandaloneFlags are introspection-only Python flags that need no script.
+var pythonStandaloneFlags = map[string]bool{
+	"-V": true, "--version": true,
+	"-h": true, "--help": true,
+}
+
+// isInlineCodePythonFlag reports whether a token makes Python run code that is
+// not an owned script file: `-c` (run code string), `-m` (run an installed
+// module, not a file), and `-` (read the program from stdin). Glued forms like
+// `-cCODE` are covered by the prefix check. Blocking these keeps a Python cron
+// to "an absolute .py file the tenant owns", the same model as php (GH #1435).
+func isInlineCodePythonFlag(a string) bool {
+	return a == "-" || a == "-c" || strings.HasPrefix(a, "-c") ||
+		a == "-m" || strings.HasPrefix(a, "-m")
+}
+
+// validatePythonCommand requires an absolute .py file inside the account's
+// docroots or home, and rejects inline-code / module-exec flags.
+func validatePythonCommand(argv []string, scriptRoots []string) (*Command, error) {
+	if len(argv) < 2 {
+		return nil, &ValidationError{
+			Code:   ErrCodeBadPathArg,
+			Detail: "python command requires an argument (an absolute .py file)",
+		}
+	}
+	for _, a := range argv[1:] {
+		if isInlineCodePythonFlag(a) {
+			return nil, &ValidationError{
+				Code:   ErrCodeBinaryNotAllowed,
+				Detail: "python inline-code flags (-c/-m/-) are not allowed; a cron command must run an absolute .py file inside your account",
+			}
+		}
+	}
+	if pythonStandaloneFlags[argv[1]] {
+		return &Command{Argv: argv}, nil
+	}
+	pathArg, ok := firstNonFlagArg(argv)
+	if !ok {
+		return &Command{Argv: argv}, nil
+	}
+	if err := validateScriptFile(pathArg, ".py", "python", scriptRoots); err != nil {
+		return nil, err
+	}
+	return &Command{Argv: argv}, nil
+}
+
+// nodeStandaloneFlags are introspection-only Node flags that need no script.
+var nodeStandaloneFlags = map[string]bool{
+	"-v": true, "--version": true,
+	"-h": true, "--help": true,
+}
+
+// isInlineCodeNodeFlag reports whether a token makes Node run inline code
+// instead of a script file: `-e`/`--eval` (evaluate) and `-p`/`--print`
+// (evaluate + print), including glued `-eCODE` (GH #1435).
+func isInlineCodeNodeFlag(a string) bool {
+	for _, f := range []string{"-e", "--eval", "-p", "--print"} {
+		if a == f || strings.HasPrefix(a, f) {
+			return true
+		}
+	}
+	return false
+}
+
+var nodeScriptExts = []string{".js", ".mjs", ".cjs"}
+
+// validateNodeCommand requires an absolute .js/.mjs/.cjs file inside the
+// account's docroots or home, and rejects inline-code flags.
+func validateNodeCommand(argv []string, scriptRoots []string) (*Command, error) {
+	if len(argv) < 2 {
+		return nil, &ValidationError{
+			Code:   ErrCodeBadPathArg,
+			Detail: "node command requires an argument (an absolute .js file)",
+		}
+	}
+	for _, a := range argv[1:] {
+		if isInlineCodeNodeFlag(a) {
+			return nil, &ValidationError{
+				Code:   ErrCodeBinaryNotAllowed,
+				Detail: "node inline-code flags (-e/--eval/-p/--print) are not allowed; a cron command must run an absolute .js file inside your account",
+			}
+		}
+	}
+	if nodeStandaloneFlags[argv[1]] {
+		return &Command{Argv: argv}, nil
+	}
+	pathArg, ok := firstNonFlagArg(argv)
+	if !ok {
+		return &Command{Argv: argv}, nil
+	}
+	if err := validateScriptFileMultiExt(pathArg, nodeScriptExts, "node", scriptRoots); err != nil {
+		return nil, err
+	}
+	return &Command{Argv: argv}, nil
+}
+
+// firstNonFlagArg returns the first argv element after argv[0] that is not a
+// -flag, and whether one was found.
+func firstNonFlagArg(argv []string) (string, bool) {
+	for i := 1; i < len(argv); i++ {
+		if strings.HasPrefix(argv[i], "-") {
+			continue
+		}
+		return argv[i], true
+	}
+	return "", false
+}
+
+// validateScriptFile checks pathArg is an absolute path with the given
+// extension, inside one of scriptRoots. label names the interpreter for errors.
+func validateScriptFile(pathArg, ext, label string, scriptRoots []string) error {
+	return validateScriptFileMultiExt(pathArg, []string{ext}, label, scriptRoots)
+}
+
+func validateScriptFileMultiExt(pathArg string, exts []string, label string, scriptRoots []string) error {
+	if !filepath.IsAbs(pathArg) {
+		return &ValidationError{
+			Code:   ErrCodeBadPathArg,
+			Detail: fmt.Sprintf("%s script path must be absolute, got %q", label, pathArg),
+		}
+	}
+	okExt := false
+	for _, e := range exts {
+		if strings.HasSuffix(pathArg, e) {
+			okExt = true
+			break
+		}
+	}
+	if !okExt {
+		return &ValidationError{
+			Code:   ErrCodeBadPathArg,
+			Detail: fmt.Sprintf("%s script path must end in %s, got %q", label, strings.Join(exts, "/"), pathArg),
+		}
+	}
+	return validatePathArg(pathArg, scriptRoots)
 }
 
 // validateWPCommand checks a wp command has required --path=<docroot> argument.

--- a/internal/cronvalidate/cron_fuzz_test.go
+++ b/internal/cronvalidate/cron_fuzz_test.go
@@ -24,7 +24,7 @@ func FuzzValidateCommand(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, input string) {
 		// Call the validator - must not panic
-		cmd, err := ValidateCommand(input, ownedDocroots)
+		cmd, err := ValidateCommand(input, ownedDocroots, "")
 
 		// If we get an error, it must have a code
 		if err != nil {

--- a/internal/cronvalidate/cron_injection_test.go
+++ b/internal/cronvalidate/cron_injection_test.go
@@ -22,7 +22,7 @@ func TestRejectControlCharInjection(t *testing.T) {
 		"wp cron event run --path=" + dr + " \"\n[Service]\"",
 	}
 	for _, p := range payloads {
-		if _, err := ValidateCommand(p, []string{dr}); err == nil {
+		if _, err := ValidateCommand(p, []string{dr}, ""); err == nil {
 			t.Errorf("control-char payload was ACCEPTED (injection): %q", p)
 		}
 	}
@@ -33,7 +33,7 @@ func TestRejectControlCharInjection(t *testing.T) {
 func TestTabStillAllowed(t *testing.T) {
 	dr := "/home/u/public_html"
 	// tab between args; should not be rejected for the control-char reason.
-	cmd, err := ValidateCommand("wp\tcron event run --path="+dr, []string{dr})
+	cmd, err := ValidateCommand("wp\tcron event run --path="+dr, []string{dr}, "")
 	if err != nil {
 		// It's fine if shlex/other rules reject for a different reason, but it
 		// must NOT be the control-char reject path with a real tab.

--- a/internal/cronvalidate/cron_test.go
+++ b/internal/cronvalidate/cron_test.go
@@ -334,7 +334,7 @@ func TestValidateCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := ValidateCommand(tt.raw, tt.docroots)
+			cmd, err := ValidateCommand(tt.raw, tt.docroots, "")
 
 			if tt.wantErr == "" {
 				require.NoError(t, err, tt.desc)
@@ -670,7 +670,7 @@ func BenchmarkValidateCommand(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = ValidateCommand(cmd, ownedDocroots)
+		_, _ = ValidateCommand(cmd, ownedDocroots, "")
 	}
 }
 

--- a/internal/cronvalidate/httptrigger.go
+++ b/internal/cronvalidate/httptrigger.go
@@ -212,13 +212,14 @@ func isHTTPTriggerBinary(raw string) bool {
 }
 
 // ValidateAny is the single command-validation entry point for callers
-// whose command may be either a wp/php exec OR a curl/wget http-trigger.
-// It dispatches on the first token: curl/wget -> ValidateHTTPTrigger
-// (gated on ownedDomains), everything else -> ValidateCommand (gated on
-// ownedDocroots, the wp/php closed set).
-func ValidateAny(raw string, ownedDocroots, ownedDomains []string) (*Command, error) {
+// whose command may be either a wp/php/python/node exec OR a curl/wget
+// http-trigger. It dispatches on the first token: curl/wget ->
+// ValidateHTTPTrigger (gated on ownedDomains), everything else ->
+// ValidateCommand (gated on ownedDocroots for wp/php, plus ownedHome for
+// python/node scripts).
+func ValidateAny(raw string, ownedDocroots, ownedDomains []string, ownedHome string) (*Command, error) {
 	if isHTTPTriggerBinary(raw) {
 		return ValidateHTTPTrigger(raw, ownedDomains)
 	}
-	return ValidateCommand(raw, ownedDocroots)
+	return ValidateCommand(raw, ownedDocroots, ownedHome)
 }

--- a/internal/cronvalidate/httptrigger_test.go
+++ b/internal/cronvalidate/httptrigger_test.go
@@ -101,12 +101,12 @@ func TestValidateAny_Routing(t *testing.T) {
 	dr := []string{"/home/u/domains/own.example.com/public_html"}
 	dom := ownDomains()
 
-	cmd, err := ValidateAny("curl https://own.example.com/wp-cron.php", dr, dom)
+	cmd, err := ValidateAny("curl https://own.example.com/wp-cron.php", dr, dom, "")
 	if err != nil || cmd.Kind != KindHTTPTrigger {
 		t.Fatalf("curl should route to http-trigger: cmd=%v err=%v", cmd, err)
 	}
 
-	cmd, err = ValidateAny("php /home/u/domains/own.example.com/public_html/wp-cron.php", dr, dom)
+	cmd, err = ValidateAny("php /home/u/domains/own.example.com/public_html/wp-cron.php", dr, dom, "")
 	if err != nil {
 		t.Fatalf("php should validate via wp/php path: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestValidateAny_Routing(t *testing.T) {
 
 	// A curl to a foreign host must be REJECTED, not silently accepted by
 	// the wp/php path (which would reject it for a different reason).
-	if _, err := ValidateAny("curl https://evil.com/x", dr, dom); err == nil {
+	if _, err := ValidateAny("curl https://evil.com/x", dr, dom, ""); err == nil {
 		t.Fatalf("foreign-host curl must be rejected by ValidateAny")
 	}
 }

--- a/internal/cronvalidate/multi.go
+++ b/internal/cronvalidate/multi.go
@@ -32,7 +32,7 @@ const (
 // (starting with '#') are skipped, so a pasted script's `#!/bin/bash` header is
 // tolerated — but every executable line must still pass the closed allow-list.
 // A single-line command yields a one-element slice (back-compatible).
-func ValidateAnyMulti(raw string, ownedDocroots, ownedDomains []string) ([]*Command, error) {
+func ValidateAnyMulti(raw string, ownedDocroots, ownedDomains []string, ownedHome string) ([]*Command, error) {
 	if len(raw) > maxMultiCommandBytes {
 		return nil, &ValidationError{
 			Code:   ErrCodeTooLong,
@@ -52,7 +52,7 @@ func ValidateAnyMulti(raw string, ownedDocroots, ownedDomains []string) ([]*Comm
 				Detail: fmt.Sprintf("too many commands (max %d)", maxCronCommands),
 			}
 		}
-		c, err := ValidateAny(trimmed, ownedDocroots, ownedDomains)
+		c, err := ValidateAny(trimmed, ownedDocroots, ownedDomains, ownedHome)
 		if err != nil {
 			// Prefix the failing line number so the operator can fix the right line.
 			if ve, ok := err.(*ValidationError); ok {

--- a/internal/cronvalidate/multi_test.go
+++ b/internal/cronvalidate/multi_test.go
@@ -13,7 +13,7 @@ func TestValidateAnyMulti_OrderedWPSequence(t *testing.T) {
 		"\n" + // blank line tolerated
 		"# import step\n" +
 		"wp --path=/home/u/domains/x/public_html all-import run 1 --force-run\n"
-	cmds, err := ValidateAnyMulti(raw, testDocroots, nil)
+	cmds, err := ValidateAnyMulti(raw, testDocroots, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestValidateAnyMulti_OrderedWPSequence(t *testing.T) {
 }
 
 func TestValidateAnyMulti_SingleLineBackCompat(t *testing.T) {
-	cmds, err := ValidateAnyMulti("wp --path=/home/u/domains/x/public_html cron event run --due-now", testDocroots, nil)
+	cmds, err := ValidateAnyMulti("wp --path=/home/u/domains/x/public_html cron event run --due-now", testDocroots, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestValidateAnyMulti_RejectsBadLineWithLineNumber(t *testing.T) {
 	// line 2 tries to escape the allow-list.
 	raw := "wp --path=/home/u/domains/x/public_html cron event run\n" +
 		"cd /etc && cat shadow"
-	_, err := ValidateAnyMulti(raw, testDocroots, nil)
+	_, err := ValidateAnyMulti(raw, testDocroots, nil, "")
 	if err == nil {
 		t.Fatal("expected rejection of the shell line")
 	}
@@ -54,13 +54,13 @@ func TestValidateAnyMulti_RejectsBadLineWithLineNumber(t *testing.T) {
 func TestValidateAnyMulti_MetacharOnAnyLineRejected(t *testing.T) {
 	raw := "wp --path=/home/u/domains/x/public_html cron event run\n" +
 		"php /home/u/domains/x/public_html/a.php; rm -rf /"
-	if _, err := ValidateAnyMulti(raw, testDocroots, nil); err == nil {
+	if _, err := ValidateAnyMulti(raw, testDocroots, nil, ""); err == nil {
 		t.Fatal("a metachar on any line must reject the whole job")
 	}
 }
 
 func TestValidateAnyMulti_EmptyAfterSkips(t *testing.T) {
-	if _, err := ValidateAnyMulti("#!/bin/bash\n\n# only comments\n", testDocroots, nil); err == nil {
+	if _, err := ValidateAnyMulti("#!/bin/bash\n\n# only comments\n", testDocroots, nil, ""); err == nil {
 		t.Fatal("a command with no executable lines must be rejected")
 	}
 }
@@ -69,7 +69,7 @@ func TestValidateAnyMulti_PathStillEnforcedPerLine(t *testing.T) {
 	// second line's --path points outside the owned docroot.
 	raw := "wp --path=/home/u/domains/x/public_html cron event run\n" +
 		"wp --path=/home/other/domains/y/public_html plugin list"
-	if _, err := ValidateAnyMulti(raw, testDocroots, nil); err == nil {
+	if _, err := ValidateAnyMulti(raw, testDocroots, nil, ""); err == nil {
 		t.Fatal("a --path outside owned docroots must reject the job")
 	}
 }
@@ -79,7 +79,7 @@ func TestValidateAnyMulti_TooMany(t *testing.T) {
 	for i := 0; i < maxCronCommands+1; i++ {
 		b.WriteString("wp --path=/home/u/domains/x/public_html cron event run\n")
 	}
-	if _, err := ValidateAnyMulti(b.String(), testDocroots, nil); err == nil {
+	if _, err := ValidateAnyMulti(b.String(), testDocroots, nil, ""); err == nil {
 		t.Fatalf("more than %d commands must be rejected", maxCronCommands)
 	}
 }

--- a/internal/cronvalidate/python_node_test.go
+++ b/internal/cronvalidate/python_node_test.go
@@ -1,0 +1,98 @@
+package cronvalidate
+
+import "testing"
+
+// GH #1435: python and node were advertised in the docs but the validator only
+// accepted wp/php. These lock the added interpreters: a bare/versioned/venv
+// interpreter running an absolute script file inside the account (home or a
+// docroot), with inline-code execution refused.
+
+const (
+	pnHome    = "/home/u"
+	pnDocroot = "/home/u/domains/x/public_html"
+)
+
+func pnValidate(t *testing.T, raw string) (*Command, error) {
+	t.Helper()
+	return ValidateCommand(raw, []string{pnDocroot}, pnHome)
+}
+
+func TestPython_AcceptsScriptUnderHome(t *testing.T) {
+	// The reporter's Django case: absolute manage.py + a subcommand, no cd.
+	cases := []string{
+		"python /home/u/site/manage.py migrate",
+		"python3 /home/u/site/manage.py runjobs",
+		"python3.11 /home/u/site/manage.py all-import",
+		"/home/u/venv/bin/python /home/u/site/manage.py migrate",       // virtualenv interpreter
+		"/home/u/.pyenv/versions/3.11.0/bin/python3.11 /home/u/x/m.py", // pyenv build
+		"python /home/u/domains/x/public_html/task.py",                 // docroot also allowed
+		"python -V",
+		"python --version",
+	}
+	for _, raw := range cases {
+		if _, err := pnValidate(t, raw); err != nil {
+			t.Errorf("expected accept, got %v for %q", err, raw)
+		}
+	}
+}
+
+func TestPython_Rejects(t *testing.T) {
+	cases := map[string]string{
+		"inline -c":       "python -c pass",
+		"module -m":       "python -m http.server",
+		"stdin -":         "python -",
+		"relative script": "python manage.py migrate",
+		"wrong extension": "python /home/u/site/manage.txt",
+		"outside home":    "python /home/other/site/manage.py",
+		"traversal":       "python /home/u/../other/x.py",
+		"no argument":     "python",
+	}
+	for name, raw := range cases {
+		if _, err := pnValidate(t, raw); err == nil {
+			t.Errorf("%s: expected reject, accepted %q", name, raw)
+		}
+	}
+}
+
+func TestNode_AcceptsScriptUnderHome(t *testing.T) {
+	cases := []string{
+		"node /home/u/app/server.js",
+		"nodejs /home/u/app/job.js run",
+		"/home/u/.nvm/versions/node/v20/bin/node /home/u/app/task.mjs",
+		"node /home/u/domains/x/public_html/build.cjs",
+		"node -v",
+	}
+	for _, raw := range cases {
+		if _, err := pnValidate(t, raw); err != nil {
+			t.Errorf("expected accept, got %v for %q", err, raw)
+		}
+	}
+}
+
+func TestNode_Rejects(t *testing.T) {
+	cases := map[string]string{
+		"eval -e":         "node -e code",
+		"eval --eval":     "node --eval code",
+		"print -p":        "node -p code",
+		"relative script": "node app/server.js",
+		"wrong extension": "node /home/u/app/server.ts",
+		"outside home":    "node /home/other/app/server.js",
+	}
+	for name, raw := range cases {
+		if _, err := pnValidate(t, raw); err == nil {
+			t.Errorf("%s: expected reject, accepted %q", name, raw)
+		}
+	}
+}
+
+// Without a home (ownedHome==""), a python/node script must fall under a
+// docroot — the cpanel-restore path passes home, but a defensive "" must not
+// silently widen containment.
+func TestPythonNode_NoHomeRestrictsToDocroot(t *testing.T) {
+	if _, err := ValidateCommand("python /home/u/site/manage.py migrate", []string{pnDocroot}, ""); err == nil {
+		t.Error("python under home but not docroot must be rejected when ownedHome is empty")
+	}
+	if _, err := ValidateCommand("python /home/u/domains/x/public_html/task.py", []string{pnDocroot}, ""); err != nil {
+		t.Errorf("python under docroot must pass even with empty home: %v", err)
+	}
+}

--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -30,6 +30,17 @@ type cronApplyParams struct {
 	RunAsRoot     bool     `json:"run_as_root,omitempty"`
 }
 
+// cronHomeForUser is the account's home directory — the containment root for
+// python/node cron scripts (GH #1435). Tenant homes are /home/<username>; the
+// root cron account is /root. Mirrors the panel-side derivation so the
+// pre-accept gate and this defense-in-depth re-check agree.
+func cronHomeForUser(username string) string {
+	if username == "root" {
+		return "/root"
+	}
+	return "/home/" + username
+}
+
 // cronApplyResponse is the output from cron.apply.
 type cronApplyResponse struct {
 	ServicePath string `json:"service_path"`
@@ -92,7 +103,7 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	// ValidateAny routes curl/wget self-domain crons (GH #400 Part B) to the
 	// http-trigger validator (gated on OwnedDomains); everything else stays
 	// the wp/php closed set (gated on OwnedDocroots).
-	cmds, err := cronvalidate.ValidateAnyMulti(p.Command, p.OwnedDocroots, p.OwnedDomains)
+	cmds, err := cronvalidate.ValidateAnyMulti(p.Command, p.OwnedDocroots, p.OwnedDomains, cronHomeForUser(p.Username))
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/cron_multi_test.go
+++ b/panel-agent/internal/commands/cron_multi_test.go
@@ -13,7 +13,7 @@ func TestBuildCronServiceContent_MultiCommand(t *testing.T) {
 	dr := "/home/u/domains/x/public_html"
 	raw := "wp --path=" + dr + " keyhook-properties generate-xml --file=" + dr + "/props.xml\n" +
 		"wp --path=" + dr + " all-import run 1 --force-run"
-	cmds, err := cronvalidate.ValidateAnyMulti(raw, []string{dr}, nil)
+	cmds, err := cronvalidate.ValidateAnyMulti(raw, []string{dr}, nil, "")
 	if err != nil {
 		t.Fatalf("validate: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestBuildCronServiceContent_MultiCommand(t *testing.T) {
 // from the glued `--path=<dir>` form).
 func TestBuildCronServiceContent_TwoTokenPathGates(t *testing.T) {
 	dr := "/home/u/domains/x/public_html"
-	cmds, err := cronvalidate.ValidateAnyMulti("wp --path "+dr+" plugin list", []string{dr}, nil)
+	cmds, err := cronvalidate.ValidateAnyMulti("wp --path "+dr+" plugin list", []string{dr}, nil, "")
 	if err != nil {
 		t.Fatalf("validate: %v", err)
 	}

--- a/panel-agent/internal/commands/cron_precheck_install_test.go
+++ b/panel-agent/internal/commands/cron_precheck_install_test.go
@@ -20,7 +20,7 @@ var libexecRefRe = regexp.MustCompile(`/usr/local/libexec/jabali/([A-Za-z0-9._-]
 // jabali/<name> in a rendered cron service unit, assert install/systemd/
 // <name> exists in the repo AND install.sh installs it.
 func TestGeneratedUnitLibexecHelpersAreShipped(t *testing.T) {
-	cmd, err := cronvalidate.ValidateCommand("php /home/u/public_html/wp-cron.php", []string{"/home/u/public_html"})
+	cmd, err := cronvalidate.ValidateCommand("php /home/u/public_html/wp-cron.php", []string{"/home/u/public_html"}, "")
 	if err != nil {
 		t.Fatalf("validate: %v", err)
 	}

--- a/panel-agent/internal/commands/cron_run_now.go
+++ b/panel-agent/internal/commands/cron_run_now.go
@@ -67,7 +67,7 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// Defense-in-depth: re-validate the command against the user's owned
 	// docroots (same gate as cron.apply) before executing it. Never trust
 	// the stored command blindly. GH #1435: a job may hold several commands.
-	validatedCmds, vErr := cronvalidate.ValidateAnyMulti(p.Command, p.OwnedDocroots, p.OwnedDomains)
+	validatedCmds, vErr := cronvalidate.ValidateAnyMulti(p.Command, p.OwnedDocroots, p.OwnedDomains, cronHomeForUser(p.Username))
 	if vErr != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-api/internal/api/applications_test.go
+++ b/panel-api/internal/api/applications_test.go
@@ -786,7 +786,7 @@ func TestAppCronSpecs(t *testing.T) {
 			if err := cronvalidate.ValidateCronName(c.name); err != nil {
 				t.Errorf("%s: bad cron name %q: %v", app, c.name, err)
 			}
-			if _, err := cronvalidate.ValidateCommand(c.command, owned); err != nil {
+			if _, err := cronvalidate.ValidateCommand(c.command, owned, ""); err != nil {
 				t.Errorf("%s: command rejected by allowlist %q: %v", app, c.command, err)
 			}
 		}

--- a/panel-api/internal/cronops/cronops.go
+++ b/panel-api/internal/cronops/cronops.go
@@ -169,6 +169,16 @@ func ownedTargets(ctx context.Context, d Deps, userID string) (docroots, domains
 	return docroots, domains, nil
 }
 
+// homeForUser is the account's home directory, the containment root for
+// python/node cron scripts (GH #1435). Tenant homes are /home/<username>; the
+// root cron account is /root.
+func homeForUser(username string) string {
+	if username == "root" {
+		return "/root"
+	}
+	return "/home/" + username
+}
+
 func apply(ctx context.Context, d Deps, job *models.CronJob, username string, docroots, domains []string) error {
 	actx, cancel := context.WithTimeout(ctx, agentTimeout)
 	defer cancel()
@@ -212,7 +222,7 @@ func Create(ctx context.Context, d Deps, in CreateInput) (*models.CronJob, error
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cronvalidate.ValidateAnyMulti(in.Command, docroots, domains); err != nil {
+	if _, err := cronvalidate.ValidateAnyMulti(in.Command, docroots, domains, homeForUser(username)); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrCommandInvalid, err)
 	}
 
@@ -272,7 +282,7 @@ func Update(ctx context.Context, d Deps, jobID string, patch UpdatePatch) (*mode
 		job.Name = *patch.Name
 	}
 	if patch.Command != nil {
-		if _, err := cronvalidate.ValidateAnyMulti(*patch.Command, docroots, domains); err != nil {
+		if _, err := cronvalidate.ValidateAnyMulti(*patch.Command, docroots, domains, homeForUser(username)); err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrCommandInvalid, err)
 		}
 		job.Command = cronvalidate.NormalizeMultiCommand(*patch.Command)

--- a/panel-api/internal/migrate/cpanel/restore_cron.go
+++ b/panel-api/internal/migrate/cpanel/restore_cron.go
@@ -161,7 +161,7 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 				// Defense-in-depth: never trust the rewrite — re-run it
 				// through the same validator the REST handler uses, now
 				// with the account's real docroots so the php path passes.
-				if _, vErr := cronvalidate.ValidateCommand(rewritten, ownedDocroots); vErr != nil {
+				if _, vErr := cronvalidate.ValidateCommand(rewritten, ownedDocroots, "/home/"+targetUsername); vErr != nil {
 					res.Skipped = append(res.Skipped, fmt.Sprintf(
 						"%s:%d cron_disabled_import (rewrite_revalidate_failed: %s): %s",
 						cronPath, lineNum, vErr.Error(), origCommand))
@@ -182,7 +182,7 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 
 			// Non-curl/wget: validate against the account's docroots.
 			// Pass → row. Fail → disabled-import (preserve original + note).
-			if _, vErr := cronvalidate.ValidateCommand(command, ownedDocroots); vErr != nil {
+			if _, vErr := cronvalidate.ValidateCommand(command, ownedDocroots, "/home/"+targetUsername); vErr != nil {
 				res.Skipped = append(res.Skipped, fmt.Sprintf(
 					"%s:%d cron_disabled_import (command: %s): %s",
 					cronPath, lineNum, vErr.Error(), origCommand))

--- a/panel-ui/src/shells/user/cron/CreateCronModal.tsx
+++ b/panel-ui/src/shells/user/cron/CreateCronModal.tsx
@@ -119,9 +119,9 @@ export const CreateCronModal = ({
       // Stable, test-regex-matching headline per code so users see the
       // actionable summary even if the toast scrolls.
       const headlineByCode: Record<string, string> = {
-        binary_not_allowed: "Binary not allowed — command must start with wp or php",
+        binary_not_allowed: "Binary not allowed — command must start with wp, php, python, or node",
         metachar_reject: "Shell metacharacters not allowed in command",
-        bad_path_arg: "Invalid path / traversal not allowed — must be an absolute path inside an owned docroot",
+        bad_path_arg: "Invalid path / traversal not allowed — must be an absolute path inside your account",
         bad_schedule_syntax: "Invalid schedule syntax",
         schedule_too_frequent: "Schedule too frequent — minimum 1-minute step",
         invalid_name: "Invalid name — control characters or empty",
@@ -189,7 +189,7 @@ export const CreateCronModal = ({
           rules={[
             { required: true, message: "Please enter a command" },
           ]}
-          extra="One wp/php command per line — they run in order and stop at the first failure. Use --path=<docroot> instead of cd."
+          extra="One command per line (wp / php / python / node) — they run in order and stop at the first failure. Use absolute paths instead of cd/$HOME."
         >
           <Input.TextArea
             placeholder={
@@ -203,9 +203,12 @@ export const CreateCronModal = ({
 
         <Form.Item>
           <Typography.Text type="secondary">
-            Must start with <code>wp</code>, <code>php</code>, or a specific
-            version like <code>php8.5</code> (bare <code>php</code> uses your
-            assigned version). Shell operators (|, &, $, ...) are rejected.
+            Must start with <code>wp</code>, <code>php</code> (or a version like{" "}
+            <code>php8.5</code>), <code>python</code>/<code>python3</code>,{" "}
+            <code>node</code>, or <code>curl</code>. Interpreters run an absolute
+            script file inside your account (<code>.php</code> in a docroot;{" "}
+            <code>.py</code>/<code>.js</code> anywhere under your home). Inline
+            code and shell operators (|, &, $, ...) are rejected.
           </Typography.Text>
         </Form.Item>
 


### PR DESCRIPTION
## What

The cron command allowlist accepted only `wp` / `php` / `php<X.Y>`, but `docs/site/user/cron-jobs.md` advertised `python`/`python3`, `node`, and `curl` too. A reporter (webquest-nz) followed the docs to schedule a Django `python manage.py` job and hit "not allowed" (GH #1435). `curl`/`wget` was already implemented (the self-domain http-trigger); this adds **python** and **node** and corrects the docs.

## New interpreters (mirroring the php path-discipline)

- **python** / **python3** / **python<X.Y>** (bare), or an absolute path to one (a **virtualenv**/pyenv interpreter). Must run an **absolute `.py` file inside the account**; `-c` / `-m` / stdin `-` rejected.
- **node** / **nodejs** (bare, or an absolute path — an nvm build). Must run an **absolute `.js`/`.mjs`/`.cjs` file inside the account**; `-e` / `--eval` / `-p` / `--print` rejected.

Django, with no `cd`: `python3 /home/USER/site/manage.py runjobs`, or with a venv `/home/USER/venv/bin/python /home/USER/site/manage.py migrate`.

## Containment — the one design choice

wp/php are docroot-only. A Python/Node project's entry file (`manage.py`, a script) usually lives **under the home but outside any web docroot**, so the script may sit anywhere under the account's **home or a docroot**. Home is derived as `/home/<username>` (`/root` for root crons) on **both** the panel pre-accept gate and the agent's defense-in-depth re-check, threaded as a new `ownedHome` arg through `ValidateCommand`/`ValidateAny`/`ValidateAnyMulti`.

## Security posture

All existing defenses run first and unchanged: no shell metacharacters, no control characters, no `..`, single-quoted argv into the systemd unit. The interpreter runs a file the tenant owns — exactly like the php rule — so there's **no new sandbox-escape class** (a cron already executes the tenant's own scripts as their uid; the boundary is "named file, no inline code, no shell", which is preserved). Bare `python3`/`node` resolve the system version via the cron unit PATH; a venv/pyenv/nvm build is given by absolute path. Consistent with php, an absolute *interpreter* path is accepted as-is (not pinned to home) — a follow-up could tighten interpreter paths for php+python+node together, but it adds little since the script is already tenant-controlled code.

## Docs / UI

`cron-jobs.md` rewritten to describe the real allowlist + per-interpreter rules (the old "php with any args" / "wp with any args" were also wrong). Cron create-form help text updated.

## Verification

- New `python_node_test.go`: accept (home/docroot/venv/versioned) + reject (`-c`/`-m`/`-`, `-e`/`-p`, relative, wrong ext, outside account, traversal) + empty-home-restricts-to-docroot.
- Full `cronvalidate` suite incl. **fuzz + injection** green; `cronops`, agent `commands`, `api`, cpanel-restore tests green.
- **Box-drilled on the test server** (agent `cron.run_now` as tenant `testing44`): `python3 <abs .py under home>` → exit 0, stdout `jab1435-python-ran`; `python3 -c pass` → rejected (inline); `python3 /etc/x.py` → rejected (outside account); relative path → rejected. Old agent restored after.

**Rollout:** the validator is shared (panel binary) + the agent re-checks, so both the panel and each server's agent need the update — same fleet-agent redeploy as #1408/#1416.

Tracking against GH #1435.
