### PR TITLE
refactor(egress): shared SetPolicy so HTTP + CLI can't drift (JAB-341)

### DIFF
--- a/panel-api/cmd/server/per_user_egress_ops_cmd.go
+++ b/panel-api/cmd/server/per_user_egress_ops_cmd.go
@@ -9,10 +9,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -25,9 +23,6 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
-
-// maxCLIEgressExtras mirrors maxAllowedExtras in internal/api/user_egress.go.
-const maxCLIEgressExtras = 50
 
 func egressReqRepo() repository.UserEgressRequestRepository {
 	return repository.NewUserEgressRequestRepository(sharedDB)
@@ -207,11 +202,10 @@ func newPerUserEgressSetPolicyCmd() *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
 
-			if !validCLIEgressState(state) {
+			// Fail fast on a bad --state before touching the DB; the same
+			// egressops.ValidState is the authoritative guard inside SetPolicy.
+			if !egressops.ValidState(state) {
 				return fmt.Errorf("--state must be one of off|learning|enforced (got %q)", state)
-			}
-			if len(allows) > maxCLIEgressExtras {
-				return fmt.Errorf("too many --allow entries (%d, max %d)", len(allows), maxCLIEgressExtras)
 			}
 			extras := make([]models.EgressDestination, 0, len(allows))
 			for i, a := range allows {
@@ -227,14 +221,28 @@ func newPerUserEgressSetPolicyCmd() *cobra.Command {
 				return fmt.Errorf("user %q not found", args[0])
 			}
 
-			jsonExtras, _ := json.Marshal(extras)
-			policy := &models.UserEgressPolicy{
+			// UpdatedBy is nil by design: the operator CLI has no interactive user
+			// session. The cliAuditOK row below is the CLI provenance record.
+			// SetPolicy runs the canonical validate-and-persist matrix shared with
+			// PUT /users/:id/egress, so both adapters accept/reject the same set and
+			// schedule exactly one policy write (the reconciler converges on its tick).
+			if err := egressops.SetPolicy(ctx, egressPolicyRepo(), egressops.SetPolicyInput{
 				UserID:       u.ID,
 				State:        state,
-				AllowedExtra: jsonExtras,
-			}
-			if err := egressPolicyRepo().Upsert(ctx, policy); err != nil {
-				return fmt.Errorf("upsert policy: %w", err)
+				AllowedExtra: extras,
+				UpdatedBy:    nil,
+			}); err != nil {
+				var de *egressops.DestinationError
+				switch {
+				case errors.Is(err, egressops.ErrInvalidState):
+					return fmt.Errorf("--state must be one of off|learning|enforced (got %q)", state)
+				case errors.Is(err, egressops.ErrTooManyExtras):
+					return fmt.Errorf("too many --allow entries (%d, max %d)", len(extras), egressops.MaxAllowedExtras)
+				case errors.As(err, &de):
+					return fmt.Errorf("--allow index %d: %w", de.Index, de.Err)
+				default:
+					return fmt.Errorf("upsert policy: %w", err)
+				}
 			}
 			cliAuditOK(ctx, "egress.policy.set", "user", u.ID, &u.ID)
 			fmt.Printf("set %s egress policy: state=%s, %d allowed destination(s) (reconciler will re-render nftables)\n",
@@ -249,39 +257,29 @@ func newPerUserEgressSetPolicyCmd() *cobra.Command {
 	return cmd
 }
 
-func validCLIEgressState(s string) bool {
-	return s == models.UserEgressStateOff ||
-		s == models.UserEgressStateLearning ||
-		s == models.UserEgressStateEnforced
-}
-
-// parseCLIAllow parses a CIDR[,PORT[,PROTO]] token into a validated
-// EgressDestination. Mirrors validateExtra in internal/api/user_egress.go.
+// parseCLIAllow splits a CIDR[,PORT[,PROTO]] flag token into an
+// EgressDestination. It only handles the CLI string format — the field split,
+// the numeric coercion of PORT, and lower-casing PROTO. The semantic checks
+// (valid CIDR, port range, known protocol, comment safety) and the empty-proto
+// default all live in egressops.ValidateDestination, which egressops.SetPolicy
+// runs on every entry — so the CLI and PUT /users/:id/egress reject the exact
+// same canonical matrix and cannot drift.
 func parseCLIAllow(s string) (models.EgressDestination, error) {
 	var dest models.EgressDestination
 	parts := strings.Split(s, ",")
-	cidr := strings.TrimSpace(parts[0])
-	if _, _, err := net.ParseCIDR(cidr); err != nil {
-		return dest, fmt.Errorf("cidr: %v", err)
+	if len(parts) > 3 {
+		return dest, fmt.Errorf("too many fields (want CIDR[,PORT[,PROTO]])")
 	}
-	dest.CIDR = cidr
+	dest.CIDR = strings.TrimSpace(parts[0])
 	if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
 		p, err := strconv.Atoi(strings.TrimSpace(parts[1]))
-		if err != nil || p < 1 || p > 65535 {
-			return dest, fmt.Errorf("port must be 1..65535")
+		if err != nil {
+			return dest, fmt.Errorf("port must be a number")
 		}
 		dest.Port = &p
 	}
-	proto := models.UserEgressProtocolTCP
 	if len(parts) >= 3 && strings.TrimSpace(parts[2]) != "" {
-		proto = strings.ToLower(strings.TrimSpace(parts[2]))
-	}
-	if proto != models.UserEgressProtocolTCP && proto != models.UserEgressProtocolUDP {
-		return dest, fmt.Errorf("protocol must be tcp or udp")
-	}
-	dest.Protocol = proto
-	if len(parts) > 3 {
-		return dest, fmt.Errorf("too many fields (want CIDR[,PORT[,PROTO]])")
+		dest.Protocol = strings.ToLower(strings.TrimSpace(parts[2]))
 	}
 	return dest, nil
 }

--- a/panel-api/cmd/server/per_user_egress_ops_cmd_test.go
+++ b/panel-api/cmd/server/per_user_egress_ops_cmd_test.go
@@ -2,15 +2,22 @@ package main
 
 import "testing"
 
+// parseCLIAllow now only handles the CLI string format: the field split, the
+// numeric coercion of PORT, and lower-casing PROTO. The semantic accept/reject
+// matrix (valid CIDR, port range, known protocol, comment safety) and the
+// empty-proto default moved to egressops.ValidateDestination / SetPolicy, which
+// the CLI and PUT /users/:id/egress both call — see
+// internal/egressops.TestValidateDestination_Matrix and TestSetPolicy_* for the
+// canonical-matrix coverage shared by both adapters.
 func TestParseCLIAllow(t *testing.T) {
 	ok := []struct {
 		in       string
 		cidr     string
-		port     int // -1 = nil
-		protocol string
+		port     int    // -1 = nil
+		protocol string // "" = not supplied (SetPolicy defaults it to tcp)
 	}{
-		{"10.0.0.0/8", "10.0.0.0/8", -1, "tcp"},
-		{"1.2.3.4/32,443", "1.2.3.4/32", 443, "tcp"},
+		{"10.0.0.0/8", "10.0.0.0/8", -1, ""},
+		{"1.2.3.4/32,443", "1.2.3.4/32", 443, ""},
 		{"1.2.3.4/32,53,udp", "1.2.3.4/32", 53, "udp"},
 		{"1.2.3.4/32,,udp", "1.2.3.4/32", -1, "udp"},
 		{" 10.0.0.0/8 , 80 , TCP ", "10.0.0.0/8", 80, "tcp"},
@@ -32,31 +39,16 @@ func TestParseCLIAllow(t *testing.T) {
 		}
 	}
 
+	// Only the CLI-string-format errors surface here; a non-numeric port and
+	// too-many-fields. Bad CIDR / port range / bad protocol are rejected later
+	// by egressops.ValidateDestination, not by the parser.
 	bad := []string{
-		"",                     // empty
-		"not-a-cidr",           // bare token
-		"1.2.3.4",              // IP without mask (ParseCIDR requires /n)
-		"1.2.3.4/32,99999",     // port out of range
-		"1.2.3.4/32,0",         // port 0
-		"1.2.3.4/32,443,sctp",  // bad protocol
+		"1.2.3.4/32,abc",       // non-numeric port
 		"1.2.3.4/32,443,tcp,x", // too many fields
 	}
 	for _, b := range bad {
 		if _, err := parseCLIAllow(b); err == nil {
 			t.Errorf("%q: expected error, got nil", b)
-		}
-	}
-}
-
-func TestValidCLIEgressState(t *testing.T) {
-	for _, s := range []string{"off", "learning", "enforced"} {
-		if !validCLIEgressState(s) {
-			t.Errorf("%q should be valid", s)
-		}
-	}
-	for _, s := range []string{"", "ENFORCED", "on", "block"} {
-		if validCLIEgressState(s) {
-			t.Errorf("%q should be invalid", s)
 		}
 	}
 }

--- a/panel-api/internal/api/user_egress.go
+++ b/panel-api/internal/api/user_egress.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"net"
@@ -9,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/gin-gonic/gin"
 
@@ -19,12 +17,6 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
-
-// maxAllowedExtras caps the per-user override list size. Hard ceiling
-// rather than a per-row vs per-user limit — the nft renderer emits one
-// rule per entry, and a runaway list would inflate the rule file
-// without bound.
-const maxAllowedExtras = 50
 
 // UserEgressHandlerConfig wires the M34 admin + user-facing egress
 // endpoints. All four repos are required; if any are nil the routes
@@ -134,23 +126,6 @@ func (h *userEgressHandler) adminPut(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body", "detail": err.Error()})
 		return
 	}
-	if !validEgressState(body.State) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_state"})
-		return
-	}
-	if len(body.AllowedExtra) > maxAllowedExtras {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "too_many_extras", "max": maxAllowedExtras})
-		return
-	}
-	for i := range body.AllowedExtra {
-		if err := validateExtra(&body.AllowedExtra[i]); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_destination", "detail": err.Error(), "index": i})
-			return
-		}
-	}
-
-	extras := convertExtras(body.AllowedExtra)
-	jsonExtras, _ := json.Marshal(extras)
 	claims := ginctx.Claims(c)
 	var updatedBy *string
 	if claims != nil && claims.UserID != "" {
@@ -158,14 +133,27 @@ func (h *userEgressHandler) adminPut(c *gin.Context) {
 		updatedBy = &uid
 	}
 
-	policy := &models.UserEgressPolicy{
+	// SetPolicy owns the canonical validate-and-persist matrix shared with the
+	// CLI; map its typed errors back onto the wire codes this endpoint has
+	// always returned.
+	err := egressops.SetPolicy(c.Request.Context(), h.cfg.Policies, egressops.SetPolicyInput{
 		UserID:       userID,
 		State:        body.State,
-		AllowedExtra: jsonExtras,
+		AllowedExtra: convertExtras(body.AllowedExtra),
 		UpdatedBy:    updatedBy,
-	}
-	if err := h.cfg.Policies.Upsert(c.Request.Context(), policy); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "upsert", "detail": err.Error()})
+	})
+	if err != nil {
+		var de *egressops.DestinationError
+		switch {
+		case errors.Is(err, egressops.ErrInvalidState):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_state"})
+		case errors.Is(err, egressops.ErrTooManyExtras):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "too_many_extras", "max": egressops.MaxAllowedExtras})
+		case errors.As(err, &de):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_destination", "detail": de.Err.Error(), "index": de.Index})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "upsert", "detail": err.Error()})
+		}
 		return
 	}
 	row, err := h.cfg.Policies.Get(c.Request.Context(), userID)
