### PR TITLE
refactor(php-pools): one PHP Pool Lifecycle module for HTTP + CLI (JAB-360)

### DIFF
--- a/panel-api/cmd/server/php_pool_parity_cmd.go
+++ b/panel-api/cmd/server/php_pool_parity_cmd.go
@@ -16,50 +16,23 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// reconcilePHPPoolCLI fires php.pool.apply for a pool, replicating
-// api.reconcilePHPPoolViaAgent (load user, build admin values/flags, apply,
-// persist status).
-func reconcilePHPPoolCLI(ctx context.Context, pool *models.PHPPool) error {
-	pools := repository.NewPHPPoolRepository(sharedDB)
-	user, err := repository.NewUserRepository(sharedDB).FindByID(ctx, pool.UserID)
-	if err != nil || user == nil || user.Username == nil {
-		return fmt.Errorf("resolve pool owner: %w", err)
+// phpPoolReconcileDeps builds the shared reconcile dependencies from the CLI's
+// process-wide DB handle + agent client. JAB-360: the CLI used to carry a
+// hand-copied reconcile that had drifted from the HTTP one (no versioned
+// slug/additive, no extended pm.* / slowlog / extensions / Xdebug), so a CLI
+// mutation on a non-default pool applied to the user's DEFAULT socket. Both
+// adapters now call phppoolops.ReconcileViaAgent.
+func phpPoolReconcileDeps() phppoolops.ReconcileDeps {
+	return phppoolops.ReconcileDeps{
+		Agent:     sharedAgent,
+		Users:     repository.NewUserRepository(sharedDB),
+		Overrides: repository.NewPHPPoolIniOverrideRepository(sharedDB),
+		Pools:     repository.NewPHPPoolRepository(sharedDB),
 	}
-	overrides, err := repository.NewPHPPoolIniOverrideRepository(sharedDB).ListByPool(ctx, pool.ID)
-	if err != nil {
-		return fmt.Errorf("list overrides: %w", err)
-	}
-	adminValues := []map[string]string{}
-	adminFlags := []map[string]string{}
-	for _, o := range overrides {
-		kv := map[string]string{"name": o.Directive, "value": o.Value}
-		if o.Kind == "flag" {
-			adminFlags = append(adminFlags, kv)
-		} else {
-			adminValues = append(adminValues, kv)
-		}
-	}
-	actx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	_, aerr := sharedAgent.Call(actx, "php.pool.apply", map[string]any{
-		"username":                     *user.Username,
-		"php_version":                  pool.PHPVersion,
-		"pm_mode":                      pool.PmMode,
-		"pm_max_children":              pool.PmMaxChildren,
-		"process_idle_timeout_seconds": pool.ProcessIdleTimeoutSeconds,
-		"admin_values":                 adminValues,
-		"admin_flags":                  adminFlags,
-	})
-	if aerr != nil {
-		msg := "agent failed: " + aerr.Error()
-		_ = pools.SetStatus(ctx, pool.ID, "error", &msg)
-		return aerr
-	}
-	_ = pools.SetStatus(ctx, pool.ID, "ready", nil)
-	return nil
 }
 
 func newPHPPoolListCmd() *cobra.Command {
@@ -105,10 +78,18 @@ func newPHPPoolCreateCmd() *cobra.Command {
 			if user == "" || version == "" {
 				return fmt.Errorf("--user and --php-version are required")
 			}
-			switch pmMode {
-			case "ondemand", "dynamic", "static":
-			default:
-				return fmt.Errorf("--pm-mode must be ondemand|dynamic|static")
+			// JAB-360: validate + clamp through the shared create-side validator
+			// (admin-scoped caps — the operator CLI is privileged) so a CLI pool
+			// can't exceed the pm_max_children cap / idle ceiling / FPM
+			// dynamic-mode invariants a tenant-facing create enforces. It also
+			// fills defaults for the extended pm.* set the CLI has no flags for.
+			tuning, msg, _, ok := phppoolops.ResolveCreateTuning(true, phppoolops.CreateTuning{
+				PmMode:                    pmMode,
+				PmMaxChildren:             maxChildren,
+				ProcessIdleTimeoutSeconds: idleTimeout,
+			})
+			if !ok {
+				return fmt.Errorf("invalid pool tuning: %s", msg)
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 			defer cancel()
@@ -132,13 +113,20 @@ func newPHPPoolCreateCmd() *cobra.Command {
 			}
 			pool := &models.PHPPool{
 				ID: ulid.Make().String(), UserID: u.ID, PHPVersion: version,
-				PmMode: pmMode, PmMaxChildren: maxChildren, ProcessIdleTimeoutSeconds: idleTimeout,
-				Status: "pending",
+				PmMode:                         tuning.PmMode,
+				PmMaxChildren:                  tuning.PmMaxChildren,
+				ProcessIdleTimeoutSeconds:      tuning.ProcessIdleTimeoutSeconds,
+				PmStartServers:                 tuning.PmStartServers,
+				PmMinSpareServers:              tuning.PmMinSpareServers,
+				PmMaxSpareServers:              tuning.PmMaxSpareServers,
+				PmMaxRequests:                  tuning.PmMaxRequests,
+				RequestTerminateTimeoutSeconds: tuning.RequestTerminateTimeoutSeconds,
+				Status:                         "pending",
 			}
 			if err := repo.Create(ctx, pool); err != nil {
 				return fmt.Errorf("create pool: %w", err)
 			}
-			if err := reconcilePHPPoolCLI(ctx, pool); err != nil {
+			if err := phppoolops.ReconcileViaAgent(phpPoolReconcileDeps(), *pool); err != nil {
 				return fmt.Errorf("pool created but apply failed: %w", err)
 			}
 			cliAuditOK(ctx, "php_pool.create", "php_pool", pool.ID, &u.ID)
@@ -272,7 +260,7 @@ func newPHPPoolIniAddCmd() *cobra.Command {
 			if err := repository.NewPHPPoolIniOverrideRepository(sharedDB).Create(ctx, ov); err != nil {
 				return fmt.Errorf("create override: %w", err)
 			}
-			if err := reconcilePHPPoolCLI(ctx, pool); err != nil {
+			if err := phppoolops.ReconcileViaAgent(phpPoolReconcileDeps(), *pool); err != nil {
 				return fmt.Errorf("override saved but apply failed: %w", err)
 			}
 			cliAuditOK(ctx, "php_pool.ini_add", "php_pool_ini", ov.ID, &pool.UserID)
@@ -309,7 +297,7 @@ func newPHPPoolIniUpdateCmd() *cobra.Command {
 			if perr != nil {
 				return fmt.Errorf("load pool: %w", perr)
 			}
-			if err := reconcilePHPPoolCLI(ctx, pool); err != nil {
+			if err := phppoolops.ReconcileViaAgent(phpPoolReconcileDeps(), *pool); err != nil {
 				return fmt.Errorf("override updated but apply failed: %w", err)
 			}
 			cliAuditOK(ctx, "php_pool.ini_update", "php_pool_ini", ov.ID, &pool.UserID)
@@ -343,7 +331,7 @@ func newPHPPoolIniRemoveCmd() *cobra.Command {
 			if perr != nil {
 				return fmt.Errorf("load pool: %w", perr)
 			}
-			if err := reconcilePHPPoolCLI(ctx, pool); err != nil {
+			if err := phppoolops.ReconcileViaAgent(phpPoolReconcileDeps(), *pool); err != nil {
 				return fmt.Errorf("override removed but apply failed: %w", err)
 			}
 			cliAuditOK(ctx, "php_pool.ini_remove", "php_pool_ini", ov.ID, &pool.UserID)

--- a/panel-api/cmd/server/php_pool_parity_cmd_create_test.go
+++ b/panel-api/cmd/server/php_pool_parity_cmd_create_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPHPPoolCreate_RoutesThroughSharedLifecycle pins the JAB-360 parity: the
+// CLI create + ini mutations must drive the SAME phppoolops module the HTTP
+// handlers do, not a hand-copied reconcile. cmd/server has no DB/agent fixture,
+// so this source-pins the wiring (repo precedent: the delete guard test above);
+// the behavioural matrix is unit-tested in internal/phppoolops.
+func TestPHPPoolCreate_RoutesThroughSharedLifecycle(t *testing.T) {
+	src, err := os.ReadFile("php_pool_parity_cmd.go")
+	if err != nil {
+		t.Fatalf("read php_pool_parity_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	// Create must clamp/validate through the shared create-side validator with
+	// admin-scoped caps — the operator CLI is privileged, but a CLI pool must
+	// still obey the pm_max_children cap + FPM dynamic-mode invariants a
+	// tenant-facing create enforces (the old CLI create wrote pm_max_children
+	// raw, with no cap and no dynamic constraint).
+	if !strings.Contains(s, "phppoolops.ResolveCreateTuning(true,") {
+		t.Fatal("CLI create must validate/clamp via phppoolops.ResolveCreateTuning (admin-scoped) — a CLI pool must not exceed the caps/tuning a tenant create enforces (JAB-360)")
+	}
+
+	// Every mutation must reconcile via the shared op, which resolves the
+	// versioned slug/additive + carries the full pm.* / slowlog / extensions /
+	// Xdebug model. The old reconcilePHPPoolCLI omitted all of that, so a CLI
+	// mutation on a non-default pool applied to the user's DEFAULT socket.
+	if !strings.Contains(s, "phppoolops.ReconcileViaAgent(phpPoolReconcileDeps()") {
+		t.Fatal("CLI mutations must reconcile via phppoolops.ReconcileViaAgent (versioned slug + full payload), not a hand-copied apply (JAB-360)")
+	}
+	if strings.Contains(s, "reconcilePHPPoolCLI") {
+		t.Fatal("the stale hand-copied reconcilePHPPoolCLI must be gone — it had drifted from the HTTP reconcile (JAB-360)")
+	}
+}

--- a/panel-api/internal/api/php_pool_extensions.go
+++ b/panel-api/internal/api/php_pool_extensions.go
@@ -176,7 +176,7 @@ func (h *phpPoolExtensionsHandler) set(c *gin.Context) {
 		return
 	}
 	c.Set("audit_target", "php_extensions:"+pool.PHPVersion)
-	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
 	c.JSON(http.StatusOK, gin.H{"enabled": []string(clean)})
 }
 

--- a/panel-api/internal/api/php_pool_opcache.go
+++ b/panel-api/internal/api/php_pool_opcache.go
@@ -195,7 +195,7 @@ func (h *phpUserTuningHandler) setOpcache(c *gin.Context) {
 	// conf is on disk before the restart below re-reads it.
 	pool.Status = "pending"
 	_ = h.cfg.PHPPools.Update(c.Request.Context(), pool)
-	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
 	if fresh, err := h.cfg.PHPPools.FindByID(c.Request.Context(), pool.ID); err == nil && fresh != nil && fresh.Status == "error" {
 		detail := ""
 		if fresh.LastError != nil {

--- a/panel-api/internal/api/php_pool_reconcile.go
+++ b/panel-api/internal/api/php_pool_reconcile.go
@@ -1,100 +1,36 @@
 package api
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
-	"time"
-
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// reconcilePHPPoolViaAgent fires php.pool.apply against the agent for the
-// given pool, then writes the resulting status back to the DB. Designed
-// to be called inside `go ...` from request handlers so a user-driven
-// version/config change converges immediately instead of waiting for the
-// next reconciler tick.
+// reconcilePHPPoolViaAgent fires php.pool.apply for the given pool and writes
+// the resulting status back to the DB. It delegates to
+// phppoolops.ReconcileViaAgent so the HTTP handlers and the operator CLI drive
+// the identical apply (slug/additive + the full pm.* + slowlog + extensions +
+// Xdebug model); see that package for the payload.
 //
-// Used by both the admin /php-pools/:id PUT path and the user-driven
-// POST /domains/:id/php-pool path so the two flows behave identically.
-// Callers are expected to have already flipped pool.Status to "pending"
-// (or its equivalent) before invoking — the helper itself overwrites
-// status with "ready" on success or "error" on failure.
+// pool is taken BY VALUE: callers that spawn it with `go` pass a copy, so the
+// fire-and-forget reconcile cannot race a handler that keeps mutating its own
+// pool (JAB-360 removes that repo-wide `-race` flake). Callers that need the
+// resulting status (the synchronous opcache path) read it back from the DB.
+//
+// Used by the admin /php-pools/:id paths and the user-driven
+// /domains/:id/php-pool path so the flows behave identically.
 func reconcilePHPPoolViaAgent(
 	ag agent.AgentInterface,
 	users repository.UserRepository,
 	overrides repository.PHPPoolIniOverrideRepository,
 	pools repository.PHPPoolRepository,
-	pool *models.PHPPool,
+	pool models.PHPPool,
 ) {
-	agentCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	user, err := users.FindByID(agentCtx, pool.UserID)
-	if err != nil {
-		slog.ErrorContext(agentCtx, "reconcilePHPPoolViaAgent: load user", "error", err, "pool_id", pool.ID)
-		return
-	}
-
-	overridesList, err := overrides.ListByPool(agentCtx, pool.ID)
-	if err != nil {
-		slog.ErrorContext(agentCtx, "reconcilePHPPoolViaAgent: list overrides", "error", err, "pool_id", pool.ID)
-		return
-	}
-
-	adminValues := []map[string]string{}
-	adminFlags := []map[string]string{}
-	for _, override := range overridesList {
-		kv := map[string]string{"name": override.Directive, "value": override.Value}
-		if override.Kind == "flag" {
-			adminFlags = append(adminFlags, kv)
-		} else {
-			adminValues = append(adminValues, kv)
-		}
-	}
-
-	// GH #329: resolve the pool's slug so a versioned pool applies to its own
-	// socket/instance rather than the default per-user one. isDefault = the
-	// pool is the user's earliest (created_at ASC).
-	username := ""
-	if user.Username != nil {
-		username = *user.Username
-	}
-	isDefault := true
-	if list, lerr := pools.ListByUserID(agentCtx, pool.UserID); lerr == nil && len(list) > 0 {
-		isDefault = list[0].ID == pool.ID
-	}
-	slug := models.PoolSlug(username, pool.PHPVersion, isDefault)
-
-	_, err = ag.Call(agentCtx, "php.pool.apply", map[string]any{
-		"username":                          username,
-		"slug":                              slug,
-		"additive":                          !isDefault,
-		"php_version":                       pool.PHPVersion,
-		"pm_mode":                           pool.PmMode,
-		"pm_max_children":                   pool.PmMaxChildren,
-		"process_idle_timeout_seconds":      pool.ProcessIdleTimeoutSeconds,
-		"pm_start_servers":                  pool.PmStartServers,
-		"pm_min_spare_servers":              pool.PmMinSpareServers,
-		"pm_max_spare_servers":              pool.PmMaxSpareServers,
-		"pm_max_requests":                   pool.PmMaxRequests,
-		"request_terminate_timeout_seconds": pool.RequestTerminateTimeoutSeconds,
-		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
-		"admin_values":                      adminValues,
-		"admin_flags":                       adminFlags,
-		"extra_extensions":                  []string(pool.ExtraExtensions),
-		"xdebug_enabled":                    pool.XdebugEnabled,
-	})
-	if err != nil {
-		pool.Status = "error"
-		errMsg := fmt.Sprintf("agent failed: %v", err)
-		pool.LastError = &errMsg
-		_ = pools.Update(agentCtx, pool)
-		return
-	}
-	pool.Status = "ready"
-	pool.LastError = nil
-	_ = pools.Update(agentCtx, pool)
+	_ = phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+		Agent:     ag,
+		Users:     users,
+		Overrides: overrides,
+		Pools:     pools,
+	}, pool)
 }

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -341,6 +341,6 @@ func (h *phpUserTuningHandler) applyToPool(c *gin.Context, pool *models.PHPPool,
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
 	c.JSON(http.StatusOK, gin.H{"data": pool})
 }

--- a/panel-api/internal/api/php_pool_xdebug.go
+++ b/panel-api/internal/api/php_pool_xdebug.go
@@ -104,6 +104,6 @@ func (h *phpXdebugHandler) set(c *gin.Context) {
 		return
 	}
 	c.Set("audit_target", "php_xdebug:"+pool.PHPVersion)
-	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
 	c.JSON(http.StatusOK, gin.H{"enabled": pool.XdebugEnabled})
 }

--- a/panel-api/internal/api/php_pools.go
+++ b/panel-api/internal/api/php_pools.go
@@ -13,6 +13,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -20,70 +21,25 @@ import (
 // Resource caps (GH #339 security): pm_max_children + idle timeout are
 // tenant-settable, so they MUST be bounded — an unbounded value is a
 // resource-exhaustion DoS on the shared host.
+// Resource caps + the FPM tuning validators now live in internal/phppoolops so
+// the HTTP handlers and the operator CLI share one authority (JAB-360). These
+// package-local aliases keep the existing api call sites (packages.go,
+// php_performance_modes.go, php_pool_user_tuning.go, the update handler)
+// unchanged.
 const (
-	phpPoolUserMaxChildrenCap  = 100
-	phpPoolAdminMaxChildrenCap = 2000
-	phpPoolMaxIdleTimeoutSec   = 86400
-	phpPoolMaxRequestsCap      = 100000 // worker recycle bound (0 = disabled)
-	phpPoolMaxTerminateSec     = 3600   // request_terminate_timeout ceiling (0 = disabled)
+	phpPoolUserMaxChildrenCap  = phppoolops.UserMaxChildrenCap
+	phpPoolAdminMaxChildrenCap = phppoolops.AdminMaxChildrenCap
+	phpPoolMaxIdleTimeoutSec   = phppoolops.MaxIdleTimeoutSec
+	phpPoolMaxRequestsCap      = phppoolops.MaxRequestsCap
+	phpPoolMaxTerminateSec     = phppoolops.MaxTerminateSec
 )
 
-// clampToPackageCap bounds pm_max_children (and dependent spare/start servers)
-// to a hosting package's fpm_max_children_cap, then re-runs the FPM dynamic
-// constraint via resolvePMTuning. Load-bearing safety for the L1/L2 user tiers
-// (GH #339 phase 2): whatever a non-admin produces can never exceed the cap.
 func clampToPackageCap(cap uint32, mode string, maxChildren, start, minSpare, maxSpare, maxReq, terminate *uint32) (string, bool) {
-	if cap > 0 && *maxChildren > cap {
-		*maxChildren = cap
-	}
-	if *start > *maxChildren {
-		*start = *maxChildren
-	}
-	if *maxSpare > *maxChildren {
-		*maxSpare = *maxChildren
-	}
-	return resolvePMTuning(mode, *maxChildren, start, minSpare, maxSpare, maxReq, terminate)
+	return phppoolops.ClampToPackageCap(cap, mode, maxChildren, start, minSpare, maxSpare, maxReq, terminate)
 }
 
-// resolvePMTuning applies defaults, caps, and the FPM dynamic-mode constraint
-// (min_spare <= start <= max_spare <= max_children) to the extended pm.* fields
-// (GH #339). It MUTATES the pointed-to values (fills dynamic defaults clamped to
-// max_children) and returns a client error + false when invalid. start/spare are
-// ignored by FPM outside dynamic mode, so they are only constrained there.
 func resolvePMTuning(mode string, maxChildren uint32, start, minSpare, maxSpare, maxReq, terminate *uint32) (string, bool) {
-	if *maxReq > phpPoolMaxRequestsCap {
-		return fmt.Sprintf("pm_max_requests must be <= %d", phpPoolMaxRequestsCap), false
-	}
-	if *terminate > phpPoolMaxTerminateSec {
-		return fmt.Sprintf("request_terminate_timeout_seconds must be <= %d", phpPoolMaxTerminateSec), false
-	}
-	if mode != "dynamic" {
-		return "", true
-	}
-	if *maxSpare == 0 {
-		if maxChildren < 3 {
-			*maxSpare = maxChildren
-		} else {
-			*maxSpare = 3
-		}
-	}
-	if *start == 0 {
-		if *maxSpare < 2 {
-			*start = *maxSpare
-		} else {
-			*start = 2
-		}
-	}
-	if *minSpare == 0 {
-		*minSpare = 1
-		if *minSpare > *start {
-			*minSpare = *start
-		}
-	}
-	if !(*minSpare <= *start && *start <= *maxSpare && *maxSpare <= maxChildren) {
-		return "dynamic pm requires pm_min_spare_servers <= pm_start_servers <= pm_max_spare_servers <= pm_max_children", false
-	}
-	return "", true
+	return phppoolops.ResolvePMTuning(mode, maxChildren, start, minSpare, maxSpare, maxReq, terminate)
 }
 
 type PHPPoolHandlerConfig struct {
@@ -309,53 +265,32 @@ func (h *phpPoolHandler) create(c *gin.Context) {
 		return
 	}
 
-	// Validate pm_mode
-	validPmModes := map[string]bool{"static": true, "ondemand": true, "dynamic": true}
-	if req.PmMode == "" {
-		req.PmMode = "ondemand" // default
-	} else if !validPmModes[req.PmMode] {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "invalid_pm_mode",
-			"detail": "pm_mode must be static, ondemand, or dynamic",
-		})
+	// JAB-360: one shared create-side validator (mode + defaults + admin/user
+	// pm_max_children cap + idle ceiling + FPM dynamic constraint) so the
+	// operator CLI create can't drift from this handler. The returned field key
+	// maps 1:1 onto the error codes this endpoint has always returned.
+	tuning, msg, field, ok := phppoolops.ResolveCreateTuning(claims.IsAdmin, phppoolops.CreateTuning{
+		PmMode:                         req.PmMode,
+		PmMaxChildren:                  req.PmMaxChildren,
+		ProcessIdleTimeoutSeconds:      req.ProcessIdleTimeoutSeconds,
+		PmStartServers:                 req.PmStartServers,
+		PmMinSpareServers:              req.PmMinSpareServers,
+		PmMaxSpareServers:              req.PmMaxSpareServers,
+		PmMaxRequests:                  req.PmMaxRequests,
+		RequestTerminateTimeoutSeconds: req.RequestTerminateTimeoutSeconds,
+	})
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": field, "detail": msg})
 		return
 	}
-
-	// Validate pm_max_children (GH #339 security: bound it — see the cap consts).
-	if req.PmMaxChildren == 0 {
-		req.PmMaxChildren = 20 // default
-	}
-	maxChildren := uint32(phpPoolUserMaxChildrenCap)
-	if claims.IsAdmin {
-		maxChildren = phpPoolAdminMaxChildrenCap
-	}
-	if req.PmMaxChildren > maxChildren {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "pm_max_children_too_high",
-			"detail": fmt.Sprintf("pm_max_children must be <= %d", maxChildren),
-		})
-		return
-	}
-
-	// Validate process_idle_timeout_seconds.
-	if req.ProcessIdleTimeoutSeconds == 0 {
-		req.ProcessIdleTimeoutSeconds = 60 // default
-	}
-	if req.ProcessIdleTimeoutSeconds > phpPoolMaxIdleTimeoutSec {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "process_idle_timeout_too_high",
-			"detail": fmt.Sprintf("process_idle_timeout_seconds must be <= %d", phpPoolMaxIdleTimeoutSec),
-		})
-		return
-	}
-
-	// GH #339: defaults + caps + FPM dynamic constraint for the fuller pm.* set.
-	if msg, ok := resolvePMTuning(req.PmMode, req.PmMaxChildren,
-		&req.PmStartServers, &req.PmMinSpareServers, &req.PmMaxSpareServers,
-		&req.PmMaxRequests, &req.RequestTerminateTimeoutSeconds); !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "pm_tuning_invalid", "detail": msg})
-		return
-	}
+	req.PmMode = tuning.PmMode
+	req.PmMaxChildren = tuning.PmMaxChildren
+	req.ProcessIdleTimeoutSeconds = tuning.ProcessIdleTimeoutSeconds
+	req.PmStartServers = tuning.PmStartServers
+	req.PmMinSpareServers = tuning.PmMinSpareServers
+	req.PmMaxSpareServers = tuning.PmMaxSpareServers
+	req.PmMaxRequests = tuning.PmMaxRequests
+	req.RequestTerminateTimeoutSeconds = tuning.RequestTerminateTimeoutSeconds
 
 	// Check if user already has a pool (MVP constraint: one pool per user)
 	existingPool, err := h.cfg.PHPPools.FindByUserID(ctx, targetUserID)
@@ -404,7 +339,7 @@ func (h *phpPoolHandler) create(c *gin.Context) {
 	slog.InfoContext(ctx, "php_pool.created", "user_id", pool.UserID, "pool_id", pool.ID, "php_version", pool.PHPVersion, "pm_mode", pool.PmMode)
 
 	// Trigger agent to reconcile the pool asynchronously (fire-and-forget)
-	go h.reconcilePoolAsync(pool)
+	go h.reconcilePoolAsync(*pool)
 
 	c.JSON(http.StatusCreated, pool)
 }
@@ -533,7 +468,7 @@ func (h *phpPoolHandler) update(c *gin.Context) {
 	slog.InfoContext(ctx, "php_pool.updated", "user_id", pool.UserID, "pool_id", pool.ID, "old_pm_mode", oldPmMode, "new_pm_mode", pool.PmMode, "old_pm_max_children", oldPmMaxChildren, "new_pm_max_children", pool.PmMaxChildren)
 
 	// Trigger agent to re-reconcile the pool asynchronously (fire-and-forget)
-	go h.reconcilePoolAsync(pool)
+	go h.reconcilePoolAsync(*pool)
 
 	c.JSON(http.StatusOK, pool)
 }
@@ -774,7 +709,7 @@ func (h *phpPoolHandler) createIniOverride(c *gin.Context) {
 	_ = h.cfg.PHPPools.Update(ctx, pool)
 
 	// Trigger agent to re-reconcile the pool
-	go h.reconcilePoolAsync(pool)
+	go h.reconcilePoolAsync(*pool)
 
 	c.JSON(http.StatusCreated, override)
 }
@@ -855,7 +790,7 @@ func (h *phpPoolHandler) updateIniOverride(c *gin.Context) {
 	_ = h.cfg.PHPPools.Update(ctx, pool)
 
 	// Trigger agent to re-reconcile the pool
-	go h.reconcilePoolAsync(pool)
+	go h.reconcilePoolAsync(*pool)
 
 	c.JSON(http.StatusOK, override)
 }
@@ -923,7 +858,7 @@ func (h *phpPoolHandler) deleteIniOverride(c *gin.Context) {
 	_ = h.cfg.PHPPools.Update(ctx, pool)
 
 	// Trigger agent to re-reconcile the pool
-	go h.reconcilePoolAsync(pool)
+	go h.reconcilePoolAsync(*pool)
 
 	c.JSON(http.StatusNoContent, nil)
 }
@@ -933,6 +868,6 @@ func (h *phpPoolHandler) deleteIniOverride(c *gin.Context) {
 // reconcilePoolAsync triggers a pool reconciliation in the background.
 // Implementation lives in php_pool_reconcile.go so the user-driven
 // /domains/:id/php-pool path can share it without depending on phpPoolHandler.
-func (h *phpPoolHandler) reconcilePoolAsync(pool *models.PHPPool) {
+func (h *phpPoolHandler) reconcilePoolAsync(pool models.PHPPool) {
 	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
 }

--- a/panel-api/internal/phppoolops/phppoolops.go
+++ b/panel-api/internal/phppoolops/phppoolops.go
@@ -1,0 +1,248 @@
+// Package phppoolops owns the PHP-FPM pool lifecycle logic that the HTTP
+// handlers (internal/api) and the operator CLI (cmd/server) both drive:
+// the create-side resource caps + FPM dynamic-mode tuning validation, and the
+// agent php.pool.apply reconcile.
+//
+// JAB-360: before this package the CLI carried a hand-copied reconcile
+// (cmd/server reconcilePHPPoolCLI) that had already drifted from the HTTP one —
+// it omitted the versioned slug/additive (GH #329), the fuller pm.* set, the
+// slowlog timeout, extra extensions and Xdebug. A CLI ini mutation on a
+// non-default (per-version) pool therefore applied to the user's DEFAULT
+// socket. Making both adapters call one module removes the drift by
+// construction, and the caps validator closes the parallel gap where CLI
+// `create` wrote pm_max_children with no cap and no dynamic-mode constraint.
+package phppoolops
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Resource caps (GH #339 security): pm_max_children + idle timeout are
+// tenant-settable, so they MUST be bounded — an unbounded value is a
+// resource-exhaustion DoS on the shared host.
+const (
+	UserMaxChildrenCap  = 100
+	AdminMaxChildrenCap = 2000
+	MaxIdleTimeoutSec   = 86400
+	MaxRequestsCap      = 100000 // worker recycle bound (0 = disabled)
+	MaxTerminateSec     = 3600   // request_terminate_timeout ceiling (0 = disabled)
+
+	defaultMaxChildren = 20
+	defaultIdleTimeout = 60
+)
+
+// ClampToPackageCap bounds pm_max_children (and dependent spare/start servers)
+// to a hosting package's fpm_max_children_cap, then re-runs the FPM dynamic
+// constraint via ResolvePMTuning. Load-bearing safety for the L1/L2 user tiers
+// (GH #339 phase 2): whatever a non-admin produces can never exceed the cap.
+func ClampToPackageCap(cap uint32, mode string, maxChildren, start, minSpare, maxSpare, maxReq, terminate *uint32) (string, bool) {
+	if cap > 0 && *maxChildren > cap {
+		*maxChildren = cap
+	}
+	if *start > *maxChildren {
+		*start = *maxChildren
+	}
+	if *maxSpare > *maxChildren {
+		*maxSpare = *maxChildren
+	}
+	return ResolvePMTuning(mode, *maxChildren, start, minSpare, maxSpare, maxReq, terminate)
+}
+
+// ResolvePMTuning applies defaults, caps, and the FPM dynamic-mode constraint
+// (min_spare <= start <= max_spare <= max_children) to the extended pm.* fields
+// (GH #339). It MUTATES the pointed-to values (fills dynamic defaults clamped to
+// max_children) and returns a client error + false when invalid. start/spare are
+// ignored by FPM outside dynamic mode, so they are only constrained there.
+func ResolvePMTuning(mode string, maxChildren uint32, start, minSpare, maxSpare, maxReq, terminate *uint32) (string, bool) {
+	if *maxReq > MaxRequestsCap {
+		return fmt.Sprintf("pm_max_requests must be <= %d", MaxRequestsCap), false
+	}
+	if *terminate > MaxTerminateSec {
+		return fmt.Sprintf("request_terminate_timeout_seconds must be <= %d", MaxTerminateSec), false
+	}
+	if mode != "dynamic" {
+		return "", true
+	}
+	if *maxSpare == 0 {
+		if maxChildren < 3 {
+			*maxSpare = maxChildren
+		} else {
+			*maxSpare = 3
+		}
+	}
+	if *start == 0 {
+		if *maxSpare < 2 {
+			*start = *maxSpare
+		} else {
+			*start = 2
+		}
+	}
+	if *minSpare == 0 {
+		*minSpare = 1
+		if *minSpare > *start {
+			*minSpare = *start
+		}
+	}
+	if !(*minSpare <= *start && *start <= *maxSpare && *maxSpare <= maxChildren) {
+		return "dynamic pm requires pm_min_spare_servers <= pm_start_servers <= pm_max_spare_servers <= pm_max_children", false
+	}
+	return "", true
+}
+
+// CreateTuning is the create-side pm.* input/output for one adapter-neutral
+// validation pass. Zero fields mean "not provided" (the create convention);
+// ResolveCreateTuning fills them with defaults.
+type CreateTuning struct {
+	PmMode                         string
+	PmMaxChildren                  uint32
+	ProcessIdleTimeoutSeconds      uint32
+	PmStartServers                 uint32
+	PmMinSpareServers              uint32
+	PmMaxSpareServers              uint32
+	PmMaxRequests                  uint32
+	RequestTerminateTimeoutSeconds uint32
+}
+
+// ResolveCreateTuning applies the create-side defaults, the admin/user
+// pm_max_children cap, the idle-timeout ceiling, and the FPM dynamic-mode
+// constraint. It returns the resolved values plus a typed client error — a
+// message and a stable field key so HTTP maps it to a 400 error code and the
+// CLI to a usage error. isAdmin picks the higher pm_max_children cap (the
+// operator CLI `create` is admin-scoped, like an admin HTTP create).
+//
+// This is the single create-side validator both adapters call, so an operator
+// CLI create can no longer produce a pool outside the caps and dynamic-mode
+// invariants a tenant-facing create enforces (JAB-360 AC 1).
+func ResolveCreateTuning(isAdmin bool, in CreateTuning) (out CreateTuning, errMsg, field string, ok bool) {
+	out = in
+	if out.PmMode == "" {
+		out.PmMode = "ondemand"
+	} else if out.PmMode != "static" && out.PmMode != "ondemand" && out.PmMode != "dynamic" {
+		return out, "pm_mode must be static, ondemand, or dynamic", "invalid_pm_mode", false
+	}
+
+	if out.PmMaxChildren == 0 {
+		out.PmMaxChildren = defaultMaxChildren
+	}
+	cap := uint32(UserMaxChildrenCap)
+	if isAdmin {
+		cap = AdminMaxChildrenCap
+	}
+	if out.PmMaxChildren > cap {
+		return out, fmt.Sprintf("pm_max_children must be <= %d", cap), "pm_max_children_too_high", false
+	}
+
+	if out.ProcessIdleTimeoutSeconds == 0 {
+		out.ProcessIdleTimeoutSeconds = defaultIdleTimeout
+	}
+	if out.ProcessIdleTimeoutSeconds > MaxIdleTimeoutSec {
+		return out, fmt.Sprintf("process_idle_timeout_seconds must be <= %d", MaxIdleTimeoutSec), "process_idle_timeout_too_high", false
+	}
+
+	if msg, valid := ResolvePMTuning(out.PmMode, out.PmMaxChildren,
+		&out.PmStartServers, &out.PmMinSpareServers, &out.PmMaxSpareServers,
+		&out.PmMaxRequests, &out.RequestTerminateTimeoutSeconds); !valid {
+		return out, msg, "pm_tuning_invalid", false
+	}
+	return out, "", "", true
+}
+
+// ReconcileDeps are the repositories + agent ReconcileViaAgent needs. Adapters
+// build it from their own DB handle/agent client.
+type ReconcileDeps struct {
+	Agent     agent.AgentInterface
+	Users     repository.UserRepository
+	Overrides repository.PHPPoolIniOverrideRepository
+	Pools     repository.PHPPoolRepository
+}
+
+// ReconcileViaAgent fires php.pool.apply for pool, then writes the resulting
+// status back to the DB via SetStatus. It resolves the pool's versioned slug
+// (GH #329) so a non-default per-version pool applies to its own socket rather
+// than the user's default one, and carries the complete pm.* + slowlog +
+// extra-extensions + Xdebug model.
+//
+// pool is taken BY VALUE on purpose: callers that fire it in a goroutine pass a
+// copy, so the fire-and-forget reconcile cannot race the handler that keeps
+// mutating its own *pool (the repo-wide `-race` flake this consolidation
+// removes). Returns the agent error (nil on success) so the CLI can surface
+// "apply failed"; HTTP callers run it in a goroutine and read status back from
+// the DB.
+func ReconcileViaAgent(deps ReconcileDeps, pool models.PHPPool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	user, err := deps.Users.FindByID(ctx, pool.UserID)
+	if err != nil {
+		slog.ErrorContext(ctx, "phppoolops.ReconcileViaAgent: load user", "error", err, "pool_id", pool.ID)
+		return err
+	}
+
+	overridesList, err := deps.Overrides.ListByPool(ctx, pool.ID)
+	if err != nil {
+		slog.ErrorContext(ctx, "phppoolops.ReconcileViaAgent: list overrides", "error", err, "pool_id", pool.ID)
+		return err
+	}
+
+	adminValues := []map[string]string{}
+	adminFlags := []map[string]string{}
+	for _, override := range overridesList {
+		kv := map[string]string{"name": override.Directive, "value": override.Value}
+		if override.Kind == "flag" {
+			adminFlags = append(adminFlags, kv)
+		} else {
+			adminValues = append(adminValues, kv)
+		}
+	}
+
+	// GH #329: resolve the pool's slug so a versioned pool applies to its own
+	// socket/instance rather than the default per-user one. isDefault = the
+	// pool is the user's earliest (created_at ASC).
+	username := ""
+	if user != nil && user.Username != nil {
+		username = *user.Username
+	}
+	isDefault := true
+	if list, lerr := deps.Pools.ListByUserID(ctx, pool.UserID); lerr == nil && len(list) > 0 {
+		isDefault = list[0].ID == pool.ID
+	}
+	slug := models.PoolSlug(username, pool.PHPVersion, isDefault)
+
+	_, aerr := deps.Agent.Call(ctx, "php.pool.apply", map[string]any{
+		"username":                          username,
+		"slug":                              slug,
+		"additive":                          !isDefault,
+		"php_version":                       pool.PHPVersion,
+		"pm_mode":                           pool.PmMode,
+		"pm_max_children":                   pool.PmMaxChildren,
+		"process_idle_timeout_seconds":      pool.ProcessIdleTimeoutSeconds,
+		"pm_start_servers":                  pool.PmStartServers,
+		"pm_min_spare_servers":              pool.PmMinSpareServers,
+		"pm_max_spare_servers":              pool.PmMaxSpareServers,
+		"pm_max_requests":                   pool.PmMaxRequests,
+		"request_terminate_timeout_seconds": pool.RequestTerminateTimeoutSeconds,
+		"slowlog_timeout_seconds":           pool.SlowlogTimeoutSeconds,
+		"admin_values":                      adminValues,
+		"admin_flags":                       adminFlags,
+		"extra_extensions":                  []string(pool.ExtraExtensions),
+		"xdebug_enabled":                    pool.XdebugEnabled,
+	})
+	if aerr != nil {
+		pool.Status = "error"
+		msg := fmt.Sprintf("agent failed: %v", aerr)
+		pool.LastError = &msg
+		_ = deps.Pools.Update(ctx, &pool)
+		return aerr
+	}
+	pool.Status = "ready"
+	pool.LastError = nil
+	_ = deps.Pools.Update(ctx, &pool)
+	return nil
+}

--- a/panel-api/internal/phppoolops/phppoolops_test.go
+++ b/panel-api/internal/phppoolops/phppoolops_test.go
@@ -1,0 +1,265 @@
+package phppoolops_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ---- ResolveCreateTuning: the one create-side contract matrix both the HTTP
+// handler and the CLI create route through (JAB-360 AC 4). ----
+
+func TestResolveCreateTuning_Matrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		isAdmin bool
+		in      phppoolops.CreateTuning
+		wantOK  bool
+		field   string
+		// spot-checks on the resolved output (only asserted when wantOK)
+		mode        string
+		maxChildren uint32
+		idle        uint32
+	}{
+		{
+			name: "defaults fill mode/max_children/idle", isAdmin: false,
+			in:     phppoolops.CreateTuning{},
+			wantOK: true, mode: "ondemand", maxChildren: 20, idle: 60,
+		},
+		{
+			name: "user cap boundary 100 ok", isAdmin: false,
+			in:     phppoolops.CreateTuning{PmMaxChildren: 100},
+			wantOK: true, mode: "ondemand", maxChildren: 100, idle: 60,
+		},
+		{
+			name: "user cap rejects 101", isAdmin: false,
+			in:     phppoolops.CreateTuning{PmMaxChildren: 101},
+			wantOK: false, field: "pm_max_children_too_high",
+		},
+		{
+			name: "admin allows 500 (above user cap)", isAdmin: true,
+			in:     phppoolops.CreateTuning{PmMaxChildren: 500},
+			wantOK: true, mode: "ondemand", maxChildren: 500, idle: 60,
+		},
+		{
+			name: "admin cap rejects 2001", isAdmin: true,
+			in:     phppoolops.CreateTuning{PmMaxChildren: 2001},
+			wantOK: false, field: "pm_max_children_too_high",
+		},
+		{
+			name: "invalid pm_mode", isAdmin: true,
+			in:     phppoolops.CreateTuning{PmMode: "turbo"},
+			wantOK: false, field: "invalid_pm_mode",
+		},
+		{
+			name: "idle timeout ceiling exceeded", isAdmin: true,
+			in:     phppoolops.CreateTuning{ProcessIdleTimeoutSeconds: phppoolops.MaxIdleTimeoutSec + 1},
+			wantOK: false, field: "process_idle_timeout_too_high",
+		},
+		{
+			name: "pm_max_requests ceiling exceeded", isAdmin: true,
+			in:     phppoolops.CreateTuning{PmMaxRequests: phppoolops.MaxRequestsCap + 1},
+			wantOK: false, field: "pm_tuning_invalid",
+		},
+		{
+			name: "request_terminate ceiling exceeded", isAdmin: true,
+			in:     phppoolops.CreateTuning{RequestTerminateTimeoutSeconds: phppoolops.MaxTerminateSec + 1},
+			wantOK: false, field: "pm_tuning_invalid",
+		},
+		{
+			name: "dynamic ordering invalid (start > max_spare)", isAdmin: true,
+			in:     phppoolops.CreateTuning{PmMode: "dynamic", PmMaxChildren: 2, PmStartServers: 5},
+			wantOK: false, field: "pm_tuning_invalid",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, msg, field, ok := phppoolops.ResolveCreateTuning(tc.isAdmin, tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Empty(t, field)
+				assert.Empty(t, msg)
+				assert.Equal(t, tc.mode, out.PmMode)
+				assert.Equal(t, tc.maxChildren, out.PmMaxChildren)
+				assert.Equal(t, tc.idle, out.ProcessIdleTimeoutSeconds)
+			} else {
+				assert.Equal(t, tc.field, field, "field key")
+				assert.NotEmpty(t, msg, "a client detail message")
+			}
+		})
+	}
+}
+
+// TestResolveCreateTuning_DynamicFillsDefaults: dynamic mode with only
+// max_children set fills start/min-spare/max-spare within the FPM ordering.
+func TestResolveCreateTuning_DynamicFillsDefaults(t *testing.T) {
+	out, _, _, ok := phppoolops.ResolveCreateTuning(true, phppoolops.CreateTuning{PmMode: "dynamic", PmMaxChildren: 10})
+	require.True(t, ok)
+	assert.Equal(t, uint32(3), out.PmMaxSpareServers)
+	assert.Equal(t, uint32(2), out.PmStartServers)
+	assert.Equal(t, uint32(1), out.PmMinSpareServers)
+	assert.True(t, out.PmMinSpareServers <= out.PmStartServers &&
+		out.PmStartServers <= out.PmMaxSpareServers &&
+		out.PmMaxSpareServers <= out.PmMaxChildren)
+}
+
+// ---- ReconcileViaAgent: slug/additive + full payload parity ----
+
+type fakeAgent struct {
+	command string
+	params  map[string]any
+	err     error
+}
+
+func (f *fakeAgent) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	f.command = command
+	if m, ok := params.(map[string]any); ok {
+		f.params = m
+	}
+	return nil, f.err
+}
+
+type fakeUsers struct {
+	repository.UserRepository
+	user *models.User
+}
+
+func (f *fakeUsers) FindByID(_ context.Context, _ string) (*models.User, error) { return f.user, nil }
+
+type fakeOverrides struct {
+	repository.PHPPoolIniOverrideRepository
+	list []models.PHPPoolIniOverride
+}
+
+func (f *fakeOverrides) ListByPool(_ context.Context, _ string) ([]models.PHPPoolIniOverride, error) {
+	return f.list, nil
+}
+
+type setStatusCall struct {
+	status  string
+	lastErr *string
+}
+
+type fakePools struct {
+	repository.PHPPoolRepository
+	list     []models.PHPPool
+	statuses []setStatusCall
+}
+
+func (f *fakePools) ListByUserID(_ context.Context, _ string) ([]models.PHPPool, error) {
+	return f.list, nil
+}
+
+// Update is the terminal status write ReconcileViaAgent makes (whole row, as
+// the HTTP reconcile it replaces always did) — capture the status + last_error.
+func (f *fakePools) Update(_ context.Context, p *models.PHPPool) error {
+	f.statuses = append(f.statuses, setStatusCall{status: p.Status, lastErr: p.LastError})
+	return nil
+}
+
+func username(s string) *string { return &s }
+
+func TestReconcileViaAgent_DefaultPool_UsesBareUsernameSlug(t *testing.T) {
+	ag := &fakeAgent{}
+	pool := models.PHPPool{
+		ID: "P1", UserID: "U1", PHPVersion: "8.3", PmMode: "ondemand",
+		PmMaxChildren: 25, ProcessIdleTimeoutSeconds: 60, PmStartServers: 2,
+		PmMinSpareServers: 1, PmMaxSpareServers: 3, PmMaxRequests: 500,
+		RequestTerminateTimeoutSeconds: 30, SlowlogTimeoutSeconds: 10,
+		ExtraExtensions: models.StringList{"redis"}, XdebugEnabled: true,
+	}
+	pools := &fakePools{list: []models.PHPPool{pool}} // pool is the user's only/first → default
+
+	err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+		Agent:     ag,
+		Users:     &fakeUsers{user: &models.User{ID: "U1", Username: username("alice")}},
+		Overrides: &fakeOverrides{},
+		Pools:     pools,
+	}, pool)
+	require.NoError(t, err)
+
+	assert.Equal(t, "php.pool.apply", ag.command)
+	assert.Equal(t, "alice", ag.params["slug"], "default pool keeps the bare username slug")
+	assert.Equal(t, false, ag.params["additive"])
+	// The full pm.* + slowlog + extensions + xdebug model must be on the wire —
+	// the exact fields the CLI's old hand-copied reconcile dropped.
+	assert.Equal(t, uint32(2), ag.params["pm_start_servers"])
+	assert.Equal(t, uint32(1), ag.params["pm_min_spare_servers"])
+	assert.Equal(t, uint32(3), ag.params["pm_max_spare_servers"])
+	assert.Equal(t, uint32(500), ag.params["pm_max_requests"])
+	assert.Equal(t, uint32(30), ag.params["request_terminate_timeout_seconds"])
+	assert.Equal(t, uint32(10), ag.params["slowlog_timeout_seconds"])
+	assert.Equal(t, []string{"redis"}, ag.params["extra_extensions"])
+	assert.Equal(t, true, ag.params["xdebug_enabled"])
+	require.Len(t, pools.statuses, 1)
+	assert.Equal(t, "ready", pools.statuses[0].status)
+	assert.Nil(t, pools.statuses[0].lastErr)
+}
+
+// TestReconcileViaAgent_NonDefaultPool_UsesVersionedSlug is the load-bearing
+// bug JAB-360 fixes: a mutation on a per-version (non-default) pool must apply
+// to that pool's own versioned socket, not the user's default one. The CLI's
+// old reconcile sent no slug at all.
+func TestReconcileViaAgent_NonDefaultPool_UsesVersionedSlug(t *testing.T) {
+	ag := &fakeAgent{}
+	def := models.PHPPool{ID: "P1", UserID: "U1", PHPVersion: "8.1"}
+	target := models.PHPPool{ID: "P2", UserID: "U1", PHPVersion: "8.2", PmMode: "ondemand"}
+	pools := &fakePools{list: []models.PHPPool{def, target}} // first (created_at ASC) is P1 → target is NOT default
+
+	err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+		Agent:     ag,
+		Users:     &fakeUsers{user: &models.User{ID: "U1", Username: username("alice")}},
+		Overrides: &fakeOverrides{},
+		Pools:     pools,
+	}, target)
+	require.NoError(t, err)
+	assert.Equal(t, "alice-php8.2", ag.params["slug"], "per-version pool applies to its own socket")
+	assert.Equal(t, true, ag.params["additive"])
+}
+
+// TestReconcileViaAgent_OverridesSplitByKind: value vs flag overrides land in
+// the right agent bucket.
+func TestReconcileViaAgent_OverridesSplitByKind(t *testing.T) {
+	ag := &fakeAgent{}
+	pool := models.PHPPool{ID: "P1", UserID: "U1", PHPVersion: "8.3", PmMode: "ondemand"}
+	err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+		Agent: ag,
+		Users: &fakeUsers{user: &models.User{ID: "U1", Username: username("alice")}},
+		Overrides: &fakeOverrides{list: []models.PHPPoolIniOverride{
+			{Directive: "memory_limit", Value: "256M", Kind: "value"},
+			{Directive: "display_errors", Value: "off", Kind: "flag"},
+		}},
+		Pools: &fakePools{list: []models.PHPPool{pool}},
+	}, pool)
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]string{{"name": "memory_limit", "value": "256M"}}, ag.params["admin_values"])
+	assert.Equal(t, []map[string]string{{"name": "display_errors", "value": "off"}}, ag.params["admin_flags"])
+}
+
+// TestReconcileViaAgent_AgentError_SetsErrorStatus: a failed apply returns the
+// agent error and records status=error so the caller (CLI) can surface it.
+func TestReconcileViaAgent_AgentError_SetsErrorStatus(t *testing.T) {
+	agentErr := errors.New("socket down")
+	ag := &fakeAgent{err: agentErr}
+	pool := models.PHPPool{ID: "P1", UserID: "U1", PHPVersion: "8.3", PmMode: "ondemand"}
+	pools := &fakePools{list: []models.PHPPool{pool}}
+	err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+		Agent:     ag,
+		Users:     &fakeUsers{user: &models.User{ID: "U1", Username: username("alice")}},
+		Overrides: &fakeOverrides{},
+		Pools:     pools,
+	}, pool)
+	require.ErrorIs(t, err, agentErr)
+	require.Len(t, pools.statuses, 1)
+	assert.Equal(t, "error", pools.statuses[0].status)
+	require.NotNil(t, pools.statuses[0].lastErr)
+	assert.Contains(t, *pools.statuses[0].lastErr, "socket down")
+}


