### PR TITLE
refactor(settings): shared settingsops optional-module EffectPlan (JAB-294)

### DIFF
--- a/panel-api/cmd/server/settings_cmd.go
+++ b/panel-api/cmd/server/settings_cmd.go
@@ -113,9 +113,8 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load settings: %w", err)
 	}
 
-	// Snapshot the fields whose change drives a host side effect, plus a full
-	// pre-mutation copy so settingsops can classify the nginx effect.
-	prev := sideEffectSnapshot(s)
+	// Full pre-mutation snapshot. settingsops derives every host side effect
+	// (optional modules + nginx) by diffing it against the merged settings.
 	before := *s
 
 	// Apply each key=value. Unknown key / bad value → hard error (criterion #4).
@@ -140,7 +139,7 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 	}
 
 	// REST precondition: tenant Docker requires the marketplace engine.
-	if s.DockerAppsForUsersEnabled && !prev.dockerForUsers && !s.DockerMarketplaceEnabled {
+	if s.DockerAppsForUsersEnabled && !before.DockerAppsForUsersEnabled && !s.DockerMarketplaceEnabled {
 		return fmt.Errorf("docker_apps_for_users_enabled requires docker_marketplace_enabled (enable the Docker marketplace first)")
 	}
 
@@ -151,7 +150,7 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 	// Side effects, synchronous, in the REST order. A failure here means the DB
 	// is updated but the host apply failed — report it explicitly (no silent
 	// drift) and exit non-zero.
-	if applyErr := applySettingsSideEffects(ctx, cmd, repo, s, before, prev); applyErr != nil {
+	if applyErr := applySettingsSideEffects(ctx, cmd, repo, s, before); applyErr != nil {
 		cliAuditErr(ctx, "server_settings.update", "server_settings", "1", nil)
 		return applyErr
 	}
@@ -164,30 +163,11 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// sideEffectState captures the pre-change values that decide which host side
-// effects fire (mirrors the REST handler's prev* locals).
-type sideEffectState struct {
-	hostname       string
-	postgres       bool
-	dockerMarket   bool
-	dockerForUsers bool
-	python         bool
-}
-
-func sideEffectSnapshot(s *models.ServerSettings) sideEffectState {
-	return sideEffectState{
-		hostname:       s.Hostname,
-		postgres:       s.PostgresEnabled,
-		dockerMarket:   s.DockerMarketplaceEnabled,
-		dockerForUsers: s.DockerAppsForUsersEnabled,
-		python:         s.PythonAppsEnabled,
-	}
-}
-
 // applySettingsSideEffects dispatches the agent calls the REST PATCH would,
 // synchronously, with the REST per-operation timeouts. Returns the first
-// failure (the DB is already persisted at this point).
-func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repository.ServerSettingsRepository, s *models.ServerSettings, before models.ServerSettings, prev sideEffectState) error {
+// failure (the DB is already persisted at this point). `before` is the full
+// pre-change snapshot; settingsops derives every transition from it.
+func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repository.ServerSettingsRepository, s *models.ServerSettings, before models.ServerSettings) error {
 	out := cmd.OutOrStdout()
 
 	// Hostname → apply to the OS. Mirrors the REST PATCH, which dispatches
@@ -195,57 +175,61 @@ func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repo
 	// goroutine; here synchronous like the rest of this command so the operator
 	// sees the result inline). The panel-cert reconciler reissues the panel
 	// certificate for the new name on its next pass — same as the UI flow.
-	if s.Hostname != prev.hostname {
+	if s.Hostname != before.Hostname {
 		fmt.Fprintf(out, "Applying hostname change (system.set_hostname %s)…\n", s.Hostname)
 		if err := callAgentTimeout(ctx, 30*time.Second, "system.set_hostname", map[string]any{"hostname": s.Hostname}); err != nil {
 			return fmt.Errorf("DB updated, but system.set_hostname failed: %w", err)
 		}
 	}
 
-	if s.PostgresEnabled != prev.postgres {
-		method := "db.postgres.disable"
-		if s.PostgresEnabled {
-			method = "db.postgres.install"
-		}
-		fmt.Fprintf(out, "Applying Postgres change (%s) — this may take several minutes…\n", method)
-		if err := callAgentTimeout(ctx, 5*time.Minute, method, map[string]any{}); err != nil {
-			return fmt.Errorf("DB updated, but %s failed: %w", method, err)
+	// Optional-module lifecycle. settingsops.ModuleEffects owns every verb, its
+	// params, timeout, and the failed-enable rollback decision (JAB-294), shared
+	// with the REST PATCH. The CLI dispatches the subset it has setters for —
+	// postgres, docker marketplace, tenant docker, python — synchronously (unlike
+	// REST's best-effort goroutines) so the operator sees each result inline; the
+	// execution policy stays this adapter's. The dns/mail/quota/security/ftp module
+	// loop and FTP config-reapply are REST-only: there are no CLI setters for those
+	// flags, so those effects are always no-ops here (like nginx cache in JAB-290).
+	// The module still owns them; the CLI simply does not consume them.
+	plan := settingsops.ModuleEffects(&before, s)
+
+	if call := plan.Postgres.Call; call != nil {
+		fmt.Fprintf(out, "Applying Postgres change (%s) — this may take several minutes…\n", call.Method)
+		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
+			return fmt.Errorf("DB updated, but %s failed: %w", call.Method, err)
 		}
 	}
 
-	if s.DockerMarketplaceEnabled != prev.dockerMarket {
-		method := "docker.disable"
-		if s.DockerMarketplaceEnabled {
-			method = "docker.install"
-		}
-		fmt.Fprintf(out, "Applying Docker marketplace change (%s) — this may take several minutes…\n", method)
-		if err := callAgentTimeout(ctx, 10*time.Minute, method, map[string]any{}); err != nil {
-			return fmt.Errorf("DB updated, but %s failed: %w", method, err)
+	if call := plan.Docker.Call; call != nil {
+		fmt.Fprintf(out, "Applying Docker marketplace change (%s) — this may take several minutes…\n", call.Method)
+		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
+			return fmt.Errorf("DB updated, but %s failed: %w", call.Method, err)
 		}
 	}
 
-	if s.DockerAppsForUsersEnabled != prev.dockerForUsers {
-		fmt.Fprintf(out, "Applying tenant Docker change (docker.tenant_set enabled=%v) — this may take several minutes…\n", s.DockerAppsForUsersEnabled)
-		if err := callAgentTimeout(ctx, 12*time.Minute, "docker.tenant_set", map[string]any{"enabled": s.DockerAppsForUsersEnabled}); err != nil {
-			// On a failed ENABLE, revert the flag so the UI/DB reflects that the
-			// host setup did not happen (mirrors the REST revert).
-			if s.DockerAppsForUsersEnabled {
+	if call := plan.DockerTenant.Call; call != nil {
+		fmt.Fprintf(out, "Applying tenant Docker change (%s enabled=%v) — this may take several minutes…\n", call.Method, s.DockerAppsForUsersEnabled)
+		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
+			// On a failed ENABLE, revert the flag so the DB reflects that host setup
+			// did not happen. settingsops owns the decision (RevertOnEnableFailure);
+			// the repo write is this adapter's (mirrors the REST revert).
+			if plan.DockerTenant.RevertOnEnableFailure {
 				rctx, rcancel := context.WithTimeout(context.Background(), 15*time.Second)
 				if cur, gerr := repo.Get(rctx); gerr == nil && cur != nil {
 					cur.DockerAppsForUsersEnabled = false
 					_ = repo.Upsert(rctx, cur)
 				}
 				rcancel()
+				return fmt.Errorf("DB updated, but %s failed (flag reverted): %w", call.Method, err)
 			}
-			return fmt.Errorf("DB updated, but docker.tenant_set failed (flag reverted): %w", err)
+			return fmt.Errorf("DB updated, but %s failed: %w", call.Method, err)
 		}
 	}
 
-	// Python: install runtime on enable only (disable leaves packages).
-	if s.PythonAppsEnabled != prev.python && s.PythonAppsEnabled {
+	if call := plan.Python.Call; call != nil {
 		fmt.Fprintln(out, "Installing Python app runtime — this may take several minutes…")
-		if err := callAgentTimeout(ctx, 10*time.Minute, "app.python.install_runtime", map[string]any{}); err != nil {
-			return fmt.Errorf("DB updated, but app.python.install_runtime failed: %w", err)
+		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
+			return fmt.Errorf("DB updated, but %s failed: %w", call.Method, err)
 		}
 	}
 
@@ -254,8 +238,8 @@ func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repo
 	// Cache stays false; nginxDirty is the touched signal. Dispatch is
 	// synchronous (unlike REST's best-effort goroutine) so the operator sees the
 	// result inline — the CLI's execution policy stays in this adapter.
-	plan := settingsops.NginxEffects(&before, s, settingsops.NginxTouched{Tunables: nginxDirty})
-	if call := plan.Tunables.Call; call != nil {
+	nginxPlan := settingsops.NginxEffects(&before, s, settingsops.NginxTouched{Tunables: nginxDirty})
+	if call := nginxPlan.Tunables.Call; call != nil {
 		fmt.Fprintln(out, "Applying nginx tunables (validated with nginx -t)…")
 		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
 			return fmt.Errorf("DB updated, but %s failed: %w", call.Method, err)

--- a/panel-api/cmd/server/settings_cmd_dispatch_test.go
+++ b/panel-api/cmd/server/settings_cmd_dispatch_test.go
@@ -14,9 +14,9 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/settingsops"
 )
 
-// nginxTestSettings has every nginx tunable populated; hostname/postgres/docker/
-// python are left at their zero values and matched by prev so only the nginx
-// side effect fires.
+// nginxTestSettings has every nginx tunable populated; the module flags are left
+// at their zero values (matched by a zero `before`) so only the nginx side effect
+// fires.
 func nginxTestSettings() *models.ServerSettings {
 	return &models.ServerSettings{
 		SSHPort:                  22,
@@ -50,6 +50,38 @@ func stubSettingsDispatch(t *testing.T, retErr error) *[]settingsops.AgentCall {
 	return &calls
 }
 
+// recordingRepo is a minimal ServerSettingsRepository that records Upsert calls
+// so the docker-tenant revert path can be asserted.
+type recordingRepo struct {
+	current *models.ServerSettings
+	upserts []*models.ServerSettings
+}
+
+func (r *recordingRepo) Get(context.Context) (*models.ServerSettings, error) {
+	cp := *r.current
+	return &cp, nil
+}
+func (r *recordingRepo) Upsert(_ context.Context, s *models.ServerSettings) error {
+	cp := *s
+	r.upserts = append(r.upserts, &cp)
+	r.current = &cp
+	return nil
+}
+func (r *recordingRepo) EnsureVAPID(context.Context, string) (bool, error) { return false, nil }
+func (r *recordingRepo) SetDigestLastSent(context.Context, string) error   { return nil }
+func (r *recordingRepo) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
+func (r *recordingRepo) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
+}
+
+func applyCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	return cmd
+}
+
 // TestApplySideEffects_NginxDispatchesSharedWire proves the CLI executes the
 // settingsops plan synchronously with the exact wire (JAB-290 AC5: the CLI's
 // execution policy stays in the adapter; the wire is shared).
@@ -59,10 +91,7 @@ func TestApplySideEffects_NginxDispatchesSharedWire(t *testing.T) {
 	calls := stubSettingsDispatch(t, nil)
 
 	s := nginxTestSettings()
-	cmd := &cobra.Command{}
-	cmd.SetOut(&bytes.Buffer{})
-
-	err := applySettingsSideEffects(context.Background(), cmd, nil, s, models.ServerSettings{}, sideEffectSnapshot(s))
+	err := applySettingsSideEffects(context.Background(), applyCmd(), nil, s, models.ServerSettings{})
 	require.NoError(t, err)
 
 	require.Len(t, *calls, 1, "exactly one nginx dispatch (no cache verb on the CLI)")
@@ -94,26 +123,104 @@ func TestApplySideEffects_NginxFailureSurfaced(t *testing.T) {
 	stubSettingsDispatch(t, errors.New("nginx -t rejected config"))
 
 	s := nginxTestSettings()
-	cmd := &cobra.Command{}
-	cmd.SetOut(&bytes.Buffer{})
-
-	err := applySettingsSideEffects(context.Background(), cmd, nil, s, models.ServerSettings{}, sideEffectSnapshot(s))
+	err := applySettingsSideEffects(context.Background(), applyCmd(), nil, s, models.ServerSettings{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "DB updated, but nginx.tunables.apply failed")
 	require.Contains(t, err.Error(), "nginx -t rejected config")
 }
 
-// TestApplySideEffects_NoNginx_NoDispatch: with nginxDirty clear, nothing is
-// dispatched.
+// TestApplySideEffects_NoNginx_NoDispatch: with nginxDirty clear and no module
+// change, nothing is dispatched.
 func TestApplySideEffects_NoNginx_NoDispatch(t *testing.T) {
 	nginxDirty = false
 	calls := stubSettingsDispatch(t, nil)
 
 	s := nginxTestSettings()
-	cmd := &cobra.Command{}
-	cmd.SetOut(&bytes.Buffer{})
-
-	err := applySettingsSideEffects(context.Background(), cmd, nil, s, models.ServerSettings{}, sideEffectSnapshot(s))
+	err := applySettingsSideEffects(context.Background(), applyCmd(), nil, s, models.ServerSettings{})
 	require.NoError(t, err)
 	require.Empty(t, *calls)
+}
+
+// TestApplySideEffects_ModuleWire proves the CLI dispatches the four module
+// transitions it has setters for with the shared settingsops wire.
+func TestApplySideEffects_ModuleWire(t *testing.T) {
+	cases := []struct {
+		name           string
+		before, after  models.ServerSettings
+		wantMethod     string
+		wantParams     map[string]any
+		wantTimeoutMin time.Duration
+	}{
+		{"postgres enable", models.ServerSettings{}, models.ServerSettings{PostgresEnabled: true}, "db.postgres.install", map[string]any{}, 5},
+		{"postgres disable", models.ServerSettings{PostgresEnabled: true}, models.ServerSettings{}, "db.postgres.disable", map[string]any{}, 5},
+		{"docker enable", models.ServerSettings{}, models.ServerSettings{DockerMarketplaceEnabled: true}, "docker.install", map[string]any{}, 10},
+		{"docker-tenant enable", models.ServerSettings{DockerMarketplaceEnabled: true}, models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: true}, "docker.tenant_set", map[string]any{"enabled": true}, 12},
+		{"python enable", models.ServerSettings{}, models.ServerSettings{PythonAppsEnabled: true}, "app.python.install_runtime", map[string]any{}, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := stubSettingsDispatch(t, nil)
+			after := tc.after
+			err := applySettingsSideEffects(context.Background(), applyCmd(), nil, &after, tc.before)
+			require.NoError(t, err)
+			require.Len(t, *calls, 1)
+			require.Equal(t, tc.wantMethod, (*calls)[0].Method)
+			require.Equal(t, tc.wantParams, (*calls)[0].Params)
+			require.Equal(t, tc.wantTimeoutMin*time.Minute, (*calls)[0].Timeout)
+		})
+	}
+}
+
+// TestApplySideEffects_PythonDisableNoDispatch: disabling python installs nothing.
+func TestApplySideEffects_PythonDisableNoDispatch(t *testing.T) {
+	calls := stubSettingsDispatch(t, nil)
+	after := models.ServerSettings{}
+	err := applySettingsSideEffects(context.Background(), applyCmd(), nil, &after, models.ServerSettings{PythonAppsEnabled: true})
+	require.NoError(t, err)
+	require.Empty(t, *calls)
+}
+
+// TestApplySideEffects_DockerTenantRevertOnFailedEnable proves the CLI reverts
+// the persisted flag when a tenant-Docker ENABLE fails — settingsops flags the
+// decision (RevertOnEnableFailure), this adapter runs the repo write.
+func TestApplySideEffects_DockerTenantRevertOnFailedEnable(t *testing.T) {
+	stubSettingsDispatch(t, errors.New("unprivileged LXC: userns-remap unavailable"))
+	repo := &recordingRepo{current: &models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: true}}
+
+	after := models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: true}
+	before := models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: false}
+	err := applySettingsSideEffects(context.Background(), applyCmd(), repo, &after, before)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "flag reverted")
+	require.Len(t, repo.upserts, 1, "revert must persist exactly one flag-clearing Upsert")
+	require.False(t, repo.upserts[0].DockerAppsForUsersEnabled, "revert must clear the flag")
+}
+
+// TestApplySideEffects_DockerTenantDisableNoRevert: a failed DISABLE surfaces the
+// error but does not revert (there is nothing to undo).
+func TestApplySideEffects_DockerTenantDisableNoRevert(t *testing.T) {
+	stubSettingsDispatch(t, errors.New("agent down"))
+	repo := &recordingRepo{current: &models.ServerSettings{}}
+
+	after := models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: false}
+	before := models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: true}
+	err := applySettingsSideEffects(context.Background(), applyCmd(), repo, &after, before)
+
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "flag reverted")
+	require.Empty(t, repo.upserts, "disable failure must not revert")
+}
+
+// TestApplySideEffects_RESTOnlyModulesSkippedByCLI: the dns/mail/quota/security/
+// ftp loop is REST-only (no CLI setters). Even if `before`/`after` differ on
+// those flags, the CLI dispatches nothing for them — the fail-closed ftp.disable
+// path is never triggered from the CLI.
+func TestApplySideEffects_RESTOnlyModulesSkippedByCLI(t *testing.T) {
+	calls := stubSettingsDispatch(t, nil)
+	after := models.ServerSettings{} // ftp/dns off
+	before := models.ServerSettings{FTPEnabled: true, DNSEnabled: true, MailEnabled: true}
+	err := applySettingsSideEffects(context.Background(), applyCmd(), nil, &after, before)
+	require.NoError(t, err)
+	require.Empty(t, *calls, "REST-only module loop must not dispatch from the CLI")
 }

--- a/panel-api/cmd/server/settings_cmd_test.go
+++ b/panel-api/cmd/server/settings_cmd_test.go
@@ -110,11 +110,11 @@ func TestSettingsHostnameParity(t *testing.T) {
 
 	t.Run("change is detectable for the side effect", func(t *testing.T) {
 		s := &models.ServerSettings{ID: 1, SSHPort: 22, Hostname: "mx.jabali-panel.com"}
-		prev := sideEffectSnapshot(s)
+		before := *s
 		if err := def.apply(s, "182-54-236-60-b.jabalihosted.com"); err != nil {
 			t.Fatal(err)
 		}
-		if s.Hostname == prev.hostname {
+		if s.Hostname == before.Hostname {
 			t.Fatal("hostname change not detectable — system.set_hostname would not fire")
 		}
 	})

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -312,22 +312,16 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		return
 	}
 
+	// Full pre-merge snapshot. settingsops.ModuleEffects and NginxEffects both
+	// diff against it (nginx fields are untouched until the nginx merge far
+	// below, so this single snapshot serves both — no separate beforeNginx).
+	before := *current
+
+	// Optional-module transitions (postgres, docker marketplace + tenant, python,
+	// and the dns/mail/quota/security/ftp loop) are detected from `before` by
+	// settingsops.ModuleEffects below — no per-flag prev* locals needed here.
 	prevHostname := current.Hostname
-	prevPostgresEnabled := current.PostgresEnabled
-	prevDNSEnabled := current.DNSEnabled
-	prevMailEnabled := current.MailEnabled
-	prevQuotaEnabled := current.QuotaEnabled
-	prevSecurityEnabled := current.SecurityEnabled
-	prevFTPEnabled := current.FTPEnabled
-	prevFTPAllowPlaintext := current.FTPAllowPlaintext
-	prevFTPPasvAddress := current.FTPPasvAddress
-	prevFTPMaxClients := current.FTPMaxClients
-	prevFTPMaxPerIP := current.FTPMaxPerIP
-	prevFTPLocalMaxRateKBs := current.FTPLocalMaxRateKBs
 	prevPanelBrandText := current.PanelBrandText
-	prevDockerEnabled := current.DockerMarketplaceEnabled
-	prevDockerForUsers := current.DockerAppsForUsersEnabled
-	prevPythonEnabled := current.PythonAppsEnabled
 	prevWebadminEnabled := current.StalwartWebadminEnabled
 	prevWebadminCIDRs := current.StalwartWebadminAllowCIDRs
 	prevTimezone := current.Timezone
@@ -732,10 +726,10 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		req.NginxProxyReadTimeout != nil || req.NginxProxySendTimeout != nil ||
 		req.NginxWorkerProcesses != nil || req.NginxWorkerConnections != nil ||
 		req.NginxCustomHTTP != nil
-	// Snapshot the pre-merge nginx values so settingsops can classify the effect
-	// (changed vs explicit re-apply). The dispatch decision below stays keyed on
-	// nginxTouched/cacheCapTouched, preserving the original re-sync semantics.
-	beforeNginx := *current
+	// The pre-merge nginx values live in `before` (captured at the top, before any
+	// field merge — nginx fields are untouched until here). settingsops uses it to
+	// classify the effect (changed vs explicit re-apply). The dispatch decision
+	// below stays keyed on nginxTouched/cacheCapTouched, preserving re-sync.
 	if req.NginxClientMaxBodySize != nil {
 		current.NginxClientMaxBodySize = strings.TrimSpace(*req.NginxClientMaxBodySize)
 	}
@@ -794,7 +788,7 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	// Admin opt-in for tenant Docker apps. Enabling requires the engine; the
 	// host tenant setup itself is dispatched AFTER persist (below), detached
 	// from this request — see the background goroutine.
-	if current.DockerAppsForUsersEnabled != prevDockerForUsers &&
+	if current.DockerAppsForUsersEnabled != before.DockerAppsForUsersEnabled &&
 		current.DockerAppsForUsersEnabled && !current.DockerMarketplaceEnabled {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "docker_not_installed", "detail": "enable the Docker marketplace first"})
 		return
@@ -820,77 +814,44 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		}()
 	}
 
