### PR TITLE
refactor(ssh-keys): shared sshkeyops lifecycle for REST + CLI (JAB-292)

### DIFF
--- a/panel-api/cmd/server/sshkey_cmd.go
+++ b/panel-api/cmd/server/sshkey_cmd.go
@@ -13,14 +13,27 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeyops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeys"
 )
 
 func sshKeyRepoFromDB() repository.SSHKeyRepository {
 	return repository.NewSSHKeyRepository(sharedDB)
+}
+
+// cliSSHKeyScheduler is the operator CLI's sshkeyops.Scheduler: a no-op. A
+// short-lived CLI process has no running reconciler to schedule, so
+// authorized_keys converge on the reconciler's next ≤60s tick (the add/delete
+// output tells the operator so). Wiring it explicitly keeps the required
+// Scheduler dependency intentional rather than a nil.
+type cliSSHKeyScheduler struct{}
+
+func (cliSSHKeyScheduler) ScheduleUser(string) {}
+
+func sshKeyOpsDeps() sshkeyops.Deps {
+	return sshkeyops.Deps{Keys: sshKeyRepoFromDB(), Scheduler: cliSSHKeyScheduler{}}
 }
 
 func newSSHKeyCmd() *cobra.Command {
@@ -110,35 +123,33 @@ func newSSHKeyAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			normalized, fingerprint, err := sshkeys.ParseAndFingerprint(raw)
+			// Validation, fingerprinting, dedup, persistence, and scheduling
+			// all live in internal/sshkeyops (ADR-0083), shared with the REST
+			// handler. The CLI keeps its operator-friendly error strings.
+			key, err := sshkeyops.Add(ctx, sshKeyOpsDeps(), sshkeyops.AddRequest{
+				UserID:    u.ID,
+				Name:      name,
+				PublicKey: raw,
+			})
 			if err != nil {
 				switch {
 				case errors.Is(err, sshkeys.ErrRSATooWeak):
 					return fmt.Errorf("RSA key below 2048 bits — generate a stronger key")
 				case errors.Is(err, sshkeys.ErrUnsupportedType):
 					return fmt.Errorf("unsupported key type — use ed25519, ecdsa, or RSA ≥2048")
-				default:
+				case errors.Is(err, sshkeys.ErrInvalidKeyFormat):
 					return fmt.Errorf("invalid public key format")
-				}
-			}
-			key := &models.SSHKey{
-				ID:          ids.NewULID(),
-				UserID:      u.ID,
-				Name:        name,
-				PublicKey:   normalized,
-				Fingerprint: fingerprint,
-			}
-			if err := sshKeyRepoFromDB().Create(ctx, key); err != nil {
-				if errors.Is(err, repository.ErrConflict) {
+				case errors.Is(err, sshkeyops.ErrDuplicate):
 					return fmt.Errorf("a key with this fingerprint already exists for this user")
+				default:
+					return fmt.Errorf("create key: %w", err)
 				}
-				return fmt.Errorf("create key: %w", err)
 			}
 			if jsonOutput {
 				return printJSON(key)
 			}
 			cliAuditOK(ctx, "sshkey.add", "ssh_key", key.ID, &u.ID)
-			fmt.Printf("Added SSH key %s (%s) for user %s\n  fingerprint: %s\n", key.ID, key.Name, derefStr(u.Username), fingerprint)
+			fmt.Printf("Added SSH key %s (%s) for user %s\n  fingerprint: %s\n", key.ID, key.Name, derefStr(u.Username), key.Fingerprint)
 			fmt.Println("Reconciler tick (≤60s) will write authorized_keys.")
 			return nil
 		},
