### PR TITLE
refactor(logs): neutral module for the domain log-stream viewer (JAB-296)

### DIFF
--- a/panel-ui/src/components/LogStreamModal.tsx
+++ b/panel-ui/src/components/LogStreamModal.tsx
@@ -1,8 +1,14 @@
 import { useTranslation } from "react-i18next";
 import { useState, useEffect, useRef } from "react";
 import { Modal, Typography, Button, Space, Spin, theme } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { PauseOutlined, PlayCircleOutlined, ClearOutlined } from "@ant-design/icons";
+import {
+  MAX_LOG_LINES,
+  capLogLines,
+  stripTrailingNewline,
+  buildGoAccessHttpUrl,
+} from "../utils/logStream";
 
 const { Text } = Typography;
 
@@ -14,50 +20,9 @@ interface LogStreamModalProps {
   logType: "access" | "error" | "goaccess";
 }
 
-// Trim a single trailing CR/LF (or both) — accommodates servers that
-// send "line\n", "line\r\n", or "line" interchangeably. Keeps inner
-// newlines untouched in case a single frame carries a multi-line block.
-// The stream is "recent lines", not an archive: without a ceiling every frame
-// appended to React state and each render re-joined the WHOLE array, so cost
-// grew quadratically over the stream's lifetime. On a moderately busy domain
-// (~10 lines/s) a 15-minute stream reaches ~9k lines and the tab janks within
-// minutes while memory keeps climbing. Keep the newest MAX_LOG_LINES, which is
-// far more than fits on screen and matches what the feature advertises.
-const MAX_LOG_LINES = 2000;
-
-function capLogLines(lines: string[]): string[] {
-  return lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES) : lines;
-}
-
-const stripTrailingNewline = (s: string): string => {
-  if (typeof s !== "string") return s;
-  if (s.endsWith("\r\n")) return s.slice(0, -2);
-  if (s.endsWith("\n") || s.endsWith("\r")) return s.slice(0, -1);
-  return s;
-};
-
-// Convert the WebSocket stream URL (ws[s]://host/api/v1/logs/stream/<key>)
-// into the HTTP goaccess render URL. The HTTP route serves the GoAccess
-// HTML snapshot with its own relaxed CSP (script-src 'self' 'unsafe-inline'
-// 'unsafe-eval'), which the previous srcdoc-via-WS path could not — srcdoc
-// inherits the panel's strict parent CSP and meta CSP can only tighten.
-//
-// Returns null if streamUrl can't be parsed into the expected shape (caller
-// then shows a "no stream" placeholder instead of crashing).
-const buildGoAccessHttpUrl = (streamUrl: string): string | null => {
-  try {
-    const u = new URL(streamUrl);
-    if (u.protocol === "ws:") u.protocol = "http:";
-    else if (u.protocol === "wss:") u.protocol = "https:";
-    // Append /goaccess.html if not already present (some callers may pre-build).
-    if (!u.pathname.endsWith("/goaccess.html")) {
-      u.pathname = u.pathname.replace(/\/+$/, "") + "/goaccess.html";
-    }
-    return u.toString();
-  } catch {
-    return null;
-  }
-};
+// The stream lifecycle stays in this component; the pure pieces it relies on
+// (MAX_LOG_LINES cap, newline trim, GoAccess URL derivation) live in
+// ../utils/logStream so they can be unit-tested (JAB-296).
 
 export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: LogStreamModalProps) => {
   const { t } = useTranslation();

--- a/panel-ui/src/shells/admin/logs/DomainLogsTab.tsx
+++ b/panel-ui/src/shells/admin/logs/DomainLogsTab.tsx
@@ -13,7 +13,7 @@ import {
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
-import { LogStreamModal } from "./LogStreamModal";
+import { LogStreamModal } from "../../../components/LogStreamModal";
 
 const { Text } = Typography;
 

--- a/panel-ui/src/shells/user/logs/UserLogsPage.tsx
+++ b/panel-ui/src/shells/user/logs/UserLogsPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
-import { LogStreamModal } from "../../admin/logs/LogStreamModal";
+import { LogStreamModal } from "../../../components/LogStreamModal";
 import { AccountActivity } from "../activity/AccountActivity";
 import { useSearchParams } from "react-router";
 

--- a/panel-ui/src/utils/logStream.test.ts
+++ b/panel-ui/src/utils/logStream.test.ts
@@ -1,0 +1,76 @@
+// logStream.test.ts — the JAB-296 "neutral Module tests" for the log-stream
+// WebSocket newline handling, the ring-buffer cap, and the GoAccess URL
+// derivation, now that they are pure and out of the .tsx component.
+import { describe, it, expect } from "vitest";
+import {
+  MAX_LOG_LINES,
+  capLogLines,
+  stripTrailingNewline,
+  buildGoAccessHttpUrl,
+} from "./logStream";
+
+describe("capLogLines", () => {
+  it("leaves a below-cap buffer untouched", () => {
+    const lines = ["a", "b", "c"];
+    expect(capLogLines(lines)).toEqual(lines);
+    expect(capLogLines([])).toEqual([]);
+  });
+  it("leaves an exactly-at-cap buffer untouched", () => {
+    const lines = Array.from({ length: MAX_LOG_LINES }, (_, i) => String(i));
+    expect(capLogLines(lines)).toHaveLength(MAX_LOG_LINES);
+    expect(capLogLines(lines)[0]).toBe("0");
+  });
+  it("keeps only the newest MAX_LOG_LINES when over the cap, dropping the oldest", () => {
+    const lines = Array.from({ length: MAX_LOG_LINES + 5 }, (_, i) => String(i));
+    const capped = capLogLines(lines);
+    expect(capped).toHaveLength(MAX_LOG_LINES);
+    // Oldest five dropped; newest retained.
+    expect(capped[0]).toBe("5");
+    expect(capped[capped.length - 1]).toBe(String(MAX_LOG_LINES + 4));
+  });
+});
+
+describe("stripTrailingNewline", () => {
+  it.each([
+    ["line\n", "line"],
+    ["line\r\n", "line"],
+    ["line\r", "line"],
+    ["line", "line"],
+    ["", ""],
+    ["\n", ""],
+    ["\r\n", ""],
+  ])("%j → %j", (input, want) => {
+    expect(stripTrailingNewline(input)).toBe(want);
+  });
+  it("trims only ONE trailing newline and keeps inner newlines", () => {
+    expect(stripTrailingNewline("a\nb\n")).toBe("a\nb");
+    expect(stripTrailingNewline("a\nb\n\n")).toBe("a\nb\n");
+  });
+});
+
+describe("buildGoAccessHttpUrl", () => {
+  it("maps ws:// to http:// and appends /goaccess.html", () => {
+    expect(buildGoAccessHttpUrl("ws://host/api/v1/logs/stream/abc")).toBe(
+      "http://host/api/v1/logs/stream/abc/goaccess.html",
+    );
+  });
+  it("maps wss:// to https://", () => {
+    expect(buildGoAccessHttpUrl("wss://host/api/v1/logs/stream/abc")).toBe(
+      "https://host/api/v1/logs/stream/abc/goaccess.html",
+    );
+  });
+  it("does not double-append when the path already ends in /goaccess.html", () => {
+    expect(buildGoAccessHttpUrl("wss://host/logs/stream/abc/goaccess.html")).toBe(
+      "https://host/logs/stream/abc/goaccess.html",
+    );
+  });
+  it("trims trailing slashes before appending", () => {
+    expect(buildGoAccessHttpUrl("ws://host/logs/stream/abc/")).toBe(
+      "http://host/logs/stream/abc/goaccess.html",
+    );
+  });
+  it("returns null on an unparseable stream URL", () => {
+    expect(buildGoAccessHttpUrl("not a url")).toBeNull();
+    expect(buildGoAccessHttpUrl("")).toBeNull();
+  });
+});

--- a/panel-ui/src/utils/logStream.ts
+++ b/panel-ui/src/utils/logStream.ts
@@ -1,0 +1,52 @@
+// logStream.ts — the pure, audience-neutral pieces of the domain log-stream
+// viewer (JAB-296). Extracted out of the LogStreamModal component so the
+// WebSocket newline handling, the ring-buffer cap, and the GoAccess URL
+// derivation can be unit-tested on their own — they used to be untestable
+// module-locals inside a .tsx.
+
+// The stream is "recent lines", not an archive: without a ceiling every frame
+// appended to React state and each render re-joined the WHOLE array, so cost
+// grew quadratically over the stream's lifetime. On a moderately busy domain
+// (~10 lines/s) a 15-minute stream reaches ~9k lines and the tab janks within
+// minutes while memory keeps climbing. Keep the newest MAX_LOG_LINES, which is
+// far more than fits on screen and matches what the feature advertises.
+export const MAX_LOG_LINES = 2000;
+
+// capLogLines keeps only the newest MAX_LOG_LINES entries.
+export function capLogLines(lines: string[]): string[] {
+  return lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES) : lines;
+}
+
+// stripTrailingNewline trims a single trailing CR/LF (or both) — accommodates
+// servers that send "line\n", "line\r\n", or "line" interchangeably. Keeps
+// inner newlines untouched in case a single frame carries a multi-line block.
+export const stripTrailingNewline = (s: string): string => {
+  if (typeof s !== "string") return s;
+  if (s.endsWith("\r\n")) return s.slice(0, -2);
+  if (s.endsWith("\n") || s.endsWith("\r")) return s.slice(0, -1);
+  return s;
+};
+
+// buildGoAccessHttpUrl converts the WebSocket stream URL
+// (ws[s]://host/api/v1/logs/stream/<key>) into the HTTP GoAccess render URL.
+// The HTTP route serves the GoAccess HTML snapshot with its own relaxed CSP
+// (script-src 'self' 'unsafe-inline' 'unsafe-eval'), which the previous
+// srcdoc-via-WS path could not — srcdoc inherits the panel's strict parent CSP
+// and meta CSP can only tighten.
+//
+// Returns null if streamUrl can't be parsed into the expected shape (caller
+// then shows a "no stream" placeholder instead of crashing).
+export const buildGoAccessHttpUrl = (streamUrl: string): string | null => {
+  try {
+    const u = new URL(streamUrl);
+    if (u.protocol === "ws:") u.protocol = "http:";
+    else if (u.protocol === "wss:") u.protocol = "https:";
+    // Append /goaccess.html if not already present (some callers may pre-build).
+    if (!u.pathname.endsWith("/goaccess.html")) {
+      u.pathname = u.pathname.replace(/\/+$/, "") + "/goaccess.html";
+    }
+    return u.toString();
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## JAB-296 — neutral module for the domain log-stream viewer

The log-stream viewer modal lived under `shells/admin/logs/`, and the tenant
`UserLogsPage` imported it **from the admin shell** — the ticket's own tell that
"the current seam is misplaced." Its WebSocket newline handling, the ring-buffer
cap, and the GoAccess URL derivation were also module-locals inside the `.tsx`,
so none of that behaviour could be unit-tested.

This slice makes the viewer audience-neutral and its pure logic testable:

- **`utils/logStream.ts`** — the pure pieces, exported: `MAX_LOG_LINES` +
  `capLogLines` (ring-buffer cap), `stripTrailingNewline` (WS newline trim), and
  `buildGoAccessHttpUrl` (`ws[s]://` → `http[s]://` + `/goaccess.html`).
- **`components/LogStreamModal.tsx`** — the modal moved out of the admin shell
  into the neutral `components/` dir (git **rename**, behaviour unchanged), now
  importing the helpers from `utils/logStream`. Its props were already
  audience-neutral.
- **`DomainLogsTab`** (admin) and **`UserLogsPage`** (tenant) import the modal
  from the neutral path; the tenant no longer reaches into the admin shell.

### Tests — `utils/logStream.test.ts` (16)
Cap boundary (below / at / over `MAX_LOG_LINES`, oldest-dropped), newline trim
(`\n`, `\r\n`, `\r`, none, inner newlines preserved), and the GoAccess URL
matrix (ws→http, wss→https, no double-append, trailing slash, unparseable →
null).

`tsc -b`, eslint (0 errors), vitest green. Pure refactor + relocation — no
behaviour change, no backend change, no box deploy.

### Left for the module-parent (JAB-296 stays open)
The stream-creation lifecycle, the aggregate-vs-per-domain request identity
(tenant can never emit an aggregate request), close-once / expired-stream
tolerance, and the pause/resume/error component behaviour — the full neutral
orchestration extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
