### PR TITLE
fix(users): route REST package assignment through the User Account Lifecycle op (JAB-283)

### DIFF
--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -21,7 +21,6 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 )
@@ -29,6 +28,16 @@ import (
 // UserHandlerConfig plugs the users resource handlers into the router. Repo
 // is the only required field; BcryptCost defaults to bcrypt.DefaultCost;
 // Agent is optional and used for best-effort OS user provisioning.
+
+// userReconciler is the reconciler surface the users handlers need: the limits
+// reconcile after a package change (this satisfies userops.LimitsReconciler, so
+// it can be handed straight to SetPackage) and the SSH-key reconcile after a
+// forwarding toggle. An interface so a nil is a genuine nil and tests can fake it.
+type userReconciler interface {
+	ReconcileUserLimits(ctx context.Context)
+	ReconcileSSHKeysForUser(ctx context.Context, userID string) error
+}
+
 type UserHandlerConfig struct {
 	Repo            repository.UserRepository
 	BcryptCost      int
@@ -58,8 +67,13 @@ type UserHandlerConfig struct {
 	// DomainTeardowns persists the JAB-236 tombstones that make the
 	// cascade's domain teardown durable across panel restarts.
 	DomainTeardowns repository.DomainTeardownRepository
-	Reconciler      *reconciler.Reconciler
-	Log             *slog.Logger
+	// Reconciler is the reconciler surface the user handlers dispatch to: the
+	// limits reconcile after an admin package change (via userops.SetPackage,
+	// which it satisfies) and the SSH-key reconcile after a forwarding toggle.
+	// Typed as an interface (JAB-283) so tests can inject a fake and an unset
+	// field is a genuine nil; prod passes the real *reconciler.Reconciler.
+	Reconciler userReconciler
+	Log        *slog.Logger
 	// AuditEvents records the admin SSH-forwarding toggle (GH #1229), a
 	// hardening-relaxation control. Optional; nil skips the audit write.
 	AuditEvents repository.AuditEventRepository
@@ -396,13 +410,6 @@ func (h *userHandler) update(c *gin.Context) {
 		return
 	}
 
-	// Snapshot pre-update package assignment so the trailing
-	// reconcile-limits dispatch only fires on actual changes.
-	prevPackageID := ""
-	if existing.PackageID != nil {
-		prevPackageID = *existing.PackageID
-	}
-
 	// Refuse demoting the last admin — otherwise a careless PATCH locks
 	// everyone out. Check BEFORE mutating anything.
 	if req.IsAdmin != nil && existing.IsAdmin && !*req.IsAdmin {
@@ -427,60 +434,35 @@ func (h *userHandler) update(c *gin.Context) {
 	if req.NameLast != nil {
 		existing.NameLast = *req.NameLast
 	}
-	// Validate and apply package_id if provided (including clearing it with empty
-	// string). Admin-only (GH #481): package assignment controls quotas/feature
-	// limits, so a non-admin owner cannot move themselves between packages — the
-	// field is silently ignored for non-admins (the owner UI never sends it).
-	if req.PackageID != nil && claims.IsAdmin {
-		if *req.PackageID != "" {
-			if h.cfg.Packages == nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-				return
-			}
-			// Shared validation with the automation API (ADR-0164).
-			if err := userops.ValidatePackage(ctx, h.userOpsDeps(), *req.PackageID); err != nil {
-				if errors.Is(err, userops.ErrInvalidPackage) {
-					c.JSON(http.StatusBadRequest, gin.H{
-						"error":  "invalid_package_id",
-						"detail": "hosting package not found",
-					})
-					return
-				}
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-				return
-			}
-			existing.PackageID = req.PackageID
-		} else {
-			// Empty string means clear the package assignment
-			existing.PackageID = nil
-		}
-	}
-
 	// Per-user webmail toggle (GH #316): admin-only, like package_id. The owner
 	// UI never sends it, so silently ignore for non-admins.
 	if req.WebmailEnabled != nil && claims.IsAdmin {
 		existing.WebmailEnabled = *req.WebmailEnabled
 	}
 
-	if err := h.cfg.Repo.Update(ctx, existing); err != nil {
+	// Persist. When an admin assigns/replaces/clears the package (admin-only,
+	// GH #481 — the owner UI never sends the field), route through the User
+	// Account Lifecycle operation (JAB-283) instead of writing the field and
+	// dispatching the reconcile inline: SetPackage validates the package BEFORE
+	// persisting, persists the whole row (including the field updates above),
+	// and schedules the limits reconcile exactly once on an actual change — the
+	// same operation the automation billing API already uses. Every other
+	// update persists directly.
+	if req.PackageID != nil && claims.IsAdmin {
+		if err := userops.SetPackage(ctx, h.userOpsDeps(), existing, req.PackageID, h.cfg.Reconciler); err != nil {
+			if errors.Is(err, userops.ErrInvalidPackage) {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error":  "invalid_package_id",
+					"detail": "hosting package not found",
+				})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+	} else if err := h.cfg.Repo.Update(ctx, existing); err != nil {
 		h.translateErr(c, err)
 		return
-	}
-
-	// If the package assignment actually changed, kick the limits
-	// reconciler immediately so POSIX quota + cgroup drop-ins land
-	// without waiting for the next 60s ReconcileAll tick. Background
-	// goroutine — PATCH responds as soon as the DB row is durable.
-	newPackageID := ""
-	if existing.PackageID != nil {
-		newPackageID = *existing.PackageID
-	}
-	if newPackageID != prevPackageID && h.cfg.Reconciler != nil {
-		go func() {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			h.cfg.Reconciler.ReconcileUserLimits(bgCtx)
-		}()
 	}
 
 	// Flip is_admin in its own call so the repo's privilege-safe Update

--- a/panel-api/internal/api/users_package_lifecycle_test.go
+++ b/panel-api/internal/api/users_package_lifecycle_test.go
@@ -1,0 +1,233 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeLimitsReconciler structurally satisfies the users handler's reconciler
+// interface. ReconcileUserLimits records the call count and signals `fired`
+// (SetPackage dispatches it in a background goroutine, so the tests sync on the
+// channel before asserting). ReconcileSSHKeysForUser is unused here.
+type fakeLimitsReconciler struct {
+	mu    sync.Mutex
+	n     int
+	fired chan struct{}
+}
+
+func (f *fakeLimitsReconciler) ReconcileUserLimits(_ context.Context) {
+	f.mu.Lock()
+	f.n++
+	f.mu.Unlock()
+	select {
+	case f.fired <- struct{}{}:
+	default:
+	}
+}
+func (f *fakeLimitsReconciler) ReconcileSSHKeysForUser(_ context.Context, _ string) error { return nil }
+func (f *fakeLimitsReconciler) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.n
+}
+
+func newFakeReconciler() *fakeLimitsReconciler {
+	return &fakeLimitsReconciler{fired: make(chan struct{}, 1)}
+}
+
+// buildRouterWithReconciler mirrors buildRouterWithPackages but also wires a
+// reconciler so the limits-reconcile dispatch is observable.
+func buildRouterWithReconciler(
+	repo repository.UserRepository,
+	pkgRepo repository.PackageRepository,
+	rec *fakeLimitsReconciler,
+	claims *auth.AccessClaims,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("/api/v1", func(c *gin.Context) {
+		if claims != nil {
+			ginctx.SetClaims(c, claims)
+		}
+		c.Next()
+	})
+	api.RegisterUserRoutes(g, api.UserHandlerConfig{
+		Repo:       repo,
+		Packages:   pkgRepo,
+		Reconciler: rec,
+		BcryptCost: bcrypt.MinCost,
+	})
+	return r
+}
+
+// expectReconcile asserts whether the limits reconcile fired. When want is
+// true it blocks (with a generous timeout) for the background goroutine; when
+// false it waits a short grace and asserts nothing fired.
+func expectReconcile(t *testing.T, rec *fakeLimitsReconciler, want bool) {
+	t.Helper()
+	if want {
+		select {
+		case <-rec.fired:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a limits reconcile, got none")
+		}
+		assert.Equal(t, 1, rec.count(), "limits reconcile must fire exactly once")
+	} else {
+		select {
+		case <-rec.fired:
+			t.Fatal("expected NO limits reconcile, but one fired")
+		case <-time.After(150 * time.Millisecond):
+		}
+		assert.Equal(t, 0, rec.count(), "no limits reconcile expected")
+	}
+}
+
+// TestUsers_Patch_PackageAssign_ReconcilesOnce: assigning a package routes
+// through userops.SetPackage, which schedules the limits reconcile exactly once.
+func TestUsers_Patch_PackageAssign_ReconcilesOnce(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	target := makeUser(t, "u@example.com", false, "password01")
+	repo.seed(admin)
+	repo.seed(target)
+	pkgRepo := newMemPackageRepo()
+	pkg := &models.HostingPackage{ID: ids.NewULID(), Name: "Premium"}
+	pkgRepo.seed(pkg)
+	rec := newFakeReconciler()
+
+	r := buildRouterWithReconciler(repo, pkgRepo, rec, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	w := doJSON(t, r, http.MethodPatch, "/api/v1/users/"+target.ID, map[string]any{"package_id": pkg.ID})
+	require.Equal(t, http.StatusOK, w.Code)
+	expectReconcile(t, rec, true)
+}
+
+// TestUsers_Patch_PackageReplace_ReconcilesOnce: replacing one package with a
+// different one is still a single reconcile.
+func TestUsers_Patch_PackageReplace_ReconcilesOnce(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	pkgOld := ids.NewULID()
+	target := makeUser(t, "u@example.com", false, "password01")
+	target.PackageID = &pkgOld
+	repo.seed(admin)
+	repo.seed(target)
+	pkgRepo := newMemPackageRepo()
+	pkgRepo.seed(&models.HostingPackage{ID: pkgOld, Name: "Old"})
+	pkgNew := &models.HostingPackage{ID: ids.NewULID(), Name: "New"}
+	pkgRepo.seed(pkgNew)
+	rec := newFakeReconciler()
+
+	r := buildRouterWithReconciler(repo, pkgRepo, rec, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	w := doJSON(t, r, http.MethodPatch, "/api/v1/users/"+target.ID, map[string]any{"package_id": pkgNew.ID})
+	require.Equal(t, http.StatusOK, w.Code)
+	expectReconcile(t, rec, true)
+}
+
+// TestUsers_Patch_PackageUnchanged_NoReconcile: re-assigning the SAME package
+// persists but does not reconcile (SetPackage's next==prev guard) — the case
+// the old inline "newPackageID != prevPackageID" also had to get right.
+func TestUsers_Patch_PackageUnchanged_NoReconcile(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	pkgID := ids.NewULID()
+	target := makeUser(t, "u@example.com", false, "password01")
+	target.PackageID = &pkgID
+	repo.seed(admin)
+	repo.seed(target)
+	pkgRepo := newMemPackageRepo()
+	pkgRepo.seed(&models.HostingPackage{ID: pkgID, Name: "Same"})
+	rec := newFakeReconciler()
+
+	r := buildRouterWithReconciler(repo, pkgRepo, rec, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	w := doJSON(t, r, http.MethodPatch, "/api/v1/users/"+target.ID, map[string]any{"package_id": pkgID})
+	require.Equal(t, http.StatusOK, w.Code)
+	expectReconcile(t, rec, false)
+}
+
+// TestUsers_Patch_PackageRemove_ReconcilesOnce: clearing the package (empty
+// string) is a change, so it reconciles once — completing the assign/replace/
+// remove parity matrix.
+func TestUsers_Patch_PackageRemove_ReconcilesOnce(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	pkgID := ids.NewULID()
+	target := makeUser(t, "u@example.com", false, "password01")
+	target.PackageID = &pkgID
+	repo.seed(admin)
+	repo.seed(target)
+	pkgRepo := newMemPackageRepo()
+	pkgRepo.seed(&models.HostingPackage{ID: pkgID, Name: "ToRemove"})
+	rec := newFakeReconciler()
+
+	r := buildRouterWithReconciler(repo, pkgRepo, rec, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	w := doJSON(t, r, http.MethodPatch, "/api/v1/users/"+target.ID, map[string]any{"package_id": ""})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out models.User
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	require.Nil(t, out.PackageID)
+	expectReconcile(t, rec, true)
+}
+
+// TestUsers_Patch_EmailOnly_NoReconcile: a non-package field change never
+// touches the limits reconciler.
+func TestUsers_Patch_EmailOnly_NoReconcile(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	target := makeUser(t, "u@example.com", false, "password01")
+	repo.seed(admin)
+	repo.seed(target)
+	pkgRepo := newMemPackageRepo()
+	rec := newFakeReconciler()
+
+	r := buildRouterWithReconciler(repo, pkgRepo, rec, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	w := doJSON(t, r, http.MethodPatch, "/api/v1/users/"+target.ID, map[string]any{"email": "new@example.com"})
+	require.Equal(t, http.StatusOK, w.Code)
+	expectReconcile(t, rec, false)
+}
+
+// TestUsers_Patch_PackageAndEmailTogether: a single PATCH carrying both a
+// package change and an unrelated field persists BOTH — the package change
+// routes through SetPackage, whose Update writes the whole row (including the
+// email applied before it).
+func TestUsers_Patch_PackageAndEmailTogether(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	target := makeUser(t, "u@example.com", false, "password01")
+	repo.seed(admin)
+	repo.seed(target)
+	pkgRepo := newMemPackageRepo()
+	pkg := &models.HostingPackage{ID: ids.NewULID(), Name: "Premium"}
+	pkgRepo.seed(pkg)
+	rec := newFakeReconciler()
+
+	r := buildRouterWithReconciler(repo, pkgRepo, rec, &auth.AccessClaims{UserID: admin.ID, IsAdmin: true})
+	w := doJSON(t, r, http.MethodPatch, "/api/v1/users/"+target.ID, map[string]any{
+		"email":      "moved@example.com",
+		"package_id": pkg.ID,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var out models.User
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	require.NotNil(t, out.PackageID)
+	assert.Equal(t, pkg.ID, *out.PackageID)
+	assert.Equal(t, "moved@example.com", out.Email)
+	expectReconcile(t, rec, true)
+}


### PR DESCRIPTION
## JAB-283 — route REST package assignment through the lifecycle op

`PATCH /users/:id` re-implemented package assignment inline — validate the
package, write `user.PackageID`, then dispatch a limits reconcile if it changed.
`userops.SetPackage` already owns exactly that sequence, and the **automation
billing API already routes through it**, so the two entry points carried drifted
copies of the same logic.

### The change
- On an admin package change (assign / replace / clear — admin-only, GH #481;
  the owner UI never sends the field) the handler now calls
  `userops.SetPackage(ctx, deps, existing, req.PackageID, reconciler)`. It
  **validates before persisting**, persists the whole row (including the
  email/name/webmail updates already applied to `existing`), and schedules the
  limits reconcile **exactly once** on an actual change. Every other update
  persists directly via `Repo.Update` as before.
- `UserHandlerConfig.Reconciler` becomes a narrow `userReconciler` interface
  (`ReconcileUserLimits` + `ReconcileSSHKeysForUser`, both already used) instead
  of the concrete `*reconciler.Reconciler`: it hands straight to `SetPackage`
  (satisfies `userops.LimitsReconciler`), an unset field is a genuine nil (no
  typed-nil-in-interface hazard), and tests can inject a fake. Prod passes the
  real reconciler unchanged.
- The invalid-package response is **preserved** (400 `invalid_package_id`)
  rather than routed through the automation-shaped `mapUserOpsErr` (which returns
  404) — REST wire compatibility kept.

### Tests (REST/automation parity — a fake reconciler counting the dispatch)
assign / replace / **remove** each reconcile exactly once; re-assigning the
**same** package and an **email-only** PATCH reconcile zero times; a single
PATCH carrying both a package change and an email persists **both**. Existing
assign / clear / invalid-package / owner-cannot-set tests unchanged.

`go build ./...`, `go vet ./...`, `-race` on `internal/api` + `internal/userops`
+ `cmd/server`, gofmt — all green.

### AC status (this ticket is concrete, not a module-parent)
- ✅ Every package-assignment entry point uses the lifecycle op (REST now +
  automation already; no CLI assign path exists — CLI only reads `PackageID`).
- ✅ Invalid packages fail before persistence (400, tested). Protected state:
  the last-admin-demote guard still runs before any mutation.
- ✅ A successful change schedules limits reconciliation exactly once (tested for
  assign/replace/remove; zero for no-op/unrelated).
- ✅ Unrelated account fields unchanged (tested: email persists alongside a
  package change).
- ✅ REST + automation parity tests cover assign, replace, remove.

**One honest caveat (not addressed here):** the automation path rejects
assigning a package to an *admin* user (409 "admin users have no hosting
package"); the REST path does not add that guard (it never did, and adding it
would change existing REST behaviour). If you want that guard for full parity,
say so and it's a one-liner follow-up. Otherwise I believe this closes JAB-283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