@@ -164,10 +175,13 @@ func newSSHKeyDeleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
-			repo := sshKeyRepoFromDB()
-			k, err := repo.FindByID(ctx, args[0])
+			deps := sshKeyOpsDeps()
+			// Unscoped lookup (OwnerID empty) — the operator CLI deletes any
+			// user's key by ID; the shared owner-scope guard is for the REST
+			// caller. Fetch first so the confirmation prompt can show the key.
+			k, err := sshkeyops.Find(ctx, deps, sshkeyops.FindRequest{KeyID: args[0]})
 			if err != nil {
-				if errors.Is(err, repository.ErrNotFound) {
+				if errors.Is(err, sshkeyops.ErrNotFound) {
 					return fmt.Errorf("key %q not found", args[0])
 				}
 				return fmt.Errorf("lookup key: %w", err)
@@ -181,7 +195,7 @@ func newSSHKeyDeleteCmd() *cobra.Command {
 					return nil
 				}
 			}
-			if err := repo.Delete(ctx, k.ID); err != nil {
+			if err := sshkeyops.RemoveKey(ctx, deps, k); err != nil {
 				return fmt.Errorf("delete key: %w", err)
 			}
 			if jsonOutput {

--- a/panel-api/cmd/server/sshkey_cmd_pin_test.go
+++ b/panel-api/cmd/server/sshkey_cmd_pin_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSSHKeyCLI_RoutesThroughSharedModule pins the ssh-key add/delete commands
+// to internal/sshkeyops (ADR-0083, JAB-292): the former inline
+// ParseAndFingerprint + models.SSHKey construction + repo.Create/Delete copy is
+// gone, so validation and persistence can't drift from the REST handler.
+// cmd/server has no seeded-DB fixture, so this follows the repo's source-pin
+// precedent (domain_email_cmd_test.go, log_cmd_scope_test.go).
+func TestSSHKeyCLI_RoutesThroughSharedModule(t *testing.T) {
+	src, err := os.ReadFile("sshkey_cmd.go")
+	if err != nil {
+		t.Fatalf("read sshkey_cmd.go: %v", err)
+	}
+	s := string(src)
+	for _, want := range []string{"sshkeyops.Add(", "sshkeyops.RemoveKey(", "sshkeyops.Find("} {
+		if !strings.Contains(s, want) {
+			t.Errorf("ssh-key CLI must route through %s", want)
+		}
+	}
+	// The validation + fingerprinting must live in the shared module, not
+	// inline in the CLI (that is the drift ADR-0083 removes).
+	if strings.Contains(s, "ParseAndFingerprint(") {
+		t.Error("key validation/fingerprinting must live in sshkeyops, not inline in the CLI")
+	}
+}

--- a/panel-api/internal/api/ssh_keys.go
+++ b/panel-api/internal/api/ssh_keys.go
@@ -10,9 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeyops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeys"
 )
 
@@ -38,6 +37,38 @@ func RegisterSSHKeysRoutes(g *gin.RouterGroup, cfg SSHKeysHandlerConfig) {
 }
 
 type sshKeysHandler struct{ cfg SSHKeysHandlerConfig }
+
+// sshKeyScheduler adapts the handler's in-process reconciler to
+// sshkeyops.Scheduler. It preserves the pre-extraction convergence contract:
+// an async, detached 30s reconcile (a client disconnect must not cancel the
+// authorized_keys write), warn-logged on error. Nil reconciler → no-op.
+type sshKeyScheduler struct {
+	reconciler interface {
+		ReconcileSSHKeysForUser(ctx context.Context, userID string) error
+	}
+	logger *slog.Logger
+}
+
+func (s sshKeyScheduler) ScheduleUser(userID string) {
+	if s.reconciler == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.reconciler.ReconcileSSHKeysForUser(ctx, userID); err != nil && s.logger != nil {
+			s.logger.WarnContext(ctx, "ssh key: reconcile user", "user_id", userID, "error", err)
+		}
+	}()
+}
+
+// deps builds the shared-lifecycle dependencies for this request.
+func (h *sshKeysHandler) deps() sshkeyops.Deps {
+	return sshkeyops.Deps{
+		Keys:      h.cfg.SSHKeys,
+		Scheduler: sshKeyScheduler{reconciler: h.cfg.Reconciler, logger: h.cfg.Logger},
+	}
+}
 
 // createSSHKeyRequest is the body for POST /api/v1/ssh-keys.
 type createSSHKeyRequest struct {
@@ -76,62 +107,37 @@ func (h *sshKeysHandler) create(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-	userID := claims.UserID
 
-	// Validate and parse the public key
-	normalizedKey, fingerprint, err := sshkeys.ParseAndFingerprint(req.PublicKey)
+	// Validation, fingerprinting, duplicate detection, persistence, and the
+	// per-user reconcile schedule all live in internal/sshkeyops (ADR-0083);
+	// this handler maps the transport in and the typed result out. The
+	// scheduler adapter preserves the async, detached convergence behavior.
+	key, err := sshkeyops.Add(ctx, h.deps(), sshkeyops.AddRequest{
+		UserID:    claims.UserID,
+		Name:      req.Name,
+		PublicKey: req.PublicKey,
+	})
 	if err != nil {
-		if errors.Is(err, sshkeys.ErrInvalidKeyFormat) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_key"})
-			return
-		}
-		if errors.Is(err, sshkeys.ErrRSATooWeak) {
+		switch {
+		case errors.Is(err, sshkeys.ErrRSATooWeak):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "rsa_too_weak"})
-			return
-		}
-		if errors.Is(err, sshkeys.ErrUnsupportedType) {
+		case errors.Is(err, sshkeys.ErrUnsupportedType):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported_key_type"})
-			return
-		}
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_key"})
-		return
-	}
-
-	// Create the SSH key
-	key := &models.SSHKey{
-		ID:          ids.NewULID(),
-		UserID:      userID,
-		Name:        req.Name,
-		PublicKey:   normalizedKey,
-		Fingerprint: fingerprint,
-	}
-
-	if err := h.cfg.SSHKeys.Create(ctx, key); err != nil {
-		if errors.Is(err, repository.ErrConflict) {
+		case errors.Is(err, sshkeys.ErrInvalidKeyFormat):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_key"})
+		case errors.Is(err, sshkeyops.ErrDuplicate):
 			c.JSON(http.StatusConflict, gin.H{"error": "duplicate_key"})
-			return
+		default:
+			h.cfg.Logger.ErrorContext(ctx, "create ssh key: store key", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed_to_store_key"})
 		}
-		h.cfg.Logger.ErrorContext(ctx, "create ssh key: store key", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed_to_store_key"})
 		return
-	}
-
-	// Trigger per-user SSH keys reconciliation asynchronously
-	if h.cfg.Reconciler != nil {
-		go func() {
-			reconcileCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if err := h.cfg.Reconciler.ReconcileSSHKeysForUser(reconcileCtx, userID); err != nil {
-				h.cfg.Logger.WarnContext(reconcileCtx, "create ssh key: reconcile user",
-					"user_id", userID, "key_id", key.ID, "error", err)
-			}
-		}()
 	}
 
 	c.JSON(http.StatusCreated, sshKeyResponse{
 		ID:          key.ID,
 		Name:        key.Name,
-		Fingerprint: fingerprint,
+		Fingerprint: key.Fingerprint,
 		CreatedAt:   key.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	})
 }
@@ -183,10 +189,13 @@ func (h *sshKeysHandler) delete(c *gin.Context) {
 	userID := claims.UserID
 	keyID := c.Param("id")
 
-	// Verify ownership
-	_, err := h.cfg.SSHKeys.FindByIDAndUserID(ctx, keyID, userID)
+	// Owner-scoped lookup (ErrNotFound collapses missing + not-owned so a
+	// caller can't probe another user's key IDs), then delete + schedule the
+	// per-user reconcile — both in internal/sshkeyops (ADR-0083). The two-step
+	// keeps the handler's distinct 404 / verify-500 / delete-500 codes.
+	key, err := sshkeyops.Find(ctx, h.deps(), sshkeyops.FindRequest{KeyID: keyID, OwnerID: userID})
 	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
+		if errors.Is(err, sshkeyops.ErrNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "key_not_found"})
 			return
 		}
@@ -196,24 +205,11 @@ func (h *sshKeysHandler) delete(c *gin.Context) {
 		return
 	}
 
-	// Delete the key
-	if err := h.cfg.SSHKeys.Delete(ctx, keyID); err != nil {
+	if err := sshkeyops.RemoveKey(ctx, h.deps(), key); err != nil {
 		h.cfg.Logger.ErrorContext(ctx, "delete ssh key: delete key",
 			"key_id", keyID, "user_id", userID, "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed_to_delete_key"})
 		return
-	}
-
-	// Trigger per-user SSH keys reconciliation asynchronously
-	if h.cfg.Reconciler != nil {
-		go func() {
-			reconcileCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if err := h.cfg.Reconciler.ReconcileSSHKeysForUser(reconcileCtx, userID); err != nil {
-				h.cfg.Logger.WarnContext(reconcileCtx, "delete ssh key: reconcile user",
-					"user_id", userID, "key_id", keyID, "error", err)
-			}
-		}()
 	}
 
 	c.Status(http.StatusNoContent)

--- a/panel-api/internal/api/ssh_keys_http_test.go
+++ b/panel-api/internal/api/ssh_keys_http_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// validSSHKey is a real ed25519 authorized-keys line (the handler actually
+// parses + fingerprints it via internal/sshkeys).
+const validSSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINhDTlDCUJiIIWOejraVqB0FPMRzhFUhtt7Ih0tnPAPs test@jabali"
+
+// sshKeyHTTPRouter wires the ssh-keys routes with claims for userID. These are
+// the first real HTTP-level tests of the handler (JAB-292); the pre-existing
+// ssh_keys_test.go cases were stubs that never exercised the routes.
+//
+// The scheduler fires an async reconcile goroutine; these tests deliberately do
+// not assert its callCount (that would race the goroutine's write). Schedule-
+// once is proven synchronously in sshkeyops_test.go. If you ever assert the
+// reconcile call here, add a WaitGroup/channel — don't read callCount directly.
+func sshKeyHTTPRouter(repo *mockSSHKeyRepository, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID})
+		c.Next()
+	})
+	RegisterSSHKeysRoutes(v1, SSHKeysHandlerConfig{
+		SSHKeys:    repo,
+		Reconciler: &mockSSHKeyReconciler{},
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	return r
+}
+
+func sshRaw(r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestSSHKeysHTTP_Create_HappyPath_201(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{}}
+	r := sshKeyHTTPRouter(repo, "user1")
+
+	w := sshRaw(r, http.MethodPost, "/api/v1/ssh-keys",
+		`{"name":"laptop","public_key":"`+validSSHKey+`"}`)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotEmpty(t, body["id"])
+	require.Equal(t, "laptop", body["name"])
+	require.NotEmpty(t, body["fingerprint"])
+	require.Len(t, repo.keys, 1, "row persisted")
+}
+
+func TestSSHKeysHTTP_Create_InvalidKey_400(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{}}
+	r := sshKeyHTTPRouter(repo, "user1")
+
+	w := sshRaw(r, http.MethodPost, "/api/v1/ssh-keys", `{"name":"x","public_key":"not a key"}`)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid_key")
+	require.Empty(t, repo.keys)
+}
+
+func TestSSHKeysHTTP_Create_MissingPublicKey_400(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{}}
+	r := sshKeyHTTPRouter(repo, "user1")
+
+	w := sshRaw(r, http.MethodPost, "/api/v1/ssh-keys", `{"name":"x"}`)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid_body")
+}
+
+func TestSSHKeysHTTP_Create_Duplicate_409(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{}}
+	r := sshKeyHTTPRouter(repo, "user1")
+	body := `{"name":"laptop","public_key":"` + validSSHKey + `"}`
+
+	require.Equal(t, http.StatusCreated, sshRaw(r, http.MethodPost, "/api/v1/ssh-keys", body).Code)
+	w := sshRaw(r, http.MethodPost, "/api/v1/ssh-keys", body)
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Contains(t, w.Body.String(), "duplicate_key")
+}
+
+func TestSSHKeysHTTP_Delete_Owned_204(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{
+		"k1": {ID: "k1", UserID: "user1", Name: "laptop", Fingerprint: "fp"},
+	}}
+	r := sshKeyHTTPRouter(repo, "user1")
+
+	w := sshRaw(r, http.MethodDelete, "/api/v1/ssh-keys/k1", "")
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Empty(t, repo.keys, "key deleted")
+}
+
+func TestSSHKeysHTTP_Delete_NotFound_404(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{}}
+	r := sshKeyHTTPRouter(repo, "user1")
+
+	w := sshRaw(r, http.MethodDelete, "/api/v1/ssh-keys/nope", "")
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "key_not_found")
+}
+
+// Owner scoping: user1 must not be able to delete user2's key — 404, and the
+// row survives (ErrNotFound collapses missing + not-owned).
+func TestSSHKeysHTTP_Delete_OtherUsersKey_404(t *testing.T) {
+	repo := &mockSSHKeyRepository{keys: map[string]*models.SSHKey{
+		"k2": {ID: "k2", UserID: "user2", Name: "theirs", Fingerprint: "fp2"},
+	}}
+	r := sshKeyHTTPRouter(repo, "user1")
+
+	w := sshRaw(r, http.MethodDelete, "/api/v1/ssh-keys/k2", "")
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "key_not_found")
+	require.Len(t, repo.keys, 1, "another user's key must survive")
+}

