### PR TITLE
fix(dns): migrated zones with UTF-8/IDN records land in PowerDNS (GH #1459)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4390,6 +4390,13 @@ SQL
     _log "PowerDNS schema already present in jabali_pdns — skipping reload"
   fi
 
+  # GH #1459: the stock schema just loaded creates records.content as
+  # latin1, which fails the INSERT (MariaDB 1366) for any UTF-8 TXT / IDN
+  # record and rolls back the whole atomic zone upsert. Widen it here too,
+  # so fresh installs are correct out of the box (the same converger also
+  # runs on `jabali update` for the existing fleet). Idempotent + gated.
+  ensure_pdns_records_utf8mb4
+
   # Write pdns.conf. Single file, minimal surface.
   #
   # Idempotency (M6.3): render to $pdns_conf.new first; if byte-identical
@@ -5919,6 +5926,54 @@ AXFRDENY
       || _warn "pdns restart failed after AXFR config — new setting applies on next pdns restart"
   else
     _log "pdns not active — AXFR ACL staged in $conf for next start"
+  fi
+}
+
+# GH #1459: widen jabali_pdns.records.content to utf8mb4 on EXISTING boxes.
+#
+# The stock PowerDNS schema (install_powerdns loads it from
+# schema.mysql.sql) creates the whole `records` table as latin1, even
+# though the jabali_pdns DATABASE default is utf8mb4. The agent connects
+# charset=utf8mb4 (pdns.ReadEnvAndConnect), so a record whose content
+# carries a code point outside latin1 — a UTF-8 TXT value, an IDN target —
+# fails the INSERT with MariaDB error 1366 ("Incorrect string value"). And
+# because dns.zone.upsert wraps the domains INSERT + every record INSERT in
+# ONE transaction, that single failure rolls back the WHOLE zone: the
+# domain silently never appears in pdns (dig returns nothing) while the
+# panel still shows the zone "provisioned" (that status is the dns_zones
+# row, not pdns). Reporter hit exactly this on a HestiaCP migration.
+#
+# install_powerdns does NOT run on `jabali update`, so this converger
+# carries the widening to the fleet (same lesson as ensure_pdns_zone_cache
+# / ensure_pdns_axfr_deny above).
+#
+# Only `content` moves — and to TEXT, because utf8mb4 caps VARCHAR at
+# ~16k chars while the current column is varchar(64000); TEXT holds 65535
+# bytes so no existing value can be truncated by the conversion. content
+# is unindexed, so there is no index key-length concern. `name` stays
+# latin1 on purpose: the panel punycode/length-validates every record and
+# zone name at compile (dnscompile.NormalizeName), so names are always
+# ASCII and latin1-safe — and the `nametype_index (name,type)` key stays
+# a cheap latin1 index. `ordername` (latin1_bin, DNSSEC canonical order)
+# is left untouched. Idempotent + gated on the current charset so a
+# converged box no-ops after the one-time ALTER.
+ensure_pdns_records_utf8mb4() {
+  # No jabali_pdns.records on a box where the DNS module was never installed.
+  local have
+  have="$(mariadb -uroot -Ns -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='jabali_pdns' AND table_name='records';" 2>/dev/null || echo 0)"
+  [[ "$have" == "1" ]] || return 0
+
+  local cur
+  cur="$(mariadb -uroot -Ns -e "SELECT CHARACTER_SET_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='jabali_pdns' AND TABLE_NAME='records' AND COLUMN_NAME='content';" 2>/dev/null)"
+  if [[ "$cur" == "utf8mb4" ]]; then
+    return 0  # already widened — no-op
+  fi
+
+  _log "widening jabali_pdns.records.content to utf8mb4 (GH #1459 — UTF-8 TXT / IDN records were rolling back whole zones on migration)"
+  if mariadb -uroot jabali_pdns -e "ALTER TABLE records MODIFY content TEXT CHARACTER SET utf8mb4 DEFAULT NULL;"; then
+    _ok "jabali_pdns.records.content widened to utf8mb4 (was ${cur:-latin1}) — UTF-8 record content now stores instead of failing the atomic zone upsert"
+  else
+    _warn "failed to widen jabali_pdns.records.content to utf8mb4 — UTF-8 TXT / IDN records may still fail to provision (GH #1459)"
   fi
 }
 
