### PR TITLE
refactor(domain-mail): shared DKIM-rotation lifecycle + fix email_enabled_at clobber (JAB-286)

### DIFF
--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -49,3 +49,24 @@ func TestDomainEmailCLI_NoSSLScheduleWired(t *testing.T) {
 		t.Error("CLI deps must not wire SSL flip (see file header); that is a box-verified behavior change")
 	}
 }
+
+// TestDKIMRotateCLI_RoutesThroughSharedModule pins the DKIM-rotate command to
+// the shared lifecycle (JAB-286): the former inline agent-call / unmarshal /
+// UpdateEmailState copy is gone, and the behavioral matrix now lives once in
+// internal/domainmailops/domainmailops_test.go. cmd/server has no seeded-DB
+// fixture, so this follows the repo's source-pin precedent.
+func TestDKIMRotateCLI_RoutesThroughSharedModule(t *testing.T) {
+	src, err := os.ReadFile("domain_email_dkim_rotate_cmd.go")
+	if err != nil {
+		t.Fatalf("read domain_email_dkim_rotate_cmd.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "domainmailops.RotateDKIM(") {
+		t.Error("email-dkim-rotate must route through domainmailops.RotateDKIM")
+	}
+	// Direct persistence must not have crept back in — the module owns the
+	// UpdateEmailState write (the doc comment may still name the agent verb).
+	if strings.Contains(s, "UpdateEmailState(") {
+		t.Error("DKIM-rotate persistence must live in the shared module, not inline in the CLI")
+	}
+}

--- a/panel-api/cmd/server/domain_email_dkim_rotate_cmd.go
+++ b/panel-api/cmd/server/domain_email_dkim_rotate_cmd.go
@@ -5,37 +5,24 @@
 //   - Periodic rotation policy (3-12 months recommended)
 //   - Post-incident credential rotation
 //
-// Pipeline mirrors domain.email_enable's DNS publish path:
-//  1. Resolve domain by name or ID
-//  2. agent.domain.email_dkim_rotate — generates fresh keypair,
-//     snapshots old key to <domain>.key.old, reloads Stalwart
-//  3. UpdateEmailState writes the new dkim_public_key into
-//     domains row
-//  4. Wipe old M6-managed DNS records + republish so the new
-//     DKIM TXT lands at jabali._domainkey.<domain>
-//
-// On agent failure: bail before DB + DNS writes (no partial state).
-// On DB / DNS failure post-agent-success: surface as warning + leave
-// keys + DB drifted; operator can re-run to converge.
+// The rotation lifecycle (agent domain.email_dkim_rotate → persist the
+// new public key → wipe + republish the M6-managed DNS) lives in
+// internal/domainmailops.RotateDKIM (JAB-286), shared with the REST
+// handler so the two adapters can't drift on ordering or key handling.
+// This command owns only argument parsing, the operator-friendly
+// "not enabled" hint, and output shaping.
 package main
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailops"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
-
-type domainEmailDKIMRotateResponse struct {
-	OldDKIMPublicKey string `json:"old_dkim_public_key,omitempty"`
-	NewDKIMPublicKey string `json:"new_dkim_public_key"`
-	OldKeyBackupPath string `json:"old_key_backup_path,omitempty"`
-}
 
 func newDomainEmailDKIMRotateCmd() *cobra.Command {
 	return &cobra.Command{
@@ -62,57 +49,34 @@ to rotate). Run domain email-enable first if needed.`,
 			if err != nil {
 				return err
 			}
-			if !dom.EmailEnabled {
-				return fmt.Errorf("email not enabled for %s — run 'jabali domain email-enable %s' first", dom.Name, dom.Name)
-			}
 
-			// Agent rotation — generates fresh key, snapshots old.
-			raw, err := deps.Call(ctx, "domain.email_dkim_rotate", map[string]any{
-				"domain_name": dom.Name,
-			})
+			res, warnings, err := domainmailops.RotateDKIM(ctx, deps, dom)
 			if err != nil {
-				return fmt.Errorf("agent domain.email_dkim_rotate: %w", err)
+				// Keep the operator-friendly hint for the common "not enabled"
+				// case; the other sentinels carry enough detail on their own.
+				if errors.Is(err, domainmailops.ErrEmailNotEnabled) {
+					return fmt.Errorf("email not enabled for %s — run 'jabali domain email-enable %s' first", dom.Name, dom.Name)
+				}
+				return err
 			}
-			var resp domainEmailDKIMRotateResponse
-			if err := json.Unmarshal(raw, &resp); err != nil {
-				return fmt.Errorf("agent bad response: %w", err)
-			}
-			if resp.NewDKIMPublicKey == "" {
-				return fmt.Errorf("agent returned empty new DKIM public key")
-			}
-
-			// Persist new pubkey in domains row.
-			selector := "jabali" // EmailRecordsSelector — kept stable across rotations
-			if err := deps.Domains.UpdateEmailState(ctx, dom.ID, repository.DomainEmailState{
-				Enabled:       true,
-				DkimSelector:  &selector,
-				DkimPublicKey: &resp.NewDKIMPublicKey,
-			}); err != nil {
-				return fmt.Errorf("update domains row with new dkim_public_key: %w", err)
-			}
-
-			// Wipe old M6-managed DNS records + republish so the
-			// new DKIM TXT lands at jabali._domainkey.<domain>.
-			domainmailops.DeleteManagedDNSOnDisable(ctx, deps, dom.ID)
-			warnings := domainmailops.SyncManagedDNSOnEnable(ctx, deps, dom.ID, selector, resp.NewDKIMPublicKey)
 
 			if jsonOutput {
 				return printJSON(map[string]any{
 					"domain_name":         dom.Name,
-					"old_dkim_public_key": resp.OldDKIMPublicKey,
-					"new_dkim_public_key": resp.NewDKIMPublicKey,
-					"old_key_backup_path": resp.OldKeyBackupPath,
+					"old_dkim_public_key": res.OldDKIMPublicKey,
+					"new_dkim_public_key": res.NewDKIMPublicKey,
+					"old_key_backup_path": res.OldKeyBackupPath,
 					"warnings":            warnings,
 				})
 			}
 			cliAuditOK(ctx, "domain.email_dkim_rotate", "domain", dom.Name, &dom.UserID)
 			fmt.Printf("DKIM rotated for %s\n", dom.Name)
-			if resp.OldDKIMPublicKey != "" {
-				fmt.Printf("Old DKIM TXT: %s\n", resp.OldDKIMPublicKey)
+			if res.OldDKIMPublicKey != "" {
+				fmt.Printf("Old DKIM TXT: %s\n", res.OldDKIMPublicKey)
 			}
-			fmt.Printf("New DKIM TXT: %s\n", resp.NewDKIMPublicKey)
-			if resp.OldKeyBackupPath != "" {
-				fmt.Printf("Old key backup: %s (rm after DNS propagation confirmed)\n", resp.OldKeyBackupPath)
+			fmt.Printf("New DKIM TXT: %s\n", res.NewDKIMPublicKey)
+			if res.OldKeyBackupPath != "" {
+				fmt.Printf("Old key backup: %s (rm after DNS propagation confirmed)\n", res.OldKeyBackupPath)
 			}
 			for _, w := range warnings {
 				fmt.Printf("warning: %s\n", w)

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -28,6 +28,10 @@ type mockDomainRepo struct {
 	// DDNS path which walks a user's domains). Nil keeps the historical
 	// empty-return behaviour for tests that don't exercise ListByUserID.
 	listByUserResult []models.Domain
+	// emailStateErr, when set, is returned by UpdateEmailState — lets a test
+	// exercise the persistence-failure branch (e.g. the DKIM-rotate handler's
+	// 500 persist_failed mapping).
+	emailStateErr error
 }
 
 func newMockDomainRepo() *mockDomainRepo {
@@ -123,6 +127,9 @@ func (m *mockDomainRepo) SetSharedCertificate(context.Context, string, *string, 
 }
 
 func (m *mockDomainRepo) UpdateEmailState(ctx context.Context, id string, state repository.DomainEmailState) error {
+	if m.emailStateErr != nil {
+		return m.emailStateErr
+	}
 	d, ok := m.domains[id]
 	if !ok {
 		return repository.ErrNotFound

--- a/panel-api/internal/api/domain_email.go
+++ b/panel-api/internal/api/domain_email.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -107,48 +106,36 @@ func (h *domainEmailHandler) rotateDKIM(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
-	if !dom.EmailEnabled {
-		c.JSON(http.StatusConflict, gin.H{"error": "email_not_enabled", "detail": "enable email on this domain before rotating DKIM"})
-		return
-	}
-	if h.cfg.Agent == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unconfigured"})
-		return
-	}
-	raw, err := h.cfg.Agent.Call(ctx, "domain.email_dkim_rotate", map[string]any{"domain_name": dom.Name})
+	// The rotation lifecycle (email-enabled guard, agent call, new-key
+	// validation, persistence, wipe + republish of the M6-managed DNS) lives in
+	// internal/domainmailops (JAB-286); this handler only maps the typed result
+	// onto the REST contract. h.deps() wires the same DNS repos the enable path
+	// uses, and agentCall is nil when the agent is unconfigured (→ 503).
+	res, warnings, err := domainmailops.RotateDKIM(ctx, h.deps(), dom)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_rotate_failed", "detail": firstLineString(err.Error())})
+		switch {
+		case errors.Is(err, domainmailops.ErrEmailNotEnabled):
+			c.JSON(http.StatusConflict, gin.H{"error": "email_not_enabled", "detail": "enable email on this domain before rotating DKIM"})
+		case errors.Is(err, domainmailops.ErrAgentUnconfigured):
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unconfigured"})
+		case errors.Is(err, domainmailops.ErrAgentFailed):
+			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_rotate_failed", "detail": firstLineString(err.Error())})
+		case errors.Is(err, domainmailops.ErrAgentBadResponse):
+			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_bad_response", "detail": "agent returned no new DKIM key"})
+		case errors.Is(err, domainmailops.ErrPersistFailed):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "persist_failed", "detail": firstLineString(err.Error())})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
 		return
 	}
-	var resp struct {
-		OldDKIMPublicKey string `json:"old_dkim_public_key"`
-		NewDKIMPublicKey string `json:"new_dkim_public_key"`
-		OldKeyBackupPath string `json:"old_key_backup_path"`
-	}
-	if jerr := json.Unmarshal(raw, &resp); jerr != nil || resp.NewDKIMPublicKey == "" {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_bad_response", "detail": "agent returned no new DKIM key"})
-		return
-	}
-	selector := "jabali" // EmailRecordsSelector — stable across rotations
-	if uerr := h.cfg.Domains.UpdateEmailState(ctx, dom.ID, repository.DomainEmailState{
-		Enabled:       true,
-		DkimSelector:  &selector,
-		DkimPublicKey: &resp.NewDKIMPublicKey,
-	}); uerr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "persist_failed", "detail": firstLineString(uerr.Error())})
-		return
-	}
-	// Wipe the old M6-managed records + republish so the new DKIM TXT replaces
-	// the old one immediately (reconciler re-converges on its next tick too).
-	h.deleteEmailDNSOnDisable(ctx, dom.ID)
-	warnings := h.syncEmailDNSOnEnable(ctx, dom.ID, selector, resp.NewDKIMPublicKey)
 	c.JSON(http.StatusOK, gin.H{
 		"domain_id":           dom.ID,
 		"domain_name":         dom.Name,
-		"dkim_selector":       selector,
-		"old_dkim_public_key": resp.OldDKIMPublicKey,
-		"new_dkim_public_key": resp.NewDKIMPublicKey,
-		"old_key_backup_path": resp.OldKeyBackupPath,
+		"dkim_selector":       res.Selector,
+		"old_dkim_public_key": res.OldDKIMPublicKey,
+		"new_dkim_public_key": res.NewDKIMPublicKey,
+		"old_key_backup_path": res.OldKeyBackupPath,
 		"warnings":            warnings,
 	})
 }
@@ -317,25 +304,6 @@ func (h *domainEmailHandler) disable(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
-}
-
-// syncEmailDNSOnEnableInline is the free-function form of the M6 DNS
-// sync. Shared by the email-enable HTTP handler and the auto-enable
-// path in domain.create. Best-effort: returns a slice of human-
-// readable warning messages (conflicts, hard errors) for the UI to
-// surface. Never returns an error — the email_enable flip has already
-// succeeded by the time we get here, and the mailbox system stays
-// usable without the convenience records.
-// syncEmailDNSOnEnable + deleteEmailDNSOnDisable are thin method-form
-// wrappers so the DKIM-rotate path (which wipes then republishes) reads
-// naturally; the M6 DNS logic itself lives in internal/domainmailops so the
-// enable/disable and rotate paths share one implementation.
-func (h *domainEmailHandler) syncEmailDNSOnEnable(ctx context.Context, domainID, selector, dkimPub string) []string {
-	return domainmailops.SyncManagedDNSOnEnable(ctx, h.deps(), domainID, selector, dkimPub)
-}
-
-func (h *domainEmailHandler) deleteEmailDNSOnDisable(ctx context.Context, domainID string) {
-	domainmailops.DeleteManagedDNSOnDisable(ctx, h.deps(), domainID)
 }
 
 // buildHintsWithStatus projects the authoritative M6 record set onto

--- a/panel-api/internal/api/domain_email_test.go
+++ b/panel-api/internal/api/domain_email_test.go
@@ -522,3 +522,101 @@ func TestDomains_Create_AutoEnableFailureStillReturns201(t *testing.T) {
 	require.Nil(t, resp.DkimSelector, "no DKIM material when agent never ran")
 	require.Nil(t, resp.EmailEnabledAt, "email_enabled_at unset when agent never ran")
 }
+
+// --- DKIM rotation (JAB-286) — the rotate handler had no tests before the
+// lifecycle moved into internal/domainmailops; these pin the six-code error
+// contract + the 200 shape the module's typed results map onto. ---
+
+// dkimRotateRouter wires the domain-email routes with one pre-seeded domain
+// owned by user1. withAgent controls whether an agent is present (so the
+// nil-agent 503 path is reachable); emailEnabled seeds the rotate guard.
+func dkimRotateRouter(t *testing.T, ma *mockAgent, withAgent, emailEnabled bool) (*gin.Engine, *mockDomainRepo) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "user1", IsAdmin: false})
+		c.Next()
+	})
+	domains := newMockDomainRepo()
+	domains.domains["dom1"] = &models.Domain{ID: "dom1", UserID: "user1", Name: "example.com", EmailEnabled: emailEnabled}
+	cfg := DomainEmailHandlerConfig{Domains: domains}
+	if withAgent {
+		cfg.Agent = ma
+	}
+	RegisterDomainEmailRoutes(v1, cfg)
+	return r, domains
+}
+
+func doRotate(t *testing.T, r *gin.Engine) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/v1/domains/dom1/email/dkim-rotate", nil))
+	return w
+}
+
+func TestDomainEmail_RotateDKIM_Success(t *testing.T) {
+	ma := &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		require.Equal(t, "domain.email_dkim_rotate", cmd)
+		return json.RawMessage(`{"old_dkim_public_key":"p=OLD","new_dkim_public_key":"p=NEW","old_key_backup_path":"/etc/x.old"}`), nil
+	}}
+	r, _ := dkimRotateRouter(t, ma, true, true)
+	w := doRotate(t, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, "jabali", body["dkim_selector"])
+	require.Equal(t, "p=NEW", body["new_dkim_public_key"])
+	require.Equal(t, "p=OLD", body["old_dkim_public_key"])
+	require.Equal(t, "/etc/x.old", body["old_key_backup_path"])
+	require.Equal(t, 1, ma.callCount)
+}
+
+func TestDomainEmail_RotateDKIM_NotEnabled_409(t *testing.T) {
+	ma := &mockAgent{callFn: func(context.Context, string, any) (json.RawMessage, error) {
+		t.Fatal("agent must not be called when email is disabled")
+		return nil, nil
+	}}
+	r, _ := dkimRotateRouter(t, ma, true, false)
+	w := doRotate(t, r)
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Contains(t, w.Body.String(), "email_not_enabled")
+	require.Equal(t, 0, ma.callCount)
+}
+
+func TestDomainEmail_RotateDKIM_AgentUnconfigured_503(t *testing.T) {
+	r, _ := dkimRotateRouter(t, nil, false, true)
+	w := doRotate(t, r)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Contains(t, w.Body.String(), "agent_unconfigured")
+}
+
+func TestDomainEmail_RotateDKIM_AgentFailed_502(t *testing.T) {
+	ma := &mockAgent{callErr: errors.New("dial: connection refused")}
+	r, _ := dkimRotateRouter(t, ma, true, true)
+	w := doRotate(t, r)
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	require.Contains(t, w.Body.String(), "agent_rotate_failed")
+}
+
+func TestDomainEmail_RotateDKIM_BadResponse_502(t *testing.T) {
+	ma := &mockAgent{callFn: func(context.Context, string, any) (json.RawMessage, error) {
+		return json.RawMessage(`{"old_dkim_public_key":"p=OLD","new_dkim_public_key":""}`), nil
+	}}
+	r, _ := dkimRotateRouter(t, ma, true, true)
+	w := doRotate(t, r)
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	require.Contains(t, w.Body.String(), "agent_bad_response")
+}
+
+func TestDomainEmail_RotateDKIM_PersistFailed_500(t *testing.T) {
+	ma := &mockAgent{callFn: func(context.Context, string, any) (json.RawMessage, error) {
+		return json.RawMessage(`{"new_dkim_public_key":"p=NEW"}`), nil
+	}}
+	r, domains := dkimRotateRouter(t, ma, true, true)
+	domains.emailStateErr = errors.New("db down")
+	w := doRotate(t, r)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "persist_failed")
+}

--- a/panel-api/internal/domainmailops/domainmailops.go
+++ b/panel-api/internal/domainmailops/domainmailops.go
@@ -19,11 +19,16 @@
 // *models.Domain and mutates it in place on a successful enable so the caller
 // can echo the new state without re-fetching.
 //
+// RotateDKIM (JAB-286) shares the DKIM-rotation lifecycle the REST handler and
+// operator CLI both drove: agent domain.email_dkim_rotate → persist the new
+// public key → wipe + republish the M6-managed DNS.
+//
 // Not yet routed through here: the reconciler's per-tick provisioning
 // (internal/reconciler/panel_primary_dkim.go — ensurePanelPrimaryDKIM /
-// ensureTenantEmailEnabled), which carries its own reserved-TLD and
-// already-provisioned guards and a distinct panel-cert lineage. JAB-288 stays a
-// module-parent until that fourth caller is migrated.
+// ensureTenantEmailEnabled + its own managed-DNS convergence), which carries
+// its own reserved-TLD and already-provisioned guards and a distinct panel-cert
+// lineage. JAB-288 and JAB-286 stay module-parents until that fourth caller is
+// migrated.
 package domainmailops
 
 import (
@@ -45,6 +50,14 @@ import (
 // Ed25519 DKIM keypair — all fast. 30s is generous. Matches the value the REST
 // handler and reconciler used before extraction.
 const agentTimeout = 30 * time.Second
+
+// rotateTimeout bounds the agent budget for domain.email_dkim_rotate. Longer
+// than agentTimeout: rotation generates a fresh Ed25519 keypair, snapshots the
+// old private key to disk, and reloads Stalwart — heavier than a plain enable.
+// Matches the 60s the CLI already wrapped its rotate call in; the REST rotate
+// had no cap at all, so routing through here adds a benign upper bound on the
+// request path.
+const rotateTimeout = 60 * time.Second
 
 // CallFunc runs one agent command. Both adapters' agent callers already have
 // this exact signature (agent.AgentInterface.Call and the CLI's agentCaller),
@@ -82,6 +95,12 @@ var (
 	ErrAgentUnconfigured = errors.New("domainmailops: agent unconfigured")
 	ErrAgentFailed       = errors.New("domainmailops: agent call failed")
 	ErrAgentBadResponse  = errors.New("domainmailops: agent returned bad response")
+	// ErrEmailNotEnabled is returned by RotateDKIM when the domain has no
+	// email enabled — there is no existing key to rotate.
+	ErrEmailNotEnabled = errors.New("domainmailops: email not enabled")
+	// ErrPersistFailed wraps a repository failure while writing the rotated
+	// key, so the adapter can tell a persistence fault from an agent one.
+	ErrPersistFailed = errors.New("domainmailops: persist new dkim key failed")
 )
 
 // Enable runs the shared "flip email on for this domain" flow: invokes
@@ -190,6 +209,95 @@ func Disable(ctx context.Context, d Deps, dom *models.Domain) error {
 	dom.EmailEnabled = false
 	dom.EmailEnabledAt = nil
 	return nil
+}
+
+// RotateResult carries the agent's DKIM rotation output for the adapter to
+// echo. Selector is the stable "jabali" selector; the old public key + backup
+// path are informational (the operator removes the .old key after DNS
+// propagation).
+type RotateResult struct {
+	Selector         string
+	OldDKIMPublicKey string
+	NewDKIMPublicKey string
+	OldKeyBackupPath string
+}
+
+// RotateDKIM rotates the domain's DKIM keypair (ADR-0043 §"Rotation";
+// operator-driven, not automatic). The agent generates a fresh Ed25519 key,
+// snapshots the old private key, and reloads Stalwart; we persist the new
+// public key under the stable "jabali" selector, then wipe + republish the
+// M6-managed DNS so the new DKIM TXT replaces the old at
+// jabali._domainkey.<domain>. The reconciler re-converges on its next tick too,
+// so the immediate republish is a belt-and-suspenders UI refresh.
+//
+// Ordering mirrors Enable and is the whole point of the guard sequence: agent
+// first (a failed rotate or an incomplete response leaves the DB row and DNS
+// untouched — the last usable key stays authoritative), then persist, then
+// best-effort DNS. On nil err the passed dom is mutated (selector + public key)
+// so the caller can echo the new state without re-fetching.
+//
+// The persist step writes the domain's *existing* email_enabled_at back
+// unchanged: UpdateEmailState always assigns that column from the struct, so a
+// zero value would NULL it on every rotation even though email stays enabled.
+// Rotation is timestamp-neutral.
+//
+// Wrapped errors: ErrEmailNotEnabled, ErrAgentUnconfigured, ErrAgentFailed,
+// ErrAgentBadResponse, ErrPersistFailed. DNS conflict / missing-zone stay
+// best-effort []string warnings (same contract as Enable).
+func RotateDKIM(ctx context.Context, d Deps, dom *models.Domain) (RotateResult, []string, error) {
+	if !dom.EmailEnabled {
+		return RotateResult{}, nil, ErrEmailNotEnabled
+	}
+	if d.Call == nil {
+		return RotateResult{}, nil, ErrAgentUnconfigured
+	}
+	agentCtx, cancel := context.WithTimeout(ctx, rotateTimeout)
+	defer cancel()
+	raw, err := d.Call(agentCtx, "domain.email_dkim_rotate", map[string]any{
+		"domain_name": dom.Name,
+	})
+	if err != nil {
+		return RotateResult{}, nil, fmt.Errorf("%w: %v", ErrAgentFailed, err)
+	}
+	var resp struct {
+		OldDKIMPublicKey string `json:"old_dkim_public_key"`
+		NewDKIMPublicKey string `json:"new_dkim_public_key"`
+		OldKeyBackupPath string `json:"old_key_backup_path"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return RotateResult{}, nil, fmt.Errorf("%w: unmarshal: %v", ErrAgentBadResponse, err)
+	}
+	if resp.NewDKIMPublicKey == "" {
+		// Incomplete response — never overwrite the last usable key.
+		return RotateResult{}, nil, fmt.Errorf("%w: no new dkim public key", ErrAgentBadResponse)
+	}
+
+	selector := dnscompile.EmailRecordsSelector
+	pubKey := resp.NewDKIMPublicKey
+	if err := d.Domains.UpdateEmailState(ctx, dom.ID, repository.DomainEmailState{
+		Enabled:        true,
+		DkimSelector:   &selector,
+		DkimPublicKey:  &pubKey,
+		EmailEnabledAt: dom.EmailEnabledAt, // preserve — see doc comment
+	}); err != nil {
+		return RotateResult{}, nil, fmt.Errorf("%w: %v", ErrPersistFailed, err)
+	}
+
+	// Mutate caller's struct so the response reflects the rotated key.
+	dom.DkimSelector = &selector
+	dom.DkimPublicKey = &pubKey
+
+	// Wipe the old M6-managed records + republish so the new DKIM TXT replaces
+	// the old one immediately (reconciler re-converges on its next tick too).
+	DeleteManagedDNSOnDisable(ctx, d, dom.ID)
+	warnings := SyncManagedDNSOnEnable(ctx, d, dom.ID, selector, pubKey)
+
+	return RotateResult{
+		Selector:         selector,
+		OldDKIMPublicKey: resp.OldDKIMPublicKey,
+		NewDKIMPublicKey: pubKey,
+		OldKeyBackupPath: resp.OldKeyBackupPath,
+	}, warnings, nil
 }
 
 // SyncManagedDNSOnEnable publishes the M6 DNS record set (DKIM TXT, autoconfig/

--- a/panel-api/internal/domainmailops/domainmailops_test.go
+++ b/panel-api/internal/domainmailops/domainmailops_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -353,4 +355,154 @@ func TestDisable_UpdateStateError_NoDNSDelete(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "update email_enabled row")
 	require.False(t, records.deleted, "DNS cleanup only runs after the state flip persists")
+}
+
+// --- RotateDKIM (JAB-286) ---
+
+// rotateReply is a well-formed domain.email_dkim_rotate response.
+func rotateReply(newKey string) json.RawMessage {
+	return json.RawMessage(`{"old_dkim_public_key":"v=DKIM1; k=ed25519; p=OLD","new_dkim_public_key":"` +
+		newKey + `","old_key_backup_path":"/etc/jabali-panel/dkim/example.com.key.old"}`)
+}
+
+// enabledDomain is a domain with email already on and a known enabled-at
+// timestamp, so a rotation test can assert the timestamp is preserved.
+func enabledDomain() (*models.Domain, time.Time) {
+	at := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	d := newDomain()
+	d.EmailEnabled = true
+	d.EmailEnabledAt = &at
+	sel := "jabali"
+	old := "v=DKIM1; k=ed25519; p=OLD"
+	d.DkimSelector = &sel
+	d.DkimPublicKey = &old
+	return d, at
+}
+
+func TestRotateDKIM_HappyPath_PersistsPair_RepublishesDNS_PreservesEnabledAt(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	d.Call = func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		require.Equal(t, "domain.email_dkim_rotate", cmd)
+		return rotateReply("v=DKIM1; k=ed25519; p=NEW"), nil
+	}
+	dom, enabledAt := enabledDomain()
+
+	res, warnings, err := RotateDKIM(context.Background(), d, dom)
+	require.NoError(t, err)
+	require.Empty(t, warnings, "clean zone → no warnings")
+	require.Equal(t, "jabali", res.Selector)
+	require.Equal(t, "v=DKIM1; k=ed25519; p=NEW", res.NewDKIMPublicKey)
+	require.Equal(t, "v=DKIM1; k=ed25519; p=OLD", res.OldDKIMPublicKey)
+	require.Equal(t, "/etc/jabali-panel/dkim/example.com.key.old", res.OldKeyBackupPath)
+
+	// One selector/public-key pair persisted (AC1).
+	require.NotNil(t, domains.updated)
+	require.True(t, domains.updated.Enabled)
+	require.NotNil(t, domains.updated.DkimSelector)
+	require.Equal(t, "jabali", *domains.updated.DkimSelector)
+	require.NotNil(t, domains.updated.DkimPublicKey)
+	require.Equal(t, "v=DKIM1; k=ed25519; p=NEW", *domains.updated.DkimPublicKey)
+
+	// email_enabled_at preserved, not NULLed (the latent-bug fix).
+	require.NotNil(t, domains.updated.EmailEnabledAt)
+	require.Equal(t, enabledAt, *domains.updated.EmailEnabledAt)
+
+	// Old M6 records wiped, then the exact new pair republished (AC1).
+	require.True(t, records.deleted)
+	require.Equal(t, dnscompile.EmailRecordsManagedBy, records.deletedManagedBy)
+	require.GreaterOrEqual(t, m6Count(records.created), 1)
+	var sawDKIM bool
+	for _, r := range records.created {
+		if r.Type == "TXT" && strings.Contains(r.Name, "_domainkey") {
+			sawDKIM = true
+			require.Contains(t, r.Content, "p=NEW", "republished DKIM TXT must carry the NEW key")
+		}
+	}
+	require.True(t, sawDKIM, "a DKIM TXT record must be republished")
+
+	// Caller struct mutated so the adapter can echo without re-fetching.
+	require.NotNil(t, dom.DkimPublicKey)
+	require.Equal(t, "v=DKIM1; k=ed25519; p=NEW", *dom.DkimPublicKey)
+}
+
+func TestRotateDKIM_NotEnabled_NothingCalled(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	called := false
+	d.Call = func(context.Context, string, any) (json.RawMessage, error) { called = true; return nil, nil }
+	dom := newDomain() // EmailEnabled = false
+
+	_, _, err := RotateDKIM(context.Background(), d, dom)
+	require.ErrorIs(t, err, ErrEmailNotEnabled)
+	require.False(t, called, "agent must not be called for a mail-off domain")
+	require.Nil(t, domains.updated)
+	require.False(t, records.deleted)
+}
+
+func TestRotateDKIM_AgentUnconfigured_NoPersist(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	d.Call = nil
+	dom, _ := enabledDomain()
+
+	_, _, err := RotateDKIM(context.Background(), d, dom)
+	require.ErrorIs(t, err, ErrAgentUnconfigured)
+	require.Nil(t, domains.updated)
+	require.False(t, records.deleted)
+}
+
+func TestRotateDKIM_AgentFailed_NoPersist_NoWipe(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	d.Call = func(context.Context, string, any) (json.RawMessage, error) {
+		return nil, errors.New("dial: connection refused")
+	}
+	dom, _ := enabledDomain()
+
+	_, _, err := RotateDKIM(context.Background(), d, dom)
+	require.ErrorIs(t, err, ErrAgentFailed)
+	require.Contains(t, err.Error(), "connection refused")
+	require.Nil(t, domains.updated, "last usable key stays authoritative")
+	require.False(t, records.deleted, "no DNS wipe when the agent fails")
+}
+
+// AC2: an incomplete agent response (missing new key) must never overwrite the
+// last usable state — no persist, no DNS wipe.
+func TestRotateDKIM_EmptyNewKey_NoPersist_NoWipe(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	d.Call = func(context.Context, string, any) (json.RawMessage, error) {
+		return json.RawMessage(`{"old_dkim_public_key":"v=DKIM1; k=ed25519; p=OLD","new_dkim_public_key":""}`), nil
+	}
+	dom, _ := enabledDomain()
+
+	_, _, err := RotateDKIM(context.Background(), d, dom)
+	require.ErrorIs(t, err, ErrAgentBadResponse)
+	require.Nil(t, domains.updated, "empty new key must not overwrite the last usable key")
+	require.False(t, records.deleted, "and must not wipe DNS")
+}
+
+func TestRotateDKIM_Malformed_NoPersist(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	d.Call = func(context.Context, string, any) (json.RawMessage, error) {
+		return json.RawMessage(`not-json`), nil
+	}
+	dom, _ := enabledDomain()
+
+	_, _, err := RotateDKIM(context.Background(), d, dom)
+	require.ErrorIs(t, err, ErrAgentBadResponse)
+	require.Nil(t, domains.updated)
+	require.False(t, records.deleted)
+}
+
+// AC3: persistence failure is an explicit typed result, and the DNS wipe only
+// runs after the row persists.
+func TestRotateDKIM_PersistError_Typed_NoWipe(t *testing.T) {
+	domains, _, records, d := baseDeps()
+	domains.updateErr = errors.New("db down")
+	d.Call = func(context.Context, string, any) (json.RawMessage, error) {
+		return rotateReply("v=DKIM1; k=ed25519; p=NEW"), nil
+	}
+	dom, _ := enabledDomain()
+
+	_, _, err := RotateDKIM(context.Background(), d, dom)
+	require.ErrorIs(t, err, ErrPersistFailed)
+	require.Contains(t, err.Error(), "db down")
+	require.False(t, records.deleted, "DNS wipe only runs after the new key persists")
 }