-	// M37 Phase 4: Postgres opt-in. flip true → install + start;
-	// flip false → stop + disable (data preserved). Dispatch in
-	// the background — install can take up to ~60s on apt-get and
-	// the PATCH should not block the UI for that long. The DB row
-	// already reflects the operator intent; reconcile will eventually
-	// catch up on retry.
-	if current.PostgresEnabled != prevPostgresEnabled && h.cfg.Agent != nil {
-		go func(target bool) {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-			method := "db.postgres.disable"
-			if target {
-				method = "db.postgres.install"
-			}
-			if _, err := h.cfg.Agent.Call(bgCtx, method, map[string]any{}); err != nil {
-				h.cfg.Log.Error("agent postgres lifecycle failed",
-					"method", method, "err", err)
-			}
-		}(current.PostgresEnabled)
-	}
-
-	// M353 module install-on-enable. Flipping an optional module On must INSTALL
-	// its packages if they're missing (not just flip the DB flag). Mirrors the
-	// postgres pattern: background dispatch of system.module.install so the PATCH
-	// doesn't block on apt. Wired only for modules install.sh supports at runtime
-	// today. On flip false→true install the module; on flip true→false stop +
-	// disable its services (system.module.disable — data preserved, guardrails
-	// like ufw/pdns-recursor left running). Transition-dispatch only, with ONE
-	// exception: for most modules there is deliberately NO auto
-	// disable-convergence (stopping a "disabled" service every tick would fight
-	// an operator troubleshooting a manual start, and is destructive when a
-	// status read is wrong — unlike install-convergence). FTP is the exception
-	// (JAB-259): it is a security shutoff, so it takes the fail-closed ftp.disable
-	// verb here AND is reconciled toward inactive+masked+ports-closed every tick
-	// (convergeFtpDisabled) — a disabled FTP that stays reachable is a security
-	// hole, not a troubleshooting convenience.
+	// Optional-module lifecycle (JAB-294). settingsops.ModuleEffects is the single
+	// owner of every optional-module transition table, agent verb/params/timeout,
+	// and the failed-enable rollback decision (postgres, docker marketplace +
+	// tenant, python, and the dns/mail/quota/security/ftp system.module.* loop).
+	// The REST handler and the CLI both execute this one plan — the CLI consuming
+	// only the subset it has setters for. This adapter dispatches each non-no-op
+	// effect the REST way: detached, best-effort, one goroutine per effect, so a
+	// slow apt install or a client disconnect never blocks or aborts the PATCH.
+	// The DB row already holds operator intent; a failed apply reconciles on the
+	// next pass. FTP disable is the fail-closed exception (JAB-259): it takes the
+	// ftp.disable verb (not the fail-soft system.module.disable) and is reconciled
+	// toward inactive+masked+ports-closed every tick by convergeFtpDisabled — a
+	// disabled FTP that stays reachable is a security hole. For most modules there
+	// is deliberately NO disable-convergence (stopping a "disabled" service every
+	// tick would fight an operator troubleshooting a manual start).
+	modulePlan := settingsops.ModuleEffects(&before, current)
 	if h.cfg.Agent != nil {
-		for _, m := range []struct {
-			key           string
-			prev, current bool
-		}{
-			{"dns", prevDNSEnabled, current.DNSEnabled},
-			{"mail", prevMailEnabled, current.MailEnabled},
-			{"quota", prevQuotaEnabled, current.QuotaEnabled},
-			{"security", prevSecurityEnabled, current.SecurityEnabled},
-			{"ftp", prevFTPEnabled, current.FTPEnabled},
-		} {
-			switch {
-			case m.current && !m.prev:
-				h.dispatchModuleInstall(m.key)
-			case !m.current && m.prev:
-				if m.key == "ftp" {
-					// JAB-259: fail-closed shutoff (stop+mask+close ports+verify),
-					// not the generic fail-soft disable.
-					h.dispatchFtpDisable()
-				} else {
-					h.dispatchModuleDisable(m.key)
-				}
-			}
+		if call := modulePlan.Postgres.Call; call != nil {
+			go h.dispatchSettingsCall(*call, "agent postgres lifecycle failed")
 		}
-		// GH #1053: vsftpd.conf is rendered from ftp_allow_plaintext +
-		// ftp_pasv_address at module-install time. When either changes while
-		// the module stays enabled, re-dispatch the (idempotent) install so
-		// the config re-renders and vsftpd restarts with the new values.
-		if current.FTPEnabled && prevFTPEnabled &&
-			(current.FTPAllowPlaintext != prevFTPAllowPlaintext ||
-				current.FTPPasvAddress != prevFTPPasvAddress ||
-				current.FTPMaxClients != prevFTPMaxClients ||
-				current.FTPMaxPerIP != prevFTPMaxPerIP ||
-				current.FTPLocalMaxRateKBs != prevFTPLocalMaxRateKBs) {
-			h.dispatchModuleInstall("ftp")
+		for _, me := range modulePlan.Modules {
+			call := me.Call
+			if call == nil {
+				continue
+			}
+			logMsg := "agent module install failed"
+			switch call.Method {
+			case "system.module.disable":
+				logMsg = "agent module disable failed"
+			case "ftp.disable":
+				logMsg = "ftp fail-closed disable failed (reconciler will retry)"
+			}
+			go h.dispatchSettingsCall(*call, logMsg)
+		}
+		// GH #1053: FTP config change while the module stays enabled re-renders
+		// vsftpd.conf via the idempotent install.
+		if call := modulePlan.FTPReapply.Call; call != nil {
+			go h.dispatchSettingsCall(*call, "agent module install failed")
 		}
 	}
 
@@ -909,66 +870,22 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		}(current.PanelBrandText)
 	}
 
