### PR TITLE
feat(domains): independent Web / Mail / DNS services per domain (GH #1449)

### DIFF
--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -69,6 +69,14 @@ type createDomainInput struct {
 	// the automation path lets the first reconciler tick bootstrap the cert,
 	// exactly like the `jabali domain create` CLI. GUI create leaves it false.
 	SkipInlineSSL bool
+	// WebDisabled / DNSDisabled (GH #1449) opt the domain OUT of a service.
+	// INVERTED on purpose: the zero value (false) means the service is ON, so
+	// every existing caller (GUI create, automation) keeps creating a
+	// full-service web+dns domain without changing a line. WebDisabled=true →
+	// docroot-less (no vhost/PHP/web-SSL): a DNS-only zone or a mail-only
+	// domain. DNSDisabled=true → the panel does not host DNS (external DNS).
+	WebDisabled bool
+	DNSDisabled bool
 }
 
 // createDomainError carries the exact HTTP shape the inline create() used, so
@@ -105,6 +113,24 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 
 	if in.OwnerID == "" {
 		return nil, &createDomainError{http.StatusBadRequest, "user_id is required", ""}
+	}
+
+	// GH #1449: Web / DNS are independent services. Both default ON (the
+	// inverted *Disabled inputs are zero=false for every existing caller). A
+	// web-off domain is docroot-less (DNS-only zone / mail-only domain) and so
+	// cannot be a reverse-proxy, carry a preview URL, or have a document root.
+	webEnabled := !in.WebDisabled
+	dnsEnabled := !in.DNSDisabled
+	if !webEnabled {
+		if in.ReverseProxy {
+			return nil, &createDomainError{http.StatusBadRequest, "web_disabled_no_reverse_proxy", "a reverse-proxy domain requires web hosting"}
+		}
+		if in.TempURLEnabled {
+			return nil, &createDomainError{http.StatusBadRequest, "web_disabled_no_temp_url", "a preview URL requires web hosting"}
+		}
+		if strings.TrimSpace(in.DocRoot) != "" {
+			return nil, &createDomainError{http.StatusBadRequest, "web_disabled_no_docroot", "a web-disabled domain has no document root"}
+		}
 	}
 
 	user, err := h.cfg.Users.FindByID(ctx, in.OwnerID)
@@ -148,7 +174,11 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 	// is confined to the domain's own tree; an admin may use anywhere under
 	// the owner's home. See createDomainInput.ActorIsAdmin.
 	docRoot := strings.TrimSpace(in.DocRoot)
-	if in.ActorIsAdmin {
+	if !webEnabled {
+		// GH #1449: web-off domain — no document root at all (validated empty
+		// above). Leave DocRoot="" so no vhost is ever rendered for it.
+		docRoot = ""
+	} else if in.ActorIsAdmin {
 		if err := validateDocumentRoot(docRoot, *user.Username, in.Name); err != nil {
 			return nil, &createDomainError{http.StatusBadRequest, "invalid_document_root", err.Error()}
 		}
@@ -157,7 +187,7 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 			return nil, &createDomainError{http.StatusBadRequest, "invalid_document_root", err.Error()}
 		}
 	}
-	if docRoot == "" {
+	if webEnabled && docRoot == "" {
 		docRoot = "/home/" + *user.Username + "/domains/" + in.Name + "/public_html"
 	}
 
@@ -209,6 +239,20 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 	if sslMode == models.SSLModeNone && mailEnabled {
 		return nil, &createDomainError{http.StatusBadRequest, "ssl_none_with_email", "a mail-enabled domain needs TLS; choose le/self or set mail provider to none"}
 	}
+	// GH #1449: a domain must host at least ONE Jabali service. Web off + DNS
+	// off + no Jabali mail leaves nothing for the panel to do (external mail
+	// without our DNS publishes no records here either).
+	if !webEnabled && !dnsEnabled && !mailEnabled {
+		return nil, &createDomainError{http.StatusBadRequest, "no_service_selected", "select at least one service: web hosting, DNS, or mail"}
+	}
+	// GH #1449: a DNS-only domain (web off + no Jabali mail) has nothing to
+	// serve over TLS — force ssl_mode=none so the reconciler never tries to
+	// issue a cert for a name whose web and mail both live elsewhere. A
+	// mail-only domain (web off, mail on) keeps its le/self mode for the
+	// mail-support SANs.
+	if !webEnabled && !mailEnabled {
+		sslMode = models.SSLModeNone
+	}
 
 	now := time.Now().UTC()
 	domain := &models.Domain{
@@ -226,8 +270,12 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		SkipAutoSAN:     mailSkipSAN,
 		CreateWWW:       in.CreateWWW,
 		TempURLEnabled:  in.TempURLEnabled,
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		// GH #1449: inverted storage — disabled is the non-zero (always-
+		// written) state, so a full-service create leaves both zero.
+		WebDisabled: in.WebDisabled,
+		DNSDisabled: in.DNSDisabled,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 
 	// GH #1175: a reverse-proxy domain draws a loopback port from the shared
@@ -301,8 +349,11 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 
 	// JAB-170 phase 5: auto-attach a covering shared cert (HTTPS instantly, no
 	// ACME) and skip the inline ACME below.
+	// GH #1449: shared-cert auto-attach + inline SSL are web-cert fast paths.
+	// A web-off domain has no web cert (DNS-only → ssl none; mail-only → the
+	// reconciler issues its mail-support SANs on the next tick), so skip both.
 	attachedShared := false
-	if h.cfg.SharedCerts != nil {
+	if webEnabled && h.cfg.SharedCerts != nil {
 		if cert := h.findCoveringSharedCert(ctx, domain.Name, domain.UserID); cert != nil {
 			if err := h.cfg.Domains.SetSharedCertificate(ctx, domain.ID, &cert.ID, models.SSLModeShared); err == nil {
 				domain.SSLMode = models.SSLModeShared
@@ -318,7 +369,7 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 	// Inline SSL (30s): ACME with self-signed fallback. Never errors — cert
 	// state is already in DB. JAB-233: automation skips this (SkipInlineSSL);
 	// the first reconciler tick bootstraps the cert instead.
-	if !attachedShared && !in.SkipInlineSSL && h.cfg.Reconciler != nil {
+	if webEnabled && !attachedShared && !in.SkipInlineSSL && h.cfg.Reconciler != nil {
 		inlineCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		h.cfg.Reconciler.ReconcileSSLInline(inlineCtx, domain)
 		cancel()

--- a/panel-api/internal/api/domain_create_service_flags_test.go
+++ b/panel-api/internal/api/domain_create_service_flags_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1449: Web / Mail / DNS are independent services. createDomainOp must
+// honour the WebDisabled / DNSDisabled opt-outs, hold web-only options to
+// web-enabled domains, and refuse a domain that hosts nothing.
+func TestCreateDomainOp_ServiceFlags(t *testing.T) {
+	uname := "alice"
+	owner := &models.User{ID: "u-alice", Email: "alice@example.com", Username: &uname}
+
+	newH := func() (*domainHandler, *dcDomains) {
+		dom := newDCDomains()
+		h := &domainHandler{cfg: DomainHandlerConfig{Users: newAbUsers(owner), Domains: dom}}
+		return h, dom
+	}
+
+	t.Run("DNS-only: web off + no mail → docroot-less, ssl none, dns on", func(t *testing.T) {
+		h, dom := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "zone.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if !d.WebDisabled {
+			t.Error("WebDisabled should be true")
+		}
+		if d.DNSDisabled {
+			t.Error("DNSDisabled should be false (DNS is the whole point)")
+		}
+		if d.DocRoot != "" {
+			t.Errorf("web-off domain must have empty DocRoot, got %q", d.DocRoot)
+		}
+		if d.SSLMode != models.SSLModeNone {
+			t.Errorf("DNS-only domain SSLMode should be forced none, got %q", d.SSLMode)
+		}
+		if d.EmailEnabled {
+			t.Error("DNS-only domain must not have email enabled")
+		}
+		if len(dom.created) != 1 {
+			t.Fatalf("domain should be created, got %d", len(dom.created))
+		}
+	})
+
+	t.Run("mail-only: web off + jabali mail → docroot-less, ssl kept, email on", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "mail.example.com",
+			MailProvider: models.MailProviderJabali,
+			SSLMode:      models.SSLModeLE,
+			WebDisabled:  true,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if !d.WebDisabled {
+			t.Error("WebDisabled should be true")
+		}
+		if d.DocRoot != "" {
+			t.Errorf("mail-only domain must have empty DocRoot, got %q", d.DocRoot)
+		}
+		if d.SSLMode != models.SSLModeLE {
+			t.Errorf("mail-only domain keeps its le mode for mail SANs, got %q", d.SSLMode)
+		}
+		if !d.EmailEnabled {
+			t.Error("mail-only domain must have email enabled")
+		}
+	})
+
+	t.Run("external DNS: manage-dns off on a web domain", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "ext.example.com",
+			MailProvider: models.MailProviderNone,
+			SSLMode:      models.SSLModeNone,
+			DNSDisabled:  true,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.WebDisabled {
+			t.Error("WebDisabled should be false (this is a web domain)")
+		}
+		if !d.DNSDisabled {
+			t.Error("DNSDisabled should be true (external DNS)")
+		}
+		if d.DocRoot == "" {
+			t.Error("a web domain must still derive a DocRoot")
+		}
+	})
+
+	t.Run("web-off rejects a reverse proxy", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID: owner.ID, Name: "rp.example.com",
+			MailProvider: models.MailProviderNone, WebDisabled: true, ReverseProxy: true,
+		})
+		if oerr == nil || oerr.Code != "web_disabled_no_reverse_proxy" {
+			t.Fatalf("want web_disabled_no_reverse_proxy, got %v", oerr)
+		}
+	})
+
+	t.Run("web-off rejects a document root", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID: owner.ID, Name: "dr.example.com",
+			MailProvider: models.MailProviderNone, WebDisabled: true,
+			DocRoot: "/home/alice/domains/dr.example.com/public_html",
+		})
+		if oerr == nil || oerr.Code != "web_disabled_no_docroot" {
+			t.Fatalf("want web_disabled_no_docroot, got %v", oerr)
+		}
+	})
+
+	t.Run("all services off is refused", func(t *testing.T) {
+		h, dom := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID: owner.ID, Name: "nothing.example.com",
+			MailProvider: models.MailProviderNone, WebDisabled: true, DNSDisabled: true,
+		})
+		if oerr == nil || oerr.Code != "no_service_selected" {
+			t.Fatalf("want no_service_selected, got %v", oerr)
+		}
+		if len(dom.created) != 0 {
+			t.Fatalf("no domain must be created when nothing is hosted, got %d", len(dom.created))
+		}
+	})
+
+	t.Run("full-service default is unchanged (both flags off)", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID: owner.ID, Name: "full.example.com",
+			MailProvider: models.MailProviderNone, SSLMode: models.SSLModeNone, SkipInlineSSL: true,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.WebDisabled || d.DNSDisabled {
+			t.Errorf("a default create must be full-service: WebDisabled=%v DNSDisabled=%v", d.WebDisabled, d.DNSDisabled)
+		}
+		if d.DocRoot == "" {
+			t.Error("full-service domain must derive a DocRoot")
+		}
+	})
+}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -118,6 +118,14 @@ type createDomainRequest struct {
 	// it needs a cert upload, set via PUT /domains/:id/ssl/custom after create.
 	// Empty defaults to 'le'.
 	SSLMode string `json:"ssl_mode"`
+	// WebEnabled / ManageDNS (GH #1449) are the "Add Web Domain" service
+	// checkboxes: both default ON (nil == checked == current behaviour), so a
+	// caller only sends false to OPT OUT. WebEnabled=false → no vhost/docroot/
+	// PHP (a mail-only or DNS-only entry); ManageDNS=false → the panel does not
+	// host DNS for this domain (external DNS). Pointers so an absent field is
+	// the default-on, distinct from an explicit false.
+	WebEnabled *bool `json:"web_enabled"`
+	ManageDNS  *bool `json:"manage_dns"`
 }
 
 // normalizeDomainName canonicalizes a domain for storage (GH #884): trim
