### PR TITLE
refactor(settings): shared settingsops validation + nginx EffectPlan (JAB-290)

### DIFF
--- a/panel-api/cmd/server/settings_cmd.go
+++ b/panel-api/cmd/server/settings_cmd.go
@@ -1,13 +1,14 @@
 // `jabali settings get|set` (Gitea #539): a root-only CLI surface for
 // inspecting and patching server settings without a browser session or raw
-// SQL. Validation reuses api.ValidateServerSettings — the exact rules the REST
-// PATCH applies. Side effects (postgres/docker/python installs, nginx reload)
-// are dispatched SYNCHRONOUSLY here (unlike the REST handler's background
-// goroutines) so the operator sees success/failure inline; the agent's own
-// `nginx -t` gate is the second validation layer for nginx tunables. The
-// side-effect dispatch is duplicated from the REST handler, not shared — the
-// handler's gin/goroutine coupling makes extraction impractical, so this is a
-// known drift point. Mutations are CLI-audited as actor_kind=cli (#537).
+// SQL. Validation reuses settingsops.Validate and the nginx side effect reuses
+// settingsops.NginxEffects — the exact rules and agent wire the REST PATCH
+// applies (JAB-290). Side effects (postgres/docker/python installs, nginx
+// reload) are dispatched SYNCHRONOUSLY here (unlike the REST handler's
+// background goroutines) so the operator sees success/failure inline; the
+// agent's own `nginx -t` gate is the second validation layer for nginx
+// tunables. The remaining side effects (hostname/postgres/docker/python) are
+// still mirrored from the REST handler rather than shared — JAB-294 folds those
+// into settingsops. Mutations are CLI-audited as actor_kind=cli (#537).
 package main
 
 import (
@@ -21,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/settingsops"
 )
 
 func newSettingsCmd() *cobra.Command {
@@ -112,8 +113,10 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load settings: %w", err)
 	}
 
-	// Snapshot the fields whose change drives a host side effect.
+	// Snapshot the fields whose change drives a host side effect, plus a full
+	// pre-mutation copy so settingsops can classify the nginx effect.
 	prev := sideEffectSnapshot(s)