-	// M48 docker marketplace opt-in. Mirrors the postgres pattern
-	// above: flip true -> install_docker_engine; flip false -> stop
-	// + disable units, data under /var/lib/jabali/docker-apps left
-	// intact. Background dispatch so the operator's PATCH does not
-	// block on apt-get.
-	if current.DockerMarketplaceEnabled != prevDockerEnabled && h.cfg.Agent != nil {
-		go func(target bool) {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
-			method := "docker.disable"
-			if target {
-				method = "docker.install"
-			}
-			if _, err := h.cfg.Agent.Call(bgCtx, method, map[string]any{}); err != nil {
-				h.cfg.Log.Error("agent docker lifecycle failed",
-					"method", method, "err", err)
-			}
-		}(current.DockerMarketplaceEnabled)
-	}
-
-	// Tenant Docker opt-in: run the host tenant setup (userns-remap, ~minutes)
-	// or teardown DETACHED from this request, so a client disconnect can't kill
-	// a half-done docker retrofit. The host flag the agent writes is the source
-	// of truth for the docker_apps_user_enabled capability, so a failed enable
-	// simply leaves the tab hidden (no DB/host drift to reconcile).
-	if current.DockerAppsForUsersEnabled != prevDockerForUsers && h.cfg.Agent != nil {
-		go func(target bool) {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
-			defer cancel()
-			if _, err := h.cfg.Agent.Call(bgCtx, "docker.tenant_set", map[string]any{"enabled": target}); err != nil {
-				h.cfg.Log.Error("agent docker.tenant_set failed", "enabled", target, "err", err)
-				// On a failed ENABLE (e.g. unprivileged LXC — GH #272), revert the
-				// DB flag so the UI toggle reflects reality (host setup did NOT
-				// happen) instead of showing "enabling…" forever. Fresh context:
-				// bgCtx may already be exhausted from the agent call/timeout.
-				if target {
-					rctx, rcancel := context.WithTimeout(context.Background(), 15*time.Second)
-					defer rcancel()
-					if cur, gerr := h.cfg.Repo.Get(rctx); gerr == nil && cur != nil {
-						cur.DockerAppsForUsersEnabled = false
-						if uerr := h.cfg.Repo.Upsert(rctx, cur); uerr != nil {
-							h.cfg.Log.Error("revert docker_apps_for_users after failed enable", "err", uerr)
-						}
-					}
-				}
-			}
-		}(current.DockerAppsForUsersEnabled)
-	}
-
-	// ADR-0131: install the Python app runtime prerequisites on enable
-	// (mirrors the docker/postgres opt-ins). Disable leaves packages in
-	// place. Background dispatch so the PATCH does not block on apt.
-	if current.PythonAppsEnabled != prevPythonEnabled && current.PythonAppsEnabled && h.cfg.Agent != nil {
-		go func() {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
-			if _, err := h.cfg.Agent.Call(bgCtx, "app.python.install_runtime", map[string]any{}); err != nil {
-				h.cfg.Log.Error("agent python runtime install failed", "err", err)
-			}
-		}()
+	// Optional-module lifecycle, continued: docker marketplace, tenant Docker, and
+	// the Python runtime — the same settingsops plan. Tenant Docker additionally
+	// reverts its persisted flag if an ENABLE fails (GH #272 — unprivileged LXC):
+	// the module flags the decision (RevertOnEnableFailure), this adapter runs the
+	// Repo write (dispatchDockerTenant). Python installs on enable only; disable
+	// leaves packages, which the module encodes as a no-op.
+	if h.cfg.Agent != nil {
+		if call := modulePlan.Docker.Call; call != nil {
+			go h.dispatchSettingsCall(*call, "agent docker lifecycle failed")
+		}
+		if call := modulePlan.DockerTenant.Call; call != nil {
+			go h.dispatchDockerTenant(*call, modulePlan.DockerTenant.RevertOnEnableFailure)
+		}
+		if call := modulePlan.Python.Call; call != nil {
+			go h.dispatchSettingsCall(*call, "agent python runtime install failed")
+		}
 	}
 
 	// Apply timezone to the OS via agent if changed and not empty.
@@ -1104,16 +1021,16 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	// way: async, detached, best-effort (the DB already holds the truth; a later
 	// reconcile syncs on failure). Dispatch stays keyed on Touched, so the
 	// re-sync semantics are unchanged.
-	nginxPlan := settingsops.NginxEffects(&beforeNginx, current, settingsops.NginxTouched{
+	nginxPlan := settingsops.NginxEffects(&before, current, settingsops.NginxTouched{
 		Tunables: nginxTouched,
 		Cache:    cacheCapTouched,
 	})
 	if h.cfg.Agent != nil {
 		if call := nginxPlan.Tunables.Call; call != nil {
-			go h.dispatchNginx(*call, "agent nginx tunables apply failed")
+			go h.dispatchSettingsCall(*call, "agent nginx tunables apply failed")
 		}
 		if call := nginxPlan.Cache.Call; call != nil {
-			go h.dispatchNginx(*call, "agent nginx cache capacity apply failed")
+			go h.dispatchSettingsCall(*call, "agent nginx cache capacity apply failed")
 		}
 	}
 
@@ -1133,15 +1050,44 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	c.JSON(http.StatusOK, current)
 }
 
-// dispatchNginx executes one settingsops nginx AgentCall the REST way: detached
+// dispatchSettingsCall executes one settingsops AgentCall the REST way: detached
 // from the request (a client disconnect must not cancel the apply), bounded by
 // the call's own timeout, best-effort (failure is logged, not surfaced — the DB
 // already holds the truth and a later reconcile syncs). Run it in a goroutine.
-func (h *serverSettingsHandler) dispatchNginx(call settingsops.AgentCall, logMsg string) {
+// Shared by the nginx and optional-module dispatches (JAB-290 / JAB-294).
+func (h *serverSettingsHandler) dispatchSettingsCall(call settingsops.AgentCall, logMsg string) {
 	bgCtx, cancel := context.WithTimeout(context.Background(), call.Timeout)
 	defer cancel()
 	if _, err := h.cfg.Agent.Call(bgCtx, call.Method, call.Params); err != nil {
-		h.cfg.Log.Error(logMsg, "err", err)
+		// Log method + params so the module key / postgres|docker method survives
+		// (a superset of the pre-refactor per-verb attributes).
+		h.cfg.Log.Error(logMsg, "method", call.Method, "params", call.Params, "err", err)
+	}
+}
+
+// dispatchDockerTenant runs the tenant-Docker toggle detached, and — when the
+// module flagged this as an ENABLE that must not leave a false "enabling…" state
+// on failure (GH #272, unprivileged LXC) — reverts the persisted flag so the UI
+// reflects that host setup did not happen. settingsops owns the decision
+// (revertOnFailure); the revert itself (Repo.Get→clear→Upsert) is persistence and
+// stays this adapter's job because it needs the handler's own repo handle. Run
+// it in a goroutine.
+func (h *serverSettingsHandler) dispatchDockerTenant(call settingsops.AgentCall, revertOnFailure bool) {
+	bgCtx, cancel := context.WithTimeout(context.Background(), call.Timeout)
+	defer cancel()
+	if _, err := h.cfg.Agent.Call(bgCtx, call.Method, call.Params); err != nil {
+		h.cfg.Log.Error("agent docker.tenant_set failed", "params", call.Params, "err", err)
+		if !revertOnFailure {
+			return
+		}
+		rctx, rcancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer rcancel()
+		if cur, gerr := h.cfg.Repo.Get(rctx); gerr == nil && cur != nil {
+			cur.DockerAppsForUsersEnabled = false
+			if uerr := h.cfg.Repo.Upsert(rctx, cur); uerr != nil {
+				h.cfg.Log.Error("revert docker_apps_for_users after failed enable", "err", uerr)
+			}
+		}
 	}
 }
 
@@ -1303,34 +1249,10 @@ func (h *serverSettingsHandler) dispatchModuleInstall(key string) {
 	}()
 }
 
-// dispatchModuleDisable stops + disables a module's services in the background
-// when the module is turned OFF. Data is preserved (never purged), so
-// re-enabling restarts the services via the idempotent install path. Detached
-// so the PATCH returns immediately.
-func (h *serverSettingsHandler) dispatchModuleDisable(key string) {
-	go func() {
-		bgCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		if _, err := h.cfg.Agent.Call(bgCtx, "system.module.disable", map[string]any{"key": key}); err != nil {
-			h.cfg.Log.Error("agent module disable failed", "key", key, "err", err)
-		}
-	}()
-}
-
-// dispatchFtpDisable runs the FAIL-CLOSED FTP shutoff (JAB-259) instead of the
-// generic fail-soft system.module.disable: stop + mask vsftpd, remove its UFW
-// rules, and verify inactive+masked. Async like the other module dispatches —
-// the reconciler's convergeFtpDisabled retries until the daemon is confirmed
-// down and the ports are closed, so a failure here is logged, never lost.
-func (h *serverSettingsHandler) dispatchFtpDisable() {
-	go func() {
-		bgCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		if _, err := h.cfg.Agent.Call(bgCtx, "ftp.disable", map[string]any{}); err != nil {
-			h.cfg.Log.Error("ftp fail-closed disable failed (reconciler will retry)", "err", err)
-		}
-	}()
-}
+// The module-disable and fail-closed FTP-disable transitions now flow through
+// settingsops.ModuleEffects + dispatchSettingsCall (JAB-294); the standalone
+// dispatchModuleDisable / dispatchFtpDisable helpers were retired. Install still
+// has its own helper because the module status endpoint re-dispatches it.
 
 // installableModules are the module keys with a runtime install path (mirrors
 // install.sh's --install-module dispatcher + the agent allowlist). api_enabled

--- a/panel-api/internal/api/server_settings_module_dispatch_test.go
+++ b/panel-api/internal/api/server_settings_module_dispatch_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// This file characterizes the exact optional-module agent wire the REST PATCH
+// dispatches (postgres / docker marketplace / tenant docker / python and the
+// dns/mail/quota/security/ftp system.module.* loop). Every assertion was written
+// and run GREEN against the pre-refactor handler to lock the wire, so the
+// JAB-294 settingsops extraction is proven byte-identical: same verb, params,
+// and — critically for JAB-259 — ftp disable stays the fail-closed ftp.disable
+// verb, never the generic system.module.disable.
+
+// moduleCallParams waits for command (dispatch is an async goroutine) and
+// returns its decoded params. Fails if none arrives.
+func moduleCallParams(t *testing.T, mock *agent.MockClient, command string) map[string]any {
+	t.Helper()
+	params := map[string]any{}
+	require.Eventually(t, func() bool {
+		for _, c := range mock.Calls() {
+			if c.Command == command {
+				if len(c.Params) > 0 {
+					require.NoError(t, json.Unmarshal(c.Params, &params))
+				}
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, command+" was never dispatched")
+	return params
+}
+
+// requireNoCommand asserts command is never dispatched within a short window.
+func requireNoCommand(t *testing.T, mock *agent.MockClient, command string) {
+	t.Helper()
+	require.Never(t, func() bool {
+		return nginxCommandDispatched(mock, command)
+	}, 250*time.Millisecond, 10*time.Millisecond, command+" should not have been dispatched")
+}
+
+// patchSettings runs a PATCH against a handler seeded with existing, registering
+// canned OK responses for every command name in expectVerbs so the mock does not
+// log unknown-command errors, and returns the mock for wire assertions.
+func patchSettings(t *testing.T, existing *models.ServerSettings, body map[string]any, expectVerbs ...string) *agent.MockClient {
+	t.Helper()
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	mockAgent := agent.NewMockClient()
+	for _, v := range expectVerbs {
+		mockAgent.On(v, map[string]any{"status": "ok"})
+	}
+	r := settingsRouter(true, mockRepo, mockAgent)
+
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "PATCH should succeed; body=%s", rec.Body.String())
+	return mockAgent
+}
+
+func TestServerSettingsPatch_Postgres_Wire(t *testing.T) {
+	t.Run("enable", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, PostgresEnabled: false},
+			map[string]any{"postgres_enabled": true}, "db.postgres.install")
+		require.Equal(t, map[string]any{}, moduleCallParams(t, m, "db.postgres.install"))
+		requireNoCommand(t, m, "db.postgres.disable")
+	})
+	t.Run("disable", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, PostgresEnabled: true},
+			map[string]any{"postgres_enabled": false}, "db.postgres.disable")
+		require.Equal(t, map[string]any{}, moduleCallParams(t, m, "db.postgres.disable"))
+		requireNoCommand(t, m, "db.postgres.install")
+	})
+	t.Run("noop unrelated patch", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, PostgresEnabled: true},
+			map[string]any{"postgres_enabled": true}, "db.postgres.install")
+		requireNoCommand(t, m, "db.postgres.install")
+		requireNoCommand(t, m, "db.postgres.disable")
+	})
+}
+
+func TestServerSettingsPatch_ModuleLoop_Wire(t *testing.T) {
+	for _, key := range []string{"dns", "mail", "quota", "security"} {
+		key := key
+		t.Run(key+" enable", func(t *testing.T) {
+			existing := &models.ServerSettings{ID: 1, SSHPort: 22}
+			m := patchSettings(t, existing, map[string]any{key + "_enabled": true}, "system.module.install")
+			require.Equal(t, map[string]any{"key": key}, moduleCallParams(t, m, "system.module.install"))
+		})
+		t.Run(key+" disable", func(t *testing.T) {
+			existing := &models.ServerSettings{ID: 1, SSHPort: 22}
+			setModuleFlag(existing, key, true)
+			m := patchSettings(t, existing, map[string]any{key + "_enabled": false}, "system.module.disable")
+			require.Equal(t, map[string]any{"key": key}, moduleCallParams(t, m, "system.module.disable"))
+		})
+	}
+}
+
+// TestServerSettingsPatch_FTP_FailClosed is the assertion that must never
+// regress: turning FTP OFF fires the fail-closed ftp.disable verb (JAB-259),
+// NOT the generic system.module.disable.
+func TestServerSettingsPatch_FTP_FailClosed(t *testing.T) {
+	t.Run("enable installs", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, FTPEnabled: false},
+			map[string]any{"ftp_enabled": true}, "system.module.install")
+		require.Equal(t, map[string]any{"key": "ftp"}, moduleCallParams(t, m, "system.module.install"))
+		requireNoCommand(t, m, "ftp.disable")
+	})
+	t.Run("disable is fail-closed ftp.disable, not module.disable", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, FTPEnabled: true},
+			map[string]any{"ftp_enabled": false}, "ftp.disable")
+		require.Equal(t, map[string]any{}, moduleCallParams(t, m, "ftp.disable"))
+		requireNoCommand(t, m, "system.module.disable")
+	})
+	t.Run("config change while enabled re-renders via install", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, FTPEnabled: true, FTPAllowPlaintext: false}
+		m := patchSettings(t, existing, map[string]any{"ftp_allow_plaintext": true}, "system.module.install")
+		require.Equal(t, map[string]any{"key": "ftp"}, moduleCallParams(t, m, "system.module.install"))
+		requireNoCommand(t, m, "ftp.disable")
+	})
+	t.Run("enable does not also fire a reapply", func(t *testing.T) {
+		// false->true with a config field also set: install once, no extra reapply.
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, FTPEnabled: false, FTPAllowPlaintext: false}
+		m := patchSettings(t, existing,
+			map[string]any{"ftp_enabled": true, "ftp_allow_plaintext": true}, "system.module.install")
+		require.Equal(t, map[string]any{"key": "ftp"}, moduleCallParams(t, m, "system.module.install"))
+		// exactly one install call
+		var n int
+		for _, c := range m.Calls() {
+			if c.Command == "system.module.install" {
+				n++
+			}
+		}
+		require.Equal(t, 1, n, "enable+config-set must install once, not install+reapply")
+	})
+}
+
+func TestServerSettingsPatch_DockerMarketplace_Wire(t *testing.T) {
+	t.Run("enable", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, DockerMarketplaceEnabled: false},
+			map[string]any{"docker_marketplace_enabled": true}, "docker.install")
+		require.Equal(t, map[string]any{}, moduleCallParams(t, m, "docker.install"))
+		requireNoCommand(t, m, "docker.disable")
+	})
+	t.Run("disable", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, DockerMarketplaceEnabled: true},
+			map[string]any{"docker_marketplace_enabled": false}, "docker.disable")
+		require.Equal(t, map[string]any{}, moduleCallParams(t, m, "docker.disable"))
+	})
+}
+
+func TestServerSettingsPatch_DockerTenant_Wire(t *testing.T) {
+	t.Run("enable carries enabled=true", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: false}
+		m := patchSettings(t, existing, map[string]any{"docker_apps_for_users_enabled": true}, "docker.tenant_set")
+		require.Equal(t, map[string]any{"enabled": true}, moduleCallParams(t, m, "docker.tenant_set"))
+	})
+	t.Run("disable carries enabled=false", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: true}
+		m := patchSettings(t, existing, map[string]any{"docker_apps_for_users_enabled": false}, "docker.tenant_set")
+		require.Equal(t, map[string]any{"enabled": false}, moduleCallParams(t, m, "docker.tenant_set"))
+	})
+}
+
+func TestServerSettingsPatch_Python_Wire(t *testing.T) {
+	t.Run("enable installs runtime", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, PythonAppsEnabled: false},
+			map[string]any{"python_apps_enabled": true}, "app.python.install_runtime")
+		require.Equal(t, map[string]any{}, moduleCallParams(t, m, "app.python.install_runtime"))
+	})
+	t.Run("disable installs nothing", func(t *testing.T) {
+		m := patchSettings(t, &models.ServerSettings{ID: 1, SSHPort: 22, PythonAppsEnabled: true},
+			map[string]any{"python_apps_enabled": false})
+		requireNoCommand(t, m, "app.python.install_runtime")
+	})
+}
+
+// setModuleFlag flips one of the generic-loop module flags on s.
+func setModuleFlag(s *models.ServerSettings, key string, v bool) {
+	switch key {
+	case "dns":
+		s.DNSEnabled = v
+	case "mail":
+		s.MailEnabled = v
+	case "quota":
+		s.QuotaEnabled = v
+	case "security":
+		s.SecurityEnabled = v
+	case "ftp":
+		s.FTPEnabled = v
+	}
+}