--- a/panel-api/internal/sshkeyops/sshkeyops.go
+++ b/panel-api/internal/sshkeyops/sshkeyops.go
@@ -1,0 +1,142 @@
+// Package sshkeyops is the shared SSH-key lifecycle (ADR-0083, JAB-292): one
+// implementation of key normalization + strength/type validation (via
+// internal/sshkeys), fingerprinting, duplicate detection, persistence,
+// owner-scoped deletion, and per-user convergence scheduling — that the REST
+// handler (internal/api/ssh_keys.go) and the operator CLI
+// (cmd/server/sshkey_cmd.go) both route through, so validation and persistence
+// can't drift between them. ADR-0083 named this package as promised-but-unbuilt
+// alongside dbops/cronops.
+//
+// Per ADR-0083 the module is transport-agnostic: no net/http, no cobra, no
+// os.Exit. Convergence is fire-and-forget through the Scheduler interface (the
+// REST adapter wraps the in-process reconciler's async, detached
+// ReconcileSSHKeysForUser; the CLI wraps a no-op because a short-lived CLI
+// process has no running reconciler — its authorized_keys land on the
+// reconciler's next ≤60s tick). Keeping scheduling behind the interface makes
+// it the single coalescing point a future restore-batch slice can reuse.
+//
+// Not yet routed through here: the restore paths that still write ssh_keys rows
+// directly (internal/backupmetadata/apply.go, internal/migrate/cpanel/
+// restore_sshkeys.go). JAB-292 stays a module-parent until those use an explicit
+// restore operation that batches scheduling per owner (AC4).
+package sshkeyops
+
+import (
+	"context"
+	"errors"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeys"
+)
+
+// Scheduler requests per-user authorized_keys convergence after a successful
+// mutation. Fire-and-forget: implementations must not block the caller (the
+// REST adapter dispatches an async, detached reconcile; the CLI is a no-op).
+// Declared here rather than importing the reconciler so this neutral module has
+// no dependency on the reconciler or api packages.
+type Scheduler interface {
+	ScheduleUser(userID string)
+}
+
+// Deps is the collaborator set the lifecycle needs. Scheduler is required —
+// both adapters wire one (the CLI a no-op); the nil guard is defensive so a
+// mis-wired caller degrades to "no immediate convergence" rather than panicking.
+type Deps struct {
+	Keys      repository.SSHKeyRepository
+	Scheduler Scheduler
+}
+
+var (
+	// ErrDuplicate wraps repository.ErrConflict: a key with the same
+	// fingerprint already exists for the owner.
+	ErrDuplicate = errors.New("sshkeyops: duplicate key")
+	// ErrNotFound covers both "no such key" and "not owned by the caller" —
+	// deliberately indistinguishable so an owner-scoped delete can't probe
+	// another user's key IDs.
+	ErrNotFound = errors.New("sshkeyops: key not found")
+)
+
+// AddRequest is the input to Add.
+type AddRequest struct {
+	UserID    string
+	Name      string
+	PublicKey string
+}
+
+// Add validates + fingerprints the public key, persists it, and schedules a
+// per-user reconcile. Validation errors are the internal/sshkeys sentinels
+// (ErrInvalidKeyFormat / ErrRSATooWeak / ErrUnsupportedType), returned as-is so
+// both adapters map them to their transport without re-declaring the taxonomy.
+// A repository conflict becomes ErrDuplicate. Scheduling happens only after the
+// row persists — a failed persist schedules nothing.
+func Add(ctx context.Context, d Deps, req AddRequest) (*models.SSHKey, error) {
+	normalized, fingerprint, err := sshkeys.ParseAndFingerprint(req.PublicKey)
+	if err != nil {
+		return nil, err // sshkeys.Err* sentinel, unwrapped for errors.Is
+	}
+	key := &models.SSHKey{
+		ID:          ids.NewULID(),
+		UserID:      req.UserID,
+		Name:        req.Name,
+		PublicKey:   normalized,
+		Fingerprint: fingerprint,
+	}
+	if err := d.Keys.Create(ctx, key); err != nil {
+		if errors.Is(err, repository.ErrConflict) {
+			return nil, ErrDuplicate
+		}
+		return nil, err
+	}
+	d.schedule(key.UserID)
+	return key, nil
+}
+
+// FindRequest identifies a key, optionally owner-scoped. When OwnerID is
+// non-empty the lookup is scoped to that owner (the REST path passes the
+// caller's ID); empty means unscoped/admin (the operator CLI).
+type FindRequest struct {
+	KeyID   string
+	OwnerID string
+}
+
+// Find looks up a key with FindRequest's owner-scope rules without deleting it,
+// so an adapter can render a confirmation prompt or a delete's 404/500 split.
+// ErrNotFound covers both missing and not-owned.
+func Find(ctx context.Context, d Deps, req FindRequest) (*models.SSHKey, error) {
+	var (
+		key *models.SSHKey
+		err error
+	)
+	if req.OwnerID != "" {
+		key, err = d.Keys.FindByIDAndUserID(ctx, req.KeyID, req.OwnerID)
+	} else {
+		key, err = d.Keys.FindByID(ctx, req.KeyID)
+	}
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return key, nil
+}
+
+// RemoveKey deletes an already-found key and schedules a reconcile for the
+// key's owner (not the caller). Takes the row from Find so an adapter that
+// needs it for a prompt or an error split doesn't look it up twice. A failed
+// delete schedules nothing.
+func RemoveKey(ctx context.Context, d Deps, key *models.SSHKey) error {
+	if err := d.Keys.Delete(ctx, key.ID); err != nil {
+		return err
+	}
+	d.schedule(key.UserID)
+	return nil
+}
+
+func (d Deps) schedule(userID string) {
+	if d.Scheduler != nil {
+		d.Scheduler.ScheduleUser(userID)
+	}
+}

