### PR TITLE
test(agent): fix flaky peercred UID-gate test (write/close race under -race)

### DIFF
--- a/panel-agent/internal/server/server_test.go
+++ b/panel-agent/internal/server/server_test.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -61,8 +63,19 @@ func roundTrip(t *testing.T, sock string, req agentwire.Request) agentwire.Respo
 
 	b, err := json.Marshal(req)
 	require.NoError(t, err)
-	_, err = conn.Write(append(b, '\n'))
-	require.NoError(t, err)
+	// A server that rejects on connect — the SO_PEERCRED UID gate — sends its
+	// permission-denied envelope and closes the connection immediately, so this
+	// write can lose the race with that close and return EPIPE/ECONNRESET. That
+	// is NOT a test failure: the rejection is already buffered and the scan
+	// below still returns it. Fail only on an unexpected write error. (Without
+	// this, TestServer_UIDGate_RejectsUnauthorizedUID flaked under -race with
+	// "write: broken pipe".)
+	if _, werr := conn.Write(append(b, '\n')); werr != nil &&
+		!errors.Is(werr, syscall.EPIPE) &&
+		!errors.Is(werr, syscall.ECONNRESET) &&
+		!errors.Is(werr, net.ErrClosed) {
+		require.NoError(t, werr)
+	}
 	// half-close write so server stops reading
 	if uc, ok := conn.(interface{ CloseWrite() error }); ok {
 		_ = uc.CloseWrite()


### PR DESCRIPTION
## What

`TestServer_UIDGate_RejectsUnauthorizedUID` flaked under `go test -race` — it failed the "Go tests + vet" check on two unrelated PRs this session (#1499, #1502, both changing zero Go), with:

```
write unix @->/tmp/.../a.sock: write: broken pipe
```

## Cause

The SO_PEERCRED UID gate rejects on connect: it sends its permission-denied envelope and **closes the connection immediately**. The shared `roundTrip` test helper did `conn.Write(...); require.NoError(t, err)`, so when the server's close won the race against the client's write, the write returned `EPIPE` and the test died — even though the rejection response was already buffered and readable (the scan right below would have returned it). `-race` widens the window, so it surfaced intermittently on CI.

## Fix

Tolerate a close-race write error (`EPIPE` / `ECONNRESET` / `net.ErrClosed`) and let the scan return the buffered response; still fail on any other write error. Happy-path tests are unaffected (their writes succeed).

## Verification

`go test -race -count=100 ./internal/server/` — green (that test was intermittently failing before). `go vet` clean.

Not a product change — test reliability only. Removes a recurring merge blocker.
