### PR TITLE
refactor(domains): one shared SSL-state matrix for admin + tenant lists (JAB-300)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -27,6 +27,7 @@ import { apiClient } from "../../../apiClient";
 import { columnSearchProps } from "../../../components/columnSearch";
 import { RowActionButton } from "../../../components/RowActionButton";
 import { humanBytes } from "../../../utils/bytes";
+import { getSSLTag } from "../../../utils/sslState";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
 import { useDeleteMutation, useOneQuery } from "../../../hooks/useQueries";
@@ -114,29 +115,15 @@ const renderRedirect = (d: Domain) => {
   return <span style={{ color: "#bbb" }}>—</span>;
 };
 
+// JAB-300: the admin list renders the SSL badge through the shared
+// utils/sslState matrix (getSSLTag) — the same one the tenant + Mail Domains
+// lists use — so the two screens can't drift. This folds the nested admin wire
+// (`ssl: { status: "issued", issuer }`) onto the canonical flat `ssl_state`
+// vocabulary; a valid Let's Encrypt cert now renders gold (matching the tenant
+// list + the operator's colour request) instead of the old admin-only green.
 const renderSSL = (ssl: SSLBadge | null | undefined) => {
-  if (!ssl) return <Tag>Off</Tag>;
-  switch (ssl.status) {
-    case "issued":
-      return <Tag color="green">{ssl.issuer || "Let's Encrypt"}</Tag>;
-    case "none":
-      return <Tag>None</Tag>;
-    case "provisioning":
-      return <Tag color="orange">Self-signed…</Tag>;
-    case "self_signed":
-      return <Tag color="orange">Self-signed</Tag>;
-    case "pending":
-    case "issuing":
-    case "renewing":
-    case "pending_acme_retry":
-      return <Tag color="green">Issuing…</Tag>;
-    case "failed":
-      return <Tag color="red">Failed</Tag>;
-    case "revoked":
-      return <Tag color="red">Revoked</Tag>;
-    default:
-      return <Tag>Off</Tag>;
-  }
+  const { color, label } = getSSLTag(ssl);
+  return <Tag color={color}>{label}</Tag>;
 };
 
 export type Domain = {

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -24,7 +24,7 @@ import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { sorterToParams } from "../../../utils/tableSorter";
-import { getSSLTagColor, getSSLTagLabel } from "../../../utils/sslState";
+import { getSSLTag } from "../../../utils/sslState";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { DomainDocRootModal } from "./DomainDocRootModal";
@@ -248,9 +248,12 @@ export const UserDomainList = () => {
           <Table.Column<Domain>
             dataIndex="ssl_state"
             title={t("userdomainlist.ssl")}
-            render={(state?: string) => (
-              <Tag color={getSSLTagColor(state)}>{getSSLTagLabel(state)}</Tag>
-            )}
+            render={(state?: string) => {
+              // JAB-300: shared matrix entry point — same getSSLTag the admin
+              // list renders through, so the two screens stay identical.
+              const { color, label } = getSSLTag(state);
+              return <Tag color={color}>{label}</Tag>;
+            }}
           />
           <Table.Column<Domain>
             title={t("userdomainlist.redirect")}

--- a/panel-ui/src/utils/sslState.test.ts
+++ b/panel-ui/src/utils/sslState.test.ts
@@ -1,0 +1,171 @@
+// sslState.test.ts — the JAB-300 "one tested SSL state matrix" that normalizes
+// BOTH the tenant flat `ssl_state` wire and the admin nested `ssl: { status,
+// issuer }` wire onto one color/label rendering. The parity block is the point:
+// the two wire shapes for the same underlying state must render identically.
+import { describe, it, expect } from "vitest";
+import {
+  getSSLTagColor,
+  getSSLTagLabel,
+  normalizeSSLBadge,
+  getSSLTag,
+} from "./sslState";
+
+describe("getSSLTagColor (flat ssl_state matrix)", () => {
+  const cases: Array<[string | undefined, string]> = [
+    ["active_le", "gold"],
+    ["active", "green"],
+    ["provisioning", "orange"],
+    ["self_signed", "orange"],
+    ["pending", "green"],
+    ["issuing", "green"],
+    ["renewing", "green"],
+    ["pending_acme_retry", "green"],
+    ["custom", "green"],
+    ["failed", "red"],
+    ["error", "red"],
+    ["revoked", "red"],
+    ["none", "default"],
+    ["off", "default"],
+    ["", "default"],
+    [undefined, "default"],
+    ["something_new", "default"],
+  ];
+  it.each(cases)("%s → %s", (state, color) => {
+    expect(getSSLTagColor(state)).toBe(color);
+  });
+});
+
+describe("getSSLTagLabel (flat ssl_state matrix)", () => {
+  const cases: Array<[string | undefined, string]> = [
+    ["active_le", "Let's Encrypt"],
+    ["active", "Active"],
+    ["none", "None"],
+    ["provisioning", "Self-signed…"],
+    ["self_signed", "Self-signed"],
+    ["pending", "Issuing…"],
+    ["issuing", "Issuing…"],
+    ["renewing", "Issuing…"],
+    ["pending_acme_retry", "Issuing…"],
+    ["custom", "Custom"],
+    ["failed", "Failed"],
+    ["error", "Failed"],
+    ["revoked", "Revoked"],
+    ["off", "Off"],
+    ["", "Off"],
+    [undefined, "Off"],
+    // Unknown states fall through to the raw string so an unexpected backend
+    // state is visible rather than silently rendered "Off".
+    ["brand_new_state", "brand_new_state"],
+  ];
+  it.each(cases)("%s → %s", (state, label) => {
+    expect(getSSLTagLabel(state)).toBe(label);
+  });
+});
+
+// The AC's teeth: pin the matrix to what the two backends ACTUALLY emit, so a
+// new backend state can't slip through to the raw-string passthrough unnoticed.
+describe("backend SSL vocabularies are fully pinned (no raw passthrough)", () => {
+  const KNOWN_LABELS = new Set([
+    "Let's Encrypt",
+    "Active",
+    "None",
+    "Self-signed…",
+    "Self-signed",
+    "Issuing…",
+    "Failed",
+    "Revoked",
+    "Off",
+    "Custom",
+  ]);
+  // Flat wire — internal/repository/domain_repository.go computeSSLState.
+  const FLAT_STATES = ["off", "pending", "active_le", "self_signed", "failed"];
+  // Admin nested wire — internal/api/domains.go sslBadgeForDomain +
+  // sslBadgeFromCert set status = cert.Status (models/ssl_certificate.go) plus
+  // the literal "none"/"provisioning".
+  const ADMIN_STATUSES = [
+    "pending",
+    "issuing",
+    "issued",
+    "failed",
+    "revoked",
+    "renewing",
+    "self_signed",
+    "custom",
+    "pending_acme_retry",
+    "none",
+    "provisioning",
+  ];
+
+  it.each(FLAT_STATES)("flat ssl_state %s resolves to a known label", (s) => {
+    expect(KNOWN_LABELS.has(getSSLTag(s).label)).toBe(true);
+  });
+  it.each(ADMIN_STATUSES)("admin nested status %s resolves to a known label", (s) => {
+    // issuer mirrors what sslBadgeFromCert hardcodes for issued/renewing certs.
+    expect(KNOWN_LABELS.has(getSSLTag({ status: s, issuer: "Let's Encrypt" }).label)).toBe(true);
+  });
+});
+
+describe("normalizeSSLBadge (nested admin wire → canonical flat state)", () => {
+  it("folds the admin 'issued' spelling onto active_le, keeping the issuer", () => {
+    expect(normalizeSSLBadge({ status: "issued", issuer: "Let's Encrypt" })).toEqual({
+      state: "active_le",
+      issuer: "Let's Encrypt",
+    });
+  });
+  it("passes a non-diverging status through unchanged", () => {
+    expect(normalizeSSLBadge({ status: "self_signed" })).toEqual({
+      state: "self_signed",
+      issuer: undefined,
+    });
+  });
+  it("treats a null badge or a badge with no status as Off ('')", () => {
+    expect(normalizeSSLBadge(null)).toEqual({ state: "" });
+    expect(normalizeSSLBadge(undefined)).toEqual({ state: "" });
+    expect(normalizeSSLBadge({ status: "" })).toEqual({ state: "" });
+    expect(normalizeSSLBadge({ status: null })).toEqual({ state: "" });
+  });
+});
+
+describe("getSSLTag (single entry point for both wire shapes)", () => {
+  it("renders a flat ssl_state string", () => {
+    expect(getSSLTag("active_le")).toEqual({ color: "gold", label: "Let's Encrypt" });
+    expect(getSSLTag("self_signed")).toEqual({ color: "orange", label: "Self-signed" });
+    expect(getSSLTag("failed")).toEqual({ color: "red", label: "Failed" });
+    expect(getSSLTag("")).toEqual({ color: "default", label: "Off" });
+    expect(getSSLTag(undefined)).toEqual({ color: "default", label: "Off" });
+  });
+
+  it("renders a nested admin badge, using the issuer as the label on a good cert", () => {
+    expect(getSSLTag({ status: "issued", issuer: "Let's Encrypt" })).toEqual({
+      color: "gold",
+      label: "Let's Encrypt",
+    });
+    // A custom-uploaded cert's issuer/CN overrides the generic label.
+    expect(getSSLTag({ status: "issued", issuer: "DigiCert Inc" })).toEqual({
+      color: "gold",
+      label: "DigiCert Inc",
+    });
+    // Issued but no issuer supplied → falls back to the canonical label.
+    expect(getSSLTag({ status: "issued" })).toEqual({ color: "gold", label: "Let's Encrypt" });
+    expect(getSSLTag({ status: "failed" })).toEqual({ color: "red", label: "Failed" });
+    // The issuer is ignored for non-active states.
+    expect(getSSLTag({ status: "failed", issuer: "whoever" })).toEqual({
+      color: "red",
+      label: "Failed",
+    });
+    expect(getSSLTag(null)).toEqual({ color: "default", label: "Off" });
+    expect(getSSLTag({ status: "" })).toEqual({ color: "default", label: "Off" });
+  });
+
+  it("PARITY: the nested and flat wire cases for the same state render identically", () => {
+    // A valid Let's Encrypt cert: admin sends { status: 'issued' }, tenant
+    // sends 'active_le'. Both must produce the same badge (the drift this slice
+    // removes — admin used to render this green, tenant gold).
+    expect(getSSLTag({ status: "issued", issuer: "Let's Encrypt" })).toEqual(
+      getSSLTag("active_le"),
+    );
+    expect(getSSLTag({ status: "self_signed" })).toEqual(getSSLTag("self_signed"));
+    expect(getSSLTag({ status: "revoked" })).toEqual(getSSLTag("revoked"));
+    expect(getSSLTag(null)).toEqual(getSSLTag(""));
+  });
+});

--- a/panel-ui/src/utils/sslState.ts
+++ b/panel-ui/src/utils/sslState.ts
@@ -12,6 +12,7 @@ export const getSSLTagColor = (state?: string): string => {
     case "active_le":
       return "gold"; // Let's Encrypt rendered yellow per operator request
     case "active":
+    case "custom": // a valid admin-uploaded custom cert serves TLS
       return "green";
     case "provisioning":
       return "orange";
@@ -26,6 +27,7 @@ export const getSSLTagColor = (state?: string): string => {
     case "error":
     case "revoked":
       return "red";
+    // "off"/"none"/""/undefined and any unknown state → neutral tag.
     default:
       return "default";
   }
@@ -48,15 +50,73 @@ export const getSSLTagLabel = (state?: string): string => {
     case "renewing":
     case "pending_acme_retry":
       return "Issuing…";
+    case "custom":
+      return "Custom";
     case "failed":
     case "error":
       return "Failed";
     case "revoked":
       return "Revoked";
+    // "off" is the flat wire's disabled state (computeSSLState); render it the
+    // same as the empty/undefined case rather than the raw lowercase string.
+    case "off":
     case "":
     case undefined:
       return "Off";
     default:
       return state;
   }
+};
+
+// SSLBadgeLike is the admin domain list's nested SSL wire shape (GET
+// /admin/domains embeds `ssl: { status, issuer, … }`), as opposed to the
+// tenant list's flat `ssl_state` string. The admin backend spells a valid
+// certificate `status: "issued"`; the flat wire spells the same thing
+// `active_le`. JAB-300 folds both onto one color/label matrix so the two
+// domain screens can't drift (admin used to render Let's Encrypt green while
+// the tenant/Mail lists render it gold per the operator's request).
+export type SSLBadgeLike = {
+  status?: string | null;
+  issuer?: string | null;
+} | null | undefined;
+
+// nestedStatusToFlat maps the admin nested-badge vocabulary onto the canonical
+// flat `ssl_state` vocabulary the matrix above is keyed on. Only "issued"
+// diverges — every other admin status (self_signed, pending, issuing,
+// renewing, pending_acme_retry, failed, revoked, none, provisioning) already
+// matches the flat spelling, so an unmapped status passes through unchanged.
+const nestedStatusToFlat: Record<string, string> = {
+  issued: "active_le",
+};
+
+// normalizeSSLBadge reduces a nested admin SSL badge to the canonical flat
+// state plus its issuer. A badge with no status (or a null badge) normalizes
+// to "" — the "Off" case.
+export const normalizeSSLBadge = (
+  ssl: SSLBadgeLike,
+): { state: string; issuer?: string | null } => {
+  if (!ssl || !ssl.status) return { state: "" };
+  return { state: nestedStatusToFlat[ssl.status] ?? ssl.status, issuer: ssl.issuer };
+};
+
+// getSSLTag resolves the Tag color + label for EITHER a flat `ssl_state`
+// string or an admin nested SSL badge — the single entry point both domain
+// screens render through. For an active certificate the badge's issuer (e.g. a
+// custom-uploaded cert's CN) overrides the generic label, preserving the admin
+// list's behaviour of showing the issuer name on a good cert.
+export const getSSLTag = (
+  input: string | SSLBadgeLike,
+): { color: string; label: string } => {
+  let state: string;
+  let issuer: string | null | undefined;
+  if (input && typeof input === "object") {
+    ({ state, issuer } = normalizeSSLBadge(input));
+  } else {
+    state = input ?? "";
+  }
+  const activeWithIssuer = (state === "active_le" || state === "active") && !!issuer;
+  return {
+    color: getSSLTagColor(state),
+    label: activeWithIssuer ? (issuer as string) : getSSLTagLabel(state),
+  };
 };


### PR DESCRIPTION
## JAB-300 — one shared SSL-state matrix for the admin + tenant domain lists

> **Operator heads-up (one visible change):** the **admin** domain list's Let's
> Encrypt badge goes **green → gold**, to match the tenant + Mail Domains lists
> (and the existing "LE rendered yellow per operator request" in the shared
> util). If you'd rather admin keep green, say so — it's a one-line revert of the
> `active_le` colour and nothing else in this PR depends on it.

### The drift
The two domain lists rendered a domain's SSL badge two different ways over two
different wire shapes:

| | admin `DomainList` | tenant `UserDomainList` |
|---|---|---|
| wire | nested `ssl: { status, issuer }` | flat `ssl_state` string |
| valid cert | `status: "issued"` → **green**, issuer label | `active_le` → **gold** "Let's Encrypt" |
| mapping | inline `renderSSL` in the page | shared `utils/sslState.ts` (also Mail Domains) |

Same certificate, different colour on the two screens — and the tenant util
already carried a comment that it "still mirrors admin DomainList renderSSL",
i.e. two copies that drift by hand.

### The slice (JAB-300 "one tested SSL state matrix …")
- `utils/sslState.ts` gains **`normalizeSSLBadge`** (folds the nested admin badge
  onto the canonical flat vocabulary — only `issued` diverges → `active_le`) and
  **`getSSLTag`**, the single entry point resolving colour+label for *either* a
  flat `ssl_state` string *or* a nested badge. On an active cert the badge issuer
  overrides the generic label (preserves the admin list's "show issuer on a good
  cert").
- **Admin `DomainList` and tenant `UserDomainList` both render through `getSSLTag`.**
- **Pinning the matrix to the two real backend vocabularies** (`computeSSLState`
  + `sslBadgeFromCert` / `models.SSLStatus*`) surfaced two states that fell
  through to the raw lowercase string: **`off`** (flat disabled state) now
  renders "Off", and **`custom`** (a valid admin-uploaded cert) now renders green
  "Custom".

### Tests — `utils/sslState.test.ts` (56)
- colour/label matrix over both wire shapes;
- a **parity block** asserting the nested and flat cases for the same state
  render identically (`getSSLTag({status:"issued"…}) === getSSLTag("active_le")`);
- a **vocabulary-pinning block** listing every state the two backends actually
  emit, failing if one resolves to a raw-string passthrough (this is what caught
  `off`/`custom`).

`tsc -b`, eslint, and the existing admin/tenant domain + Mail Domains suites
(16) stay green. **No backend change, pure render path, no box deploy.**

### Deliberately left for the module-parent (JAB-300 stays open)
- The admin nested wire's `sslBadgeFromCert` **hardcodes issuer "Let's Encrypt"
  for every issued cert**, so a non-LE custom cert is still labelled "Let's
  Encrypt" on the admin list. That's a *backend* fix (mirror `computeSSLState`'s
  `/etc/letsencrypt/` path check), out of scope for this frontend matrix.
- The full admin+tenant Domain Inventory module extraction (shared view model,
  audience scope, mutation/invalidation unification) — the rest of the ticket.

No authed browser pass from this session; the badge colour/label change is worth
a human glance on both lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
