### PR TITLE
refactor(applications): shared install-status vocabulary for the app lists (JAB-334)

### DIFF
--- a/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
+++ b/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
@@ -3,8 +3,9 @@
 // Admins modify installs by opening the relevant user's panel directly
 // in their own browser tab — no in-panel impersonation after M20.
 //
-// Status badge styling is inlined from UserApplicationList to keep
-// coupling low and avoid tight dependency on that component.
+// Status badge metadata + the transitional-poll rule are shared with the
+// tenant list via utils/applicationStatus (JAB-334) — a neutral module, so
+// neither shell depends on the other.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
@@ -13,9 +14,6 @@ import { Card, Input, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   AppstoreOutlined,
-  LoadingOutlined,
-  CheckCircleOutlined,
-  ExclamationCircleOutlined,
   DeleteOutlined,
   LoginOutlined,
   SearchOutlined,
@@ -28,6 +26,11 @@ import { useTableURL } from "../../../hooks/useTableURL";
 import { useMagicLink } from "../../../hooks/useMagicLink";
 import { apiClient } from "../../../apiClient";
 import { CmsIcon } from "../../user/applications/CmsIcon";
+import {
+  applicationStatusMeta,
+  anyTransitional,
+  type ApplicationStatus,
+} from "../../../utils/applicationStatus";
 
 type ApplicationInstall = {
   id: string;
@@ -41,37 +44,12 @@ type ApplicationInstall = {
   owner_username?: string;
   locale: string;
   subdirectory: string;
-  status:
-    | "pending"
-    | "installing"
-    | "cloning"
-    | "deleting"
-    | "ready"
-    | "failed";
+  status: ApplicationStatus;
   version: string | null;
   last_error: string;
   created_at: string;
   updated_at: string;
 };
-
-const STATUS_META: Record<
-  ApplicationInstall["status"],
-  { color: string; icon: React.ReactNode; label: string; spinning: boolean }
-> = {
-  pending:    { color: "default",    icon: <LoadingOutlined spin />,      label: "Pending",    spinning: true  },
-  installing: { color: "processing", icon: <LoadingOutlined spin />,      label: "Installing", spinning: true  },
-  cloning:    { color: "processing", icon: <LoadingOutlined spin />,      label: "Cloning",    spinning: true  },
-  deleting:   { color: "warning",    icon: <LoadingOutlined spin />,      label: "Deleting",   spinning: true  },
-  ready:      { color: "success",    icon: <CheckCircleOutlined />,       label: "Ready",      spinning: false },
-  failed:     { color: "error",      icon: <ExclamationCircleOutlined />, label: "Failed",     spinning: false },
-};
-
-const TRANSITIONAL = new Set<ApplicationInstall["status"]>([
-  "pending",
-  "installing",
-  "cloning",
-  "deleting",
-]);
 
 interface AdminActionsCellProps {
   record: ApplicationInstall;
@@ -147,9 +125,7 @@ export const AdminApplicationList = () => {
   // Poll while any row is transitional — same cadence as the
   // user-shell list. Cheaper than running a second useQuery with
   // its own subscription.
-  const hasTransitional = query.items.some((r) =>
-    TRANSITIONAL.has(r.status),
-  );
+  const hasTransitional = anyTransitional(query.items);
   useEffect(() => {
     if (!hasTransitional) return;
     const h = setInterval(() => query.refetch(), 5000);
@@ -287,7 +263,7 @@ export const AdminApplicationList = () => {
             dataIndex="status"
             title={t("adminapplicationlist.status")}
             render={(status: ApplicationInstall["status"], record) => {
-              const meta = STATUS_META[status] ?? STATUS_META.pending;
+              const meta = applicationStatusMeta(status);
               const tag = (
                 <Tag color={meta.color} icon={meta.icon}>
                   {meta.label}

--- a/panel-ui/src/shells/user/applications/UserApplicationList.tsx
+++ b/panel-ui/src/shells/user/applications/UserApplicationList.tsx
@@ -13,7 +13,6 @@ import {
   AppstoreOutlined,
   PlusSquareOutlined,
   ImportOutlined,
-  LoadingOutlined,
   CheckCircleOutlined,
   ExclamationCircleOutlined,
   SyncOutlined,
@@ -25,6 +24,12 @@ import {
   SettingOutlined,
 } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
+import {
+  applicationStatusMeta,
+  anyTransitional,
+  isTransitionalStatus,
+  type ApplicationStatus,
+} from "../../../utils/applicationStatus";
 import { sorterToParams } from "../../../utils/tableSorter";
 
 import { columnSearchProps } from "../../../components/columnSearch";
@@ -53,38 +58,13 @@ type ApplicationInstall = {
   admin_email: string;
   locale: string;
   subdirectory: string;
-  status:
-    | "pending"
-    | "installing"
-    | "cloning"
-    | "deleting"
-    | "ready"
-    | "failed";
+  status: ApplicationStatus;
   version: string | null;
   last_error: string;
   cache_enabled?: boolean;
   created_at: string;
   updated_at: string;
 };
-
-const STATUS_META: Record<
-  ApplicationInstall["status"],
-  { color: string; icon: React.ReactNode; label: string; spinning: boolean }
-> = {
-  pending:    { color: "default",    icon: <LoadingOutlined spin />,      label: "Pending",    spinning: true  },
-  installing: { color: "processing", icon: <LoadingOutlined spin />,      label: "Installing", spinning: true  },
-  cloning:    { color: "processing", icon: <LoadingOutlined spin />,      label: "Cloning",    spinning: true  },
-  deleting:   { color: "warning",    icon: <LoadingOutlined spin />,      label: "Deleting",   spinning: true  },
-  ready:      { color: "success",    icon: <CheckCircleOutlined />,       label: "Ready",      spinning: false },
-  failed:     { color: "error",      icon: <ExclamationCircleOutlined />, label: "Failed",     spinning: false },
-};
-
-const TRANSITIONAL = new Set<ApplicationInstall["status"]>([
-  "pending",
-  "installing",
-  "cloning",
-  "deleting",
-]);
 
 interface ActionsCellProps {
   record: ApplicationInstall;
@@ -278,9 +258,7 @@ export const UserApplicationList = () => {
   // cloning/deleting). Five-second cadence matches what Refine's old
   // refetchInterval returned. refetch identity is stable, so only
   // `active` triggers re-installing the timer.
-  const hasTransitional = tableQuery.items.some((r) =>
-    TRANSITIONAL.has(r.status),
-  );
+  const hasTransitional = anyTransitional(tableQuery.items);
   useEffect(() => {
     if (!hasTransitional) return;
     const h = setInterval(() => {
@@ -446,7 +424,7 @@ export const UserApplicationList = () => {
                   const rows = tableQuery.items;
                   const installedCount = tableQuery.total;
                   const readyCount = rows.filter((r) => r.status === "ready").length;
-                  const inProgressCount = rows.filter((r) => TRANSITIONAL.has(r.status)).length;
+                  const inProgressCount = rows.filter((r) => isTransitionalStatus(r.status)).length;
                   const failedCount = rows.filter((r) => r.status === "failed").length;
                   const catalogCount = registry.data?.length ?? 0;
                   const pct = (n: number) =>
@@ -530,7 +508,7 @@ export const UserApplicationList = () => {
               const label = `${base}${path}`;
               const isLink = record.status === "ready" && !!domainName;
               const appKey = record.app_type || "wordpress";
-              const meta = STATUS_META[record.status] ?? STATUS_META.pending;
+              const meta = applicationStatusMeta(record.status);
               const statusTag = (
                 <Tag color={meta.color} icon={meta.icon}>
                   {meta.label}

--- a/panel-ui/src/utils/applicationStatus.test.tsx
+++ b/panel-ui/src/utils/applicationStatus.test.tsx
@@ -1,0 +1,75 @@
+// applicationStatus.test.tsx — pins the shared Application Inventory status
+// vocabulary (JAB-334) so the admin and tenant lists can't drift on which
+// states exist, how they render, or which keep the list polling.
+import { describe, it, expect } from "vitest";
+import { isValidElement } from "react";
+import {
+  APPLICATION_STATUS_META,
+  APPLICATION_TRANSITIONAL,
+  isTransitionalStatus,
+  anyTransitional,
+  applicationStatusMeta,
+  type ApplicationStatus,
+} from "./applicationStatus";
+
+const ALL_STATUSES: ApplicationStatus[] = [
+  "pending",
+  "installing",
+  "cloning",
+  "deleting",
+  "ready",
+  "failed",
+];
+
+describe("APPLICATION_STATUS_META", () => {
+  it("covers every status with a color, label, and a real icon element", () => {
+    for (const s of ALL_STATUSES) {
+      const meta = APPLICATION_STATUS_META[s];
+      expect(meta).toBeDefined();
+      expect(typeof meta.color).toBe("string");
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(isValidElement(meta.icon)).toBe(true);
+    }
+  });
+  it("labels the settled states green/red and the rest as work-in-progress", () => {
+    expect(APPLICATION_STATUS_META.ready).toMatchObject({ color: "success", label: "Ready", spinning: false });
+    expect(APPLICATION_STATUS_META.failed).toMatchObject({ color: "error", label: "Failed", spinning: false });
+    expect(APPLICATION_STATUS_META.installing).toMatchObject({ color: "processing", spinning: true });
+  });
+});
+
+describe("transitional rule", () => {
+  it("marks exactly pending/installing/cloning/deleting as transitional", () => {
+    expect([...APPLICATION_TRANSITIONAL].sort()).toEqual(
+      ["cloning", "deleting", "installing", "pending"],
+    );
+    expect(isTransitionalStatus("pending")).toBe(true);
+    expect(isTransitionalStatus("deleting")).toBe(true);
+    expect(isTransitionalStatus("ready")).toBe(false);
+    expect(isTransitionalStatus("failed")).toBe(false);
+  });
+
+  it("INVARIANT: spinning === transitional for every status", () => {
+    for (const s of ALL_STATUSES) {
+      expect(APPLICATION_STATUS_META[s].spinning).toBe(isTransitionalStatus(s));
+    }
+  });
+
+  it("anyTransitional is true iff a row is still settling", () => {
+    expect(anyTransitional([])).toBe(false);
+    expect(anyTransitional([{ status: "ready" }, { status: "failed" }])).toBe(false);
+    expect(anyTransitional([{ status: "ready" }, { status: "installing" }])).toBe(true);
+  });
+});
+
+describe("applicationStatusMeta", () => {
+  it("returns the status's own metadata", () => {
+    expect(applicationStatusMeta("ready").label).toBe("Ready");
+  });
+  it("falls back to pending for an unknown status", () => {
+    // Both lists used `STATUS_META[s] ?? STATUS_META.pending`; a status the
+    // backend hasn't taught the frontend renders as Pending, not a crash.
+    const unknown = "resizing" as ApplicationStatus;
+    expect(applicationStatusMeta(unknown)).toBe(APPLICATION_STATUS_META.pending);
+  });
+});

--- a/panel-ui/src/utils/applicationStatus.ts
+++ b/panel-ui/src/utils/applicationStatus.ts
@@ -1,0 +1,64 @@
+// applicationStatus.ts — the shared install-status vocabulary for the
+// Application Inventory (JAB-334). Admin and tenant application lists used to
+// each define an identical status union, STATUS_META badge map, and
+// TRANSITIONAL set, plus their own copies of "poll while transitional" and
+// "STATUS_META[s] ?? pending". Those are unified here so the two lists can't
+// drift on which states exist, how they render, or which ones keep polling.
+//
+// Icons are built with createElement so this stays a plain .ts util (no JSX)
+// — a shared constants/functions module, not a component file.
+import { createElement, type ReactNode } from "react";
+import {
+  LoadingOutlined,
+  CheckCircleOutlined,
+  ExclamationCircleOutlined,
+} from "@icons";
+
+export type ApplicationStatus =
+  | "pending"
+  | "installing"
+  | "cloning"
+  | "deleting"
+  | "ready"
+  | "failed";
+
+export interface ApplicationStatusMeta {
+  color: string;
+  icon: ReactNode;
+  label: string;
+  spinning: boolean;
+}
+
+const spinner = createElement(LoadingOutlined, { spin: true });
+
+export const APPLICATION_STATUS_META: Record<ApplicationStatus, ApplicationStatusMeta> = {
+  pending:    { color: "default",    icon: spinner,                                 label: "Pending",    spinning: true  },
+  installing: { color: "processing", icon: spinner,                                 label: "Installing", spinning: true  },
+  cloning:    { color: "processing", icon: spinner,                                 label: "Cloning",    spinning: true  },
+  deleting:   { color: "warning",    icon: spinner,                                 label: "Deleting",   spinning: true  },
+  ready:      { color: "success",    icon: createElement(CheckCircleOutlined),      label: "Ready",      spinning: false },
+  failed:     { color: "error",      icon: createElement(ExclamationCircleOutlined), label: "Failed",    spinning: false },
+};
+
+// The transitional states — a row in one of these is still settling, so the
+// list keeps polling until it lands on ready/failed. One rule for both lists.
+export const APPLICATION_TRANSITIONAL: ReadonlySet<ApplicationStatus> = new Set<ApplicationStatus>([
+  "pending",
+  "installing",
+  "cloning",
+  "deleting",
+]);
+
+export const isTransitionalStatus = (status: ApplicationStatus): boolean =>
+  APPLICATION_TRANSITIONAL.has(status);
+
+// anyTransitional — does any row still need the list to poll?
+export const anyTransitional = (
+  rows: ReadonlyArray<{ status: ApplicationStatus }>,
+): boolean => rows.some((r) => isTransitionalStatus(r.status));
+
+// applicationStatusMeta resolves a status to its badge metadata, falling back
+// to the pending row for an unknown status (the `?? STATUS_META.pending` both
+// lists used).
+export const applicationStatusMeta = (status: ApplicationStatus): ApplicationStatusMeta =>
+  APPLICATION_STATUS_META[status] ?? APPLICATION_STATUS_META.pending;


### PR DESCRIPTION
## JAB-334 — shared install-status vocabulary for the application lists

The admin and tenant application inventories each defined a **byte-identical**
copy of the install-status union, the `STATUS_META` badge map
(color/icon/label/spinning), and the `TRANSITIONAL` set — plus their own copies
of "poll while any row is transitional" and "`STATUS_META[s] ?? pending`". The
admin file even carried a comment that its badge styling was *"inlined from
UserApplicationList to keep coupling low"* — a deliberate copy that could drift.

### The slice
Consolidate onto one neutral module — **`utils/applicationStatus.ts`**:
- `ApplicationStatus` (the status union) + `APPLICATION_STATUS_META` (the badge
  map), defined once;
- `APPLICATION_TRANSITIONAL` + `isTransitionalStatus` + `anyTransitional` — the
  one polling rule both lists use to decide whether to keep refetching (the AC's
  "transitional states use one polling rule");
- `applicationStatusMeta(s)` — the `?? pending` fallback both lists had inline.

Both lists import from it and drop their local copies; each keeps its own
`ApplicationInstall` row type (the tenant's has `cache_enabled`), now
referencing the shared status union. Icons are built with `createElement` so the
module stays a plain `.ts` (no JSX, no react-refresh smell). **Pure refactor** —
the metadata is identical to what shipped, so no badge or polling change.

### Tests — `utils/applicationStatus.test.tsx` (7)
Every status has color/label/real icon; the transitional set is exactly
pending/installing/cloning/deleting; the **`spinning === transitional`
invariant**; `anyTransitional` over row sets; and the unknown-status → pending
fallback.

`tsc -b`, eslint (0 errors/0 warnings), vitest + the existing app-list suites
green. No backend change, no box deploy.

### Left for the module-parent (JAB-334 stays open)
Canonical rows, shared delete/invalidation, centralized login (magic-link)
capability, and the role-specific install/cache/clone/migrate/scan actions — the
full Adapter split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