@@ -703,6 +711,9 @@ func (h *domainHandler) create(c *gin.Context) {
 		TempURLEnabled:   req.TempURLEnabled,
 		ReverseProxy:     req.ReverseProxy,
 		ReverseProxyPort: req.ReverseProxyPort,
+		// GH #1449: both default ON — only an explicit false opts out.
+		WebDisabled: req.WebEnabled != nil && !*req.WebEnabled,
+		DNSDisabled: req.ManageDNS != nil && !*req.ManageDNS,
 	})
 	if oerr != nil {
 		body := gin.H{"error": oerr.Code}

--- a/panel-api/internal/db/migrations/000289_domain_service_flags.down.sql
+++ b/panel-api/internal/db/migrations/000289_domain_service_flags.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domains
+  DROP COLUMN dns_disabled,
+  DROP COLUMN web_disabled;

--- a/panel-api/internal/db/migrations/000289_domain_service_flags.up.sql
+++ b/panel-api/internal/db/migrations/000289_domain_service_flags.up.sql
@@ -1,0 +1,16 @@
+-- GH #1449: make Web / Mail / DNS independent services per domain.
+--   web_disabled: when 1 the domain has NO web vhost / docroot / PHP — a
+--     docroot-less entry (DNS-only zone, or mail-only domain). Mail already
+--     toggles via mail_provider; this adds the web toggle.
+--   dns_disabled: when 1 the reconciler does NOT create/converge a PowerDNS
+--     zone for this domain — the tenant runs DNS elsewhere (external DNS).
+--
+-- Stored INVERTED (disabled, DEFAULT 0) on purpose: the zero value means the
+-- service is ON, so (a) the whole existing fleet stays full-service with no
+-- data change, (b) the non-default state is a NON-zero value, which GORM
+-- always writes — sidestepping the email_enabled zero-value scar (migration
+-- 000123) without every create having to set the flag, and (c) every existing
+-- in-memory test fixture keeps its web+dns behaviour untouched.
+ALTER TABLE domains
+  ADD COLUMN web_disabled TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN dns_disabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/dnscompile/bootstrap.go
+++ b/panel-api/internal/dnscompile/bootstrap.go
@@ -32,7 +32,14 @@ import (
 //     sent from the apex IP (not just from the mail host's A record)
 //     still passes SPF checks — e.g. panel-local scripts sending via
 //     the local stalwart over the apex bind.
-func BootstrapRecords(zoneID, zoneName string, srv *models.ServerSettings, idNew func() string, includeMail, includeWWW bool) []models.DNSRecord {
+//
+// includeApex (GH #1449) seeds the apex A/AAAA at this server's public IP.
+// A web-off domain (DNS-only zone / mail-only domain) passes false: its apex
+// points wherever the tenant's real web host is, so the panel must NOT seed —
+// or later re-assert (convergeApexAddrRecords is likewise web-gated) — an apex
+// pointing at this box. mail A/AAAA (includeMail) and www (includeWWW) are
+// independent.
+func BootstrapRecords(zoneID, zoneName string, srv *models.ServerSettings, idNew func() string, includeApex, includeMail, includeWWW bool) []models.DNSRecord {
 	now := time.Now().UTC()
 	// GH #527: honor server_settings.default_dns_ttl for bootstrap records
 	// instead of a hardcoded value, so the operator's configured default
@@ -58,15 +65,22 @@ func BootstrapRecords(zoneID, zoneName string, srv *models.ServerSettings, idNew
 		return out
 	}
 
-	// Apex + mail host IPs. www is added as a CNAME below.
+	// Apex + mail host IPs. www is added as a CNAME below. The apex A/AAAA
+	// is seeded only for a web-enabled domain (includeApex) — a DNS-only or
+	// mail-only zone leaves the apex for the tenant to point at their own web
+	// host. mail A/AAAA is independent (includeMail).
 	if srv.PublicIPv4 != "" {
-		out = append(out, mk("@", "A", srv.PublicIPv4, 0))
+		if includeApex {
+			out = append(out, mk("@", "A", srv.PublicIPv4, 0))
+		}
 		if includeMail {
 			out = append(out, mk("mail", "A", srv.PublicIPv4, 0))
 		}
 	}
 	if srv.PublicIPv6 != "" {
-		out = append(out, mk("@", "AAAA", srv.PublicIPv6, 0))
+		if includeApex {
+			out = append(out, mk("@", "AAAA", srv.PublicIPv6, 0))
+		}
 		if includeMail {
 			out = append(out, mk("mail", "AAAA", srv.PublicIPv6, 0))
 		}

--- a/panel-api/internal/dnscompile/bootstrap_test.go
+++ b/panel-api/internal/dnscompile/bootstrap_test.go
@@ -36,7 +36,7 @@ func TestBootstrapRecords_WWWIsCNAMEToApex(t *testing.T) {
 		"zone1",
 		"example.com",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		true,
 	)
@@ -63,7 +63,7 @@ func TestBootstrapRecords_MailStaysA_NotCNAME(t *testing.T) {
 		"zone1",
 		"example.com",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1", PublicIPv6: "2001:db8::1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		true,
 	)
@@ -91,7 +91,7 @@ func TestBootstrapRecords_MXTargetIsFQDN(t *testing.T) {
 		"zone1",
 		"example.com",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		true,
 	)
@@ -112,7 +112,7 @@ func TestBootstrapRecords_MXSkippedWhenZoneNameEmpty(t *testing.T) {
 		"zone1",
 		"",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		true,
 	)
@@ -139,7 +139,7 @@ func TestBootstrapRecords_SPFIncludesIP4AndIP6(t *testing.T) {
 				"zone1",
 				"example.com",
 				&models.ServerSettings{PublicIPv4: tt.v4, PublicIPv6: tt.v6},
-				bootIDCounter(),
+				bootIDCounter(), true,
 				true,
 				true,
 			)
@@ -162,7 +162,7 @@ func TestBootstrapRecords_SPFIncludesIP4AndIP6(t *testing.T) {
 }
 
 func TestBootstrapRecords_NoServerSettingsReturnsEmpty(t *testing.T) {
-	recs := BootstrapRecords("zone1", "example.com", nil, bootIDCounter(), true, true)
+	recs := BootstrapRecords("zone1", "example.com", nil, bootIDCounter(), true, true, true)
 	if len(recs) != 0 {
 		t.Errorf("expected 0 records when srv is nil, got %d", len(recs))
 	}
@@ -175,7 +175,7 @@ func TestBootstrapRecords_WWWSkippedWhenZoneNameEmpty(t *testing.T) {
 		"zone1",
 		"",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		true,
 	)
@@ -194,7 +194,7 @@ func TestBootstrapRecords_AllManagedTrue_ManagedByNil(t *testing.T) {
 		"zone1",
 		"example.com",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		true,
 	)
@@ -216,7 +216,7 @@ func TestBootstrapRecords_NSARecord_InZone(t *testing.T) {
 		NS2Name:    "ns2.example.com",
 		NS2IPv4:    "203.0.113.11",
 	}
-	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, true)
+	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, true, true)
 	ns1 := findRec(t, recs, "ns1", "A")
 	if ns1.Content != "203.0.113.10" {
 		t.Errorf("ns1 A content = %q, want 203.0.113.10", ns1.Content)
@@ -233,7 +233,7 @@ func TestBootstrapRecords_NSARecord_OffZone_Skipped(t *testing.T) {
 		NS1Name:    "ns1.other-zone.net",
 		NS1IPv4:    "203.0.113.10",
 	}
-	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, true)
+	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, true, true)
 	for _, r := range recs {
 		if r.Name == "ns1" && r.Type == "A" {
 			t.Errorf("ns1 A leaked into zone where ns1_name lives elsewhere: %+v", r)
@@ -243,7 +243,7 @@ func TestBootstrapRecords_NSARecord_OffZone_Skipped(t *testing.T) {
 
 func TestBootstrapRecords_NSARecord_EmptyConfig_Noop(t *testing.T) {
 	srv := &models.ServerSettings{PublicIPv4: "203.0.113.10"}
-	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, true)
+	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, true, true)
 	for _, r := range recs {
 		if (r.Name == "ns1" || r.Name == "ns2") && r.Type == "A" {
 			t.Errorf("ns A record emitted without ns_name/ns_ipv4 config: %+v", r)
@@ -256,7 +256,7 @@ func TestBootstrapRecords_NSARecord_EmptyConfig_Noop(t *testing.T) {
 // ns records (GH #189: a "No mail" domain never even briefly has mail DNS).
 func TestBootstrapRecords_NoMailOmitsMailRows(t *testing.T) {
 	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1", PublicIPv6: "2001:db8::1"}
-	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), false, true)
+	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), true, false, true)
 
 	for _, r := range recs {
 		switch {
@@ -279,6 +279,28 @@ func TestBootstrapRecords_NoMailOmitsMailRows(t *testing.T) {
 	}
 }
 
+// GH #1449: includeApex=false (a web-off DNS-only / mail-only domain) must
+// omit the apex A/AAAA pointing at this box — the tenant's web lives
+// elsewhere — while still emitting the mail rows when includeMail=true.
+func TestBootstrapRecords_NoApexOmitsApexAddr(t *testing.T) {
+	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1", PublicIPv6: "2001:db8::1"}
+	recs := BootstrapRecords("zone-1", "example.com", srv, bootIDCounter(), false, true, false)
+
+	if findRecOpt(recs, "@", "A") != nil {
+		t.Error("web-off bootstrap must not seed an apex A pointing at this box")
+	}
+	if findRecOpt(recs, "@", "AAAA") != nil {
+		t.Error("web-off bootstrap must not seed an apex AAAA pointing at this box")
+	}
+	// Mail rows still present (mail-only domain).
+	if findRecOpt(recs, "mail", "A") == nil {
+		t.Error("mail A should still be bootstrapped for a mail-only domain")
+	}
+	if findRecOpt(recs, "@", "MX") == nil {
+		t.Error("MX should still be bootstrapped for a mail-only domain")
+	}
+}
+
 func findRecOpt(recs []models.DNSRecord, name, typ string) *models.DNSRecord {
 	for i := range recs {
 		if recs[i].Name == name && recs[i].Type == typ {
@@ -295,7 +317,7 @@ func TestBootstrapRecords_WWWOptOut(t *testing.T) {
 		"zone1",
 		"example.com",
 		&models.ServerSettings{PublicIPv4: "192.0.2.1"},
-		bootIDCounter(),
+		bootIDCounter(), true,
 		true,
 		false,
 	)

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -221,6 +221,23 @@ type Domain struct {
 	// sites-enabled. Disabled domains still have their config on disk.
 	IsEnabled bool `gorm:"type:tinyint(1);not null;default:1" json:"is_enabled"`
 
+	// GH #1449: Web / Mail / DNS are independent services on a domain row.
+	//   WebDisabled=true → docroot-less: no vhost, no PHP, no web SSL, no
+	//     apex-A convergence (a DNS-only zone or a mail-only domain).
+	//   DNSDisabled=true → the reconciler does NOT create/converge a
+	//     PowerDNS zone (tenant runs DNS elsewhere).
+	// Mail is toggled by MailProvider (none = off), unchanged.
+	//
+	// Stored INVERTED (disabled, DB DEFAULT 0) so the zero value = service ON:
+	// the whole existing fleet + every in-memory test fixture stays
+	// full-service untouched, and the non-default (disabled) is a NON-zero
+	// value that GORM always writes — no email_enabled zero-value scar
+	// (models/domain.go EmailEnabled note, migration 000123), no need to set
+	// the flag on every create. The API/UI speak positive ("web_enabled" /
+	// "manage_dns" checkboxes on create; enabled = !web_disabled on read).
+	WebDisabled bool `gorm:"column:web_disabled;type:tinyint(1);not null;default:0" json:"web_disabled"`
+	DNSDisabled bool `gorm:"column:dns_disabled;type:tinyint(1);not null;default:0" json:"dns_disabled"`
+
 	// IsQuotaSuspended marks domains the M13.1.1 bandwidth reconciler
 	// disabled because their owning user crossed BandwidthQuotaMB.
 	// Disambiguates panel-driven disables from manual operator

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1767,6 +1767,14 @@ func (r *Reconciler) effectiveInterceptErrors(ctx context.Context, domain *model
 // pool-regeneration pass, which must re-dispatch regardless of the cache
 // (a pool config change is out-of-band to the per-domain payload hash).
 func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Domain, force bool) {
+	if domain.WebDisabled {
+		// GH #1449: a web-off domain (DNS-only zone / mail-only domain) has
+		// no docroot and no HTTP vhost — skip the web render entirely. Its
+		// DNS zone and mail (MX/DKIM/mail-cert SANs) still converge via the
+		// dedicated paths in reconcileEnabledDomain. Mirrors the docroot-less
+		// IsPanelPrimary / docker_app rows.
+		return
+	}
 	user, err := r.users.FindByID(ctx, domain.UserID)
 	if err != nil {
 		r.log.Error("failed to fetch user for domain", "domain_id", domain.ID, "user_id", domain.UserID, "err", err)
@@ -2321,6 +2329,15 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 	if r.dnsZones == nil {
 		return // DNS feature not wired — skip
 	}
+	if domain.DNSDisabled {
+		// GH #1449: the tenant runs DNS elsewhere — never create or
+		// converge a PowerDNS zone for this domain. Placed BEFORE the
+		// find/auto-create below so a disabled zone can't resurrect every
+		// tick. (Tearing down a zone already in pdns when DNS is turned
+		// OFF later is a separate follow-up; the dns.zone.delete verb
+		// exists for it.)
+		return
+	}
 
 	zone, err := r.dnsZones.FindByDomainID(ctx, domain.ID)
 	if err != nil {
@@ -2349,7 +2366,11 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 			// their mail rows. GH #189: a "No mail" domain never even briefly
 			// has mail DNS.
 			includeMail := domain.MailProvider == "" || domain.MailProvider == models.MailProviderJabali
-			boots := dnscompile.BootstrapRecords(zone.ID, zone.Name, srv, ids.NewULID, includeMail, domain.CreateWWW)
+			// GH #1449: a web-off domain (DNS-only / mail-only) doesn't seed an
+			// apex A or a www CNAME pointing at this box — its web lives elsewhere.
+			includeApex := !domain.WebDisabled
+			includeWWW := !domain.WebDisabled && domain.CreateWWW
+			boots := dnscompile.BootstrapRecords(zone.ID, zone.Name, srv, ids.NewULID, includeApex, includeMail, includeWWW)
 			for i := range boots {
 				if err := r.dnsRecords.Create(ctx, &boots[i]); err != nil {
 					r.log.Error("bootstrap record failed", "err", err)
@@ -3269,6 +3290,13 @@ func (r *Reconciler) convergeApexAddrRecords(ctx context.Context, zone *models.D
 	if r.dnsRecords == nil || zone == nil || domain == nil {
 		return
 	}
+	if domain.WebDisabled {
+		// GH #1449: a web-off domain's apex points at the tenant's real web
+		// host, not this box — never assert/re-assert an apex A/AAAA here
+		// (the bootstrap seed is likewise web-gated). The tenant edits the
+		// apex freely in the DNS zone.
+		return
+	}
 	// Without the IP pool we have no source of truth for what the
 	// effective addresses should be. Skipping is safe because the
 	// pre-M24 BootstrapRecords already wrote the server-primary
@@ -3621,7 +3649,7 @@ func (r *Reconciler) reconcileEnabledDomain(ctx context.Context, name string, do
 	// reconciler tick was pure spam ("puzzle.linux-hosting.net"
 	// loop). Only log for real tenant domains where the missing
 	// state is actionable.
-	if !agentSites[name] && !domain.IsPanelPrimary {
+	if !agentSites[name] && !domain.IsPanelPrimary && !domain.WebDisabled {
 		r.log.Info("reconcile: creating missing domain", "domain", name)
 	}
 	r.reconcileDNSZone(ctx, domain)
@@ -3641,6 +3669,28 @@ func (r *Reconciler) reconcileEnabledDomain(ctx context.Context, name string, do
 	if domain.IsPanelPrimary {
 		r.reconcileRecursorForward(ctx, name)
 		r.ensurePanelPrimaryDKIM(ctx, domain)
+		return
+	}
+
+	// GH #1449: a web-off tenant domain (DNS-only zone or mail-only domain)
+	// has no docroot / vhost / PHP. Converge only its DNS (above), SSL
+	// (mail-support SANs via reachableSANs — a no-op for a DNS-only zone on
+	// ssl_mode='none'), MTA-STS, mail provisioning, and M6.5 email features.
+	// Skips ensureDomainPHPBinding + createDomainOnAgent. Mirrors the
+	// docroot-less IsPanelPrimary mail-only path, for tenants.
+	if domain.WebDisabled {
+		sslCtx, sslCancel := context.WithTimeout(ctx, 2*time.Minute)
+		r.reconcileSSLForDomain(sslCtx, domain)
+		sslCancel()
+		r.reconcileMTAStsForDomain(ctx, domain)
+		r.ensureTenantEmailEnabled(ctx, domain)
+		r.ensureTenantDKIMRecords(ctx, domain)
+		if !domain.DNSDisabled {
+			r.reconcileRecursorForward(ctx, name)
+		}
+		if err := phases.ReconcileDomainAll(ctx, domain, nil); err != nil {
+			r.log.Error("reconcile: M6.5 phase domain reconciliation failed (web-off)", "domain", name, "err", err)
+		}
 		return
 	}
 
@@ -3676,7 +3726,12 @@ func (r *Reconciler) reconcileEnabledDomain(ctx context.Context, name string, do
 	r.createDomainOnAgent(ctx, domain, false)
 	// M6.3: ensure the recursor has a forwarder for this zone so
 	// local resolution hits pdns-server on loopback :5300. Idempotent.
-	r.reconcileRecursorForward(ctx, name)
+	// GH #1449: only when we actually host the zone — a domain on external
+	// DNS must resolve via public recursion, not be pinned to our (empty)
+	// pdns for its own name.
+	if !domain.DNSDisabled {
+		r.reconcileRecursorForward(ctx, name)
+	}
 
 	// M6.5: Email features (forwarders, autoresponders, catch-all, disclaimer,
 	// shared folders, logs). Each feature is registered as a Phase during init(),

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2859,6 +2859,19 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 		staging = r.cfg.ACME.StagingOnly
 	}
 
+	// GH #1449: a web-off domain (mail-only) has NO webroot — DocRoot is ""
+	// and we serve no apex vhost — so an HTTP-01 attempt is guaranteed to
+	// fail on the empty webroot AND its apex points at the tenant's real web
+	// host, not us. Both would just burn Let's Encrypt's failed-auth quota.
+	// Issue the mail-support cert via DNS-01 when we host the zone (the TXT
+	// validates the apex + mail SANs regardless of where the A record points),
+	// otherwise park with a clear reason — never HTTP-01. The self-signed
+	// bootstrap above already keeps Stalwart/webmail serving TLS meanwhile.
+	if domain.WebDisabled {
+		r.tryDNS01OrPark(ctx, domain, cert, srv, staging)
+		return
+	}
+
 	{
 		preCtx, preCancel := context.WithTimeout(ctx, 6*time.Second)
 		addrs, queried := r.dnsPreflight(preCtx, domain.Name)

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -27,17 +27,32 @@ type UserDomainCreateInput = {
   // GH #1401: optional — the specific local port to proxy to (e.g. your app
   // already listens on 6875). Left blank, the panel auto-assigns a free port.
   reverse_proxy_port?: number;
+  // GH #1449: Web / Mail / DNS are independent services. Both default ON —
+  // the drawer only sends false to opt OUT. web_enabled=false → a docroot-less
+  // DNS-only zone or mail-only domain; manage_dns=false → external DNS.
+  web_enabled?: boolean;
+  manage_dns?: boolean;
 };
 type DomainCreated = { id: string; reverse_proxy_port?: number };
+
+// GH #1449: one drawer, three entry points. "web" is the classic Add Web
+// Domain (with opt-outs); "dns" adds a DNS-only zone; "mail" adds a mail-only
+// domain. The mode presets web_enabled / mail_provider and hides the fields
+// that don't apply.
+export type DomainDrawerMode = "web" | "dns" | "mail";
 
 export interface UserDomainDrawerProps {
   open: boolean;
   onClose: () => void;
+  mode?: DomainDrawerMode;
 }
 
-export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
+export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDrawerProps) => {
   const { t } = useTranslation();
   const [form] = Form.useForm<UserDomainCreateInput>();
+  const isWeb = mode === "web";
+  const isDNS = mode === "dns";
+  const isMail = mode === "mail";
   // GH #1409: when the mail module isn't installed, Jabali Mail isn't a real
   // choice — default to None and disable it. `!== false` treats the brief
   // pre-load state as installed so a mail-enabled server never flickers to None.
@@ -65,9 +80,26 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
       // A reverse-proxy domain has no document root; drop any value the field
       // may have kept (antd preserves unmounted field values by default) so we
       // never send a docroot the server would validate but never use.
-      const payload = values.reverse_proxy ? { ...values, doc_root: undefined } : values;
+      let payload: UserDomainCreateInput = values.reverse_proxy
+        ? { ...values, doc_root: undefined }
+        : values;
+      // GH #1449: a web-off entry (DNS-only zone / mail-only domain) must not
+      // carry web-only fields antd may have kept for hidden inputs.
+      if (!isWeb) {
+        payload = {
+          name: values.name,
+          web_enabled: false,
+          manage_dns: isDNS ? true : values.manage_dns,
+          mail_provider: isDNS ? "none" : values.mail_provider,
+          m365_onmicrosoft: values.m365_onmicrosoft,
+          google_dkim: values.google_dkim,
+          ssl_mode: isDNS ? "none" : values.ssl_mode,
+        };
+      }
       const created = await createMutation.mutateAsync(payload);
-      feedback.message.success("Domain added");
+      feedback.message.success(
+        isDNS ? "DNS zone added" : isMail ? "Mail domain added" : "Domain added",
+      );
       // GH #1175: the assigned loopback port is the one piece of info the user
       // must act on (bind their app to it), so surface it in a modal that
       // stays until dismissed rather than a toast they might miss.
@@ -85,7 +117,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
 
   return (
     <Drawer
-      title={t("userdomaindrawer.add_domain")}
+      title={isDNS ? "Add DNS Zone" : isMail ? "Add Mail Domain" : t("userdomaindrawer.add_domain")}
       open={open}
       onClose={onClose}
       width={isDesktop ? 480 : undefined}
@@ -116,7 +148,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
             (they have no docroot). The server confines a tenant's path to this
             domain's own tree, so pointing at another domain or elsewhere in the
             home is rejected. */}
-        {!reverseProxy && (
+        {isWeb && !reverseProxy && (
           <Form.Item
             label={t("userdomaindrawer.document_root")}
             name="doc_root"
@@ -126,6 +158,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
           </Form.Item>
         )}
 
+        {(isWeb || isMail) && (
         <Form.Item
           label={t("userdomaindrawer.mail")}
           name="mail_provider"
@@ -147,6 +180,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
             ]}
           />
         </Form.Item>
+        )}
 
         {mailProvider === "m365" && (
           <Form.Item
@@ -168,6 +202,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
           </Form.Item>
         )}
 
+        {(isWeb || isMail) && (
         <Form.Item
           label={t("userdomaindrawer.tls_certificate")}
           name="ssl_mode"
@@ -178,11 +213,26 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
             options={[
               { value: "le", label: "Let's Encrypt (recommended)" },
               { value: "self", label: "Self-signed" },
-              { value: "none", label: "None (HTTP only)" },
+              ...(isWeb ? [{ value: "none", label: "None (HTTP only)" }] : []),
             ]}
           />
         </Form.Item>
+        )}
 
+        {/* GH #1449: opt out of Jabali DNS (run DNS elsewhere). Not shown for
+            the DNS-only flow — there, hosting DNS is the whole point. */}
+        {(isWeb || isMail) && (
+          <Form.Item
+            name="manage_dns"
+            valuePropName="checked"
+            initialValue={true}
+            tooltip="Host this domain's DNS zone on this server. Uncheck if your DNS is managed elsewhere (e.g. your registrar or Cloudflare)."
+          >
+            <Checkbox>Manage DNS here</Checkbox>
+          </Form.Item>
+        )}
+
+        {isWeb && (
         <Form.Item
           name="create_www"
           valuePropName="checked"
@@ -191,7 +241,9 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         >
           <Checkbox>Create www record</Checkbox>
         </Form.Item>
+        )}
 
+        {isWeb && (
         <Form.Item
           name="temp_url_enabled"
           valuePropName="checked"
@@ -200,10 +252,12 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         >
           <Checkbox>Enable preview URL</Checkbox>
         </Form.Item>
+        )}
 
         {/* GH #1175: reverse-proxy option. The panel reserves a conflict-free
             loopback port and writes the proxy_pass vhost; the assigned port is
             shown after the domain is added. */}
+        {isWeb && (
         <Form.Item
           name="reverse_proxy"
           valuePropName="checked"
@@ -212,6 +266,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         >
           <Checkbox>Set up as a reverse proxy (run your own app on a local port)</Checkbox>
         </Form.Item>
+        )}
 
         {/* GH #1401: let the tenant type their app's port; blank = auto-assign.
             Server validates it (range + system-port denylist + not-in-use). */}

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -205,10 +205,13 @@ export const UserDomainList = () => {
         <Dropdown
           trigger={["click"]}
           menu={{
+            // GH #1449 + #1417/#1419: only offer a service the server actually
+            // runs — hide "DNS Zone" when the DNS module is off, "Mail Domain"
+            // when mail is off (`!== false` treats the pre-load state as on).
             items: [
               { key: "web", label: "Web Domain" },
-              { key: "dns", label: "DNS Zone" },
-              { key: "mail", label: "Mail Domain" },
+              ...(caps?.dns_enabled !== false ? [{ key: "dns", label: "DNS Zone" }] : []),
+              ...(caps?.mail_enabled !== false ? [{ key: "mail", label: "Mail Domain" }] : []),
             ],
             onClick: ({ key }) => openDrawer(key as DomainDrawerMode),
           }}

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -40,7 +40,7 @@ import { DomainRedirectsButton } from "../../DomainRedirectsButton";
 import { TenantNginxRulesButton } from "../../DomainSettingsButton";
 import { DomainCacheButton } from "../../../components/DomainCacheButton";
 import { DomainIndexButton } from "../../DomainIndexButton";
-import { UserDomainDrawer } from "./UserDomainDrawer";
+import { UserDomainDrawer, type DomainDrawerMode } from "./UserDomainDrawer";
 import { DomainNginxOptionsModal } from "../../../components/DomainNginxOptionsModal";
 import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 
@@ -121,9 +121,30 @@ export type Domain = {
     | null;
   ssl_state?: string;
   email_enabled?: boolean;
+  // GH #1449: independent services. web_disabled = docroot-less (DNS-only /
+  // mail-only); dns_disabled = the panel doesn't host this domain's DNS.
+  web_disabled?: boolean;
+  dns_disabled?: boolean;
   bytes_30d?: number;
   created_at: string;
   updated_at: string;
+};
+
+// GH #1449: a short badge for a domain that isn't a plain full-service web
+// site, so the three row kinds are distinguishable in the list. Returns null
+// for an ordinary web domain (the common case — no badge noise).
+export const serviceBadge = (
+  d: Pick<Domain, "web_disabled" | "dns_disabled" | "email_enabled">,
+): { label: string; color: string } | null => {
+  if (d.web_disabled) {
+    return d.email_enabled
+      ? { label: "Mail only", color: "purple" }
+      : { label: "DNS only", color: "blue" };
+  }
+  if (d.dns_disabled) {
+    return { label: "External DNS", color: "default" };
+  }
+  return null;
 };
 
 type ActiveModal = { domainId: string; type: "redirects" | "index" | "directory-privacy" | "caching" | "nginx-options" | "rewrite-rules" | "document-root" } | null;
@@ -136,6 +157,12 @@ export const UserDomainList = () => {
   const { data: caps } = useServerCapabilities();
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // GH #1449: the same drawer serves three add-flows (web / dns-only / mail-only).
+  const [drawerMode, setDrawerMode] = useState<DomainDrawerMode>("web");
+  const openDrawer = (mode: DomainDrawerMode) => {
+    setDrawerMode(mode);
+    setDrawerOpen(true);
+  };
   const query = useTableURL<Domain>({
     resource: "domains",
     defaultSort: "name",
@@ -171,13 +198,25 @@ export const UserDomainList = () => {
         <Typography.Title level={3} style={{ margin: 0 }}>
           <GlobalOutlined /> Domains
         </Typography.Title>
-        <Button
-          type="primary"
-          icon={<PlusSquareOutlined />}
-          onClick={() => setDrawerOpen(true)}
+        {/* GH #1449: Web / DNS / Mail are independent services — offer each as
+            its own add-flow. "Web Domain" keeps the full form (with Mail + DNS
+            opt-outs); the other two add a docroot-less DNS-only zone or a
+            mail-only domain. */}
+        <Dropdown
+          trigger={["click"]}
+          menu={{
+            items: [
+              { key: "web", label: "Web Domain" },
+              { key: "dns", label: "DNS Zone" },
+              { key: "mail", label: "Mail Domain" },
+            ],
+            onClick: ({ key }) => openDrawer(key as DomainDrawerMode),
+          }}
         >
-          Add Domain
-        </Button>
+          <Button type="primary" icon={<PlusSquareOutlined />}>
+            Add
+          </Button>
+        </Dropdown>
       </Space>
 
       <Card>
@@ -206,9 +245,18 @@ export const UserDomainList = () => {
               currentQ: query.params.q,
               onSearch: (v) => query.setParams({ q: v, page: 1 }),
             })}
-            render={(name: string, record: Domain) => (
+            render={(name: string, record: Domain) => {
+              const svc = serviceBadge(record);
+              return (
               <>
                 {renderDomainCell(name, record.doc_root)}
+                {svc && (
+                  <div>
+                    <Tag color={svc.color} style={{ fontSize: 12 }}>
+                      {svc.label}
+                    </Tag>
+                  </div>
+                )}
                 {record.reverse_proxy_port ? (
                   <div>
                     <Tooltip title={`Reverse proxy — run your app on 127.0.0.1:${record.reverse_proxy_port}`}>
@@ -232,7 +280,8 @@ export const UserDomainList = () => {
                   </div>
                 )}
               </>
-            )}
+              );
+            }}
           />
           <Table.Column<Domain>
             dataIndex="is_enabled"
@@ -496,7 +545,7 @@ export const UserDomainList = () => {
           />
         </SearchableTableStringQ>
       </Card>
-      <UserDomainDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <UserDomainDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} mode={drawerMode} />
     </div>
   );
 };

--- a/panel-ui/src/shells/user/domains/serviceBadge.test.ts
+++ b/panel-ui/src/shells/user/domains/serviceBadge.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { serviceBadge } from "./UserDomainList";
+
+// GH #1449: the list badge distinguishes the three row kinds and stays silent
+// for an ordinary full-service web domain.
+describe("serviceBadge", () => {
+  it("no badge for a plain web domain", () => {
+    expect(serviceBadge({ web_disabled: false, dns_disabled: false, email_enabled: true })).toBeNull();
+  });
+
+  it("DNS only when web off and no mail", () => {
+    expect(serviceBadge({ web_disabled: true, email_enabled: false })?.label).toBe("DNS only");
+  });
+
+  it("Mail only when web off and mail on", () => {
+    expect(serviceBadge({ web_disabled: true, email_enabled: true })?.label).toBe("Mail only");
+  });
+
+  it("External DNS when a web domain opts out of hosted DNS", () => {
+    expect(serviceBadge({ web_disabled: false, dns_disabled: true })?.label).toBe("External DNS");
+  });
+});


### PR DESCRIPTION
## Problem (GH #1449)

Adding a domain always created a web vhost **and** a DNS zone, and "No Mail" only *deactivated* mail. Tenants who host only DNS, only email, or only a website for a given domain couldn't add or manage those services independently (HestiaCP does).

## Approach — service flags on the domain row

Rather than fork separate tables, Web / Mail / DNS become independent toggles on the existing `domains` row — the pattern `IsPanelPrimary` and `docker_app` already use for docroot-less domains, and how mail already toggles via `mail_provider`:

- **`web_disabled`** → docroot-less: no vhost / PHP / web-SSL / apex-A. A DNS-only zone or a mail-only domain.
- **`dns_disabled`** → the reconciler doesn't host DNS (external DNS).
- **mail** stays `MailProvider` (`none` = off), unchanged.

The three "Add" flows (Web / DNS Zone / Mail Domain) are the **same** `POST /domains` endpoint with preset flags — no forked orchestration, no new routes.

### Flags stored inverted (disabled, DEFAULT 0) — deliberate

Zero-value = service **ON**, so: the whole existing fleet + every in-memory test fixture stay full-service untouched, and the non-default (disabled) is a non-zero value GORM always writes — **sidestepping the `email_enabled` zero-value scar** (migration 000123) without every create having to set the flag. The API/UI speak positive (`web_enabled` / `manage_dns` checkboxes on create; `enabled = !*_disabled` on read).

## Reconciler gating (one gate per function → all call sites covered)

- `reconcileDNSZone` returns early on `dns_disabled` — **before** the find/auto-create branch, so a disabled zone can't resurrect every tick.
- A **web-off branch** in `reconcileEnabledDomain` (mirroring the docroot-less `IsPanelPrimary` path) runs DNS + mail + mail-cert SANs + MTA-STS and skips the vhost / PHP binding.
- `createDomainOnAgent` + `convergeApexAddrRecords` early-return when web is off; the bootstrap apex-A/www seed and the recursor forwarder are web/dns gated.
- **All-flags-on is byte-identical** — existing zones don't re-push (no `dnsZonePushNeeded` churn).

## SSL matrix (reuses existing machinery)

- web+mail = today; web-only = apex/www; **mail-only = DNS-01-or-park** (a web-off domain has `DocRoot=""` and no apex vhost, so HTTP-01 would fail on the empty webroot and burn LE quota — the TXT validates the apex + mail SANs when we host the zone, else it parks with a clear reason and the self-signed bootstrap keeps Stalwart/webmail on TLS); **DNS-only = ssl none** (forced).

## Create validation

`web_enabled` / `manage_dns` default ON (only a false opts out). Web-off refuses reverse-proxy / preview-URL / custom-docroot; a domain that hosts nothing (`web off + dns off + no jabali mail`) is refused; DNS-only forces ssl none.

## UI

Tenant Domains "Add" → **Web Domain / DNS Zone / Mail Domain** (dropdown gated on the DNS/mail module caps, per #1417/#1419). The shared drawer presets each mode and adds a **"Manage DNS here"** opt-out. The list badges **DNS-only / Mail-only / External-DNS** rows.

## Test plan

- [x] `go test -race ./internal/api/... ./internal/reconciler/... ./internal/dnscompile/... ./internal/models/...` — new `domain_create_service_flags_test.go` (DNS-only / mail-only / external-DNS / all-off-refused / full-service-default / web-off rejects reverse-proxy+docroot) + `bootstrap` includeApex test; all 78 existing reconciler `Domain` fixtures pass **unchanged** (the inverted zero-value)
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `tsc -b` + `vitest` (drawer modes / `serviceBadge` / existing domain gating)
- [x] **Migration 000289 up+down validated on the test server's live MariaDB**: adds both cols DEFAULT 0; a row inserted without them = `0/0` (full-service — the fleet backward-compat guarantee); down drops cleanly
- [ ] **Recommended pre-merge box-drill** (needs deploying this branch's panel-api to .60): (a) DNS-only create → pdns zone SOA+NS only, `dig` answers, no vhost, no cert row; (b) external-DNS web create → vhost, no pdns zone, no recursor forward; (c) restart → zero `dns.zone.upsert` churn on existing zones; (d) create-then-delete DNS-only + mail-only rows clean. I can run this on your go-ahead. (Delete tolerance already verified by code: `domain.delete` ignores `os.Remove` on missing vhost files.)

## Deferred (documented, per the operator's "build the full decoupling" — narrowings made visible)

- Turning a service **off later** (vhost / pdns-zone teardown — `dns.zone.delete` verb exists) and surfacing the flags on the **edit** path (a dedicated setter; the Update `.Select()` allowlist deliberately leaves them create-only for now).
- **Admin-side** create UI (this PR wires the tenant drawer; the admin `DomainCreate` is a follow-up on the same API).
- A **mail-only + external-DNS** domain still gets a panel-DB zone row from `domainmailops.Enable` (it holds the DKIM/MX values the tenant copies out), so its zone page reads "provisioned" for a zone we don't host — the same lying-UI class as #1459; worth a follow-up.
- DNS-only rows **consume `MaxDomains` quota** (intended).

## Rollout

panel-api + panel-ui + migration 000289 (additive, default 0 = no behaviour change for existing domains). No agent change.