@@ -15453,6 +15508,11 @@ provision_new_software() {
   # JAB-350: same reasoning — pin the global AXFR ACL to loopback on update so a
   # permissive global on an existing host stops leaving zones internet-transferable.
   ensure_pdns_axfr_deny
+  # GH #1459: same reasoning — widen jabali_pdns.records.content to utf8mb4 on
+  # update so a UTF-8 TXT / IDN record stops rolling back the whole zone's
+  # atomic upsert (the stock pdns schema is latin1; install_powerdns, which
+  # would fix it, does not run on this path).
+  ensure_pdns_records_utf8mb4
   # JAB-352: same reasoning — carry the SSH forwarding-lockdown drop-in to boxes
   # that only ever update (install_sftp_sshd_config runs on fresh install only),
   # so an existing tenant key can't tunnel into loopback-only services.

--- a/panel-api/internal/dnscompile/compile.go
+++ b/panel-api/internal/dnscompile/compile.go
@@ -9,7 +9,22 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/idna"
+
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// dnsNameIDNA is a lenient IDNA profile used ONLY to punycode-encode
+// labels that actually contain non-ASCII runes. Unlike idna.Lookup
+// (which mailaddr uses for e-mail domains) it does NOT enforce STD3
+// rules, because DNS record names legitimately carry underscores
+// (_dmarc, _domainkey, _acme-challenge, SRV _service._proto) and the
+// wildcard label "*". We never feed it an ASCII label, so its sole job
+// is Unicode→ASCII on genuine IDN labels.
+var dnsNameIDNA = idna.New(
+	idna.MapForLookup(),
+	idna.Transitional(false),
+	idna.StrictDomainName(false),
 )
 
 // Record is the wire shape the agent expects in dns.zone.upsert.
@@ -34,6 +49,13 @@ func SystemRecords(zone *models.DNSZone, srv *models.ServerSettings) []Record {
 		return nil
 	}
 	zoneName := strings.TrimSuffix(zone.Name, ".")
+	// GH #1459: punycode a raw-IDN apex so the SOA/NS/apex-A record
+	// names match the (also-normalized) domains.name the reconciler
+	// pushes, and stay latin1-safe for PowerDNS's records.name column.
+	// Identity for ordinary ASCII zones — no output change, no hash churn.
+	if nz, ok := NormalizeName(zoneName); ok {
+		zoneName = nz
+	}
 	// GH #527: apex SOA + NS TTLs follow the operator default like every other
 	// record (the SOA content refresh/retry/expire/minimum timers are unchanged).
 	sysTTL := models.EffectiveDNSTTL(srv)
@@ -80,6 +102,9 @@ func SystemRecords(zone *models.DNSZone, srv *models.ServerSettings) []Record {
 // from UpdatedAt — bumping it on every push is PowerDNS convention.
 func Compile(zone *models.DNSZone, records []models.DNSRecord, srv *models.ServerSettings) []Record {
 	zoneName := strings.TrimSuffix(zone.Name, ".")
+	if nz, ok := NormalizeName(zoneName); ok {
+		zoneName = nz // keep expandName's suffix in sync with the apex above
+	}
 	out := SystemRecords(zone, srv)
 
 	// Operator-editable records.
@@ -90,7 +115,15 @@ func Compile(zone *models.DNSZone, records []models.DNSRecord, srv *models.Serve
 		if r.Type == "NS" && r.Managed {
 			continue // Managed NS — regenerated above.
 		}
-		name := expandName(r.Name, zoneName)
+		name, ok := NormalizeName(expandName(r.Name, zoneName))
+		if !ok {
+			// GH #1459: a name we can't store (non-encodable IDN /
+			// over-length / malformed) would fail the latin1 records.name
+			// INSERT and roll back the ENTIRE dns.zone.upsert transaction,
+			// silently dropping the whole zone from PowerDNS. Skip just
+			// this one record so the rest of the zone still provisions.
+			continue
+		}
 		out = append(out, Record{
 			Name:     name,
 			Type:     r.Type,
@@ -102,6 +135,58 @@ func Compile(zone *models.DNSZone, records []models.DNSRecord, srv *models.Serve
 	}
 
 	return out
+}
+
+// NormalizeName renders a DNS name into the ASCII, latin1-safe form
+// PowerDNS's records.name / domains.name columns require, punycode-
+// encoding any label that carries non-ASCII runes and leaving every
+// ASCII label byte-for-byte intact (so _dmarc/_domainkey/SRV
+// underscores, the wildcard "*", hyphens and existing case are
+// preserved, and ordinary zones compile identically — no zone-cache /
+// push-hash churn).
+//
+// It returns (encoded, true) for a name that fits DNS limits (≤253
+// octets overall, each label 1..63 octets) and ("", false) for one that
+// is empty, has an empty/over-long label, or contains an IDN label that
+// cannot be encoded. A false result is the caller's cue to SKIP that
+// record rather than let it fail the atomic zone INSERT (GH #1459).
+func NormalizeName(name string) (string, bool) {
+	name = strings.TrimSuffix(strings.TrimSpace(name), ".")
+	if name == "" {
+		return "", false
+	}
+	labels := strings.Split(name, ".")
+	for i, label := range labels {
+		if label == "" {
+			return "", false // empty label, e.g. "a..b"
+		}
+		if isASCIIStr(label) {
+			if len(label) > 63 {
+				return "", false
+			}
+			continue // ASCII label — preserve verbatim (case, "_", "*", "-")
+		}
+		enc, err := dnsNameIDNA.ToASCII(label)
+		if err != nil || enc == "" || len(enc) > 63 {
+			return "", false
+		}
+		labels[i] = enc
+	}
+	out := strings.Join(labels, ".")
+	if len(out) > 253 {
+		return "", false
+	}
+	return out, true
+}
+
+// isASCIIStr reports whether s is pure 7-bit ASCII.
+func isASCIIStr(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 // expandName converts panel-side names (@, short labels, FQDN) to the

--- a/panel-api/internal/dnscompile/normalize_test.go
+++ b/panel-api/internal/dnscompile/normalize_test.go
@@ -1,0 +1,189 @@
+package dnscompile
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1459: NormalizeName must leave every ASCII name byte-identical (so
+// healthy zones compile unchanged — no push-hash / zone-cache churn) and
+// punycode only genuine IDN labels, while rejecting names PowerDNS's
+// latin1 columns cannot store (which the caller then skips instead of
+// rolling back the whole atomic zone upsert).
+func TestNormalizeName(t *testing.T) {
+	longLabel := strings.Repeat("a", 64)                 // 64 > 63 octet label limit
+	long253 := strings.Repeat("a.", 127) + "example.com" // > 253 octets total
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		// Identity for ordinary ASCII — the 99.9% path. Case, underscores,
+		// wildcard and hyphens all preserved verbatim.
+		{"plain", "www.example.com", "www.example.com", true},
+		{"apex", "example.com", "example.com", true},
+		{"dmarc underscore", "_dmarc.example.com", "_dmarc.example.com", true},
+		{"dkim underscore", "mail._domainkey.example.com", "mail._domainkey.example.com", true},
+		{"acme underscore", "_acme-challenge.example.com", "_acme-challenge.example.com", true},
+		{"srv underscores", "_25._tcp.example.com", "_25._tcp.example.com", true},
+		{"wildcard", "*.example.com", "*.example.com", true},
+		{"mixed case preserved", "WWW.Example.COM", "WWW.Example.COM", true},
+		{"hyphens", "my-host-1.example.com", "my-host-1.example.com", true},
+		{"trailing dot stripped", "www.example.com.", "www.example.com", true},
+
+		// Reject the storage-unsafe class → caller skips the record.
+		{"empty", "", "", false},
+		{"dot only", ".", "", false},
+		{"empty label", "a..b.example.com", "", false},
+		{"label too long", longLabel + ".example.com", "", false},
+		{"name too long", long253, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := NormalizeName(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("NormalizeName(%q) ok=%v, want %v (got %q)", tc.in, ok, tc.ok, got)
+			}
+			if ok && got != tc.want {
+				t.Errorf("NormalizeName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeName_IDNPunycode(t *testing.T) {
+	// München — the canonical IDN example. Its punycode form is stable.
+	got, ok := NormalizeName("münchen.example.com")
+	if !ok {
+		t.Fatal("münchen.example.com should normalize, got !ok")
+	}
+	if got != "xn--mnchen-3ya.example.com" {
+		t.Errorf("münchen punycode = %q, want xn--mnchen-3ya.example.com", got)
+	}
+
+	// A label mixing an underscore prefix with a non-ASCII rune still
+	// encodes (lenient profile — no STD3 rejection of the underscore).
+	got, ok = NormalizeName("_café.example.com")
+	if !ok {
+		t.Fatalf("_café.example.com should normalize, got !ok (%q)", got)
+	}
+	if !isASCIIStr(got) {
+		t.Errorf("normalized name must be pure ASCII, got %q", got)
+	}
+
+	// Idempotent: re-normalizing the ASCII output is a no-op.
+	again, ok := NormalizeName(got)
+	if !ok || again != got {
+		t.Errorf("NormalizeName not idempotent: %q -> %q", got, again)
+	}
+}
+
+func mkZone() *models.DNSZone {
+	return &models.DNSZone{
+		ID: "zone1", DomainID: "dom1", Name: "example.com",
+		RefreshSeconds: 3600, RetrySeconds: 600, ExpireSeconds: 604800, MinimumTTL: 3600,
+		IsEnabled: true, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+}
+
+// A record whose name cannot be stored must be dropped, NOT allowed to
+// fail the whole zone — while every other record survives (GH #1459).
+func TestCompile_SkipsUnstorableRecordName(t *testing.T) {
+	zone := mkZone()
+	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1", NS1Name: "ns1.example.com"}
+	bad := strings.Repeat("a", 64) // over-long label -> unstorable
+	recs := []models.DNSRecord{
+		{ID: "r1", ZoneID: zone.ID, Name: "good", Type: "A", Content: "192.0.2.9", TTL: 3600, IsEnabled: true},
+		{ID: "r2", ZoneID: zone.ID, Name: bad, Type: "A", Content: "192.0.2.10", TTL: 3600, IsEnabled: true},
+	}
+	out := Compile(zone, recs, srv)
+
+	var sawGood, sawBad bool
+	for _, r := range out {
+		if r.Name == "good.example.com" && r.Type == "A" {
+			sawGood = true
+		}
+		if strings.Contains(r.Name, bad) {
+			sawBad = true
+		}
+	}
+	if !sawGood {
+		t.Error("the storable record was dropped")
+	}
+	if sawBad {
+		t.Error("the unstorable record was NOT skipped — it would roll back the whole zone")
+	}
+}
+
+// An IDN record name is punycode-encoded (latin1-safe) in the compiled
+// output; the apex of an IDN zone is punycoded too.
+func TestCompile_PunycodesIDN(t *testing.T) {
+	zone := mkZone()
+	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1", NS1Name: "ns1.example.com"}
+	recs := []models.DNSRecord{
+		{ID: "r1", ZoneID: zone.ID, Name: "café", Type: "A", Content: "192.0.2.9", TTL: 3600, IsEnabled: true},
+	}
+	out := Compile(zone, recs, srv)
+
+	var found bool
+	for _, r := range out {
+		if r.Type == "A" && r.Content == "192.0.2.9" {
+			found = true
+			if !strings.HasPrefix(r.Name, "xn--") || !strings.HasSuffix(r.Name, ".example.com") {
+				t.Errorf("IDN name not punycoded: %q", r.Name)
+			}
+			if !isASCIIStr(r.Name) {
+				t.Errorf("compiled name must be ASCII, got %q", r.Name)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("IDN A record missing from compiled output")
+	}
+}
+
+func TestCompile_IDNApex(t *testing.T) {
+	zone := mkZone()
+	zone.Name = "münchen.example" // raw-IDN apex
+	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1", NS1Name: "ns1.example.com"}
+	out := Compile(zone, nil, srv)
+
+	for _, r := range out {
+		if r.Type == "SOA" {
+			if !strings.HasPrefix(r.Name, "xn--mnchen-3ya.example") {
+				t.Errorf("SOA apex not punycoded: %q", r.Name)
+			}
+			return
+		}
+	}
+	t.Fatal("no SOA in output")
+}
+
+// The compiled names for a plain ASCII zone must be byte-identical to the
+// pre-#1459 output, so already-provisioned zones never re-push.
+func TestCompile_ASCIIIdentityNoChurn(t *testing.T) {
+	zone := mkZone()
+	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1", NS1Name: "ns1.example.com"}
+	recs := []models.DNSRecord{
+		{ID: "r1", ZoneID: zone.ID, Name: "_dmarc", Type: "TXT", Content: "v=DMARC1; p=none", TTL: 3600, IsEnabled: true},
+		{ID: "r2", ZoneID: zone.ID, Name: "*", Type: "A", Content: "192.0.2.9", TTL: 3600, IsEnabled: true},
+	}
+	out := Compile(zone, recs, srv)
+
+	want := map[string]bool{"_dmarc.example.com": false, "*.example.com": false}
+	for _, r := range out {
+		if _, ok := want[r.Name]; ok {
+			want[r.Name] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("expected compiled name %q verbatim (churn/mutation)", name)
+		}
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2423,10 +2423,22 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 	zone.Serial = now.Unix()
 	_ = r.dnsZones.Update(ctx, zone)
 
+	// GH #1459: PowerDNS's domains.name column is latin1; the agent
+	// connects charset=utf8mb4, so a raw-IDN zone name would fail the
+	// domains INSERT with MySQL 1366 and roll back the WHOLE atomic
+	// dns.zone.upsert — the zone silently never lands. Send the same
+	// punycode-normalized apex the compiled records already use.
+	// Identity for ordinary ASCII zones.
+	pushZoneName, ok := dnscompile.NormalizeName(zone.Name)
+	if !ok {
+		r.log.Error("dns.zone.upsert skipped: zone name not encodable", "zone", zone.Name)
+		return
+	}
+
 	pushCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	if _, err := r.agent.Call(pushCtx, "dns.zone.upsert", map[string]any{
-		"zone":            zone.Name,
+		"zone":            pushZoneName,
 		"records":         compiled,
 		"allow_axfr_from": allowAXFR,
 		"also_notify":     alsoNotify,


### PR DESCRIPTION
## Problem (GH #1459)

A zone migrated from another panel showed **"provisioned"** in the WebUI but was **completely absent from PowerDNS** — `dig` returned nothing and `jabali_pdns.domains` had no row for it. Reboot / disable-enable / adding an A record didn't help; other migrated zones worked fine.

## Root cause

The stock PowerDNS schema creates `records.content` as **latin1** (the `jabali_pdns` DB default of utf8mb4 is overridden per-column), and the agent connects `charset=utf8mb4`. A record whose content carries a code point outside latin1 — a UTF-8 TXT value, an IDN target — fails the INSERT with **MariaDB error 1366** ("Incorrect string value").

`dns.zone.upsert` wraps the `domains` INSERT **and every record INSERT in one transaction** (`pdns/client.go` `upsertZoneCore`). So a single failing record **rolls back the whole zone** — even the `domains` row never lands — while:
- the panel's "provisioned" status is the `dns_zones` row (JAB-377), *not* pdns, so the UI still shows green, and
- the reconciler only `log.Error`s the failure and doesn't record the push hash, so it silently retries + fails every tick.

Raw-IDN zone/record **names** hit the same 1366 on the latin1 `name` columns.

## Fix

**`install.sh` — `ensure_pdns_records_utf8mb4`:** widen `records.content` to `TEXT CHARACTER SET utf8mb4`.
- utf8mb4 can't fit `varchar(64000)` (4 bytes/char → varchar ceiling ~16k chars, `ERROR 1074`); `TEXT` holds 65535 bytes so no existing value truncates. `content` is unindexed → no key-length concern.
- Idempotent + gated on the current charset; wired into `install_powerdns` (fresh install) **and** `provision_new_software` (`jabali update`) so the existing fleet migrates — `install_powerdns` alone never runs on update.
- `name` / `ordername` stay latin1 on purpose (see below).

**`dnscompile.NormalizeName`:** punycode-encodes **only** genuine IDN labels and leaves every ASCII label byte-identical — preserving `_dmarc` / `_domainkey` / SRV underscores, the wildcard `*`, hyphens and case (it uses a lenient IDNA profile, **not** the strict `idna.Lookup` that mailaddr uses, which would reject underscores). Healthy ASCII zones compile **unchanged → no push-hash / zone-cache churn.** A name it cannot store (non-encodable IDN, over-length) is **skipped** at compile, so one bad record no longer rolls back the whole zone. Applied to record names, the apex (`SystemRecords`/`Compile`), and the zone name the reconciler pushes to `domains.name`.

Because names are always punycode/ASCII after this, the latin1 `name` column (and its `nametype_index`) needs no change — only `content` (which legitimately holds UTF-8 TXT) is widened.

## Box drill (test server)

Reproduced **through the agent RPC** (validates the go-sql-driver `charset=utf8mb4` path):

| | domains row | records | result |
|---|---|---|---|
| **BEFORE** widen, UTF-8 TXT upsert | 0 | 0 | `Error 1366 ... records.content` — whole zone rolled back (the reported symptom) |
| **AFTER** widen | ✓ | ✓ | `ok`, zone lands |

- ALTER instant: **0.019s** on 950 rows; touches only `content` (name/ordername verified untouched).
- **Byte fidelity end-to-end:** stored hex `…E8AA9E`(語)`…F09F9A80`(🚀)`…C3A9`(é); `dig` at pdns-auth `:5300` serves the exact UTF-8 bytes on the wire — no mojibake. Test zone cleaned up.

## Test plan

- [x] `go test -race ./internal/dnscompile/...` — new `normalize_test.go` (identity for ASCII incl. `_dmarc`/`*`/case, punycode for IDN, skip unstorable, IDN apex, no-churn)
- [x] `go test -race ./internal/reconciler/...`
- [x] `go vet` + `gofmt` clean; `go build ./...`
- [x] `bash -n install.sh`; converger wired into both fresh + update paths
- [x] Box-drilled before/after on the test server (agent RPC + dig)

## Rollout

- **panel-api + install.sh only — no agent redeploy needed** (unlike #1416/#1458). Existing fleet boxes get the column widen on their next `jabali update`.

## Follow-up (not in this PR)

The "provisioned" status is set independently of push success, so a push failure is invisible to the tenant. Surfacing the pdns upsert error to the zone status / activity log is worth a separate change.