### PR DESCRIPTION
## JAB-360 — one PHP Pool Lifecycle module for HTTP + CLI

The operator CLI carried a hand-copied `php.pool.apply` reconcile
(`cmd/server` `reconcilePHPPoolCLI`) that had already **drifted** from the HTTP
one: it omitted the versioned slug + `additive` flag (GH #329), the fuller
`pm.*` set (start/spare servers, `max_requests`, `request_terminate`), the
slowlog timeout, extra extensions and Xdebug. So a CLI `ini add/update/remove`
on a **non-default** (per-version) pool applied to the user's **default** socket
instead of that pool's own instance. In parallel, CLI `pool create` wrote
`pm_max_children` straight from the flag with **no cap and no FPM dynamic-mode
constraint**, so an operator create could produce a pool outside the caps a
tenant-facing create enforces.

### The change — extract one shared module both adapters call
- **New `internal/phppoolops`** owns the create-side validator
  (`ResolveCreateTuning`: defaults + admin/user `pm_max_children` cap + idle
  ceiling + FPM dynamic constraint) and `ReconcileViaAgent` (versioned
  slug/`additive` + the complete wire model). The resource-cap constants and
  `ResolvePMTuning`/`ClampToPackageCap` move here; `internal/api` keeps thin
  package-local aliases so `packages.go`, `php_performance_modes.go`,
  `php_pool_user_tuning.go` and the update handler are **unchanged**.
- **HTTP create** routes through `ResolveCreateTuning`; the returned field key
  maps 1:1 onto the error codes the endpoint has always returned
  (`invalid_pm_mode`, `pm_max_children_too_high`,
  `process_idle_timeout_too_high`, `pm_tuning_invalid`) — REST wire unchanged.
- **CLI create** validates through the same `ResolveCreateTuning` (admin-scoped
  — the operator CLI is privileged), and CLI create + ini mutations reconcile
  through the shared `ReconcileViaAgent`. The stale `reconcilePHPPoolCLI` is
  deleted.
- **Race fix:** `ReconcileViaAgent` takes the pool **by value**. Callers that
  fire it with `go` pass a copy, so the fire-and-forget reconcile can no longer
  race a handler that keeps mutating its own pool — removing the repo-wide
  `-race` flake in this path. The five api call sites deref accordingly; the
  synchronous opcache path reads status back from the DB as before.

### Tests
`internal/phppoolops` carries the **one create-side contract matrix** (user/admin
caps, idle + `max_requests` + `terminate` ceilings, dynamic ordering, default
fill) plus `ReconcileViaAgent` slug/`additive`/full-payload assertions — the
load-bearing **non-default pool → versioned slug** case — and the agent-error
status path. `cmd/server` source-pins the CLI wiring to the shared module (repo
precedent: the delete-guard test — `cmd/server` has no DB/agent fixture).
Existing `php_pools` / extensions / opcache / xdebug / user-tuning handler tests
are unchanged.

`go build ./...`, `go vet ./...`, `-race` on `internal/phppoolops` +
`internal/api` + `cmd/server`, gofmt — all green. **Box-verified** on the test
host (side-effect-free): `pool create --pm-max-children 2001` is refused before
any DB write, `2000` is accepted through tuning (fails later at user lookup),
and `pool list` runs.

### AC status (concrete ticket — closes JAB-360)
- ✅ User/admin caps + dynamic tuning apply through every adapter (HTTP + CLI).
- ✅ The agent apply payload carries the complete tuning model from both
  adapters (one `ReconcileViaAgent`).
- ✅ Override ownership + reapply behaviour are shared (CLI ini mutations now
  reconcile through the same op, with the versioned slug).
- ✅ HTTP and CLI contract tests cover create/update/delete over one matrix
  (the `phppoolops` matrix; HTTP create exercises it; delete already pinned in
  JAB-342).

Deletion guards (bound-domain refusal + host removal) already shipped in
JAB-342; this carries the remaining non-security consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