@@ -386,42 +374,8 @@ func (h *userEgressHandler) policyView(row *models.UserEgressPolicy) gin.H {
 	}
 }
 
-func validEgressState(s string) bool {
-	return s == models.UserEgressStateOff ||
-		s == models.UserEgressStateLearning ||
-		s == models.UserEgressStateEnforced
-}
-
-func validateExtra(e *egressDestinationInput) error {
-	if _, _, err := net.ParseCIDR(e.CIDR); err != nil {
-		return errors.New("cidr: " + err.Error())
-	}
-	if e.Port != nil && (*e.Port < 1 || *e.Port > 65535) {
-		return errors.New("port out of range")
-	}
-	if e.Protocol == "" {
-		e.Protocol = models.UserEgressProtocolTCP
-	}
-	if e.Protocol != models.UserEgressProtocolTCP && e.Protocol != models.UserEgressProtocolUDP {
-		return errors.New("protocol must be tcp or udp")
-	}
-	if len(e.Comment) > 200 {
-		return errors.New("comment too long")
-	}
-	// The comment is rendered into /etc/nftables.d/jabali-per-user-egress.nft,
-	// which is loaded by `nft -f` as root. A newline would inject arbitrary
-	// nftables lines; a control character can make the file unparseable, which
-	// fails the whole ruleset closed-to-absent (the egress policy silently stops
-	// applying box-wide). The agent sanitises again at render time — this is the
-	// boundary half of that pair.
-	if i := strings.IndexFunc(e.Comment, func(r rune) bool {
-		return r == '\n' || r == '\r' || r == 0 || unicode.IsControl(r)
-	}); i >= 0 {
-		return errors.New("comment must not contain newlines or control characters")
-	}
-	return nil
-}
-
+// convertExtras maps the request-body destination shape onto the neutral model
+// type consumed by egressops.SetPolicy (which validates each entry).
 func convertExtras(in []egressDestinationInput) []models.EgressDestination {
 	out := make([]models.EgressDestination, 0, len(in))
 	for _, e := range in {

--- a/panel-api/internal/egressops/egressops.go
+++ b/panel-api/internal/egressops/egressops.go
@@ -9,9 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -20,6 +23,134 @@ import (
 // ErrAlreadyDecided is returned by DecideRequest when the target request is no
 // longer pending. Callers map it to a 409 (web) or a friendly message (CLI).
 var ErrAlreadyDecided = errors.New("egress request already decided")
+
+// MaxAllowedExtras caps the per-user override list size. Hard ceiling rather
+// than a per-row vs per-user limit — the nft renderer emits one rule per entry,
+// and a runaway list would inflate the rule file without bound. This is the ONE
+// definition of the cap; both the HTTP handler (PUT /users/:id/egress) and the
+// CLI (per-user-egress set-policy) enforce it through SetPolicy.
+const MaxAllowedExtras = 50
+
+// Egress set-policy validation errors. Adapters map these onto their own wire
+// (HTTP JSON error codes; CLI messages) with errors.Is / errors.As — the same
+// pattern ErrAlreadyDecided already uses, so the canonical accept/reject matrix
+// lives here and cannot drift between the two adapters.
+var (
+	// ErrInvalidState — State is not one of off|learning|enforced.
+	ErrInvalidState = errors.New("egress state must be off, learning, or enforced")
+	// ErrTooManyExtras — the allow list exceeds MaxAllowedExtras.
+	ErrTooManyExtras = errors.New("too many allowed destinations")
+)
+
+// DestinationError wraps a per-entry ValidateDestination failure with the
+// entry's index, so an adapter can tell the caller which allowed destination
+// was rejected (HTTP surfaces the index in the JSON body; the CLI names the
+// --allow position).
+type DestinationError struct {
+	Index int
+	Err   error
+}
+
+func (e *DestinationError) Error() string {
+	return fmt.Sprintf("allowed_extra[%d]: %v", e.Index, e.Err)
+}
+func (e *DestinationError) Unwrap() error { return e.Err }
+
+// ValidState reports whether s is one of the three egress states.
+func ValidState(s string) bool {
+	return s == models.UserEgressStateOff ||
+		s == models.UserEgressStateLearning ||
+		s == models.UserEgressStateEnforced
+}
+
+// ValidateDestination canonicalizes and validates one allowed-destination entry
+// in place. It defaults an empty Protocol to tcp — the single place that default
+// now lives — and rejects a bad CIDR, an out-of-range port, an unknown
+// protocol, an over-long comment, or a comment carrying a newline / control
+// character.
+//
+// The comment safety check is security-critical: the comment is rendered into
+// /etc/nftables.d/jabali-per-user-egress.nft, which is loaded by `nft -f` as
+// root. A newline would inject arbitrary nftables lines; a control character can
+// make the file unparseable, which fails the whole ruleset closed-to-absent (the
+// egress policy silently stops applying box-wide). The agent sanitises again at
+// render time — this is the boundary half of that pair. Both adapters reach nft
+// rendering only through a policy this function has cleared.
+func ValidateDestination(d *models.EgressDestination) error {
+	if _, _, err := net.ParseCIDR(d.CIDR); err != nil {
+		return errors.New("cidr: " + err.Error())
+	}
+	if d.Port != nil && (*d.Port < 1 || *d.Port > 65535) {
+		return errors.New("port out of range")
+	}
+	if d.Protocol == "" {
+		d.Protocol = models.UserEgressProtocolTCP
+	}
+	if d.Protocol != models.UserEgressProtocolTCP && d.Protocol != models.UserEgressProtocolUDP {
+		return errors.New("protocol must be tcp or udp")
+	}
+	if len(d.Comment) > 200 {
+		return errors.New("comment too long")
+	}
+	if i := strings.IndexFunc(d.Comment, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == 0 || unicode.IsControl(r)
+	}); i >= 0 {
+		return errors.New("comment must not contain newlines or control characters")
+	}
+	return nil
+}
+
+// SetPolicyInput is the canonical set-policy request shared by both adapters.
+// AllowedExtra REPLACES the user's existing allow list. UpdatedBy is the acting
+// user's id, or nil when the actor has no user identity — the operator CLI has
+// no interactive session, so it passes nil and the CLI audit row carries that
+// provenance instead. SetPolicy mutates the AllowedExtra entries in place to
+// canonicalize each one (protocol default).
+type SetPolicyInput struct {
+	UserID       string
+	State        string
+	AllowedExtra []models.EgressDestination
+	UpdatedBy    *string
+}
+
+// SetPolicy validates and persists a user's egress policy — the one
+// authoritative mutation both the HTTP handler and the CLI call, so the two can
+// never diverge (verify_wire_contract scar). It enforces the canonical matrix
+// (ValidState, MaxAllowedExtras, per-destination ValidateDestination) and
+// Upserts exactly once. Convergence stays tick-based by existing design: the
+// running reconciler re-renders nftables on its next tick — there is no per-user
+// immediate-apply handle, and this call schedules exactly one policy write, not
+// a separate dispatch.
+//
+// Errors: ErrInvalidState, ErrTooManyExtras, *DestinationError (with the failing
+// entry's Index), or a repository error from Upsert.
+func SetPolicy(ctx context.Context, policies repository.UserEgressPolicyRepository, in SetPolicyInput) error {
+	if !ValidState(in.State) {
+		return ErrInvalidState
+	}
+	if len(in.AllowedExtra) > MaxAllowedExtras {
+		return ErrTooManyExtras
+	}
+	for i := range in.AllowedExtra {
+		if err := ValidateDestination(&in.AllowedExtra[i]); err != nil {
+			return &DestinationError{Index: i, Err: err}
+		}
+	}
+	extras := in.AllowedExtra
+	if extras == nil {
+		extras = []models.EgressDestination{}
+	}
+	jsonExtras, err := json.Marshal(extras)
+	if err != nil {
+		return err
+	}
+	return policies.Upsert(ctx, &models.UserEgressPolicy{
+		UserID:       in.UserID,
+		State:        in.State,
+		AllowedExtra: jsonExtras,
+		UpdatedBy:    in.UpdatedBy,
+	})
+}
 
 // Deps are the repositories DecideRequest operates on.
 type Deps struct {
@@ -69,28 +200,31 @@ func foldRequestIntoPolicy(ctx context.Context, deps Deps, req *models.UserEgres
 		}
 	}
 	existing, _ := policy.DecodeAllowedExtra()
-	proto := req.Protocol
-	if proto == "" {
-		proto = models.UserEgressProtocolTCP
-	}
-	for _, e := range existing {
-		samePort := (e.Port == nil && req.Port == nil) ||
-			(e.Port != nil && req.Port != nil && uint(*e.Port) == *req.Port)
-		if e.CIDR == req.CIDR && samePort && e.Protocol == proto {
-			return nil // already present
-		}
-	}
 	var portPtr *int
 	if req.Port != nil {
 		v := int(*req.Port)
 		portPtr = &v
 	}
-	existing = append(existing, models.EgressDestination{
+	dest := models.EgressDestination{
 		CIDR:     req.CIDR,
 		Port:     portPtr,
-		Protocol: proto,
+		Protocol: req.Protocol, // ValidateDestination defaults an empty proto to tcp
 		Comment:  "approved request " + req.ID,
-	})
+	}
+	// The request was validated at submission time; re-run the canonical
+	// validator so the proto default comes from one place and a somehow-bad
+	// row cannot be folded into the policy.
+	if err := ValidateDestination(&dest); err != nil {
+		return err
+	}
+	for _, e := range existing {
+		samePort := (e.Port == nil && dest.Port == nil) ||
+			(e.Port != nil && dest.Port != nil && *e.Port == *dest.Port)
+		if e.CIDR == dest.CIDR && samePort && e.Protocol == dest.Protocol {
+			return nil // already present
+		}
+	}
+	existing = append(existing, dest)
 	jsonExtras, _ := json.Marshal(existing)
 	policy.AllowedExtra = jsonExtras
 	if policy.State == "" {
@@ -101,7 +235,6 @@ func foldRequestIntoPolicy(ctx context.Context, deps Deps, req *models.UserEgres
 	}
 	return deps.Policies.Upsert(ctx, policy)
 }
-
 
 // DefaultPinPath is the operator pin file for the per-user egress LEARNING
 // hold. When it contains the literal "learning", FlipMature is a no-op — an
@@ -126,13 +259,13 @@ func ReadEgressPin(path string) (pinned bool, value string) {
 // dry-run (preview) or a real promotion, so the CLI and the admin GUI render
 // from one struct.
 type FlipMatureResult struct {
-	SoakDays int                        // soak window applied (days)
-	DryRun   bool                       // true = preview only, nothing written
-	Pinned   bool                       // operator pin active → no rows flipped
-	PinValue string                     // trimmed pin file contents, for display
-	Eligible []models.UserEgressPolicy  // mature LEARNING rows (would flip / did flip)
-	Flipped  []string                   // user IDs actually flipped (empty on dry-run/pin)
-	Failed   map[string]string          // user ID → upsert error, for the rows that failed
+	SoakDays int                       // soak window applied (days)
+	DryRun   bool                      // true = preview only, nothing written
+	Pinned   bool                      // operator pin active → no rows flipped
+	PinValue string                    // trimmed pin file contents, for display
+	Eligible []models.UserEgressPolicy // mature LEARNING rows (would flip / did flip)
+	Flipped  []string                  // user IDs actually flipped (empty on dry-run/pin)
+	Failed   map[string]string         // user ID → upsert error, for the rows that failed
 }
 
 // FlipMature finds user_egress_policies rows in LEARNING older than soakDays and

--- a/panel-api/internal/egressops/egressops_test.go
+++ b/panel-api/internal/egressops/egressops_test.go
@@ -3,6 +3,7 @@ package egressops
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -166,5 +167,168 @@ func TestDecideRequest_NotFound(t *testing.T) {
 		"NOPE", models.UserEgressRequestStatusApproved, "")
 	if err != repository.ErrNotFound {
 		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- SetPolicy / ValidateDestination contract (JAB-341) --------------------
+//
+// These lock the canonical accept/reject matrix that both adapters share
+// (PUT /users/:id/egress and the CLI per-user-egress set-policy). A regression
+// in either adapter now fails here, not silently in production nft rendering.
+
+func iptr(v int) *int       { return &v }
+func sptr(s string) *string { return &s }
+
+func TestValidState(t *testing.T) {
+	for _, s := range []string{"off", "learning", "enforced"} {
+		if !ValidState(s) {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	for _, s := range []string{"", "ENFORCED", "on", "block"} {
+		if ValidState(s) {
+			t.Errorf("%q should be invalid", s)
+		}
+	}
+}
+
+func TestValidateDestination_Matrix(t *testing.T) {
+	ok := []models.EgressDestination{
+		{CIDR: "10.0.0.0/8"},
+		{CIDR: "1.2.3.4/32", Port: iptr(443)},
+		{CIDR: "1.2.3.4/32", Port: iptr(53), Protocol: "udp"},
+		{CIDR: "1.2.3.4/32", Comment: "ok comment"},
+	}
+	for _, d := range ok {
+		dd := d
+		if err := ValidateDestination(&dd); err != nil {
+			t.Errorf("%+v: unexpected error %v", d, err)
+		}
+	}
+
+	bad := []models.EgressDestination{
+		{CIDR: "not-a-cidr"},
+		{CIDR: "1.2.3.4"},                         // no mask
+		{CIDR: "1.2.3.4/32", Port: iptr(0)},       // port 0
+		{CIDR: "1.2.3.4/32", Port: iptr(99999)},   // port out of range
+		{CIDR: "1.2.3.4/32", Protocol: "sctp"},    // unknown protocol
+		{CIDR: "1.2.3.4/32", Comment: "a\nnft x"}, // newline injection
+		{CIDR: "1.2.3.4/32", Comment: "a\rb"},     // carriage return
+		{CIDR: "1.2.3.4/32", Comment: "a\x00b"},   // NUL
+		{CIDR: "1.2.3.4/32", Comment: "a\tb"},     // control char (tab)
+	}
+	for _, d := range bad {
+		dd := d
+		if err := ValidateDestination(&dd); err == nil {
+			t.Errorf("%+v: expected error, got nil", d)
+		}
+	}
+}
+
+func TestValidateDestination_DefaultsProtocol(t *testing.T) {
+	d := models.EgressDestination{CIDR: "1.2.3.4/32"}
+	if err := ValidateDestination(&d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Protocol != models.UserEgressProtocolTCP {
+		t.Errorf("empty protocol should default to tcp, got %q", d.Protocol)
+	}
+}
+
+func TestSetPolicy_PersistsOnceAndCanonicalizes(t *testing.T) {
+	pols := &fakePolicyRepo{}
+	err := SetPolicy(context.Background(), pols, SetPolicyInput{
+		UserID: "U1",
+		State:  models.UserEgressStateEnforced,
+		AllowedExtra: []models.EgressDestination{
+			{CIDR: "1.2.3.4/32", Port: iptr(443)}, // proto omitted -> tcp
+		},
+		UpdatedBy: sptr("admin1"),
+	})
+	if err != nil {
+		t.Fatalf("SetPolicy: %v", err)
+	}
+	// AC5: exactly one policy write scheduled.
+	if pols.upsertCalls != 1 {
+		t.Fatalf("expected exactly one upsert, got %d", pols.upsertCalls)
+	}
+	if pols.upserted.State != models.UserEgressStateEnforced {
+		t.Errorf("state = %q", pols.upserted.State)
+	}
+	// AC4: provenance recorded.
+	if pols.upserted.UpdatedBy == nil || *pols.upserted.UpdatedBy != "admin1" {
+		t.Errorf("updated_by = %v, want admin1", pols.upserted.UpdatedBy)
+	}
+	var extras []models.EgressDestination
+	if err := json.Unmarshal(pols.upserted.AllowedExtra, &extras); err != nil {
+		t.Fatalf("decode allowed_extra: %v", err)
+	}
+	if len(extras) != 1 || extras[0].Protocol != models.UserEgressProtocolTCP {
+		t.Errorf("destination not canonicalized: %+v", extras)
+	}
+}
+
+func TestSetPolicy_CLIProvenanceNil(t *testing.T) {
+	pols := &fakePolicyRepo{}
+	if err := SetPolicy(context.Background(), pols, SetPolicyInput{
+		UserID: "U1", State: models.UserEgressStateOff, UpdatedBy: nil,
+	}); err != nil {
+		t.Fatalf("SetPolicy: %v", err)
+	}
+	if pols.upserted.UpdatedBy != nil {
+		t.Errorf("CLI actor should leave updated_by nil, got %v", *pols.upserted.UpdatedBy)
+	}
+	// Empty list must serialize as [] (not null) so the not-null column is clean.
+	if string(pols.upserted.AllowedExtra) != "[]" {
+		t.Errorf("empty allow list = %q, want []", pols.upserted.AllowedExtra)
+	}
+}
+
+func TestSetPolicy_RejectsInvalidState(t *testing.T) {
+	pols := &fakePolicyRepo{}
+	err := SetPolicy(context.Background(), pols, SetPolicyInput{UserID: "U1", State: "block"})
+	if !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("expected ErrInvalidState, got %v", err)
+	}
+	if pols.upsertCalls != 0 {
+		t.Errorf("invalid state must not persist, got %d upserts", pols.upsertCalls)
+	}
+}
+
+func TestSetPolicy_RejectsTooManyExtras(t *testing.T) {
+	pols := &fakePolicyRepo{}
+	extras := make([]models.EgressDestination, MaxAllowedExtras+1)
+	for i := range extras {
+		extras[i] = models.EgressDestination{CIDR: "1.2.3.4/32"}
+	}
+	err := SetPolicy(context.Background(), pols, SetPolicyInput{
+		UserID: "U1", State: models.UserEgressStateEnforced, AllowedExtra: extras,
+	})
+	if !errors.Is(err, ErrTooManyExtras) {
+		t.Fatalf("expected ErrTooManyExtras, got %v", err)
+	}
+	if pols.upsertCalls != 0 {
+		t.Errorf("over-limit list must not persist, got %d upserts", pols.upsertCalls)
+	}
+}
+
+func TestSetPolicy_RejectsBadDestinationWithIndex(t *testing.T) {
+	pols := &fakePolicyRepo{}
+	err := SetPolicy(context.Background(), pols, SetPolicyInput{
+		UserID: "U1", State: models.UserEgressStateEnforced,
+		AllowedExtra: []models.EgressDestination{
+			{CIDR: "1.2.3.4/32"},                      // index 0 ok
+			{CIDR: "1.2.3.4/32", Comment: "x\nnft y"}, // index 1 injection
+		},
+	})
+	var de *DestinationError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected *DestinationError, got %v", err)
+	}
+	if de.Index != 1 {
+		t.Errorf("DestinationError.Index = %d, want 1", de.Index)
+	}
+	if pols.upsertCalls != 0 {
+		t.Errorf("unsafe destination must not persist, got %d upserts", pols.upsertCalls)
 	}
 }


### PR DESCRIPTION
## JAB-341 — one shared Egress Policy mutation for HTTP + CLI

The per-user egress policy write (`user_egress_policies`) was implemented twice
and had begun to drift:

| | HTTP `PUT /users/:id/egress` (`adminPut`) | CLI `per-user-egress set-policy` |
|---|---|---|
| state check | `validEgressState` | `validCLIEgressState` |
| max entries | `maxAllowedExtras = 50` | `maxCLIEgressExtras = 50` |
| per-destination validation | `validateExtra` | `parseCLIAllow` |
| **comment newline / control-char reject** | **yes** | **no** |
| **updated-by provenance** | **yes (admin ULID)** | **no (dropped)** |

Two separate validators mean a bad comment or an over-limit list could be
accepted on one path and rejected on the other — and the CLI could write a
comment carrying a newline straight toward `nft -f`, the exact injection the
HTTP path guards against.

### The change — extract one authoritative mutation into `internal/egressops`
- **`ValidateDestination`** — the canonical per-entry matrix (CIDR, port range,
  protocol whitelist, comment length, and the security-critical newline /
  control-character reject) plus the single empty-protocol default.
  `foldRequestIntoPolicy` (approve path) now calls it too, so the
  `empty proto -> tcp` default lives in **one** place instead of three.
- **`MaxAllowedExtras`** — the one definition of the list cap (replaces the two
  `= 50` constants).
- **`SetPolicy(ctx, policies, SetPolicyInput)`** — validate-and-persist, called
  by both adapters. It Upserts **exactly once**; convergence stays **tick-based
  by existing design** — the reconciler re-renders nftables on its next tick,
  and there is no per-user immediate-apply handle to add, so "schedule
  convergence exactly once" is one authoritative policy write.
- **Typed errors** `ErrInvalidState` / `ErrTooManyExtras` /
  `*DestinationError{Index}` — each adapter maps the same failures onto its own
  wire via `errors.Is` / `errors.As`. The HTTP JSON codes (`invalid_state`,
  `too_many_extras` + `max`, `invalid_destination` + `detail` + `index`) are
  preserved byte-for-byte.

### Adapters
- **HTTP `adminPut`** routes through `SetPolicy`; `validateExtra`,
  `validEgressState`, and the `maxAllowedExtras` const are deleted.
- **CLI `set-policy`** routes through `SetPolicy` and now enforces the
  comment-safety + destination matrix it never had. `parseCLIAllow` shrinks to
  pure CLI-string handling (field split, numeric port coercion, proto
  lower-casing); the semantic checks belong to `ValidateDestination`.
- **CLI provenance is explicit**: `UpdatedBy` is passed `nil` **by design** —
  the operator CLI has no interactive user session, and the `cliAuditOK` row is
  the CLI's provenance record. `updated_by` is a ULID-shaped user-id column
  (`policyView` → wire → UI) with nowhere to render a non-user sentinel, so
  nil-by-design beats a synthetic marker.

### Tests
`internal/egressops` gains the shared accept/reject **contract**:
`ValidateDestination` matrix (including every injection form — newline, CR,
NUL, tab), `SetPolicy` exactly-once persist + protocol canonicalization,
provenance passthrough and CLI-nil, and the three typed-error paths (invalid
state, too-many, bad-destination-with-index). The `cmd/server` `parseCLIAllow`
test narrows to the CLI string format now that the semantic matrix is asserted
once in `egressops`. Existing `DecideRequest` / `FlipMature` tests unchanged.

`go build ./...`, `go vet ./...`, `-race` on `internal/egressops` +
`internal/api` + `cmd/server`, and `gofmt` — all green. No box round-trip: no
agent, nft renderer, reconciler, or migration surface changes — a
validate-and-persist consolidation with wire-preserving error codes.

### AC status (concrete ticket — closes JAB-341)
- ✅ Both adapters accept/reject the same canonical policy matrix (one
  `ValidateDestination` / `SetPolicy`).
- ✅ Unsafe comments / control characters cannot reach nft rendering (the CLI
  now enforces the reject the HTTP path always had).
- ✅ Maximum entries is defined once (`egressops.MaxAllowedExtras`).
- ✅ Updated-by provenance is explicit for CLI (nil-by-design + audit row) and
  HTTP (admin ULID).
- ✅ Successful mutation schedules nft convergence exactly once (one Upsert;
  convergence remains tick-based by existing design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