### PR DESCRIPTION
## Summary

DKIM rotation (agent `domain.email_dkim_rotate` generates a fresh Ed25519 key +
snapshots the old → persist the new public key under the stable `jabali`
selector → wipe + republish the M6-managed DNS so the new key lands at
`jabali._domainkey.<domain>`) was implemented **twice, verbatim**: the REST
handler (`internal/api/domain_email.go`) and the operator CLI
(`cmd/server/domain_email_dkim_rotate_cmd.go`). The managed-DNS half was already
shared through `internal/domainmailops` (JAB-288); this folds the rotation core
in too.

## Design

`domainmailops.RotateDKIM(ctx, Deps, *Domain) (RotateResult, warnings, err)`,
routed by both adapters. It owns the guard order (email-enabled, then agent),
fail-closed validation (an incomplete agent response — missing new key — never
overwrites the last usable key or touches DNS), persistence, and the
wipe-then-republish; it mutates the passed `Domain` in place so the adapter can
echo the rotated key without re-fetching. Typed sentinels
(`ErrEmailNotEnabled` / `ErrAgentUnconfigured` / `ErrAgentFailed` /
`ErrAgentBadResponse` / `ErrPersistFailed`, `%w`-wrapped) let each adapter map a
failure onto its transport. Both copies' hardcoded `"jabali"` is replaced by
`dnscompile.EmailRecordsSelector`.

