### PR TITLE
fix(cron): run tenant cron jobs inside the SSH sandbox (GH #1458)

### DIFF
--- a/docs/site/user/cron-jobs.md
+++ b/docs/site/user/cron-jobs.md
@@ -49,6 +49,15 @@ if one fails. Blank lines and `#` comments (including a `#!/bin/bash` shebang
 line) are ignored, so you can paste a script's body, but every executable line
 must still match the allowlist above.
 
+## Sandboxing
+
+Cron commands run inside the **same per-user sandbox as your SSH shell** — a
+read-only system, an isolated process view, and only your own home and docroots
+visible. Your scripts run normally (your files, your database, the network all
+work); what's hidden is the host's internals (other tenants, server config),
+which a cron never needs. This is why a script can't reach outside your account
+even if it shells out.
+
 ## Why systemd-user, not crontab
 
 - Per-job journal logs (`journalctl --user -u jabali-cron-<id>`).

--- a/panel-agent/cmd/jabali-ssh-shell/main.go
+++ b/panel-agent/cmd/jabali-ssh-shell/main.go
@@ -57,12 +57,26 @@ func main() {
 }
 
 func run() error {
+	// GH #1458: cron and run-now invoke `jabali-ssh-shell --exec <argv...>` to
+	// run one validated command inside the SAME per-user sandbox as SSH, so a
+	// cron that shells out (php passthru, python os.system, node child_process,
+	// wp eval) stays confined instead of escaping to an unsandboxed shell as the
+	// tenant uid. Non-interactive: no login shell, no bash re-parse.
+	var execArgv []string
+	if len(os.Args) >= 3 && os.Args[1] == "--exec" {
+		execArgv = os.Args[2:]
+	}
+
 	// GH #658: uid 0 (root) must never be trapped in the tenant sandbox. If
 	// this wrapper is ever root's login shell — e.g. a mis-created "root"
 	// panel user (GH #429) chsh'd root here — hand root a real login shell
 	// instead of the sandbox/nologin path, so a chsh mistake can't lock the
-	// operator out of SSH. The sandbox is only ever for hosting tenants.
+	// operator out of SSH. The sandbox is only ever for hosting tenants; a root
+	// cron (admin, RunAsRoot) runs its command directly, unsandboxed by design.
 	if os.Getuid() == 0 {
+		if execArgv != nil {
+			return execArgvDirect(execArgv)
+		}
 		return execRootLoginShell()
 	}
 	mode, err := readMode()
@@ -71,13 +85,27 @@ func run() error {
 	}
 	switch mode {
 	case modeBubblewrap:
-		return dispatchBubblewrap()
+		return dispatchBubblewrap(execArgv)
 	case modeNspawn:
-		return dispatchNspawn()
+		return dispatchNspawn(execArgv)
 	default:
 		return execNologin(fmt.Sprintf("unrecognised mode %q in %s (allowed: %s, %s)",
 			mode, modeFile, modeBubblewrap, modeNspawn))
 	}
+}
+
+// execArgvDirect resolves argv[0] on PATH and execs it (root --exec cron path,
+// unsandboxed by design). Returns an error only if the binary can't be found.
+func execArgvDirect(argv []string) error {
+	bin := argv[0]
+	if !strings.Contains(bin, "/") {
+		resolved, err := exec.LookPath(bin)
+		if err != nil {
+			return fmt.Errorf("exec %q: %w", bin, err)
+		}
+		bin = resolved
+	}
+	return syscall.Exec(bin, argv, os.Environ())
 }
 
 // readMode pulls the single-line mode from /etc/jabali/ssh-sandbox-mode.
@@ -109,7 +137,10 @@ func readMode() (string, error) {
 // /etc/ssh, every other tenant's /home, and every host Unix socket
 // (/run is a fresh tmpfs). On any setup error we fall back to nologin —
 // never an unsandboxed shell.
-func dispatchBubblewrap() error {
+// dispatchBubblewrap builds the per-user jail and execs into it. execArgv is
+// nil for an SSH login (interactive shell or an sshd `-c` command); for a cron
+// / run-now invocation (GH #1458) it is the validated command run directly.
+func dispatchBubblewrap(execArgv []string) error {
 	bwrap, err := exec.LookPath("bwrap")
 	if err != nil {
 		return execNologin(fmt.Sprintf("bwrap not found in PATH (apt install bubblewrap): %v", err))
@@ -154,7 +185,11 @@ func dispatchBubblewrap() error {
 	keepAlive := []*os.File{f1, f2}
 
 	shell := pickShell()
-	argv := buildBwrapArgv(name, home, passwdFD, groupFD, shell, os.Args[1:])
+	inner := execArgv
+	if inner == nil {
+		inner = interactiveInner(shell, os.Args[1:])
+	}
+	argv := buildBwrapArgv(name, home, passwdFD, groupFD, shell, inner)
 
 	err = syscall.Exec(bwrap, argv, sandboxBwrapEnv())
 	// Exec only returns on failure. Reference keepAlive past the exec so
@@ -163,12 +198,12 @@ func dispatchBubblewrap() error {
 	return execNologin(fmt.Sprintf("exec bwrap: %v", err))
 }
 
-// buildBwrapArgv assembles the bwrap command line. When the wrapper was
-// invoked as `jabali-ssh-shell -c "<cmd>"` (sshd's non-interactive form,
-// used by scp/rsync/git-over-ssh and `ssh host cmd`), the command is
-// forwarded into the sandbox as `<shell> -c "<cmd>"`. Otherwise a login
-// shell. invokedArgs is os.Args[1:].
-func buildBwrapArgv(name, home string, passwdFD, groupFD uintptr, shell string, invokedArgs []string) []string {
+// buildBwrapArgv assembles the bwrap command line. `inner` is the command to
+// run inside the jail after bwrap's `--`: a login shell (`<shell> -l`), an
+// sshd-forwarded command (`<shell> -c "<cmd>"`), or — for a cron/run-now
+// invocation (GH #1458) — the validated cron argv run directly with no shell.
+// The caller computes `inner`; buildBwrapArgv only assembles the jail around it.
+func buildBwrapArgv(name, home string, passwdFD, groupFD uintptr, shell string, inner []string) []string {
 	argv := []string{
 		"bwrap",
 		"--ro-bind", "/usr", "/usr",
@@ -254,13 +289,19 @@ func buildBwrapArgv(name, home string, passwdFD, groupFD uintptr, shell string, 
 		argv = append(argv, "--setenv", "LANG", lang)
 	}
 	argv = append(argv, "--")
-	// Forward an SSH-supplied command, else an interactive login shell.
-	if len(invokedArgs) >= 2 && invokedArgs[0] == "-c" {
-		argv = append(argv, shell, "-c", invokedArgs[1])
-	} else {
-		argv = append(argv, shell, "-l")
-	}
+	argv = append(argv, inner...)
 	return argv
+}
+
+// interactiveInner returns the post-`--` command for an SSH login: an
+// sshd-forwarded command (`<shell> -c "<cmd>"`, used by scp/rsync/git-over-ssh
+// and `ssh host cmd`) when invoked as `-c "<cmd>"`, else an interactive login
+// shell. invokedArgs is os.Args[1:].
+func interactiveInner(shell string, invokedArgs []string) []string {
+	if len(invokedArgs) >= 2 && invokedArgs[0] == "-c" {
+		return []string{shell, "-c", invokedArgs[1]}
+	}
+	return []string{shell, "-l"}
 }
 
 // filterPasswd returns /etc/passwd reduced to system accounts (uid <
@@ -394,7 +435,7 @@ func runtimeKeepAlive(files []*os.File) {
 // dispatchNspawn will read /etc/jabali/users/<username>/nspawn-
 // image (per-user image pin) and sudo into the M13-shipped
 // jabali-nspawn-enter helper. Step 3 follow-up.
-func dispatchNspawn() error {
+func dispatchNspawn(_ []string) error {
 	if _, err := exec.LookPath("systemd-nspawn"); err != nil {
 		return execNologin(fmt.Sprintf("systemd-nspawn not found (apt install systemd-container): %v", err))
 	}

--- a/panel-agent/cmd/jabali-ssh-shell/main_test.go
+++ b/panel-agent/cmd/jabali-ssh-shell/main_test.go
@@ -73,7 +73,7 @@ func TestBindDataFD_DeliversContentThenEOF(t *testing.T) {
 
 func TestBuildBwrapArgv_ForwardsCommandAndIsolates(t *testing.T) {
 	// interactive
-	argv := buildBwrapArgv("alice", "/home/alice", 7, 8, "/bin/bash", nil)
+	argv := buildBwrapArgv("alice", "/home/alice", 7, 8, "/bin/bash", interactiveInner("/bin/bash", nil))
 	joined := strings.Join(argv, " ")
 	for _, must := range []string{
 		"--bind /home/alice /home/alice",
@@ -92,10 +92,24 @@ func TestBuildBwrapArgv_ForwardsCommandAndIsolates(t *testing.T) {
 		t.Errorf("interactive should end in `bash -l`, got %v", argv[len(argv)-2:])
 	}
 	// command mode (scp/git/ssh host cmd)
-	argv2 := buildBwrapArgv("alice", "/home/alice", 7, 8, "/bin/bash", []string{"-c", "scp -t /home/alice"})
+	argv2 := buildBwrapArgv("alice", "/home/alice", 7, 8, "/bin/bash", interactiveInner("/bin/bash", []string{"-c", "scp -t /home/alice"}))
 	tail := argv2[len(argv2)-3:]
 	if tail[0] != "/bin/bash" || tail[1] != "-c" || tail[2] != "scp -t /home/alice" {
 		t.Errorf("command mode should forward `-c`, got %v", tail)
+	}
+	// GH #1458: --exec mode runs the cron argv DIRECTLY inside the jail — no
+	// shell, no `-c` — so the same isolation flags wrap a python/php/node cron.
+	execInner := []string{"python3", "/home/alice/site/manage.py", "migrate"}
+	argv3 := buildBwrapArgv("alice", "/home/alice", 7, 8, "/bin/bash", execInner)
+	if !strings.Contains(strings.Join(argv3, " "), "--unshare-all") {
+		t.Error("exec mode must still carry the isolation flags")
+	}
+	tail3 := argv3[len(argv3)-3:]
+	if tail3[0] != "python3" || tail3[1] != "/home/alice/site/manage.py" || tail3[2] != "migrate" {
+		t.Errorf("exec mode should run the argv directly, got %v", tail3)
+	}
+	if argv3[len(argv3)-4] != "--" {
+		t.Errorf("exec argv must sit directly after bwrap `--`, got %v", argv3[len(argv3)-4:])
 	}
 }
 

--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -30,6 +30,12 @@ type cronApplyParams struct {
 	RunAsRoot     bool     `json:"run_as_root,omitempty"`
 }
 
+// cronSandboxWrapper runs a tenant cron command inside the same per-user
+// bubblewrap/nspawn jail as SSH (GH #1458). Without it a cron that shells out
+// (php passthru, python os.system, node child_process, wp eval) would reach an
+// unsandboxed shell as the tenant uid, defeating the SSH sandbox's isolation.
+const cronSandboxWrapper = "/usr/local/bin/jabali-ssh-shell"
+
 // cronHomeForUser is the account's home directory — the containment root for
 // python/node cron scripts (GH #1435). Tenant homes are /home/<username>; the
 // root cron account is /root. Mirrors the panel-side derivation so the
@@ -270,6 +276,17 @@ func buildCronServiceContent(jobID, name string, cmds []*cronvalidate.Command, u
 	for _, cmd := range cmds {
 		var b strings.Builder
 		b.WriteString("ExecStart=")
+		// GH #1458: tenant INTERPRETER crons (wp/php/python/node) run inside the
+		// per-user SSH sandbox via `jabali-ssh-shell --exec <argv>`, so a command
+		// that shells out (php passthru, python os.system, wp eval) stays
+		// confined. Skipped for: root crons (admin — the sandbox never jails
+		// uid 0, GH #658), and the curl/wget http-trigger (a trusted
+		// `jabali cron http-trigger` GET, not tenant code, and it needs host
+		// config the jail hides).
+		if username != "root" && cmd.Kind != cronvalidate.KindHTTPTrigger {
+			b.WriteString(cronSandboxWrapper)
+			b.WriteString(" --exec ")
+		}
 		for i, token := range cmd.Argv {
 			if i > 0 {
 				b.WriteByte(' ')

--- a/panel-agent/internal/commands/cron_apply_test.go
+++ b/panel-agent/internal/commands/cron_apply_test.go
@@ -438,6 +438,32 @@ func TestBuildCronServiceContent_HTTPTrigger(t *testing.T) {
 // GH #403: a cron whose command targets a docroot gates the unit on
 // ConditionPathIsDirectory (systemd-native, no exec) instead of the former
 // cron-precheck bash ExecStartPre that tripped the M33 suspicious-exec burst.
+func TestBuildCronServiceContent_SandboxesTenantInterpreters(t *testing.T) {
+	// GH #1458: a tenant php/python cron must run inside the per-user SSH
+	// sandbox (jabali-ssh-shell --exec), so a command that shells out can't
+	// escape the jail. Root crons and http-triggers are not wrapped.
+	php := &cronvalidate.Command{Argv: []string{"php", "/home/alice/domains/x/public_html/task.php"}}
+
+	tenant := buildCronServiceContent("job1", "task", []*cronvalidate.Command{php}, "alice", []string{"/home/alice/domains/x/public_html"})
+	if !contains(tenant, "ExecStart=/usr/local/bin/jabali-ssh-shell --exec 'php' '/home/alice/domains/x/public_html/task.php'") {
+		t.Errorf("tenant php cron must be sandboxed:\n%s", tenant)
+	}
+
+	root := buildCronServiceContent("job1", "task", []*cronvalidate.Command{php}, "root", []string{"/home/alice/domains/x/public_html"})
+	if contains(root, "jabali-ssh-shell") {
+		t.Errorf("root cron must NOT be sandboxed:\n%s", root)
+	}
+	if !contains(root, "ExecStart='php' '/home/alice/domains/x/public_html/task.php'") {
+		t.Errorf("root cron must keep the raw argv:\n%s", root)
+	}
+
+	py := &cronvalidate.Command{Argv: []string{"python3", "/home/alice/site/manage.py", "migrate"}}
+	django := buildCronServiceContent("job2", "django", []*cronvalidate.Command{py}, "alice", nil)
+	if !contains(django, "ExecStart=/usr/local/bin/jabali-ssh-shell --exec 'python3' '/home/alice/site/manage.py' 'migrate'") {
+		t.Errorf("tenant python cron must be sandboxed:\n%s", django)
+	}
+}
+
 func TestBuildCronServiceContent_DocrootCondition(t *testing.T) {
 	dr := "/home/alice/domains/a.example.com/public_html"
 	cmd := &cronvalidate.Command{Argv: []string{"php", dr + "/wp-cron.php"}}

--- a/panel-agent/internal/commands/cron_run_now.go
+++ b/panel-agent/internal/commands/cron_run_now.go
@@ -114,7 +114,14 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 			// Label each step so the operator can see which command ran.
 			fmt.Fprintf(&stdout, "$ %s\n", strings.Join(vc.Argv, " "))
 		}
-		args := append([]string{"-u", p.Username, "--"}, vc.Argv...)
+		// GH #1458: run the command inside the per-user SSH sandbox (matching the
+		// scheduled timer), so "Run now" can't shell out of the jail either. Root
+		// (admin) crons stay unsandboxed, same as the timer path.
+		args := []string{"-u", p.Username, "--"}
+		if p.Username != "root" && vc.Kind != cronvalidate.KindHTTPTrigger {
+			args = append(args, cronSandboxWrapper, "--exec")
+		}
+		args = append(args, vc.Argv...)
 		cmd := execCommandContext(ctx, "runuser", args...)
 		cmd.Dir = home
 		cmd.Env = env


### PR DESCRIPTION
## Security fix

Cron jobs run as the tenant uid but **outside** the per-user SSH sandbox (bubblewrap: read-only `/usr`, isolated PID namespace, filtered `passwd`, `/etc/jabali` and other tenants' homes hidden). So a cron whose command runs an interpreter that shells out — php `passthru`, python `os.system`, node `child_process`, `wp eval` — reached an **unsandboxed** shell as the tenant: it could read host config (e.g. `/etc/jabali/config.toml`), enumerate every process, and see the full filesystem, defeating the isolation SSH enforces.

Surfaced from GH #1458: a user tried a PHP→shell cron wrapper. The report itself is answered by #1435 (python cron), but investigating it showed the cron command allowlist can't hold the "no arbitrary command as your uid outside the sandbox" line it was written for — the allowlist blocks raw shell in the *command*, but any interpreter running the tenant's own script can spawn a shell. The execution has to be confined.

**Scope:** isolation bypass / host-info disclosure, not privilege escalation — still the tenant uid, Unix permissions hold (no cross-tenant file access). It defeats the PID-namespace + filesystem-view isolation the SSH sandbox provides.

## Fix — run tenant interpreter crons in the same jail as SSH

- `jabali-ssh-shell` gains a non-interactive **`--exec <argv>`** mode: builds the per-user jail and runs the argv directly (no login shell, no bash re-parse). `buildBwrapArgv` refactored to take the post-`--` command; the interactive and sshd `-c` paths are behaviorally unchanged. uid 0 (root) is never jailed (GH #658).
- `cron.apply` renders a tenant command's ExecStart as `jabali-ssh-shell --exec <argv>`; `cron.run_now` wraps its `runuser` argv the same way.
- **Not wrapped:** root crons (admin, unsandboxed by design) and the curl/wget http-trigger (a trusted `jabali cron http-trigger` GET — no tenant code, and it needs host config the jail hides).

## Reaches existing crons automatically

The panel's cron reconciler re-runs `cron.apply` for every job; the rewritten (now-wrapped) ExecStart no longer matches the on-disk unit, so the agent re-renders it. No per-install gate.

## Verification

- New/updated tests: `--exec` argv assembly (isolation flags + direct argv, no shell); `buildCronServiceContent` sandboxes tenant php/python, leaves root + http-trigger raw. Full `panel-agent` `commands` + `jabali-ssh-shell` suites green; `go vet` clean.
- **Box-drilled on the test server, both paths** (run_now via `runuser`, and a scheduled timer unit via the user manager): a python cron RAN and was confined — `/etc/jabali` showed only `snuffleupagus` (config.toml hidden), `/usr` read-only, isolated PID namespace, and a `subprocess.run(shell=...)` inside the script could **not** read `/etc/jabali/config.toml`. Writes to the tenant's docroot still work. Old binaries restored after.

## Rollout

Agent-only (both `jabali-agent` and `jabali-ssh-shell` ship in the agent release). A fleet agent redeploy rolls it out; the reconciler then re-renders existing units. nspawn sandbox mode is still unwired upstream (as it is for SSH); bubblewrap (the default) is the path exercised here.

Tracking against GH #1458.