--- a/panel-api/internal/settingsops/modules.go
+++ b/panel-api/internal/settingsops/modules.go
@@ -1,0 +1,184 @@
+package settingsops
+
+import (
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Optional-module agent timeouts. Pinned here as the single owner so the REST
+// handler and the CLI cannot drift (they each carried their own copies before
+// JAB-294). Values match the pre-extraction goroutine / callAgentTimeout budgets.
+const (
+	postgresApplyTimeout = 5 * time.Minute
+	moduleInstallTimeout = 10 * time.Minute
+	moduleDisableTimeout = 2 * time.Minute
+	ftpDisableTimeout    = 2 * time.Minute
+	dockerApplyTimeout   = 10 * time.Minute
+	dockerTenantTimeout  = 12 * time.Minute
+	pythonInstallTimeout = 10 * time.Minute
+)
+
+// loopModuleKeys is the generic optional-module set driven by the agent's
+// system.module.* verbs, in REST dispatch order. FTP is in the set but takes a
+// fail-closed disable verb (see moduleLoopEffect). These flags are REST-only in
+// practice (the CLI exposes no setters for them), like nginx cache in JAB-290.
+var loopModuleKeys = []string{"dns", "mail", "quota", "security", "ftp"}
+
+// ModuleEffect pairs an optional-module key with its computed transition Effect.
+type ModuleEffect struct {
+	Key string
+	Effect
+}
+
+// ModulePlan is the declarative optional-module dispatch plan. Each named field
+// is one module's enable/disable/reapply transition; Modules holds the generic
+// system.module.* loop in REST dispatch order; FTPReapply re-renders vsftpd.conf
+// when FTP config changes while the module stays enabled. Every Effect with a
+// non-nil Call is dispatched by the adapter under its own policy (REST detached
+// best-effort, CLI synchronous). The module never dispatches.
+//
+// CLI adapters consume only {Postgres, Docker, DockerTenant, Python} — the
+// transitions they have setters for. Modules and FTPReapply are REST-only.
+type ModulePlan struct {
+	Postgres     Effect
+	Docker       Effect // Docker marketplace engine
+	DockerTenant Effect // tenant Docker apps (docker.tenant_set) — reverts flag on failed enable
+	Python       Effect // enable-only (disable leaves packages)
+	Modules      []ModuleEffect
+	FTPReapply   Effect
+}
+
+// ModuleEffects derives the optional-module effect plan from the validated
+// before/after settings. before is the pre-merge snapshot (old flag values);
+// after is the merged settings that will be persisted. Detection is by value
+// change (before != after) — a toggle, not a re-sync — so the module fully owns
+// transition detection here (unlike nginx, which stays touched-based).
+func ModuleEffects(before, after *models.ServerSettings) ModulePlan {
+	modules := make([]ModuleEffect, 0, len(loopModuleKeys))
+	for _, key := range loopModuleKeys {
+		modules = append(modules, ModuleEffect{
+			Key:    key,
+			Effect: moduleLoopEffect(key, moduleFlag(before, key), moduleFlag(after, key)),
+		})
+	}
+	return ModulePlan{
+		Postgres: toggleEffect(before.PostgresEnabled, after.PostgresEnabled,
+			"db.postgres.install", "db.postgres.disable", postgresApplyTimeout),
+		Docker: toggleEffect(before.DockerMarketplaceEnabled, after.DockerMarketplaceEnabled,
+			"docker.install", "docker.disable", dockerApplyTimeout),
+		DockerTenant: dockerTenantEffect(before.DockerAppsForUsersEnabled, after.DockerAppsForUsersEnabled),
+		Python:       pythonEffect(before.PythonAppsEnabled, after.PythonAppsEnabled),
+		Modules:      modules,
+		FTPReapply:   ftpReapplyEffect(before, after),
+	}
+}
+
+// moduleFlag reads one generic-loop module's flag off s.
+func moduleFlag(s *models.ServerSettings, key string) bool {
+	switch key {
+	case "dns":
+		return s.DNSEnabled
+	case "mail":
+		return s.MailEnabled
+	case "quota":
+		return s.QuotaEnabled
+	case "security":
+		return s.SecurityEnabled
+	case "ftp":
+		return s.FTPEnabled
+	}
+	return false
+}
+
+// toggleEffect is a plain on/off module: enable dispatches methodOn, disable
+// methodOff, both with an empty param map. NoOp when the flag did not change.
+func toggleEffect(before, after bool, methodOn, methodOff string, timeout time.Duration) Effect {
+	if before == after {
+		return Effect{Kind: NoOp}
+	}
+	method := methodOff
+	if after {
+		method = methodOn
+	}
+	return Effect{
+		Kind: Changed,
+		Call: &AgentCall{Method: method, Params: map[string]any{}, Timeout: timeout},
+	}
+}
+
+// moduleLoopEffect is one generic system.module.* transition. Enable installs;
+// disable stops+disables — EXCEPT ftp, which takes the fail-closed ftp.disable
+// verb (JAB-259): a "disabled" FTP that stays reachable is a security hole, so
+// it is shut off hard (and reconciled toward closed every tick), never fail-soft.
+func moduleLoopEffect(key string, before, after bool) Effect {
+	switch {
+	case after && !before:
+		return Effect{
+			Kind: Changed,
+			Call: &AgentCall{Method: "system.module.install", Params: map[string]any{"key": key}, Timeout: moduleInstallTimeout},
+		}
+	case !after && before:
+		if key == "ftp" {
+			return Effect{
+				Kind: Changed,
+				Call: &AgentCall{Method: "ftp.disable", Params: map[string]any{}, Timeout: ftpDisableTimeout},
+			}
+		}
+		return Effect{
+			Kind: Changed,
+			Call: &AgentCall{Method: "system.module.disable", Params: map[string]any{"key": key}, Timeout: moduleDisableTimeout},
+		}
+	default:
+		return Effect{Kind: NoOp}
+	}
+}
+
+// dockerTenantEffect toggles tenant Docker via docker.tenant_set{enabled}. On the
+// enable direction the effect is flagged RevertOnEnableFailure so the adapter
+// clears the persisted flag if the host setup fails (GH #272 — unprivileged LXC).
+func dockerTenantEffect(before, after bool) Effect {
+	if before == after {
+		return Effect{Kind: NoOp}
+	}
+	return Effect{
+		Kind:                  Changed,
+		Call:                  &AgentCall{Method: "docker.tenant_set", Params: map[string]any{"enabled": after}, Timeout: dockerTenantTimeout},
+		RevertOnEnableFailure: after, // revert only on a failed ENABLE
+	}
+}
+
+// pythonEffect installs the runtime on enable only; disable leaves packages in
+// place (there is no disable verb), so a true→false transition is a NoOp.
+func pythonEffect(before, after bool) Effect {
+	if after && !before {
+		return Effect{
+			Kind: Changed,
+			Call: &AgentCall{Method: "app.python.install_runtime", Params: map[string]any{}, Timeout: pythonInstallTimeout},
+		}
+	}
+	return Effect{Kind: NoOp}
+}
+
+// ftpReapplyEffect re-renders vsftpd.conf (via the idempotent system.module.install)
+// when an FTP config field changes while the module stays enabled (GH #1053).
+// It is a Reapply (module unchanged, config re-synced), distinct from an
+// enable/disable toggle — so it does NOT fire when FTP itself is toggling.
+func ftpReapplyEffect(before, after *models.ServerSettings) Effect {
+	if after.FTPEnabled && before.FTPEnabled && ftpConfigDiffers(before, after) {
+		return Effect{
+			Kind: Reapply,
+			Call: &AgentCall{Method: "system.module.install", Params: map[string]any{"key": "ftp"}, Timeout: moduleInstallTimeout},
+		}
+	}
+	return Effect{Kind: NoOp}
+}
+
+// ftpConfigDiffers reports whether any vsftpd.conf-driving field changed.
+func ftpConfigDiffers(before, after *models.ServerSettings) bool {
+	return after.FTPAllowPlaintext != before.FTPAllowPlaintext ||
+		after.FTPPasvAddress != before.FTPPasvAddress ||
+		after.FTPMaxClients != before.FTPMaxClients ||
+		after.FTPMaxPerIP != before.FTPMaxPerIP ||
+		after.FTPLocalMaxRateKBs != before.FTPLocalMaxRateKBs
+}

--- a/panel-api/internal/settingsops/modules_test.go
+++ b/panel-api/internal/settingsops/modules_test.go
@@ -1,0 +1,137 @@
+package settingsops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// findModule returns the ModuleEffect for key from a plan's generic loop.
+func findModule(t *testing.T, p ModulePlan, key string) ModuleEffect {
+	t.Helper()
+	for _, m := range p.Modules {
+		if m.Key == key {
+			return m
+		}
+	}
+	t.Fatalf("module %q not in plan", key)
+	return ModuleEffect{}
+}
+
+func TestModuleEffects_Postgres(t *testing.T) {
+	enable := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{PostgresEnabled: true})
+	require.Equal(t, Changed, enable.Postgres.Kind)
+	require.Equal(t, &AgentCall{Method: "db.postgres.install", Params: map[string]any{}, Timeout: 5 * time.Minute}, enable.Postgres.Call)
+
+	disable := ModuleEffects(&models.ServerSettings{PostgresEnabled: true}, &models.ServerSettings{})
+	require.Equal(t, &AgentCall{Method: "db.postgres.disable", Params: map[string]any{}, Timeout: 5 * time.Minute}, disable.Postgres.Call)
+
+	noop := ModuleEffects(&models.ServerSettings{PostgresEnabled: true}, &models.ServerSettings{PostgresEnabled: true})
+	require.Equal(t, NoOp, noop.Postgres.Kind)
+	require.Nil(t, noop.Postgres.Call)
+}
+
+func TestModuleEffects_DockerMarketplace(t *testing.T) {
+	enable := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{DockerMarketplaceEnabled: true})
+	require.Equal(t, &AgentCall{Method: "docker.install", Params: map[string]any{}, Timeout: 10 * time.Minute}, enable.Docker.Call)
+	disable := ModuleEffects(&models.ServerSettings{DockerMarketplaceEnabled: true}, &models.ServerSettings{})
+	require.Equal(t, &AgentCall{Method: "docker.disable", Params: map[string]any{}, Timeout: 10 * time.Minute}, disable.Docker.Call)
+}
+
+func TestModuleEffects_DockerTenant_RevertOnlyOnEnable(t *testing.T) {
+	enable := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{DockerAppsForUsersEnabled: true})
+	require.Equal(t, &AgentCall{Method: "docker.tenant_set", Params: map[string]any{"enabled": true}, Timeout: 12 * time.Minute}, enable.DockerTenant.Call)
+	require.True(t, enable.DockerTenant.RevertOnEnableFailure, "failed ENABLE must revert the persisted flag")
+
+	disable := ModuleEffects(&models.ServerSettings{DockerAppsForUsersEnabled: true}, &models.ServerSettings{})
+	require.Equal(t, map[string]any{"enabled": false}, disable.DockerTenant.Call.Params)
+	require.False(t, disable.DockerTenant.RevertOnEnableFailure, "disable must not revert")
+
+	noop := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{})
+	require.Equal(t, NoOp, noop.DockerTenant.Kind)
+	require.False(t, noop.DockerTenant.RevertOnEnableFailure)
+}
+
+func TestModuleEffects_Python_EnableOnly(t *testing.T) {
+	enable := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{PythonAppsEnabled: true})
+	require.Equal(t, &AgentCall{Method: "app.python.install_runtime", Params: map[string]any{}, Timeout: 10 * time.Minute}, enable.Python.Call)
+
+	// disable leaves packages — no verb, NoOp (not a Changed with nil Call).
+	disable := ModuleEffects(&models.ServerSettings{PythonAppsEnabled: true}, &models.ServerSettings{})
+	require.Equal(t, NoOp, disable.Python.Kind)
+	require.Nil(t, disable.Python.Call)
+}
+
+func TestModuleEffects_GenericLoop_OrderAndVerbs(t *testing.T) {
+	// order is fixed: dns, mail, quota, security, ftp
+	p := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{})
+	got := make([]string, 0, len(p.Modules))
+	for _, m := range p.Modules {
+		got = append(got, m.Key)
+	}
+	require.Equal(t, []string{"dns", "mail", "quota", "security", "ftp"}, got)
+
+	for _, key := range []string{"dns", "mail", "quota", "security"} {
+		enable := findModule(t, ModuleEffects(&models.ServerSettings{}, withModule(key, true)), key)
+		require.Equal(t, &AgentCall{Method: "system.module.install", Params: map[string]any{"key": key}, Timeout: 10 * time.Minute}, enable.Call)
+
+		disable := findModule(t, ModuleEffects(withModule(key, true), &models.ServerSettings{}), key)
+		require.Equal(t, &AgentCall{Method: "system.module.disable", Params: map[string]any{"key": key}, Timeout: 2 * time.Minute}, disable.Call, "non-ftp disable is fail-soft")
+	}
+}
+
+// TestModuleEffects_FTP_FailClosed is the assertion that must never regress:
+// FTP disable is the fail-closed ftp.disable verb (JAB-259), never
+// system.module.disable.
+func TestModuleEffects_FTP_FailClosed(t *testing.T) {
+	enable := findModule(t, ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{FTPEnabled: true}), "ftp")
+	require.Equal(t, &AgentCall{Method: "system.module.install", Params: map[string]any{"key": "ftp"}, Timeout: 10 * time.Minute}, enable.Call)
+
+	disable := findModule(t, ModuleEffects(&models.ServerSettings{FTPEnabled: true}, &models.ServerSettings{}), "ftp")
+	require.Equal(t, "ftp.disable", disable.Call.Method, "FTP disable must be fail-closed ftp.disable")
+	require.Equal(t, map[string]any{}, disable.Call.Params)
+	require.Equal(t, 2*time.Minute, disable.Call.Timeout)
+}
+
+func TestModuleEffects_FTPReapply(t *testing.T) {
+	// config change while enabled → reapply via install.
+	before := &models.ServerSettings{FTPEnabled: true, FTPAllowPlaintext: false}
+	after := &models.ServerSettings{FTPEnabled: true, FTPAllowPlaintext: true}
+	p := ModuleEffects(before, after)
+	require.Equal(t, Reapply, p.FTPReapply.Kind)
+	require.Equal(t, &AgentCall{Method: "system.module.install", Params: map[string]any{"key": "ftp"}, Timeout: 10 * time.Minute}, p.FTPReapply.Call)
+	// module itself did not toggle
+	require.Equal(t, NoOp, findModule(t, p, "ftp").Kind)
+
+	// enabling FTP with a config field also set: the toggle installs, reapply
+	// stays NoOp (it fires only when FTP was ALREADY enabled).
+	toggling := ModuleEffects(&models.ServerSettings{FTPEnabled: false, FTPAllowPlaintext: false},
+		&models.ServerSettings{FTPEnabled: true, FTPAllowPlaintext: true})
+	require.Equal(t, NoOp, toggling.FTPReapply.Kind, "reapply must not fire while FTP is toggling on")
+	require.Equal(t, Changed, findModule(t, toggling, "ftp").Kind)
+
+	// no config change → no reapply.
+	same := ModuleEffects(&models.ServerSettings{FTPEnabled: true}, &models.ServerSettings{FTPEnabled: true})
+	require.Equal(t, NoOp, same.FTPReapply.Kind)
+}
+
+// withModule returns a ServerSettings with one generic-loop module flag set.
+func withModule(key string, v bool) *models.ServerSettings {
+	s := &models.ServerSettings{}
+	switch key {
+	case "dns":
+		s.DNSEnabled = v
+	case "mail":
+		s.MailEnabled = v
+	case "quota":
+		s.QuotaEnabled = v
+	case "security":
+		s.SecurityEnabled = v
+	case "ftp":
+		s.FTPEnabled = v
+	}
+	return s
+}