## Bug fix — rotation no longer clears `email_enabled_at`

`UpdateEmailState` always assigns that column from the `DomainEmailState`
struct. Both old rotate copies passed the zero value (nil `EmailEnabledAt`), so
**every DKIM rotation NULLed `email_enabled_at`** even though the domain stayed
enabled. `RotateDKIM` writes the domain's existing timestamp back — rotation is
timestamp-neutral. Pinned by the happy-path module test
(`require.Equal(enabledAt, *domains.updated.EmailEnabledAt)`). This is the one
change in the PR an operator would actually notice.

## REST wire — mostly preserved, three deltas (all disclosed)

- 200 body keeps all seven fields; the status contract is unchanged: **409**
  `email_not_enabled` → **503** `agent_unconfigured` → **502**
  `agent_rotate_failed` → **502** `agent_bad_response` → **500** `persist_failed`
  → **200**.
- Unlike enable/disable (which route through `respondAgentErr` and never echo
  the error string), rotate inlines `firstLineString(err.Error())` into two
  `detail` fields, so those two gain the module's package prefix:
  `agent_rotate_failed` detail → `domainmailops: agent call failed: <agent first
  line>`; `persist_failed` detail → `domainmailops: persist new dkim key failed:
  <repo first line>`. **Error codes and the `error` field are unchanged**; only
  the human `detail` carries the prefix (JAB-338 `domainmailpolicy` precedent).
  The `agent_bad_response` detail is a static string and does **not** change.