+	before := *s
 
 	// Apply each key=value. Unknown key / bad value → hard error (criterion #4).
 	for _, arg := range args {
@@ -131,8 +134,8 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Same validation the REST PATCH runs.
-	if err := api.ValidateServerSettings(s); err != nil {
+	// Same validation the REST PATCH runs (settingsops owns it — JAB-290).
+	if err := settingsops.Validate(s); err != nil {
 		return fmt.Errorf("invalid settings: %w", err)
 	}
 
@@ -148,7 +151,7 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 	// Side effects, synchronous, in the REST order. A failure here means the DB
 	// is updated but the host apply failed — report it explicitly (no silent
 	// drift) and exit non-zero.
-	if applyErr := applySettingsSideEffects(ctx, cmd, repo, s, prev); applyErr != nil {
+	if applyErr := applySettingsSideEffects(ctx, cmd, repo, s, before, prev); applyErr != nil {
 		cliAuditErr(ctx, "server_settings.update", "server_settings", "1", nil)
 		return applyErr
 	}
@@ -184,7 +187,7 @@ func sideEffectSnapshot(s *models.ServerSettings) sideEffectState {
 // applySettingsSideEffects dispatches the agent calls the REST PATCH would,
 // synchronously, with the REST per-operation timeouts. Returns the first
 // failure (the DB is already persisted at this point).
-func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repository.ServerSettingsRepository, s *models.ServerSettings, prev sideEffectState) error {
+func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repository.ServerSettingsRepository, s *models.ServerSettings, before models.ServerSettings, prev sideEffectState) error {
 	out := cmd.OutOrStdout()
 
 	// Hostname → apply to the OS. Mirrors the REST PATCH, which dispatches
@@ -246,27 +249,26 @@ func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repo
 		}
 	}
 
-	if nginxDirty {
+	// nginx tunables. settingsops owns the wire (method/params/timeout), shared
+	// with the REST PATCH (JAB-290). The CLI has no cache-capacity setters, so
+	// Cache stays false; nginxDirty is the touched signal. Dispatch is
+	// synchronous (unlike REST's best-effort goroutine) so the operator sees the
+	// result inline — the CLI's execution policy stays in this adapter.
+	plan := settingsops.NginxEffects(&before, s, settingsops.NginxTouched{Tunables: nginxDirty})
+	if call := plan.Tunables.Call; call != nil {
 		fmt.Fprintln(out, "Applying nginx tunables (validated with nginx -t)…")
-		if err := callAgentTimeout(ctx, 60*time.Second, "nginx.tunables.apply", map[string]any{
-			"client_max_body_size":  s.NginxClientMaxBodySize,
-			"keepalive_timeout":     s.NginxKeepaliveTimeout,
-			"server_tokens":         s.NginxServerTokens,
-			"gzip":                  s.NginxGzip,
-			"client_body_timeout":   s.NginxClientBodyTimeout,
-			"client_header_timeout": s.NginxClientHeaderTimeout,
-			"send_timeout":          s.NginxSendTimeout,
-			"proxy_connect_timeout": s.NginxProxyConnectTimeout,
-			"proxy_read_timeout":    s.NginxProxyReadTimeout,
-			"proxy_send_timeout":    s.NginxProxySendTimeout,
-			"worker_processes":      s.NginxWorkerProcesses,
-			"worker_connections":    s.NginxWorkerConnections,
-			"custom_http":           s.NginxCustomHTTP,
-		}); err != nil {
-			return fmt.Errorf("DB updated, but nginx.tunables.apply failed: %w", err)
+		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
+			return fmt.Errorf("DB updated, but %s failed: %w", call.Method, err)
 		}
 	}
 	return nil
+}
+
+// dispatchSettingsAgentCall executes one settingsops.AgentCall synchronously via
+// the shared agent. It is a package var so tests can substitute a recorder
+// (sharedAgent is a concrete *agent.Client, not an interface).
+var dispatchSettingsAgentCall = func(ctx context.Context, call settingsops.AgentCall) error {
+	return callAgentTimeout(ctx, call.Timeout, call.Method, call.Params)
 }
 
 func callAgentTimeout(ctx context.Context, d time.Duration, method string, params map[string]any) error {
@@ -345,7 +347,7 @@ var settableKeys = map[string]settingDef{
 	// endpoints (admin session). Setting it here runs the same OS apply
 	// (system.set_hostname) the REST PATCH fires; the panel-cert reconciler then
 	// reissues the panel cert for the new name, exactly as the UI path does.
-	// FQDN-format validation is enforced by api.ValidateServerSettings below.
+	// FQDN-format validation is enforced by settingsops.Validate below.
 	"hostname": settingDef{
 		help: "panel hostname / FQDN (applies to the OS via system.set_hostname; the panel-cert reconciler reissues the cert)",
 		apply: func(s *models.ServerSettings, raw string) error {
@@ -385,7 +387,7 @@ var settableKeys = map[string]settingDef{
 			return nil
 		},
 	},
-	// nginx tunables (criterion #3) — validated by api.ValidateServerSettings.
+	// nginx tunables (criterion #3) — validated by settingsops.Validate.
 	"nginx_client_max_body_size":  nginxStrKey("nginx client_max_body_size (e.g. 50m)", func(s *models.ServerSettings, v string) { s.NginxClientMaxBodySize = v }),
 	"nginx_keepalive_timeout":     nginxStrKey("nginx keepalive_timeout (e.g. 65s)", func(s *models.ServerSettings, v string) { s.NginxKeepaliveTimeout = v }),
 	"nginx_server_tokens":         nginxBoolKey("nginx server_tokens on/off", func(s *models.ServerSettings, b bool) { s.NginxServerTokens = b }),

--- a/panel-api/cmd/server/settings_cmd_dispatch_test.go
+++ b/panel-api/cmd/server/settings_cmd_dispatch_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/settingsops"
+)
+
+// nginxTestSettings has every nginx tunable populated; hostname/postgres/docker/
+// python are left at their zero values and matched by prev so only the nginx
+// side effect fires.
+func nginxTestSettings() *models.ServerSettings {
+	return &models.ServerSettings{
+		SSHPort:                  22,
+		NginxClientMaxBodySize:   "50m",
+		NginxKeepaliveTimeout:    "65s",
+		NginxServerTokens:        true,
+		NginxGzip:                true,
+		NginxClientBodyTimeout:   "60s",
+		NginxClientHeaderTimeout: "60s",
+		NginxSendTimeout:         "60s",
+		NginxProxyConnectTimeout: "60s",
+		NginxProxyReadTimeout:    "60s",
+		NginxProxySendTimeout:    "60s",
+		NginxWorkerProcesses:     "auto",
+		NginxWorkerConnections:   1024,
+		NginxCustomHTTP:          "# hi",
+	}
+}
+
+// stubSettingsDispatch swaps in a recording dispatcher and restores the real one
+// after the test. Returns a pointer to the captured calls.
+func stubSettingsDispatch(t *testing.T, retErr error) *[]settingsops.AgentCall {
+	t.Helper()
+	var calls []settingsops.AgentCall
+	orig := dispatchSettingsAgentCall
+	dispatchSettingsAgentCall = func(_ context.Context, call settingsops.AgentCall) error {
+		calls = append(calls, call)
+		return retErr
+	}
+	t.Cleanup(func() { dispatchSettingsAgentCall = orig })
+	return &calls
+}
+
+// TestApplySideEffects_NginxDispatchesSharedWire proves the CLI executes the
+// settingsops plan synchronously with the exact wire (JAB-290 AC5: the CLI's
+// execution policy stays in the adapter; the wire is shared).
+func TestApplySideEffects_NginxDispatchesSharedWire(t *testing.T) {
+	nginxDirty = true
+	t.Cleanup(func() { nginxDirty = false })
+	calls := stubSettingsDispatch(t, nil)
+
+	s := nginxTestSettings()
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+
+	err := applySettingsSideEffects(context.Background(), cmd, nil, s, models.ServerSettings{}, sideEffectSnapshot(s))
+	require.NoError(t, err)
+
+	require.Len(t, *calls, 1, "exactly one nginx dispatch (no cache verb on the CLI)")
+	call := (*calls)[0]
+	require.Equal(t, "nginx.tunables.apply", call.Method)
+	require.Equal(t, 60*time.Second, call.Timeout)
+	require.Equal(t, map[string]any{
+		"client_max_body_size":  "50m",
+		"keepalive_timeout":     "65s",
+		"server_tokens":         true,
+		"gzip":                  true,
+		"client_body_timeout":   "60s",
+		"client_header_timeout": "60s",
+		"send_timeout":          "60s",
+		"proxy_connect_timeout": "60s",
+		"proxy_read_timeout":    "60s",
+		"proxy_send_timeout":    "60s",
+		"worker_processes":      "auto",
+		"worker_connections":    uint32(1024),
+		"custom_http":           "# hi",
+	}, call.Params)
+}
+
+// TestApplySideEffects_NginxFailureSurfaced: a failed apply is returned as a
+// non-silent error naming the verb (the DB is already persisted).
+func TestApplySideEffects_NginxFailureSurfaced(t *testing.T) {
+	nginxDirty = true
+	t.Cleanup(func() { nginxDirty = false })
+	stubSettingsDispatch(t, errors.New("nginx -t rejected config"))
+
+	s := nginxTestSettings()
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+
+	err := applySettingsSideEffects(context.Background(), cmd, nil, s, models.ServerSettings{}, sideEffectSnapshot(s))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DB updated, but nginx.tunables.apply failed")
+	require.Contains(t, err.Error(), "nginx -t rejected config")
+}
+
+// TestApplySideEffects_NoNginx_NoDispatch: with nginxDirty clear, nothing is
+// dispatched.
+func TestApplySideEffects_NoNginx_NoDispatch(t *testing.T) {
+	nginxDirty = false
+	calls := stubSettingsDispatch(t, nil)
+
+	s := nginxTestSettings()
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+
+	err := applySettingsSideEffects(context.Background(), cmd, nil, s, models.ServerSettings{}, sideEffectSnapshot(s))
+	require.NoError(t, err)
+	require.Empty(t, *calls)
+}

--- a/panel-api/cmd/server/settings_cmd_pin_test.go
+++ b/panel-api/cmd/server/settings_cmd_pin_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSettingsCLI_RoutesThroughSettingsops pins JAB-290: the `jabali settings`
+// command must derive its nginx effect + validation from internal/settingsops
+// (the shared owner the REST PATCH also uses), and must no longer hand-build the
+// nginx.tunables.apply parameter map or import the HTTP (api) package for
+// validation. The wire itself is covered in settings_cmd_dispatch_test.go and
+// internal/settingsops; this guards against a future re-fork.
+func TestSettingsCLI_RoutesThroughSettingsops(t *testing.T) {
+	src, err := os.ReadFile("settings_cmd.go")
+	if err != nil {
+		t.Fatalf("read settings_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	for _, want := range []string{"settingsops.NginxEffects(", "settingsops.Validate("} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("CLI must route through %s (JAB-290)", want)
+		}
+	}
+	// The hand-copied wire must be gone: no literal verb, no per-key param map.
+	for _, gone := range []string{`"nginx.tunables.apply"`, `"client_max_body_size":`} {
+		if strings.Contains(s, gone) {
+			t.Fatalf("CLI must not rebuild the nginx wire (%s) — settingsops owns it (JAB-290)", gone)
+		}
+	}
+	// AC1: the CLI no longer imports the HTTP package for validation.
+	if strings.Contains(s, "panel-api/internal/api\"") {
+		t.Fatal("CLI settings command must not import internal/api (JAB-290 AC1)")
+	}
+}

--- a/panel-api/cmd/server/settings_cmd_test.go
+++ b/panel-api/cmd/server/settings_cmd_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/settingsops"
 )
 
 // TestSettingsRegistryApply covers Gitea #539 criterion #4: unknown keys and
@@ -81,7 +81,7 @@ func TestSettingsRegistryApply(t *testing.T) {
 
 // TestSettingsHostnameParity covers the JAB-213 CLI gap: `settings set
 // hostname=` must (1) reach the same FQDN validation the REST PATCH uses via
-// api.ValidateServerSettings, and (2) be detectable as a change so the
+// settingsops.Validate, and (2) be detectable as a change so the
 // system.set_hostname side effect fires. Without a CLI writer for hostname the
 // free-hostname conversion could not be driven headlessly.
 func TestSettingsHostnameParity(t *testing.T) {
@@ -92,8 +92,8 @@ func TestSettingsHostnameParity(t *testing.T) {
 		if err := def.apply(s, "182-54-236-60-b.jabalihosted.com"); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
-		if err := api.ValidateServerSettings(s); err != nil {
-			t.Fatalf("ValidateServerSettings rejected a valid fqdn: %v", err)
+		if err := settingsops.Validate(s); err != nil {
+			t.Fatalf("settingsops.Validate rejected a valid fqdn: %v", err)
 		}
 	})
 
@@ -101,10 +101,10 @@ func TestSettingsHostnameParity(t *testing.T) {
 		s := &models.ServerSettings{ID: 1, SSHPort: 22}
 		// Passes the setter's non-empty guard but must fail hostnameRE.
 		if err := def.apply(s, "bad host!name"); err != nil {
-			t.Fatalf("apply should defer format checks to ValidateServerSettings: %v", err)
+			t.Fatalf("apply should defer format checks to settingsops.Validate: %v", err)
 		}
-		if err := api.ValidateServerSettings(s); err == nil {
-			t.Fatal("ValidateServerSettings accepted an invalid hostname")
+		if err := settingsops.Validate(s); err == nil {
+			t.Fatal("settingsops.Validate accepted an invalid hostname")
 		}
 	})
 

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -6,9 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
-	"net/mail"
 	"regexp"
 	"strings"
 	"time"
@@ -21,6 +19,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/settingsops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
@@ -733,6 +732,10 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		req.NginxProxyReadTimeout != nil || req.NginxProxySendTimeout != nil ||
 		req.NginxWorkerProcesses != nil || req.NginxWorkerConnections != nil ||
 		req.NginxCustomHTTP != nil
+	// Snapshot the pre-merge nginx values so settingsops can classify the effect
+	// (changed vs explicit re-apply). The dispatch decision below stays keyed on
+	// nginxTouched/cacheCapTouched, preserving the original re-sync semantics.
+	beforeNginx := *current
 	if req.NginxClientMaxBodySize != nil {
 		current.NginxClientMaxBodySize = strings.TrimSpace(*req.NginxClientMaxBodySize)
 	}
@@ -783,7 +786,7 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 
 	// Validate — reject obviously bad input so we don't persist garbage.
-	if err := ValidateServerSettings(current); err != nil {
+	if err := settingsops.Validate(current); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_settings", "detail": err.Error()})
 		return
 	}
@@ -1095,42 +1098,23 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	// lines whenever the operator touched the Nginx form. Background dispatch
 	// (atomic-write + nginx -t gate + reload happen agent-side). Re-sync
 	// semantics: re-saving the form always re-applies, healing on-disk drift.
-	if nginxTouched && h.cfg.Agent != nil {
-		go func(s models.ServerSettings) {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-			defer cancel()
-			if _, err := h.cfg.Agent.Call(bgCtx, "nginx.tunables.apply", map[string]any{
-				"client_max_body_size":  s.NginxClientMaxBodySize,
-				"keepalive_timeout":     s.NginxKeepaliveTimeout,
-				"server_tokens":         s.NginxServerTokens,
-				"gzip":                  s.NginxGzip,
-				"client_body_timeout":   s.NginxClientBodyTimeout,
-				"client_header_timeout": s.NginxClientHeaderTimeout,
-				"send_timeout":          s.NginxSendTimeout,
-				"proxy_connect_timeout": s.NginxProxyConnectTimeout,
-				"proxy_read_timeout":    s.NginxProxyReadTimeout,
-				"proxy_send_timeout":    s.NginxProxySendTimeout,
-				"worker_processes":      s.NginxWorkerProcesses,
-				"worker_connections":    s.NginxWorkerConnections,
-				"custom_http":           s.NginxCustomHTTP,
-			}); err != nil {
-				h.cfg.Log.Error("agent nginx tunables apply failed", "err", err)
-			}
-		}(*current)
-	}
-	// GH #634: apply the FastCGI cache capacity when it changed.
-	if cacheCapTouched && h.cfg.Agent != nil {
-		go func(s models.ServerSettings) {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-			defer cancel()
-			if _, err := h.cfg.Agent.Call(bgCtx, "nginx.cache.capacity_apply", map[string]any{
-				"max_size_gb":  s.NginxCacheMaxSizeGB,
-				"keyzone_mb":   s.NginxCacheKeyzoneMB,
-				"inactive_min": s.NginxCacheInactiveMin,
-			}); err != nil {
-				h.cfg.Log.Error("agent nginx cache capacity apply failed", "err", err)
-			}
-		}(*current)
+	// M55/GH #634: derive the nginx settings effect plan (tunables + FastCGI
+	// cache capacity) in settingsops — the single owner of the agent wire,
+	// shared with the CLI (JAB-290) — and dispatch each touched verb the REST
+	// way: async, detached, best-effort (the DB already holds the truth; a later
+	// reconcile syncs on failure). Dispatch stays keyed on Touched, so the
+	// re-sync semantics are unchanged.
+	nginxPlan := settingsops.NginxEffects(&beforeNginx, current, settingsops.NginxTouched{
+		Tunables: nginxTouched,
+		Cache:    cacheCapTouched,
+	})
+	if h.cfg.Agent != nil {
+		if call := nginxPlan.Tunables.Call; call != nil {
+			go h.dispatchNginx(*call, "agent nginx tunables apply failed")
+		}
+		if call := nginxPlan.Cache.Call; call != nil {
+			go h.dispatchNginx(*call, "agent nginx cache capacity apply failed")
+		}
 	}
 
 	h.cfg.Log.Info("event=audit kind=server_settings_updated actor_id=" + claims.UserID)
@@ -1149,118 +1133,23 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	c.JSON(http.StatusOK, current)
 }
 
-// ValidateServerSettings does lenient input validation matching the installer.
-// Exported so the `jabali settings` CLI applies the same rules as the REST PATCH
-// (Gitea #539).
-func ValidateServerSettings(s *models.ServerSettings) error {
-	if s.Hostname != "" && !isValidHostname(s.Hostname) {
-		return fmt.Errorf("invalid hostname")
+// dispatchNginx executes one settingsops nginx AgentCall the REST way: detached
+// from the request (a client disconnect must not cancel the apply), bounded by
+// the call's own timeout, best-effort (failure is logged, not surfaced — the DB
+// already holds the truth and a later reconcile syncs). Run it in a goroutine.
+func (h *serverSettingsHandler) dispatchNginx(call settingsops.AgentCall, logMsg string) {
+	bgCtx, cancel := context.WithTimeout(context.Background(), call.Timeout)
+	defer cancel()
+	if _, err := h.cfg.Agent.Call(bgCtx, call.Method, call.Params); err != nil {
+		h.cfg.Log.Error(logMsg, "err", err)
 	}
-	// GH #836: preview base must be a bare hostname (the wildcard label
-	// is implied; NormalizePreviewBase already stripped "*." and case).
-	if s.PreviewBase != "" && !isValidHostname(s.PreviewBase) {
-		return fmt.Errorf("preview_base: invalid hostname")
-	}
-	// IPv4
-	for label, v := range map[string]string{"public_ipv4": s.PublicIPv4, "ns1_ipv4": s.NS1IPv4, "ns2_ipv4": s.NS2IPv4} {
-		if v == "" {
-			continue
-		}
-		if net.ParseIP(v) == nil || net.ParseIP(v).To4() == nil {
-			return fmt.Errorf("%s: not a valid IPv4", label)
-		}
-	}
-	// IPv6 (optional)
-	if s.PublicIPv6 != "" {
-		ip := net.ParseIP(s.PublicIPv6)
-		if ip == nil || ip.To4() != nil {
-			return fmt.Errorf("public_ipv6: not a valid IPv6")
-		}
-	}
-	// NS names
-	for label, v := range map[string]string{"ns1_name": s.NS1Name, "ns2_name": s.NS2Name} {
-		if v == "" {
-			continue
-		}
-		if !isValidHostname(v) {
-			return fmt.Errorf("%s: invalid hostname", label)
-		}
-	}
-	// Admin email
-	if s.AdminEmail != "" {
-		if _, err := mail.ParseAddress(s.AdminEmail); err != nil {
-			return fmt.Errorf("admin_email: invalid")
-		}
-	}
-	// Timezone (optional, empty means "use OS default")
-	if s.Timezone != "" && !isValidTimezone(s.Timezone) {
-		return fmt.Errorf("timezone: invalid format")
-	}
-	// SSH port
-	if s.SSHPort < 1 || s.SSHPort > 65535 {
-		return fmt.Errorf("ssh_port: must be between 1 and 65535")
-	}
-	if s.DefaultDNSTTL != 0 && (s.DefaultDNSTTL < 60 || s.DefaultDNSTTL > 86400) {
-		return fmt.Errorf("default_dns_ttl must be 60–86400 seconds (or 0 to use built-in fallback)")
-	}
-	// Panel brand text: free-form but capped at 60 chars.
-	if len(s.PanelBrandText) > 60 {
-		return fmt.Errorf("panel_brand_text: must be <= 60 chars")
-	}
-	// Upload cap. 0 == "use compile-time default (1 GB)"; otherwise
-	// 1 MB minimum and 10 GB ceiling (matches the practical browser-
-	// upload limit and the nginx vhost client_max_body_size; admins
-	// wanting bigger should use SFTP/SCP).
-	if s.UploadMaxSizeMB != 0 && (s.UploadMaxSizeMB < 1 || s.UploadMaxSizeMB > 10240) {
-		return fmt.Errorf("upload_max_size_mb: must be 0 or between 1 and 10240")
-	}
-	// M13 SSH sandbox.
-	if s.SSHSandboxMode != "" && s.SSHSandboxMode != "bubblewrap" && s.SSHSandboxMode != "nspawn" {
-		return fmt.Errorf("ssh_sandbox_mode: must be 'bubblewrap' or 'nspawn'")
-	}
-	if s.DefaultNspawnImageVersion != "" && !isImageNamePattern(s.DefaultNspawnImageVersion) {
-		return fmt.Errorf("default_nspawn_image_version: must match [a-z0-9-]+")
-	}
-	// WorkingFolder must be absolute. install.sh ensures /var/lib/
-	// jabali exists at first boot; operator who points elsewhere is
-	// responsible for pre-creating + ACLing that dir.
-	if s.WorkingFolder != "" {
-		if !strings.HasPrefix(s.WorkingFolder, "/") {
-			return fmt.Errorf("working_folder: must be an absolute path")
-		}
-		if strings.Contains(s.WorkingFolder, "..") {
-			return fmt.Errorf("working_folder: must not contain '..'")
-		}
-	}
-	// M55 nginx tunables. Sizes/timeouts go verbatim into a config file,
-	// so reject anything not matching nginx's value grammar.
-	if s.NginxClientMaxBodySize != "" && !nginxSizeRE.MatchString(s.NginxClientMaxBodySize) {
-		return fmt.Errorf("nginx_client_max_body_size: invalid nginx size (e.g. 50m)")
-	}
-	for label, v := range map[string]string{
-		"nginx_keepalive_timeout":     s.NginxKeepaliveTimeout,
-		"nginx_client_body_timeout":   s.NginxClientBodyTimeout,
-		"nginx_client_header_timeout": s.NginxClientHeaderTimeout,
-		"nginx_send_timeout":          s.NginxSendTimeout,
-		"nginx_proxy_connect_timeout": s.NginxProxyConnectTimeout,
-		"nginx_proxy_read_timeout":    s.NginxProxyReadTimeout,
-		"nginx_proxy_send_timeout":    s.NginxProxySendTimeout,
-	} {
-		if v != "" && !nginxTimeRE.MatchString(v) {
-			return fmt.Errorf("%s: invalid nginx time (e.g. 300s)", label)
-		}
-	}
-	if s.NginxWorkerProcesses != "" && !nginxWorkerProcRE.MatchString(s.NginxWorkerProcesses) {
-		return fmt.Errorf("nginx_worker_processes: must be 'auto' or 1-99")
-	}
-	if s.NginxWorkerConnections > 1048576 {
-		return fmt.Errorf("nginx_worker_connections: must be <= 1048576")
-	}
-	if len(s.NginxCustomHTTP) > 4000 {
-		return fmt.Errorf("nginx_custom_http: must be <= 4000 chars")
-	}
-	return nil
 }
+
+// hostnameRE validates a bare hostname/IP charset. Server-settings validation
+// moved to internal/settingsops (JAB-290), but this handler still uses the
+// pattern directly for the FTP passive-address field (which lands verbatim in a
+// root-rendered config file), so the regex stays local to the api package.
+var hostnameRE = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
 
 // isImageNamePattern matches the [a-z0-9-]+ shape used everywhere
 // from agent helpers to wrapper scripts. Kept inline here so the
@@ -1279,36 +1168,6 @@ func isImageNamePattern(s string) bool {
 		}
 	}
 	return true
-}
-
-var (
-	hostnameRE = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
-	timezoneRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_+-]*(/[A-Za-z0-9_+-]+)*$`)
-
-	// M55 nginx tunable value grammars.
-	nginxSizeRE       = regexp.MustCompile(`^[0-9]+[kKmMgG]?$`)
-	nginxTimeRE       = regexp.MustCompile(`^[0-9]+(ms|s|m|h)?$`)
-	nginxWorkerProcRE = regexp.MustCompile(`^(auto|[1-9][0-9]?)$`)
-)
-
-func isValidHostname(s string) bool {
-	if len(s) > 253 {
-		return false
-	}
-	return hostnameRE.MatchString(s)
-}
-
-func isValidTimezone(s string) bool {
-	if len(s) > 64 {
-		return false
-	}
-	if strings.Contains(s, "..") {
-		return false
-	}
-	if strings.HasPrefix(s, "/") {
-		return false
-	}
-	return timezoneRE.MatchString(s)
 }
 
 // pythonRuntimeStatus reports whether the Python app runtime prerequisites

--- a/panel-api/internal/api/server_settings_nginx_test.go
+++ b/panel-api/internal/api/server_settings_nginx_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// nginxTunablesCall waits (the dispatch is an async goroutine) for the
+// nginx.tunables.apply call the PATCH handler makes and returns its decoded
+// params. Fails if none arrives. This characterizes the exact agent wire so the
+// JAB-290 settingsops extraction is proven byte-identical: the assertions were
+// written and run GREEN against the pre-refactor handler, and stay GREEN through
+// the extraction.
+func nginxTunablesCall(t *testing.T, mockAgent *agent.MockClient) map[string]any {
+	t.Helper()
+	var params map[string]any
+	require.Eventually(t, func() bool {
+		for _, c := range mockAgent.Calls() {
+			if c.Command == "nginx.tunables.apply" {
+				require.NoError(t, json.Unmarshal(c.Params, &params))
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "nginx.tunables.apply was never dispatched")
+	return params
+}
+
+func nginxCommandDispatched(mockAgent *agent.MockClient, command string) bool {
+	for _, c := range mockAgent.Calls() {
+		if c.Command == command {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServerSettingsPatch_NginxTunables_Wire pins the exact nginx.tunables.apply
+// parameter map (13 keys) the REST PATCH dispatches when a tunable is touched.
+func TestServerSettingsPatch_NginxTunables_Wire(t *testing.T) {
+	existing := &models.ServerSettings{ID: 1, SSHPort: 22}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	mockAgent := agent.NewMockClient()
+	mockAgent.On("nginx.tunables.apply", map[string]any{"status": "ok"})
+
+	r := settingsRouter(true, mockRepo, mockAgent)
+
+	body, _ := json.Marshal(map[string]any{
+		"nginx_client_max_body_size":  "50m",
+		"nginx_keepalive_timeout":     "65s",
+		"nginx_server_tokens":         true,
+		"nginx_gzip":                  true,
+		"nginx_client_body_timeout":   "60s",
+		"nginx_client_header_timeout": "60s",
+		"nginx_send_timeout":          "60s",
+		"nginx_proxy_connect_timeout": "60s",
+		"nginx_proxy_read_timeout":    "60s",
+		"nginx_proxy_send_timeout":    "60s",
+		"nginx_worker_processes":      "auto",
+		"nginx_worker_connections":    1024,
+		"nginx_custom_http":           "# hi",
+	})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	params := nginxTunablesCall(t, mockAgent)
+	require.Equal(t, map[string]any{
+		"client_max_body_size":  "50m",
+		"keepalive_timeout":     "65s",
+		"server_tokens":         true,
+		"gzip":                  true,
+		"client_body_timeout":   "60s",
+		"client_header_timeout": "60s",
+		"send_timeout":          "60s",
+		"proxy_connect_timeout": "60s",
+		"proxy_read_timeout":    "60s",
+		"proxy_send_timeout":    "60s",
+		"worker_processes":      "auto",
+		"worker_connections":    float64(1024), // JSON round-trip
+		"custom_http":           "# hi",
+	}, params)
+}
+
+// TestServerSettingsPatch_NginxCache_Wire pins the nginx.cache.capacity_apply
+// wire (REST-only; the CLI has no cache setters today).
+func TestServerSettingsPatch_NginxCache_Wire(t *testing.T) {
+	existing := &models.ServerSettings{ID: 1, SSHPort: 22}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	mockAgent := agent.NewMockClient()
+	mockAgent.On("nginx.cache.capacity_apply", map[string]any{"status": "ok"})
+
+	r := settingsRouter(true, mockRepo, mockAgent)
+
+	body, _ := json.Marshal(map[string]any{
+		"nginx_cache_max_size_gb":  4,
+		"nginx_cache_keyzone_mb":   32,
+		"nginx_cache_inactive_min": 90,
+	})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var params map[string]any
+	require.Eventually(t, func() bool {
+		for _, c := range mockAgent.Calls() {
+			if c.Command == "nginx.cache.capacity_apply" {
+				require.NoError(t, json.Unmarshal(c.Params, &params))
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "nginx.cache.capacity_apply was never dispatched")
+	require.Equal(t, map[string]any{
+		"max_size_gb":  float64(4),
+		"keyzone_mb":   float64(32),
+		"inactive_min": float64(90),
+	}, params)
+}
+
+// TestServerSettingsPatch_NoNginxChange_NoDispatch: an unrelated PATCH must not
+// dispatch either nginx verb.
+func TestServerSettingsPatch_NoNginxChange_NoDispatch(t *testing.T) {
+	existing := &models.ServerSettings{ID: 1, SSHPort: 22, Hostname: "keep.example.com"}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	mockAgent := agent.NewMockClient()
+
+	r := settingsRouter(true, mockRepo, mockAgent)
+
+	body, _ := json.Marshal(map[string]any{"admin_email": "ops@example.com"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Give any (erroneous) goroutine a chance to fire before asserting absence.
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, nginxCommandDispatched(mockAgent, "nginx.tunables.apply"))
+	require.False(t, nginxCommandDispatched(mockAgent, "nginx.cache.capacity_apply"))
+}

--- a/panel-api/internal/settingsops/nginx.go
+++ b/panel-api/internal/settingsops/nginx.go
@@ -1,0 +1,124 @@
+package settingsops
+
+import (
+	"reflect"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// nginxApplyTimeout is the per-call agent timeout for both nginx settings verbs
+// (matches the pre-extraction REST goroutine and CLI callAgentTimeout budgets).
+const nginxApplyTimeout = 60 * time.Second
+
+// Kind classifies a settings effect so an adapter (or its tests) can tell a
+// genuine value change from an explicit re-apply of the same value. The dispatch
+// decision does NOT depend on Kind — it depends only on whether the field family
+// was touched (Call != nil) — so the re-sync semantics of the original handlers
+// are preserved exactly. Kind exists for reporting and for the AC's
+// "no-op / changed / explicitly re-applied are distinguishable".
+type Kind int
+
+const (
+	// NoOp: the field family was not touched; nothing to dispatch.
+	NoOp Kind = iota
+	// Changed: touched, and at least one value differs before→after.
+	Changed
+	// Reapply: touched, but every value equals its previous value (an explicit
+	// re-sync — still dispatched, matching the original behavior).
+	Reapply
+)
+
+// AgentCall is one agent dispatch: the verb, its parameter map (the exact agent
+// wire), and the per-call timeout. This is the single owner of the nginx agent
+// wire that both adapters execute.
+type AgentCall struct {
+	Method  string
+	Params  map[string]any
+	Timeout time.Duration
+}
+
+// Effect is one settings side effect. Call is non-nil iff Kind != NoOp; an
+// adapter dispatches Call under its own execution policy. Rollback is the
+// compensating call if the apply fails; nil for nginx (the agent's own `nginx -t`
+// gate reverts a bad config, so there is no panel-side rollback). The field is
+// the seam JAB-295 (SSH) will populate.
+type Effect struct {
+	Kind     Kind
+	Call     *AgentCall
+	Rollback *AgentCall
+}
+
+// NginxTouched reports which nginx field families the adapter merged this
+// request. REST computes it from which request fields were present; the CLI from
+// which setters ran. Kept as adapter input (not re-derived here) so the module
+// preserves the exact touched-based re-sync semantics of both handlers.
+type NginxTouched struct {
+	Tunables bool
+	Cache    bool
+}
+
+// NginxPlan is the declarative plan for the nginx settings family: at most one
+// dispatch per verb (tunables + cache capacity).
+type NginxPlan struct {
+	Tunables Effect
+	Cache    Effect
+}
+
+// NginxEffects derives the nginx settings effect plan from the validated
+// before/after settings and the touched families. before is the pre-merge
+// snapshot (old values); after is the merged settings that will be persisted.
+func NginxEffects(before, after *models.ServerSettings, touched NginxTouched) NginxPlan {
+	return NginxPlan{
+		Tunables: effect(touched.Tunables, "nginx.tunables.apply",
+			nginxTunablesParams(before), nginxTunablesParams(after)),
+		Cache: effect(touched.Cache, "nginx.cache.capacity_apply",
+			nginxCacheParams(before), nginxCacheParams(after)),
+	}
+}
+
+// effect builds one Effect: NoOp when the family was not touched, otherwise an
+// AgentCall with the after-params, classified Changed vs Reapply by comparing
+// before/after.
+func effect(touched bool, method string, beforeParams, afterParams map[string]any) Effect {
+	if !touched {
+		return Effect{Kind: NoOp}
+	}
+	kind := Reapply
+	if !reflect.DeepEqual(beforeParams, afterParams) {
+		kind = Changed
+	}
+	return Effect{
+		Kind: kind,
+		Call: &AgentCall{Method: method, Params: afterParams, Timeout: nginxApplyTimeout},
+	}
+}
+
+// nginxTunablesParams is the exact nginx.tunables.apply wire (13 keys). This is
+// the single source both adapters previously copied verbatim.
+func nginxTunablesParams(s *models.ServerSettings) map[string]any {
+	return map[string]any{
+		"client_max_body_size":  s.NginxClientMaxBodySize,
+		"keepalive_timeout":     s.NginxKeepaliveTimeout,
+		"server_tokens":         s.NginxServerTokens,
+		"gzip":                  s.NginxGzip,
+		"client_body_timeout":   s.NginxClientBodyTimeout,
+		"client_header_timeout": s.NginxClientHeaderTimeout,
+		"send_timeout":          s.NginxSendTimeout,
+		"proxy_connect_timeout": s.NginxProxyConnectTimeout,
+		"proxy_read_timeout":    s.NginxProxyReadTimeout,
+		"proxy_send_timeout":    s.NginxProxySendTimeout,
+		"worker_processes":      s.NginxWorkerProcesses,
+		"worker_connections":    s.NginxWorkerConnections,
+		"custom_http":           s.NginxCustomHTTP,
+	}
+}
+
+// nginxCacheParams is the exact nginx.cache.capacity_apply wire (3 keys).
+func nginxCacheParams(s *models.ServerSettings) map[string]any {
+	return map[string]any{
+		"max_size_gb":  s.NginxCacheMaxSizeGB,
+		"keyzone_mb":   s.NginxCacheKeyzoneMB,
+		"inactive_min": s.NginxCacheInactiveMin,
+	}
+}

--- a/panel-api/internal/settingsops/nginx_test.go
+++ b/panel-api/internal/settingsops/nginx_test.go
@@ -1,0 +1,120 @@
+package settingsops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// populatedNginx is a ServerSettings with every nginx field set, used to pin the
+// exact agent wire the two adapters used to build by hand.
+func populatedNginx() *models.ServerSettings {
+	return &models.ServerSettings{
+		NginxClientMaxBodySize:   "50m",
+		NginxKeepaliveTimeout:    "65s",
+		NginxServerTokens:        true,
+		NginxGzip:                true,
+		NginxClientBodyTimeout:   "60s",
+		NginxClientHeaderTimeout: "60s",
+		NginxSendTimeout:         "60s",
+		NginxProxyConnectTimeout: "60s",
+		NginxProxyReadTimeout:    "60s",
+		NginxProxySendTimeout:    "60s",
+		NginxWorkerProcesses:     "auto",
+		NginxWorkerConnections:   1024,
+		NginxCustomHTTP:          "# hi",
+		NginxCacheMaxSizeGB:      4,
+		NginxCacheKeyzoneMB:      32,
+		NginxCacheInactiveMin:    90,
+	}
+}
+
+// TestNginxEffects_TunablesWire_Golden pins the nginx.tunables.apply wire: exact
+// method, 13-key params (native model types), and 60s timeout.
+func TestNginxEffects_TunablesWire_Golden(t *testing.T) {
+	after := populatedNginx()
+	plan := NginxEffects(&models.ServerSettings{}, after, NginxTouched{Tunables: true})
+
+	require.NotNil(t, plan.Tunables.Call)
+	call := plan.Tunables.Call
+	require.Equal(t, "nginx.tunables.apply", call.Method)
+	require.Equal(t, 60*time.Second, call.Timeout)
+	require.Equal(t, map[string]any{
+		"client_max_body_size":  "50m",
+		"keepalive_timeout":     "65s",
+		"server_tokens":         true,
+		"gzip":                  true,
+		"client_body_timeout":   "60s",
+		"client_header_timeout": "60s",
+		"send_timeout":          "60s",
+		"proxy_connect_timeout": "60s",
+		"proxy_read_timeout":    "60s",
+		"proxy_send_timeout":    "60s",
+		"worker_processes":      "auto",
+		"worker_connections":    uint32(1024),
+		"custom_http":           "# hi",
+	}, call.Params)
+}
+
+// TestNginxEffects_CacheWire_Golden pins the nginx.cache.capacity_apply wire.
+func TestNginxEffects_CacheWire_Golden(t *testing.T) {
+	after := populatedNginx()
+	plan := NginxEffects(&models.ServerSettings{}, after, NginxTouched{Cache: true})
+
+	require.NotNil(t, plan.Cache.Call)
+	call := plan.Cache.Call
+	require.Equal(t, "nginx.cache.capacity_apply", call.Method)
+	require.Equal(t, 60*time.Second, call.Timeout)
+	require.Equal(t, map[string]any{
+		"max_size_gb":  4,
+		"keyzone_mb":   32,
+		"inactive_min": 90,
+	}, call.Params)
+}
+
+// TestNginxEffects_Untouched_NoOp: nothing touched → no dispatch for either verb.
+func TestNginxEffects_Untouched_NoOp(t *testing.T) {
+	plan := NginxEffects(populatedNginx(), populatedNginx(), NginxTouched{})
+	require.Equal(t, NoOp, plan.Tunables.Kind)
+	require.Nil(t, plan.Tunables.Call)
+	require.Equal(t, NoOp, plan.Cache.Kind)
+	require.Nil(t, plan.Cache.Call)
+}
+
+// TestNginxEffects_Kind_ChangedVsReapply: touched dispatches either way, but the
+// kind distinguishes a real value change from an explicit re-apply.
+func TestNginxEffects_Kind_ChangedVsReapply(t *testing.T) {
+	before := populatedNginx()
+
+	// Same values, but touched → Reapply, and STILL dispatched (Call non-nil),
+	// preserving the original re-sync semantics.
+	same := populatedNginx()
+	reapply := NginxEffects(before, same, NginxTouched{Tunables: true, Cache: true})
+	require.Equal(t, Reapply, reapply.Tunables.Kind)
+	require.NotNil(t, reapply.Tunables.Call, "reapply must still dispatch")
+	require.Equal(t, Reapply, reapply.Cache.Kind)
+	require.NotNil(t, reapply.Cache.Call)
+
+	// Changed tunable value.
+	changed := populatedNginx()
+	changed.NginxKeepaliveTimeout = "30s"
+	changedPlan := NginxEffects(before, changed, NginxTouched{Tunables: true})
+	require.Equal(t, Changed, changedPlan.Tunables.Kind)
+
+	// Changed cache value.
+	changedCache := populatedNginx()
+	changedCache.NginxCacheMaxSizeGB = 8
+	changedCachePlan := NginxEffects(before, changedCache, NginxTouched{Cache: true})
+	require.Equal(t, Changed, changedCachePlan.Cache.Kind)
+}
+
+// TestNginxEffects_NoRollback: nginx has no panel-side rollback (the agent's
+// nginx -t gate reverts). The seam field stays nil.
+func TestNginxEffects_NoRollback(t *testing.T) {
+	plan := NginxEffects(&models.ServerSettings{}, populatedNginx(), NginxTouched{Tunables: true, Cache: true})
+	require.Nil(t, plan.Tunables.Rollback)
+	require.Nil(t, plan.Cache.Rollback)
+}

--- a/panel-api/internal/settingsops/validate.go
+++ b/panel-api/internal/settingsops/validate.go
@@ -1,0 +1,183 @@
+// Package settingsops is the transport-neutral owner of server-settings
+// validation and the declarative effect plans the REST PATCH handler and the
+// `jabali settings` CLI both execute (ADR-0083, JAB-290). It has no net/http,
+// no cobra, and no os.Exit: adapters map their transport in and execute the
+// returned plan under their own policy (REST best-effort async, CLI synchronous).
+//
+// This first vertical slice owns settings validation (moved out of internal/api
+// so the CLI no longer imports the HTTP package for it) and the nginx settings
+// effect plan (see nginx.go). JAB-294 (optional-module) and JAB-295 (SSH) add
+// their own effect plans to this package.
+package settingsops
+
+import (
+	"fmt"
+	"net"
+	"net/mail"
+	"regexp"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Validate does lenient input validation matching the installer. Both the REST
+// PATCH and the `jabali settings` CLI call it so they apply identical rules
+// (Gitea #539). Moved verbatim from internal/api.ValidateServerSettings (JAB-290).
+func Validate(s *models.ServerSettings) error {
+	if s.Hostname != "" && !isValidHostname(s.Hostname) {
+		return fmt.Errorf("invalid hostname")
+	}
+	// GH #836: preview base must be a bare hostname (the wildcard label
+	// is implied; NormalizePreviewBase already stripped "*." and case).
+	if s.PreviewBase != "" && !isValidHostname(s.PreviewBase) {
+		return fmt.Errorf("preview_base: invalid hostname")
+	}
+	// IPv4
+	for label, v := range map[string]string{"public_ipv4": s.PublicIPv4, "ns1_ipv4": s.NS1IPv4, "ns2_ipv4": s.NS2IPv4} {
+		if v == "" {
+			continue
+		}
+		if net.ParseIP(v) == nil || net.ParseIP(v).To4() == nil {
+			return fmt.Errorf("%s: not a valid IPv4", label)
+		}
+	}
+	// IPv6 (optional)
+	if s.PublicIPv6 != "" {
+		ip := net.ParseIP(s.PublicIPv6)
+		if ip == nil || ip.To4() != nil {
+			return fmt.Errorf("public_ipv6: not a valid IPv6")
+		}
+	}
+	// NS names
+	for label, v := range map[string]string{"ns1_name": s.NS1Name, "ns2_name": s.NS2Name} {
+		if v == "" {
+			continue
+		}
+		if !isValidHostname(v) {
+			return fmt.Errorf("%s: invalid hostname", label)
+		}
+	}
+	// Admin email
+	if s.AdminEmail != "" {
+		if _, err := mail.ParseAddress(s.AdminEmail); err != nil {
+			return fmt.Errorf("admin_email: invalid")
+		}
+	}
+	// Timezone (optional, empty means "use OS default")
+	if s.Timezone != "" && !isValidTimezone(s.Timezone) {
+		return fmt.Errorf("timezone: invalid format")
+	}
+	// SSH port
+	if s.SSHPort < 1 || s.SSHPort > 65535 {
+		return fmt.Errorf("ssh_port: must be between 1 and 65535")
+	}
+	if s.DefaultDNSTTL != 0 && (s.DefaultDNSTTL < 60 || s.DefaultDNSTTL > 86400) {
+		return fmt.Errorf("default_dns_ttl must be 60–86400 seconds (or 0 to use built-in fallback)")
+	}
+	// Panel brand text: free-form but capped at 60 chars.
+	if len(s.PanelBrandText) > 60 {
+		return fmt.Errorf("panel_brand_text: must be <= 60 chars")
+	}
+	// Upload cap. 0 == "use compile-time default (1 GB)"; otherwise
+	// 1 MB minimum and 10 GB ceiling (matches the practical browser-
+	// upload limit and the nginx vhost client_max_body_size; admins
+	// wanting bigger should use SFTP/SCP).
+	if s.UploadMaxSizeMB != 0 && (s.UploadMaxSizeMB < 1 || s.UploadMaxSizeMB > 10240) {
+		return fmt.Errorf("upload_max_size_mb: must be 0 or between 1 and 10240")
+	}
+	// M13 SSH sandbox.
+	if s.SSHSandboxMode != "" && s.SSHSandboxMode != "bubblewrap" && s.SSHSandboxMode != "nspawn" {
+		return fmt.Errorf("ssh_sandbox_mode: must be 'bubblewrap' or 'nspawn'")
+	}
+	if s.DefaultNspawnImageVersion != "" && !isImageNamePattern(s.DefaultNspawnImageVersion) {
+		return fmt.Errorf("default_nspawn_image_version: must match [a-z0-9-]+")
+	}
+	// WorkingFolder must be absolute. install.sh ensures /var/lib/
+	// jabali exists at first boot; operator who points elsewhere is
+	// responsible for pre-creating + ACLing that dir.
+	if s.WorkingFolder != "" {
+		if !strings.HasPrefix(s.WorkingFolder, "/") {
+			return fmt.Errorf("working_folder: must be an absolute path")
+		}
+		if strings.Contains(s.WorkingFolder, "..") {
+			return fmt.Errorf("working_folder: must not contain '..'")
+		}
+	}
+	// M55 nginx tunables. Sizes/timeouts go verbatim into a config file,
+	// so reject anything not matching nginx's value grammar.
+	if s.NginxClientMaxBodySize != "" && !nginxSizeRE.MatchString(s.NginxClientMaxBodySize) {
+		return fmt.Errorf("nginx_client_max_body_size: invalid nginx size (e.g. 50m)")
+	}
+	for label, v := range map[string]string{
+		"nginx_keepalive_timeout":     s.NginxKeepaliveTimeout,
+		"nginx_client_body_timeout":   s.NginxClientBodyTimeout,
+		"nginx_client_header_timeout": s.NginxClientHeaderTimeout,
+		"nginx_send_timeout":          s.NginxSendTimeout,
+		"nginx_proxy_connect_timeout": s.NginxProxyConnectTimeout,
+		"nginx_proxy_read_timeout":    s.NginxProxyReadTimeout,
+		"nginx_proxy_send_timeout":    s.NginxProxySendTimeout,
+	} {
+		if v != "" && !nginxTimeRE.MatchString(v) {
+			return fmt.Errorf("%s: invalid nginx time (e.g. 300s)", label)
+		}
+	}
+	if s.NginxWorkerProcesses != "" && !nginxWorkerProcRE.MatchString(s.NginxWorkerProcesses) {
+		return fmt.Errorf("nginx_worker_processes: must be 'auto' or 1-99")
+	}
+	if s.NginxWorkerConnections > 1048576 {
+		return fmt.Errorf("nginx_worker_connections: must be <= 1048576")
+	}
+	if len(s.NginxCustomHTTP) > 4000 {
+		return fmt.Errorf("nginx_custom_http: must be <= 4000 chars")
+	}
+	return nil
+}
+
+var (
+	hostnameRE = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
+	timezoneRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_+-]*(/[A-Za-z0-9_+-]+)*$`)
+
+	// M55 nginx tunable value grammars.
+	nginxSizeRE       = regexp.MustCompile(`^[0-9]+[kKmMgG]?$`)
+	nginxTimeRE       = regexp.MustCompile(`^[0-9]+(ms|s|m|h)?$`)
+	nginxWorkerProcRE = regexp.MustCompile(`^(auto|[1-9][0-9]?)$`)
+)
+
+func isValidHostname(s string) bool {
+	if len(s) > 253 {
+		return false
+	}
+	return hostnameRE.MatchString(s)
+}
+
+func isValidTimezone(s string) bool {
+	if len(s) > 64 {
+		return false
+	}
+	if strings.Contains(s, "..") {
+		return false
+	}
+	if strings.HasPrefix(s, "/") {
+		return false
+	}
+	return timezoneRE.MatchString(s)
+}
+
+// isImageNamePattern matches the [a-z0-9-]+ shape. A private copy of the
+// identical helper in internal/api (packages.go still uses that one); duplicated
+// here rather than importing api because api imports this package.
+func isImageNamePattern(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/panel-api/internal/settingsops/validate_test.go
+++ b/panel-api/internal/settingsops/validate_test.go
@@ -1,0 +1,66 @@
+package settingsops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// base is a minimally-valid settings struct (SSHPort in range); each case
+// mutates one field to exercise a single validation branch.
+func base() *models.ServerSettings { return &models.ServerSettings{SSHPort: 22} }
+
+func TestValidate_Valid(t *testing.T) {
+	s := base()
+	s.Hostname = "mx.example.com"
+	s.PublicIPv4 = "192.0.2.10"
+	s.PublicIPv6 = "2001:db8::1"
+	s.AdminEmail = "ops@example.com"
+	s.Timezone = "Europe/Amsterdam"
+	s.NginxClientMaxBodySize = "50m"
+	s.NginxKeepaliveTimeout = "65s"
+	s.NginxWorkerProcesses = "auto"
+	s.NginxWorkerConnections = 1024
+	require.NoError(t, Validate(s))
+}
+
+func TestValidate_Rejects(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*models.ServerSettings)
+		msg    string
+	}{
+		{"bad hostname", func(s *models.ServerSettings) { s.Hostname = "bad host!name" }, "invalid hostname"},
+		{"bad preview_base", func(s *models.ServerSettings) { s.PreviewBase = "no spaces!" }, "preview_base"},
+		{"bad ipv4", func(s *models.ServerSettings) { s.PublicIPv4 = "999.1.1.1" }, "public_ipv4"},
+		{"ipv6 in ipv4 field", func(s *models.ServerSettings) { s.NS1IPv4 = "2001:db8::1" }, "ns1_ipv4"},
+		{"bad ipv6", func(s *models.ServerSettings) { s.PublicIPv6 = "192.0.2.1" }, "public_ipv6"},
+		{"bad ns name", func(s *models.ServerSettings) { s.NS2Name = "bad ns!" }, "ns2_name"},
+		{"bad email", func(s *models.ServerSettings) { s.AdminEmail = "not-an-email" }, "admin_email"},
+		{"bad timezone", func(s *models.ServerSettings) { s.Timezone = "../etc" }, "timezone"},
+		{"ssh port low", func(s *models.ServerSettings) { s.SSHPort = 0 }, "ssh_port"},
+		{"dns ttl range", func(s *models.ServerSettings) { s.DefaultDNSTTL = 10 }, "default_dns_ttl"},
+		{"brand too long", func(s *models.ServerSettings) { s.PanelBrandText = string(make([]byte, 61)) }, "panel_brand_text"},
+		{"upload cap range", func(s *models.ServerSettings) { s.UploadMaxSizeMB = 20000 }, "upload_max_size_mb"},
+		{"sandbox mode", func(s *models.ServerSettings) { s.SSHSandboxMode = "docker" }, "ssh_sandbox_mode"},
+		{"nspawn image", func(s *models.ServerSettings) { s.DefaultNspawnImageVersion = "Bad_Image" }, "default_nspawn_image_version"},
+		{"working folder relative", func(s *models.ServerSettings) { s.WorkingFolder = "relative/path" }, "working_folder"},
+		{"working folder dotdot", func(s *models.ServerSettings) { s.WorkingFolder = "/var/../etc" }, "working_folder"},
+		{"nginx size", func(s *models.ServerSettings) { s.NginxClientMaxBodySize = "50megs" }, "nginx_client_max_body_size"},
+		{"nginx time", func(s *models.ServerSettings) { s.NginxSendTimeout = "1minute" }, "nginx_send_timeout"},
+		{"nginx worker_processes", func(s *models.ServerSettings) { s.NginxWorkerProcesses = "many" }, "nginx_worker_processes"},
+		{"nginx worker_connections", func(s *models.ServerSettings) { s.NginxWorkerConnections = 2000000 }, "nginx_worker_connections"},
+		{"nginx custom_http too long", func(s *models.ServerSettings) { s.NginxCustomHTTP = string(make([]byte, 4001)) }, "nginx_custom_http"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := base()
+			tc.mutate(s)
+			err := Validate(s)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.msg)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

First settings-family vertical slice from ADR-0083's `<area>ops` pattern.
The `jabali settings` CLI imported the HTTP package (`internal/api`) for
`ValidateServerSettings`, and the REST PATCH handler and the CLI each carried
their own hand-copied `nginx.tunables.apply` dispatch — same verb, 60s
timeout, identical 13-key parameter map, written out twice and free to drift.

New neutral package **`internal/settingsops`** (no `net/http`, no cobra, no
`os.Exit`):

- **`Validate(s)`** — moved verbatim from `api.ValidateServerSettings` with
  its private helpers. The CLI now calls `settingsops.Validate` and no longer
  imports `internal/api` (AC1).
- **`NginxEffects(before, after, touched) NginxPlan`** — the single owner of
  the nginx settings agent wire. Returns a declarative plan: one `Effect` per
  verb (`nginx.tunables.apply` + `nginx.cache.capacity_apply`), each carrying
  the `AgentCall` (method, exact params, 60s timeout) and a `Kind`
  (no-op / changed / reapply). The module never dispatches — the adapters
  execute the plan under their own policy.

## Dispatch semantics preserved exactly

A verb fires **iff its family was touched** (`Effect.Call != nil` ⇔ touched) —
the same re-sync behavior as before (an explicitly-set-but-unchanged value
still re-applies). `Kind` is derived from before→after for reporting/tests and
does **not** gate dispatch.

- **REST** snapshots the pre-merge nginx values, derives the plan, dispatches
  each non-nil `Call` the REST way — async, detached, best-effort, unchanged
  log strings.
- **CLI** derives the plan and dispatches the tunables `Call` synchronously
  (`Cache` stays false — the CLI has no `nginx_cache_*` setters), keeping its
  inline `DB updated, but %s failed` error. A small package-var seam
  (`dispatchSettingsAgentCall`) makes the synchronous executor testable, since
  `sharedAgent` is a concrete `*agent.Client`, not an interface.

## Acceptance criteria

- **AC1 — CLI no longer imports the HTTP package for validation:** ✅
  `settings_cmd.go` calls `settingsops.Validate` and drops the `internal/api`
  import. (Other `cmd/server/*.go` files still import `internal/api` for their
  own reasons — AC1 is about *settings validation*, which is satisfied.)
- **AC2 — nginx transition detection, command parameters, timeouts, rollback
  have one owner:** ✅ with one honest caveat. Params, timeout, rollback, and
  the changed/reapply/no-op *classification* are single-owned in `settingsops`.
  The raw *touched signal* stays adapter-side by design (REST: which request
  fields were present; CLI: which setters ran) — it's transport-shaped, so it's
  a module *input*, not something the module can re-derive.
- **AC3 — no-op / changed / explicitly re-applied distinguishable:** ✅ via
  `Kind` (`NoOp` / `Changed` / `Reapply`), tested. Dispatch stays touched-based
  so re-sync behavior is unchanged.
- **AC4 — golden tests cover before/after plans and exact agent wire:** ✅
  Module golden tests pin both verbs' exact method/params/timeout; REST
  HTTP-level tests assert the dispatched parameter maps (written and run GREEN
  against the pre-refactor handler to characterize the wire, kept GREEN through
  the extraction).
- **AC5 — separate adapter tests preserve REST best-effort vs CLI synchronous
  policy:** ✅ REST wire tests exercise the async goroutine (via
  `require.Eventually`); a CLI executor test (via the dispatch seam) proves the
  synchronous path with the identical wire and a surfaced failure.

## Notes for reviewers

- `isImageNamePattern` and `hostnameRE` stay defined in `internal/api` too:
  `packages.go` uses `isImageNamePattern`, and the PATCH handler uses
  `hostnameRE` directly for the FTP passive-address field. `settingsops` keeps
  its own private copies (api imports settingsops, so it can't import back) —
  two tiny behavior-fixed helpers duplicated to avoid a cycle.
- `nginx.cache.capacity_apply` remains REST-only in practice (no CLI cache
  setters). Pre-existing gap, not introduced here; the module covers both
  verbs, so a CLI cache setter is a one-line `Touched.Cache` flip.
- REST persists then applies best-effort, so a failed apply leaves the DB ahead
  of the host until the next reconcile — pre-existing, unchanged (JAB-295
  targets that class for SSH).
- `Effect.Rollback` is a nil seam for JAB-295 (SSH) — no behavior behind it
  (tested nil). nginx has no panel-side rollback; the agent's `nginx -t` gate
  reverts a bad config.
- Curiosity, not a change: `Validate`'s `SSHPort > 65535` branch is dead
  (`SSHPort` is `uint16`). Left as-is.

## Test plan

- [x] `internal/settingsops` — validation matrix (moved to its new home) +
      golden wire (both verbs) + classification (no-op / changed / reapply) +
      nil-rollback.
- [x] `internal/api` — new HTTP wire tests for both nginx verbs + no-dispatch
      on an unrelated PATCH.
- [x] `cmd/server` — executor test (shared wire, sync, surfaced failure) + a
      source pin guarding the delegation and the dropped `internal/api` import.
- [x] `go build ./...`, `go vet ./...`, full `go test ./...`, gofmt clean,
      `-race` on the three packages.
- [x] Rebased onto latest `origin/main`, re-ran tests post-rebase.
- No box validation warranted: no new agent verb; the wire is proven identical
  green→green; no reconciler or migration touched.

## Disposition

Unblocks JAB-295 (SSH settings EffectPlan) and JAB-294 (optional-module).
All five ACs are substantively met; per the codex arch-audit convention the
ticket stays in Backlog, but it is a reasonable Done candidate — operator's
call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
