### PR TITLE
chore(apps): adopt ITFlow 2026-09 stable — exec-free domain-expiry (GH #1461)

### DIFF
--- a/panel-agent/internal/commands/itflow_install.go
+++ b/panel-agent/internal/commands/itflow_install.go
@@ -67,9 +67,16 @@ const itflowRepoURL = "https://github.com/itflow-org/itflow.git"
 // reset the working tree to this reviewed SHA at install time and verify HEAD
 // matches — installs are reproducible and never pull an unreviewed master tip.
 // Bump deliberately (code review) when adopting a newer ITFlow.
-// 2026-08 stable (GH #928): the major release that makes cron.php a
-// dispatcher (single every-minute crontab entry).
-const itflowMasterPinnedCommit = "ccaa45b0ae9900ad731a6491559f65ff8d87a8f3"
+// 2026-09-04 stable (GH #1461): develop->master release merge (upstream
+// PR #1301). Domain-expiry lookups were rewritten to RDAP + native DNS +
+// a port-43 whois socket (functions/domain.php) — no PHP exec functions.
+// The in-app updater still shells out to git (exec/shell_exec in
+// functions/app.php) but now degrades gracefully when they're disabled.
+// Focused-review at bump time: setup_cli.php CLI interface + db.sql import
+// + config.php write unchanged (our installer contract holds); getIP()
+// still defaults to REMOTE_ADDR (GH #226 — no XFF/proxy-header trust under
+// our nginx->FPM); no exec left in the expiry path.
+const itflowMasterPinnedCommit = "dbf143d771535e1a350d02b36e7559ee153b8abb"
 
 // itflowDevelopPinnedCommit pins the `develop` branch (GH #332). develop is
 // ITFlow's active dev branch  bleeding-edge and NOT security-reviewed; we pin

--- a/panel-api/internal/apps/itflow.go
+++ b/panel-api/internal/apps/itflow.go
@@ -25,7 +25,7 @@ var ITFlow = App{
 	Tags:                 []string{"CRM", "Project management"},
 	DefaultSubdirectory:  "",
 	RequiresDB:           true,
-	InstallNotice:        "ITFlow uses PHP exec functions (proc_open / shell_exec) for its in-app updater and domain-expiry lookups, which the in-app cron runs under PHP-FPM. By default FPM blocks those functions. To enable them, an admin assigns this site's owner a hosting package with 'Allow PHP exec functions' turned on (Admin → Packages); without it, the base install still works but the updater / expiry lookups will not.",
+	InstallNotice:        "ITFlow's in-app updater runs git via PHP exec functions (exec / shell_exec), which PHP-FPM blocks by default. The base install and its domain-expiry lookups work fully without them — as of the 2026-09 stable, expiry uses RDAP + native DNS, no exec. Only the in-app updater is affected, and it now degrades gracefully: it shows the installed version from the local .git and reports that updates can't be fetched, instead of erroring. To enable in-app updates, an admin assigns this site's owner a hosting package with 'Allow PHP exec functions' turned on (Admin → Packages).",
 	EmailLogin:           true,
 	RootOnly:             true,
 	SupportedPHPVersions: nil,


### PR DESCRIPTION
## GH #1461

@johnnyq reported ITFlow shipped a new stable (master) that no longer requires `proc_open` / `shell_exec`, and asked to drop the install notice about enabling PHP exec functions.

## What I found (verified against upstream `itflow-org/itflow`)

The claim is **partly** right, so this is a coupled change, not a plain notice deletion:

- **Domain-expiry** (`functions/domain.php`) is rewritten to **RDAP + native DNS + a port-43 whois socket — no exec**. ✅
- The **in-app updater** (`functions/app.php`) **still** shells out to git (`exec("git fetch")` + `shell_exec("git log")`, lines 594/614) — but now **degrades gracefully** when those are disabled (reads status from the local `.git`, reports that updates can't be fetched, instead of erroring).
- The expiry rewrite exists only in the **new** master — jabali pinned `ccaa45b0` (2026-08), which still needs exec for expiry. So delivering the fix means **bumping the reviewed pin**, not just editing the notice.

## Change

- **Pin bump** `ccaa45b0` → `dbf143d` (2026-09-04 stable = upstream develop→master merge, PR #1301). Focused review at bump time (per the GH #455/#928 discipline — a full 194-commit line audit isn't feasible, so this targets the install-critical + security-relevant paths):
  - `setup_cli.php` CLI interface, `db.sql` import, and `config.php` write are **unchanged** — our clone + headless-setup installer contract holds.
  - `getIP()` still defaults to `REMOTE_ADDR` (GH #226 — no XFF / `CF-Connecting-IP` trust unless the define is set, which we don't set; no IP-spoofing behind our nginx→FPM).
  - `functions/domain.php` has **zero** exec/shell_exec/proc_open.
- **Notice reworded**: the base install *and* domain-expiry now work fully without PHP exec functions; only the in-app updater is affected, and it degrades gracefully. Enabling in-app updates still needs a package with "Allow PHP exec functions".
- `develop` pin left as-is (bleeding-edge, unreviewed by design).

## Test plan

- [x] `go build ./...`, `go test -race ./internal/apps/... ./internal/commands/...`, `gofmt` — no test pins the old SHA or the notice text
- [x] **Box-drilled the new pin on the test server**: `git clone` master + `reset --hard dbf143d` (HEAD verified) → `scripts/setup_cli.php` headless with our **exact** arg shape → `Setup complete!`, `db.sql` imported (141 tables), admin user created, `config.php` written, on PHP 8.4.24. `functions/domain.php` exec count = **0**. Scratch DB + dir cleaned up.

## Rollout

panel-agent (`itflow_install.go` pin) + panel-api (catalog notice) — **needs a fleet agent redeploy** on release (like #1416/#1435/#1458) so new installs use the bumped pin. Existing ITFlow installs are unaffected (they self-update along their own `.git`).