--- a/panel-api/internal/sshkeyops/sshkeyops_test.go
+++ b/panel-api/internal/sshkeyops/sshkeyops_test.go
@@ -1,0 +1,173 @@
+package sshkeyops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeys"
+)
+
+// A valid ed25519 authorized-keys line (ParseAndFingerprint really parses it).
+const validKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINhDTlDCUJiIIWOejraVqB0FPMRzhFUhtt7Ih0tnPAPs test@jabali"
+
+// The fake embeds the repository interface and overrides only the methods the
+// lifecycle touches; an un-overridden method panics on the nil embed (same
+// precedent as domainmailops / dirprivops fakes).
+type fakeKeyRepo struct {
+	repository.SSHKeyRepository
+	createErr  error
+	created    *models.SSHKey
+	findByID   *models.SSHKey
+	findScoped *models.SSHKey
+	findErr    error
+	deleteErr  error
+	deletedID  string
+}
+
+func (f *fakeKeyRepo) Create(_ context.Context, k *models.SSHKey) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created = k
+	return nil
+}
+
+func (f *fakeKeyRepo) FindByID(_ context.Context, _ string) (*models.SSHKey, error) {
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
+	return f.findByID, nil
+}
+
+func (f *fakeKeyRepo) FindByIDAndUserID(_ context.Context, _, _ string) (*models.SSHKey, error) {
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
+	return f.findScoped, nil
+}
+
+func (f *fakeKeyRepo) Delete(_ context.Context, id string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deletedID = id
+	return nil
+}
+
+type fakeSched struct{ users []string }
+
+func (f *fakeSched) ScheduleUser(u string) { f.users = append(f.users, u) }
+
+func deps(repo *fakeKeyRepo, sched Scheduler) Deps { return Deps{Keys: repo, Scheduler: sched} }
+
+func TestAdd_HappyPath_PersistsAndSchedulesOnce(t *testing.T) {
+	repo := &fakeKeyRepo{}
+	sched := &fakeSched{}
+
+	key, err := Add(context.Background(), deps(repo, sched), AddRequest{
+		UserID: "user1", Name: "laptop", PublicKey: validKey,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	require.Equal(t, "user1", key.UserID)
+	require.NotEmpty(t, key.ID, "ULID assigned")
+	require.NotEmpty(t, key.Fingerprint, "fingerprint computed")
+	require.Contains(t, key.PublicKey, "ssh-ed25519", "normalized key stored")
+
+	require.NotNil(t, repo.created, "row persisted")
+	require.Equal(t, []string{"user1"}, sched.users, "convergence scheduled exactly once for the owner")
+}
+
+func TestAdd_InvalidKey_NoPersist_NoSchedule(t *testing.T) {
+	repo := &fakeKeyRepo{}
+	sched := &fakeSched{}
+
+	_, err := Add(context.Background(), deps(repo, sched), AddRequest{
+		UserID: "user1", Name: "bad", PublicKey: "not a real key",
+	})
+	require.ErrorIs(t, err, sshkeys.ErrInvalidKeyFormat, "validation sentinel passed through unwrapped")
+	require.Nil(t, repo.created, "no row on a validation failure")
+	require.Empty(t, sched.users, "nothing scheduled on a validation failure")
+}
+
+func TestAdd_Duplicate_MapsConflict_NoSchedule(t *testing.T) {
+	repo := &fakeKeyRepo{createErr: repository.ErrConflict}
+	sched := &fakeSched{}
+
+	_, err := Add(context.Background(), deps(repo, sched), AddRequest{
+		UserID: "user1", Name: "dup", PublicKey: validKey,
+	})
+	require.ErrorIs(t, err, ErrDuplicate)
+	require.Empty(t, sched.users, "a rejected persist schedules nothing")
+}
+
+func TestAdd_CreateError_Passthrough_NoSchedule(t *testing.T) {
+	repo := &fakeKeyRepo{createErr: errors.New("db down")}
+	sched := &fakeSched{}
+
+	_, err := Add(context.Background(), deps(repo, sched), AddRequest{
+		UserID: "user1", Name: "x", PublicKey: validKey,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrDuplicate, "a non-conflict store error is not a duplicate")
+	require.Contains(t, err.Error(), "db down")
+	require.Empty(t, sched.users)
+}
+
+func TestAdd_NilScheduler_NoPanic(t *testing.T) {
+	repo := &fakeKeyRepo{}
+	key, err := Add(context.Background(), deps(repo, nil), AddRequest{
+		UserID: "user1", Name: "laptop", PublicKey: validKey,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, key)
+}
+
+func TestFind_OwnerScoped_UsesScopedLookup(t *testing.T) {
+	repo := &fakeKeyRepo{
+		findByID:   &models.SSHKey{ID: "unscoped"},
+		findScoped: &models.SSHKey{ID: "scoped"},
+	}
+	// OwnerID set → FindByIDAndUserID (returns the scoped row).
+	k, err := Find(context.Background(), deps(repo, nil), FindRequest{KeyID: "k1", OwnerID: "user1"})
+	require.NoError(t, err)
+	require.Equal(t, "scoped", k.ID)
+
+	// OwnerID empty → FindByID (returns the unscoped row).
+	k, err = Find(context.Background(), deps(repo, nil), FindRequest{KeyID: "k1"})
+	require.NoError(t, err)
+	require.Equal(t, "unscoped", k.ID)
+}
+
+func TestFind_NotFound_Collapsed(t *testing.T) {
+	repo := &fakeKeyRepo{findErr: repository.ErrNotFound}
+	// Both missing and not-owned collapse to ErrNotFound (no existence probe).
+	_, err := Find(context.Background(), deps(repo, nil), FindRequest{KeyID: "k1", OwnerID: "user1"})
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = Find(context.Background(), deps(repo, nil), FindRequest{KeyID: "k1"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestRemoveKey_DeletesAndSchedulesForOwner(t *testing.T) {
+	repo := &fakeKeyRepo{}
+	sched := &fakeSched{}
+	key := &models.SSHKey{ID: "k1", UserID: "owner9"}
+
+	err := RemoveKey(context.Background(), deps(repo, sched), key)
+	require.NoError(t, err)
+	require.Equal(t, "k1", repo.deletedID)
+	require.Equal(t, []string{"owner9"}, sched.users, "scheduled for the key's owner, not the caller")
+}
+
+func TestRemoveKey_DeleteError_NoSchedule(t *testing.T) {
+	repo := &fakeKeyRepo{deleteErr: errors.New("db down")}
+	sched := &fakeSched{}
+	err := RemoveKey(context.Background(), deps(repo, sched), &models.SSHKey{ID: "k1", UserID: "owner9"})
+	require.Error(t, err)
+	require.Empty(t, sched.users, "a failed delete schedules nothing")
+}


### PR DESCRIPTION
## Summary

Extracts the SSH-key add/delete lifecycle — shared until now only by two
verbatim copies in the REST handler (`internal/api/ssh_keys.go`) and the
operator CLI (`cmd/server/sshkey_cmd.go`) — into a neutral
`internal/sshkeyops` package, following the JAB-288 / JAB-286 pattern and
ADR-0083 (which named `sshkeyops` as promised-but-unbuilt alongside
`dbops` / `cronops`). The two adapters can no longer drift on validation,
duplicate detection, owner-scoping, or persistence.

`sshkeyops` is transport-agnostic (no `net/http`, no cobra, no `os.Exit`).
Per-user `authorized_keys` convergence is fire-and-forget through a small
`Scheduler` interface the module declares itself, so it takes no dependency
on the reconciler or `api` packages:

- **REST** wires an adapter that preserves the pre-extraction behavior
  exactly: an async, detached 30s `ReconcileSSHKeysForUser` (a client
  disconnect must not cancel the `authorized_keys` write), warn-logged on
  error.
- **CLI** wires a no-op: a short-lived CLI process has no running
  reconciler, so keys land on the reconciler's next ≤60s tick (the
  add/delete output already tells the operator so). Behavior unchanged.

Typed sentinels (`ErrDuplicate`, `ErrNotFound`) plus the existing
`internal/sshkeys` validation sentinels (`ErrInvalidKeyFormat` /
`ErrRSATooWeak` / `ErrUnsupportedType`, returned unwrapped) are the single
source both adapters map onto their own wire. `ErrNotFound` deliberately
collapses *missing* + *not-owned* so an owner-scoped delete can't probe
another user's key IDs.

## Behavior preserved

- **REST status contract unchanged:** create → 400 `rsa_too_weak` / 400
  `unsupported_key_type` / 400 `invalid_key` / 409 `duplicate_key` / 500
  `failed_to_store_key`; delete → 404 `key_not_found` / 500
  `failed_to_verify_ownership` / 500 `failed_to_delete_key` / 204.
- **CLI operator-facing error strings unchanged** (RSA-too-weak,
  unsupported-type, invalid-format, duplicate-fingerprint).

## Notes for reviewers

- `SSHKeysHandlerConfig.Reconciler` keeps its inline interface type
  unchanged — `app.go` wiring and `fakeLimitsReconciler` are untouched
  (zero blast radius).
- REST create's old `default → 400 invalid_key` fallback was **dead**
  (`ParseAndFingerprint` only ever returns the three named sentinels); the
  new `default → 500 failed_to_store_key` is the store-error path and is
  behavior-identical for validation errors.
- The reconcile warn-log line changed from `"create/delete ssh key:
  reconcile user"` (with a `key_id` field) to `"ssh key: reconcile user"`
  (`user_id` only) — the `Scheduler` interface carries only `userID`.
  **Log-only, not wire.** The nil-logger guard added on that line is inert
  in production (`Logger` is always wired).

## Not in this slice (module-parent stays open)

- **Restore paths** that still write `ssh_keys` rows directly
  (`internal/backupmetadata/apply.go`,
  `internal/migrate/cpanel/restore_sshkeys.go`) are **not** yet routed
  through `sshkeyops`. The `Scheduler` interface is the coalescing point a
  future restore-batch slice will reuse.
- The CLI's tick-based convergence (no-op scheduler) is unchanged; a
  reconciler-backed CLI scheduler is future work.

JAB-292 therefore stays a **module-parent** (Backlog) after this merge.

## Test plan

- [x] `internal/sshkeyops` unit matrix — validation-sentinel passthrough,
      duplicate → `ErrDuplicate`, owner-scope collapse to `ErrNotFound`,
      schedule-once-on-success / schedule-nothing-on-failure, nil scheduler.
- [x] **First real HTTP-level tests** of the ssh-keys handler
      (`ssh_keys_http_test.go`) — create 201/400/400/409, delete
      204/404/404-owner-scoping. The prior `ssh_keys_test.go` cases were
      stubs that never exercised the routes.
- [x] CLI pin — asserts both adapters route through `sshkeyops.Add` /
      `Find` / `RemoveKey` and no longer call `ParseAndFingerprint`
      directly.
- [x] `go build ./...`, `go vet ./...`, full `go test ./...`, gofmt clean
      on changed files, `-race` on the three affected packages.
- [x] Rebased onto latest `origin/main`, re-ran tests post-rebase.
- No box validation warranted: no agent verb, reconciler behavior, or
  migration changed; REST convergence preserved via the scheduler adapter;
  CLI behavior byte-preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