--- a/panel-api/internal/settingsops/nginx.go
+++ b/panel-api/internal/settingsops/nginx.go
@@ -43,10 +43,18 @@ type AgentCall struct {
 // compensating call if the apply fails; nil for nginx (the agent's own `nginx -t`
 // gate reverts a bad config, so there is no panel-side rollback). The field is
 // the seam JAB-295 (SSH) will populate.
+//
+// RevertOnEnableFailure marks an ENABLE transition whose persisted flag must be
+// cleared if Call fails (tenant Docker on unprivileged LXC — GH #272). The
+// module owns the decision (which module reverts, and only on the enable
+// direction); the adapter owns the execution — reverting the flag is a
+// persistence write against the adapter's own repo handle, not an agent call, so
+// it cannot be expressed as Rollback. Only DockerTenant sets this today.
 type Effect struct {
-	Kind     Kind
-	Call     *AgentCall
-	Rollback *AgentCall
+	Kind                  Kind
+	Call                  *AgentCall
+	Rollback              *AgentCall
+	RevertOnEnableFailure bool
 }
 
 // NginxTouched reports which nginx field families the adapter merged this


### PR DESCRIPTION
## Summary

The optional-module vertical slice of ADR-0083's `<area>ops` pattern, built on
the `settingsops` package from JAB-290. Before this change the REST PATCH
handler and the `jabali settings` CLI each carried their own hand-copied
dispatch for every optional-module transition — postgres, the Docker
marketplace engine, tenant Docker, the Python runtime, and the
`dns/mail/quota/security/ftp` `system.module.*` loop. Same verbs, same
parameter maps, same per-operation timeouts, written out twice and free to
drift.

New in **`internal/settingsops`** (still no `net/http`, no cobra, no `os.Exit`):

- **`ModuleEffects(before, after) ModulePlan`** — the single owner of every
  optional-module transition table, agent verb/params/timeout, and the
  failed-enable rollback decision. Detection is by value change
  (`before != after`) — a toggle, not a re-sync — so the module fully owns
  transition detection here (unlike nginx, which stays touched-based). The plan
  carries a named `Effect` per module plus the generic `system.module.*` loop
  (in REST dispatch order) and the FTP config-reapply effect. The module never
  dispatches — the adapters execute the plan under their own policy.
- **`Effect.RevertOnEnableFailure`** — marks an ENABLE transition whose
  persisted flag must be cleared if the agent call fails (tenant Docker on
  unprivileged LXC — GH #272).

## Dispatch semantics preserved exactly

Proven by characterization tests written and run **GREEN against the
pre-refactor handlers**, then kept GREEN through the extraction:

- **FTP disable stays the fail-closed `ftp.disable` verb (JAB-259)**, never the
  generic fail-soft `system.module.disable` — pinned at both the module golden
  and the REST wire. FTP install-on-enable and config-reapply-while-enabled both
  use the idempotent `system.module.install`, and reapply does **not** fire
  while FTP is toggling on.
- Python installs on enable only; disable is a no-op (leaves packages).
- Timeouts pinned in the module: postgres 5m, module install 10m / disable 2m,
  `ftp.disable` 2m, docker 10m, `docker.tenant_set` 12m, python 10m.

## Adapters

- **REST** (`internal/api/server_settings.go`): derives one `ModuleEffects` plan
  and dispatches each non-no-op effect the REST way — detached, best-effort, one
  goroutine per effect, with the unchanged per-verb log strings (and a superset
  of their structured attributes). The tenant-Docker revert-on-failed-enable
  body is unchanged, moved behind `dispatchDockerTenant`. A single pre-merge
  `before` snapshot now serves both `ModuleEffects` and `NginxEffects` (nginx
  fields are untouched until their merge, so the separate `beforeNginx` snapshot
  is gone). `dispatchNginx` is generalized to `dispatchSettingsCall`; the
  retired `dispatchModuleDisable` / `dispatchFtpDisable` helpers are removed
  (`dispatchModuleInstall` stays for the module-install endpoint).
- **CLI** (`cmd/server/settings_cmd.go`): derives the same plan and dispatches
  the subset it has setters for — postgres, docker marketplace, tenant Docker,
  python — synchronously, keeping the inline `DB updated, but %s failed` errors
  and the tenant-Docker flag revert. The `dns/mail/quota/security/ftp` loop and
  FTP config-reapply are **REST-only** (no CLI setters for those flags, so those
  effects are always no-ops here), exactly as nginx cache capacity is REST-only
  in JAB-290. The redundant `sideEffectState`/`sideEffectSnapshot` is dropped —
  the full `before` snapshot drives every transition.

## Acceptance criteria

- **AC1 — each module gets one enable/disable/reapply transition table:** ✅
  `ModuleEffects` is the single owner; both adapters consume it.
- **AC2 — exact agent commands/params/timeouts + failed-enable rollback shared:**
  ✅ with one honest caveat. The verb, params, timeout, and the *decision* to
  revert on a failed enable (`RevertOnEnableFailure`) are single-owned in
  `settingsops`. The *execution* of the revert (Repo.Get → clear flag → Upsert)
  stays adapter-side because it is a persistence write against the adapter's own
  repo handle, not an agent call — the same persistence-is-transport-shaped
  boundary as JAB-290's touched signal.
- **AC3 — REST detached best-effort, CLI synchronous:** ✅ REST dispatches one
  goroutine per effect; the CLI dispatches synchronously and surfaces the first
  failure. Adapter tests cover both policies.
- **AC4 — golden plan tests cover no-op / toggle / reapply / partial-failure:**
  ✅ no-op = `before == after`; toggle = a flip; reapply = an FTP config change
  while the module stays enabled (there is no touched-reapply here); partial
  failure = the CLI surfaces the first error and stops (exercised by the
  tenant-Docker revert test), while REST goroutines are independent by
  construction.
- **AC5 — FTP policy does not duplicate account-level effective-access rules:**
  ✅ the module fires only the host-level `system.module.install` / `ftp.disable`
  verbs; account-level FTP access rules live in the subaccount/isolation code
  and are not reimplemented here.

## Notes for reviewers

- The `dns/mail/quota/security/ftp` module loop is REST-only by design — the CLI
  exposes no setters for those flags (nginx.cache precedent). The CLI test
  `TestApplySideEffects_RESTOnlyModulesSkippedByCLI` locks this so nobody wires a
  dormant `ftp.disable` into the CLI, which would be a new, unvalidated security
  path.
- `dispatchModuleInstall` stays because the module-install endpoint
  re-dispatches it; only the disable/ftp-disable transitions moved into the plan.

## Test plan

- [x] `internal/settingsops`: golden wire per verb (method/params/timeout), Kind
      classification (no-op / changed / reapply), `RevertOnEnableFailure` only on
      the enable direction, the generic loop's order + verbs, the FTP fail-closed
      assertion, and FTP reapply's not-when-toggling case.
- [x] `internal/api`: HTTP-level wire tests for every verb, including ftp disable
      `== ftp.disable` (never `system.module.disable`), enable-installs-once (no
      extra reapply), and python-disable dispatches nothing.
- [x] `cmd/server`: module dispatch wire via the seam, the tenant-Docker
      revert-on-failed-enable path (repo sees exactly one flag-clearing Upsert),
      disable-failure-does-not-revert, and REST-only modules are not dispatched
      from the CLI.
- [x] `go build ./...`, `go vet ./...`, full `go test ./...`, gofmt clean,
      `-race` on the three packages.
- [x] Rebased onto latest `origin/main`, re-ran tests post-rebase.
- No box validation warranted: no new agent verb; the REST wire is proven
  identical green→green; and the fail-closed FTP shutoff is reachable only from
  REST (the CLI exposes no `ftp_enabled` setter), so no CLI behavior changed on
  the host.

## Disposition

JAB-294 is a module-parent, so it stays in Backlog per the codex arch-audit
convention even though all five ACs are substantively met. Continues the
settingsops line after JAB-290 (nginx + validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
