### PR TITLE
refactor(cron): one shared source for cron schedule presets (JAB-298)

### DIFF
--- a/panel-ui/src/shells/admin/cron/AdminCreateCronModal.tsx
+++ b/panel-ui/src/shells/admin/cron/AdminCreateCronModal.tsx
@@ -9,15 +9,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient, createCronJob } from "../../../apiClient";
-
-const SCHEDULE_PRESETS = [
-  { label: "Every minute", value: "* * * * *" },
-  { label: "Hourly", value: "0 * * * *" },
-  { label: "Daily at 3 AM", value: "0 3 * * *" },
-  { label: "Weekly (Sun 3 AM)", value: "0 3 * * 0" },
-  { label: "Monthly (1st 3 AM)", value: "0 3 1 * *" },
-  { label: "Advanced", value: "advanced" },
-];
+import { CRON_SCHEDULE_OPTIONS } from "../../../utils/cronSchedule";
 
 interface TargetUser {
   id: string;
@@ -180,7 +172,7 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
         <Form.Item label={t("admincreatecronmodal.schedule")} name="preset">
           <Radio.Group>
             <Space direction="vertical" size="small" style={{ width: "100%" }}>
-              {SCHEDULE_PRESETS.map((p) => (
+              {CRON_SCHEDULE_OPTIONS.map((p) => (
                 <Radio key={p.value} value={p.value}>
                   {p.label}
                   {p.value !== "advanced" && (

--- a/panel-ui/src/shells/admin/cron/AdminCronList.tsx
+++ b/panel-ui/src/shells/admin/cron/AdminCronList.tsx
@@ -32,17 +32,9 @@ import { CronLogDrawer } from "../../user/cron/CronLogDrawer";
 import { RunNowResultModal } from "../../user/cron/RunNowResultModal";
 import { AdminCreateCronModal } from "./AdminCreateCronModal";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
+import { humanizeSchedule } from "../../../utils/cronSchedule";
 
 dayjs.extend(relativeTime);
-
-const SCHEDULE_PRESETS: Record<string, string> = {
-  "* * * * *": "Every minute",
-  "0 * * * *": "Hourly",
-  "0 3 * * *": "Daily at 3 AM",
-  "0 3 * * 0": "Weekly (Sun 3 AM)",
-  "0 3 1 * *": "Monthly (1st 3 AM)",
-};
-const humanizeSchedule = (s: string): string => SCHEDULE_PRESETS[s] || s;
 
 export const AdminCronList = () => {
   const { t } = useTranslation();

--- a/panel-ui/src/shells/user/cron/CreateCronModal.tsx
+++ b/panel-ui/src/shells/user/cron/CreateCronModal.tsx
@@ -17,15 +17,7 @@ import {
   updateCronJob,
   type CronJob,
 } from "../../../apiClient";
-
-const SCHEDULE_PRESETS = [
-  { label: "Every minute", value: "* * * * *" },
-  { label: "Hourly", value: "0 * * * *" },
-  { label: "Daily at 3 AM", value: "0 3 * * *" },
-  { label: "Weekly (Sun 3 AM)", value: "0 3 * * 0" },
-  { label: "Monthly (1st 3 AM)", value: "0 3 1 * *" },
-  { label: "Advanced", value: "advanced" },
-];
+import { CRON_SCHEDULE_OPTIONS } from "../../../utils/cronSchedule";
 
 interface CreateCronModalProps {
   open: boolean;
@@ -55,7 +47,7 @@ export const CreateCronModal = ({
   useEffect(() => {
     if (!open) return;
     if (initial) {
-      const isPreset = SCHEDULE_PRESETS.some((p) => p.value === initial.schedule);
+      const isPreset = CRON_SCHEDULE_OPTIONS.some((p) => p.value === initial.schedule);
       setScheduleMode(isPreset ? initial.schedule : "advanced");
       setCustomSchedule(isPreset ? "" : initial.schedule);
     } else {
@@ -219,7 +211,7 @@ export const CreateCronModal = ({
             value={scheduleMode}
             onChange={(e) => setScheduleMode(e.target.value)}
           >
-            {SCHEDULE_PRESETS.map((preset) => (
+            {CRON_SCHEDULE_OPTIONS.map((preset) => (
               <Radio key={preset.value} value={preset.value}>
                 {preset.label}
               </Radio>

--- a/panel-ui/src/shells/user/cron/UserCronList.tsx
+++ b/panel-ui/src/shells/user/cron/UserCronList.tsx
@@ -36,20 +36,9 @@ import {
 import { CreateCronModal } from "./CreateCronModal";
 import { CronLogDrawer } from "./CronLogDrawer";
 import { RunNowResultModal } from "./RunNowResultModal";
+import { humanizeSchedule } from "../../../utils/cronSchedule";
 
 dayjs.extend(relativeTime);
-
-const SCHEDULE_PRESETS: Record<string, string> = {
-  "* * * * *": "Every minute",
-  "0 * * * *": "Hourly",
-  "0 3 * * *": "Daily at 3 AM",
-  "0 3 * * 0": "Weekly (Sun 3 AM)",
-  "0 3 1 * *": "Monthly (1st 3 AM)",
-};
-
-const humanizeSchedule = (schedule: string): string => {
-  return SCHEDULE_PRESETS[schedule] || schedule;
-};
 
 export const UserCronList = () => {
   const { t } = useTranslation();

--- a/panel-ui/src/utils/cronSchedule.test.ts
+++ b/panel-ui/src/utils/cronSchedule.test.ts
@@ -1,0 +1,55 @@
+// cronSchedule.test.ts — pins the shared cron preset source (JAB-298). The
+// derived-map parity block is the point: humanizeSchedule and the dropdown
+// options can no longer drift because both come from CRON_SCHEDULE_PRESETS.
+import { describe, it, expect } from "vitest";
+import {
+  CRON_ADVANCED,
+  CRON_SCHEDULE_PRESETS,
+  CRON_SCHEDULE_OPTIONS,
+  humanizeSchedule,
+} from "./cronSchedule";
+
+describe("humanizeSchedule", () => {
+  it("maps every known preset expression to its friendly label", () => {
+    expect(humanizeSchedule("* * * * *")).toBe("Every minute");
+    expect(humanizeSchedule("0 * * * *")).toBe("Hourly");
+    expect(humanizeSchedule("0 3 * * *")).toBe("Daily at 3 AM");
+    expect(humanizeSchedule("0 3 * * 0")).toBe("Weekly (Sun 3 AM)");
+    expect(humanizeSchedule("0 3 1 * *")).toBe("Monthly (1st 3 AM)");
+  });
+
+  it("passes a hand-written (advanced) expression through unchanged", () => {
+    expect(humanizeSchedule("*/15 * * * *")).toBe("*/15 * * * *");
+    expect(humanizeSchedule("0 0 * * 1-5")).toBe("0 0 * * 1-5");
+  });
+
+  it("passes the advanced sentinel and the empty string through unchanged", () => {
+    // 'advanced' is a modal sentinel, never a stored schedule — but the list
+    // must not invent a label for it if one ever leaks through.
+    expect(humanizeSchedule(CRON_ADVANCED)).toBe("advanced");
+    expect(humanizeSchedule("")).toBe("");
+  });
+});
+
+describe("preset sources", () => {
+  it("CRON_SCHEDULE_PRESETS holds the five real presets and no sentinel", () => {
+    expect(CRON_SCHEDULE_PRESETS).toHaveLength(5);
+    expect(CRON_SCHEDULE_PRESETS.some((p) => p.value === CRON_ADVANCED)).toBe(false);
+  });
+
+  it("CRON_SCHEDULE_OPTIONS is the presets plus the Advanced sentinel last", () => {
+    expect(CRON_SCHEDULE_OPTIONS).toHaveLength(CRON_SCHEDULE_PRESETS.length + 1);
+    expect(CRON_SCHEDULE_OPTIONS.slice(0, -1)).toEqual(CRON_SCHEDULE_PRESETS);
+    expect(CRON_SCHEDULE_OPTIONS[CRON_SCHEDULE_OPTIONS.length - 1]).toEqual({
+      label: "Advanced",
+      value: CRON_ADVANCED,
+    });
+  });
+
+  it("PARITY: humanizeSchedule round-trips every option that isn't the sentinel", () => {
+    for (const p of CRON_SCHEDULE_OPTIONS) {
+      if (p.value === CRON_ADVANCED) continue;
+      expect(humanizeSchedule(p.value)).toBe(p.label);
+    }
+  });
+});

--- a/panel-ui/src/utils/cronSchedule.ts
+++ b/panel-ui/src/utils/cronSchedule.ts
@@ -1,0 +1,44 @@
+// cronSchedule.ts — one source of truth for the cron schedule presets shown in
+// the create modals AND used to humanize a stored schedule in the cron lists
+// (JAB-298 "schedule presentation ... one Implementation").
+//
+// Before this, the same five presets were copy-pasted four times: a
+// Record<string,string> map in AdminCronList + UserCronList (for humanizing)
+// and an options array in AdminCreateCronModal + CreateCronModal (for the
+// dropdown), each free to drift. The map is now derived from the array so a
+// preset is defined exactly once.
+
+export interface CronPreset {
+  label: string;
+  value: string;
+}
+
+// CRON_ADVANCED is the create-modal sentinel for "let me type a raw cron
+// expression" — it is not a real schedule and never appears in a list.
+export const CRON_ADVANCED = "advanced";
+
+// The real schedule presets (no Advanced sentinel).
+export const CRON_SCHEDULE_PRESETS: readonly CronPreset[] = [
+  { label: "Every minute", value: "* * * * *" },
+  { label: "Hourly", value: "0 * * * *" },
+  { label: "Daily at 3 AM", value: "0 3 * * *" },
+  { label: "Weekly (Sun 3 AM)", value: "0 3 * * 0" },
+  { label: "Monthly (1st 3 AM)", value: "0 3 1 * *" },
+];
+
+// The create-modal option list = the presets plus the Advanced sentinel.
+export const CRON_SCHEDULE_OPTIONS: readonly CronPreset[] = [
+  ...CRON_SCHEDULE_PRESETS,
+  { label: "Advanced", value: CRON_ADVANCED },
+];
+
+// expr → friendly label, derived from the presets so there is one source.
+const scheduleLabels: Record<string, string> = Object.fromEntries(
+  CRON_SCHEDULE_PRESETS.map((p) => [p.value, p.label]),
+);
+
+// humanizeSchedule renders a stored cron expression: a known preset shows its
+// friendly label; anything else (a hand-written "advanced" expression) shows
+// the raw expression unchanged.
+export const humanizeSchedule = (schedule: string): string =>
+  scheduleLabels[schedule] ?? schedule;


### PR DESCRIPTION
## JAB-298 — one shared source for cron schedule presets

The five cron schedule presets were copy-pasted **four times**, in two shapes:

- a `Record<string,string>` map + a local `humanizeSchedule` in `AdminCronList`
  and `UserCronList` (the list's Schedule column);
- an options array (+ an `"Advanced"` sentinel) in `AdminCreateCronModal` and
  `CreateCronModal` (the create dropdown).

All four were byte-identical, but each could drift — a new preset or a relabel
had to be edited in four places to stay consistent, and the list label could
silently diverge from the dropdown option for the same expression.

### The slice (JAB-298 "schedule presentation … one Implementation")
`utils/cronSchedule.ts` is now the single source:
- `CRON_SCHEDULE_PRESETS` — the five presets, defined once;
- `CRON_SCHEDULE_OPTIONS` — the presets plus the `Advanced` sentinel, for the
  create dropdowns;
- `humanizeSchedule` — **derived** from the presets (`Object.fromEntries`), so
  the list label and the dropdown option can no longer disagree.

Both cron lists and both create modals import from it; the four local copies are
deleted. **Pure refactor** — the presets are identical to what shipped, so no
label or option changes.

Per the ticket's "keep the two editor modes distinct initially" constraint, only
the shared preset **data** is unified — the admin (target/root) and tenant
(self) create forms stay separate.

### Tests — `utils/cronSchedule.test.ts` (6)
`humanizeSchedule` over every preset + advanced/raw passthrough; the shape of
`PRESETS` vs `OPTIONS`; and a **parity block** asserting `humanizeSchedule`
round-trips every non-sentinel option (the "one source" guarantee).

`tsc -b`, eslint (0 errors), vitest green. No backend change, pure render path,
no box deploy.

Module-parent JAB-298 stays **open**: toggle/run/delete/refetch/busy-state as
one implementation, log + run-result overlays in a neutral module, and both
shells as thin adapters remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
