### PR TITLE
refactor(notifications): neutral channel-kind config module (JAB-336)

### DIFF
--- a/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
+++ b/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
@@ -15,7 +15,7 @@ import {
   kindLabels,
   type ChannelFormConfig,
   type ChannelKind,
-} from "./channelKindConfig";
+} from "../../../utils/channelKindConfig";
 
 export type NotificationChannel = {
   id: string;

--- a/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../../hooks/useQueries";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { AdminChannelDrawer, type NotificationChannel } from "./AdminChannelDrawer";
-import { kindColors, kindLabels } from "./channelKindConfig";
+import { kindColors, kindLabels } from "../../../utils/channelKindConfig";
 
 const RESOURCE = "admin/notifications/channels";
 

--- a/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
@@ -3,7 +3,7 @@ import { Alert, Card, Select, Space, Switch, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
-import { kindLabels, type ChannelKind } from "../notifications/channelKindConfig";
+import { kindLabels, type ChannelKind } from "../../../utils/channelKindConfig";
 
 // TenantNotificationsCard — Server Settings → General: the master switch for the
 // tenant-facing /me/notifications surface (JAB-171) plus the admin-controlled

--- a/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
+++ b/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
@@ -15,7 +15,7 @@ import {
   kindLabels,
   type ChannelFormConfig,
   type ChannelKind,
-} from "../../admin/notifications/channelKindConfig";
+} from "../../../utils/channelKindConfig";
 
 // TENANT_KINDS — the safe default server allowlist, used as a fallback only
 // (first paint / older API). JAB-326: the real list of creatable kinds comes

--- a/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
+++ b/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
@@ -17,7 +17,7 @@ import type { AxiosError } from "axios";
 import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
 import { apiClient } from "../../../apiClient";
 import { useDeleteMutation, useUpdateMutation } from "../../../hooks/useQueries";
-import { kindColors, kindLabels, type ChannelKind } from "../../admin/notifications/channelKindConfig";
+import { kindColors, kindLabels, type ChannelKind } from "../../../utils/channelKindConfig";
 import { MyChannelDrawer, TENANT_KINDS, type MyChannel } from "./MyChannelDrawer";
 
 const CH_RESOURCE = "me/notifications/channels";

--- a/panel-ui/src/utils/channelKindConfig.test.ts
+++ b/panel-ui/src/utils/channelKindConfig.test.ts
@@ -1,0 +1,71 @@
+// channelKindConfig.test.ts — invariants tsc can't express for the shared
+// notification channel-kind config (JAB-336). The Record<ChannelKind, …> maps
+// are completeness-checked by the compiler; these tests pin the behavioural
+// contracts around them (which kinds are admin-creatable, conditional-field
+// integrity, select options).
+import { describe, it, expect } from "vitest";
+import {
+  CHANNEL_KINDS,
+  kindColors,
+  kindLabels,
+  kindFields,
+  type ChannelKind,
+} from "./channelKindConfig";
+
+// All kinds in the union (kindLabels is Record<ChannelKind,…>, so its keys are
+// exactly the union) — derived, not hard-coded, so it tracks the type.
+const ALL_KINDS = Object.keys(kindLabels) as ChannelKind[];
+
+describe("channel-kind palette + labels", () => {
+  it("gives every kind a non-empty label and a colour", () => {
+    for (const k of ALL_KINDS) {
+      expect(kindLabels[k]?.length ?? 0).toBeGreaterThan(0);
+      expect(kindColors[k]?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("CHANNEL_KINDS (admin-creatable set)", () => {
+  it("lists only real kinds and never duplicates one", () => {
+    for (const k of CHANNEL_KINDS) expect(ALL_KINDS).toContain(k);
+    expect(new Set(CHANNEL_KINDS).size).toBe(CHANNEL_KINDS.length);
+  });
+
+  it("excludes webpush but includes every other kind", () => {
+    // webpush lives in the union (existing rows still render) but is managed
+    // from the Web Push tab, never created as a channel row.
+    expect(CHANNEL_KINDS).not.toContain("webpush");
+    for (const k of ALL_KINDS) {
+      if (k === "webpush") continue;
+      expect(CHANNEL_KINDS).toContain(k);
+    }
+  });
+});
+
+describe("kindFields", () => {
+  it("gives every field a name and a label, and select fields their options", () => {
+    for (const k of ALL_KINDS) {
+      for (const f of kindFields[k]) {
+        expect(f.name.length).toBeGreaterThan(0);
+        expect(f.label.length).toBeGreaterThan(0);
+        if (f.type === "select") {
+          expect(f.options?.length ?? 0).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("INTEGRITY: every dependsOn points at a field rendered for the same kind", () => {
+    // A conditional field whose dependsOn.name isn't in the same kind's field
+    // list can never be shown — a silent dead field. (email's external-SMTP
+    // fan-out is the real use of this.)
+    for (const k of ALL_KINDS) {
+      const names = new Set(kindFields[k].map((f) => f.name));
+      for (const f of kindFields[k]) {
+        if (f.dependsOn) {
+          expect(names).toContain(f.dependsOn.name);
+        }
+      }
+    }
+  });
+});

--- a/panel-ui/src/utils/channelKindConfig.ts
+++ b/panel-ui/src/utils/channelKindConfig.ts
@@ -1,7 +1,9 @@
-// channelKindConfig.tsx — per-kind form fields + palette for the M14
-// notification channel drawer. Keeps the dynamic form code in
-// AdminChannelDrawer.tsx short; adding a new channel kind is a diff to
-// this file only.
+// channelKindConfig.ts — per-kind form fields + palette for the M14
+// notification channel drawers. A neutral util (JAB-336): the admin drawer,
+// the tenant drawer, the channels tab and the tenant-notifications card all
+// read from it, so it no longer lives under the admin shell with the tenant
+// reaching into it. Pure data/types (no JSX). Adding a new channel kind is a
+// diff to this file only.
 
 export type ChannelKind =
   | "email"


### PR DESCRIPTION
## JAB-336 — neutral channel-kind config module

`channelKindConfig` — the per-kind palette, labels, and dynamic form-field specs
for the notification channel drawers — lived under `shells/admin/notifications/`,
and the tenant shell (`MyChannelDrawer`, `MyNotificationsPage`) plus the admin
settings card all imported it from there. The tenant reaching into the admin
shell for shared config is the misplaced seam this ticket calls out. The file
was also a `.tsx` despite containing **no JSX** (pure data + types).

### The slice
- **`utils/channelKindConfig.ts`** (git rename, `.tsx` → `.ts`, no behaviour
  change) — `ChannelKind`, `CHANNEL_KINDS`, `kindColors`, `kindLabels`,
  `FieldSpec`, `ChannelFormConfig`, `kindFields`. All **five** importers (both
  drawers, the channels tab, the tenant-notifications card, `MyNotificationsPage`)
  import from the neutral path; none reaches across shells.
- **`utils/channelKindConfig.test.ts`** — first tests for this file. The
  `Record<ChannelKind,…>` maps are already completeness-checked by the compiler,
  so these pin the contracts tsc **can't** express:
  - `CHANNEL_KINDS` excludes `webpush` but includes every other kind (the "web
    push is managed from its own tab, never a channel row" rule);
  - `select` fields carry `options`;
  - every conditional field's `dependsOn` points at a field rendered for the
    same kind (no silently-dead field — email's external-SMTP fan-out is the
    real use).

`tsc -b` (validates all five repointed imports), eslint (0 errors), vitest + the
existing notification suites (20) green. No behaviour change, no backend change,
no box deploy.

### Left for the module-parent (JAB-336 stays open)
Consolidating the two drawers' dynamic-form rendering + submit behaviour behind
shared policy Adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