- Rotate gains a **60s agent-call cap** it lacked (it ran on the request ctx
  with no timeout). The CLI already wrapped its rotate in 60s. Benign; keygen +
  Stalwart reload justify a longer budget than enable/disable's 30s.

## CLI

Keeps its output, JSON keys, and audit row; `ErrEmailNotEnabled` keeps the
operator-friendly "run `email-enable` first" hint. Other failures now surface
the module's package-prefixed sentinels in place of the former `agent
domain.email_dkim_rotate: …` / `agent bad response: …` strings (same precedent).

## Scope (JAB-286 stays open — module-parent)

REST + CLI route through the module. The reconciler's periodic managed-DNS
convergence (`internal/reconciler/panel_primary_dkim.go` —
`syncPanelPrimaryEmailDNS`, with its own reserved-TLD / panel-cert-lineage
guards) is the **same fourth caller deferred in JAB-288**, so AC4 (periodic
convergence uses the shared implementation) and AC5 (all adapters + reconciler
share one matrix) are not fully met. Parent stays Backlog.

## Tests

`internal/domainmailops` carries the shared contract — happy path (persisted
selector/key pair == the pair republished to DNS, wipe-before-republish,
`email_enabled_at` preserved), the fail-closed empty-key path (no persist, no
DNS wipe — AC2), agent-failed / malformed / persist-error / not-enabled /
agent-unconfigured. **The REST rotate handler had zero tests before this** —
added the six-code error contract + 200 shape. A CLI source-pin keeps the
command routed through the module.

`go build ./...`, `go vet ./...`, full `go test ./...`, and `-race` on
`domainmailops` + `api` + `cmd/server` all green. Rebased on latest
`origin/main`. No agent verb, reconciler, or migration surface changed — no box
validation warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
