### PR TITLE
feat(mail): per-domain CalDAV/CardDAV server override (GH #1462)

### DIFF
--- a/panel-api/internal/api/dav_host_validate_test.go
+++ b/panel-api/internal/api/dav_host_validate_test.go
@@ -1,0 +1,40 @@
+package api
+
+import "testing"
+
+// GH #1462: the CalDAV/CardDAV override is interpolated unquoted into
+// space-separated SRV content, so validateDAVHost must accept only a bare
+// hostname[:port] and reject anything that could corrupt the record or
+// redirect discovery (spaces, schemes, paths, bad ports).
+func TestValidateDAVHost(t *testing.T) {
+	ok := []string{
+		"",                      // empty clears the override
+		"nextcloud.example.com", // plain host
+		"dav.example.com:8443",  // host:port
+		"a.b.c.example.co.uk",   // multi-label
+		"host-1.example.com",    // hyphen
+	}
+	for _, v := range ok {
+		if err := validateDAVHost(v); err != nil {
+			t.Errorf("validateDAVHost(%q) = %v, want nil", v, err)
+		}
+	}
+
+	bad := []string{
+		"nextcloud",                        // single label (no dot)
+		"nextcloud.example.com:0",          // port 0
+		"nextcloud.example.com:70000",      // port > 65535
+		"nextcloud.example.com:abc",        // non-numeric port
+		"https://nextcloud.example.com",    // scheme
+		"nextcloud.example.com/remote.php", // path
+		"nextcloud.example.com 443",        // space (SRV-content break)
+		"next cloud.example.com",           // space in host
+		"dav.exa\nmple.com",                // internal control char (not trimmable)
+		"-bad.example.com",                 // label starts with hyphen
+	}
+	for _, v := range bad {
+		if err := validateDAVHost(v); err == nil {
+			t.Errorf("validateDAVHost(%q) = nil, want error", v)
+		}
+	}
+}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -259,6 +259,43 @@ type updateDomainRequest struct {
 	// SSLMode (GH #246) — switch TLS mode. 'custom' is set only via
 	// PUT /domains/:id/ssl/custom (needs the cert), not here.
 	SSLMode *string `json:"ssl_mode,omitempty"`
+	// GH #1462: per-domain CalDAV/CardDAV server override (hostname, optional
+	// host:port). Empty string clears it (DAV points back at mail.<domain>);
+	// absent leaves it untouched. Repoints the _caldavs/_carddavs SRV records.
+	CalDAVHost  *string `json:"caldav_host,omitempty"`
+	CardDAVHost *string `json:"carddav_host,omitempty"`
+}
+
+// davHostRe validates a CalDAV/CardDAV override: a DNS hostname (lower/mixed
+// case) with an optional :port. It is interpolated UNQUOTED into space-
+// separated SRV record content ("weight port target"), so anything but a bare
+// hostname[:port] — a space, control char, path, scheme — must be rejected
+// before it can corrupt the record or point discovery somewhere unintended.
+var davHostRe = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(:[0-9]{1,5})?$`)
+
+// validateDAVHost accepts an empty string (clears the override) or a
+// hostname[:port] that matches davHostRe with the host <=253 octets and any
+// port in 1..65535.
+func validateDAVHost(v string) error {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil
+	}
+	host := v
+	if i := strings.LastIndexByte(v, ':'); i > 0 {
+		port, err := strconv.Atoi(v[i+1:])
+		if err != nil || port < 1 || port > 65535 {
+			return errors.New("port must be 1-65535")
+		}
+		host = v[:i]
+	}
+	if len(host) > 253 {
+		return errors.New("host exceeds 253 characters")
+	}
+	if !davHostRe.MatchString(v) {
+		return errors.New("must be a hostname, optionally host:port (e.g. dav.example.com or dav.example.com:8443)")
+	}
+	return nil
 }
 
 // nullableUint64 is the M24 wrapper that lets a PATCH body distinguish
@@ -929,6 +966,23 @@ func (h *domainHandler) update(c *gin.Context) {
 	}
 	if req.DmarcTesting != nil {
 		domain.DmarcTesting = *req.DmarcTesting
+	}
+	// GH #1462: per-domain CalDAV/CardDAV override (hostname[:port]; empty clears).
+	if req.CalDAVHost != nil {
+		v := strings.TrimSpace(*req.CalDAVHost)
+		if err := validateDAVHost(v); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_caldav_host", "detail": err.Error()})
+			return
+		}
+		domain.CalDAVHost = v
+	}
+	if req.CardDAVHost != nil {
+		v := strings.TrimSpace(*req.CardDAVHost)
+		if err := validateDAVHost(v); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_carddav_host", "detail": err.Error()})
+			return
+		}
+		domain.CardDAVHost = v
 	}
 
 	if req.RedirectAllType != nil {

--- a/panel-api/internal/db/migrations/000290_domain_dav_override.down.sql
+++ b/panel-api/internal/db/migrations/000290_domain_dav_override.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domains
+  DROP COLUMN carddav_host,
+  DROP COLUMN caldav_host;

--- a/panel-api/internal/db/migrations/000290_domain_dav_override.up.sql
+++ b/panel-api/internal/db/migrations/000290_domain_dav_override.up.sql
@@ -1,0 +1,13 @@
+-- GH #1462: per-mail-domain CalDAV / CardDAV server override.
+--
+-- When set, the domain's _caldavs._tcp / _carddavs._tcp SRV records (RFC 6764
+-- autodiscovery, used by Thunderbird 155+, Apple Mail) point clients at this
+-- host instead of mail.<domain> — so calendars and contacts resolve to an
+-- external server (e.g. Nextcloud) while email stays on Stalwart. Empty (the
+-- default) keeps today's behaviour: DAV points at mail.<domain>.
+--
+-- Value is a hostname, optionally host:port (default port 443). Validated at
+-- the API boundary before it reaches the SRV record content.
+ALTER TABLE domains
+  ADD COLUMN caldav_host VARCHAR(255) NOT NULL DEFAULT '',
+  ADD COLUMN carddav_host VARCHAR(255) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -408,6 +408,16 @@ type Domain struct {
 	// UNIQUE (see migration 000057 for the reasoning).
 	IsPanelPrimary bool `gorm:"type:tinyint(1);not null;default:0;index:ix_domains_panel_primary" json:"is_panel_primary"`
 
+	// GH #1462: per-mail-domain CalDAV / CardDAV server override. Empty =
+	// default (the _caldavs._tcp / _carddavs._tcp SRV records point at
+	// mail.<domain>, i.e. Stalwart). Set to a hostname (optionally host:port)
+	// to repoint DAV autodiscovery at an external server (e.g. Nextcloud)
+	// while mail stays on Stalwart. Validated as a hostname[:port] at the API
+	// boundary before it reaches SRV record content. The reconciler converges
+	// the DAV SRV rows to match (reconcileDAVOverrideRecords).
+	CalDAVHost  string `gorm:"column:caldav_host;type:varchar(255);not null;default:''" json:"caldav_host"`
+	CardDAVHost string `gorm:"column:carddav_host;type:varchar(255);not null;default:''" json:"carddav_host"`
+
 	// M6.5 Email Features: Catch-All, Disclaimer (per-domain fields).
 	// CatchallTarget is the email address that receives unmatched domain mail.
 	// Stalwart integration: x:Domain.catchAllAddress (ADR-0051).

--- a/panel-api/internal/reconciler/dav_override_reconcile.go
+++ b/panel-api/internal/reconciler/dav_override_reconcile.go
@@ -1,0 +1,124 @@
+package reconciler
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// reconcileDAVOverrideRecords (GH #1462) converges a jabali-mail domain's
+// CalDAV / CardDAV SRV records to its per-domain override.
+//
+// BuildEmailRecords seeds four RFC 6764 rows pointing at mail.<domain>:
+//
+//	_caldavs._tcp  SRV  "1 443 mail.<domain>"   (secure, 443)
+//	_carddavs._tcp SRV  "1 443 mail.<domain>"
+//	_caldav._tcp   SRV  "1 80 mail.<domain>"    (insecure, 80)
+//	_carddav._tcp  SRV  "1 80 mail.<domain>"
+//
+// When the operator sets domain.CalDAVHost / CardDAVHost, this repoints the
+// SECURE record at that host (Thunderbird 155+, Apple Mail follow it straight
+// to e.g. Nextcloud) and DELETES the insecure :80 record — an external DAV
+// server is HTTPS-only, and advertising a plaintext endpoint we don't control
+// is wrong. Clearing the override restores both defaults. Fully owns the four
+// rows so the round-trip (set → clear) converges either way; idempotent, only
+// writes on drift. Runs after reconcileMailProviderRecords, which owns the
+// rest of the mail DNS.
+func (r *Reconciler) reconcileDAVOverrideRecords(ctx context.Context, zone *models.DNSZone, domain *models.Domain, srv *models.ServerSettings) {
+	if r.dnsRecords == nil || zone == nil || domain == nil {
+		return
+	}
+	// The m6 DAV rows only exist for jabali-hosted mail. External / none
+	// providers have them pruned; don't synthesise DAV SRVs there.
+	if !domain.EmailEnabled || (domain.MailProvider != "" && domain.MailProvider != models.MailProviderJabali) {
+		return
+	}
+
+	existing, err := r.dnsRecords.ListByZoneID(ctx, zone.ID)
+	if err != nil {
+		r.log.Warn("dav override: list records", "zone", zone.Name, "err", err)
+		return
+	}
+	mailTarget := "mail." + strings.TrimSuffix(zone.Name, ".")
+	r.convergeDAVService(ctx, zone, existing, "_caldavs._tcp", "_caldav._tcp", domain.CalDAVHost, mailTarget)
+	r.convergeDAVService(ctx, zone, existing, "_carddavs._tcp", "_carddav._tcp", domain.CardDAVHost, mailTarget)
+}
+
+// convergeDAVService owns the secure (:443) and insecure (:80) SRV rows for one
+// DAV service. override empty → both point at mailTarget (443 / 80); override
+// set → secure points at the override host, insecure is removed.
+func (r *Reconciler) convergeDAVService(ctx context.Context, zone *models.DNSZone, existing []models.DNSRecord, secureName, insecureName, override, mailTarget string) {
+	var secureRow, insecureRow *models.DNSRecord
+	for i := range existing {
+		e := existing[i]
+		if managedBy(e) != dnscompile.EmailRecordsManagedBy || e.Type != "SRV" {
+			continue
+		}
+		switch e.Name {
+		case secureName:
+			secureRow = &existing[i]
+		case insecureName:
+			insecureRow = &existing[i]
+		}
+	}
+
+	if override != "" {
+		host, port := splitDAVHostPort(override, 443)
+		wantSecure := "1 " + strconv.Itoa(port) + " " + host
+		r.upsertDAVRow(ctx, zone.ID, secureRow, secureName, wantSecure)
+		// External DAV is HTTPS-only — drop the plaintext :80 record.
+		if insecureRow != nil {
+			if err := r.dnsRecords.Delete(ctx, insecureRow.ID); err != nil {
+				r.log.Warn("dav override: delete insecure SRV", "name", insecureName, "err", err)
+			}
+		}
+		return
+	}
+
+	// No override — restore the mail.<domain> defaults for both.
+	r.upsertDAVRow(ctx, zone.ID, secureRow, secureName, "1 443 "+mailTarget)
+	r.upsertDAVRow(ctx, zone.ID, insecureRow, insecureName, "1 80 "+mailTarget)
+}
+
+// upsertDAVRow creates the m6-managed SRV row when absent, or updates its
+// content when it drifts. No-op when already correct.
+func (r *Reconciler) upsertDAVRow(ctx context.Context, zoneID string, row *models.DNSRecord, name, content string) {
+	if row != nil {
+		if row.Content == content {
+			return
+		}
+		row.Content = content
+		row.UpdatedAt = time.Now().UTC()
+		if err := r.dnsRecords.Update(ctx, row); err != nil {
+			r.log.Warn("dav override: update SRV", "name", name, "err", err)
+		}
+		return
+	}
+	m6 := dnscompile.EmailRecordsManagedBy
+	rec := &models.DNSRecord{
+		ID: ids.NewULID(), ZoneID: zoneID, Name: name, Type: "SRV", Content: content,
+		TTL: 3600, Priority: 0, Managed: true, ManagedBy: &m6, IsEnabled: true,
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	if err := r.dnsRecords.Create(ctx, rec); err != nil {
+		r.log.Warn("dav override: create SRV", "name", name, "err", err)
+	}
+}
+
+// splitDAVHostPort parses a validated "host" or "host:port" override into
+// (host, port), defaulting the port. Input is API-validated (davHostRe), so
+// this only has to separate a trailing :port; a malformed value can't reach it.
+func splitDAVHostPort(override string, defPort int) (string, int) {
+	override = strings.TrimSpace(override)
+	if i := strings.LastIndexByte(override, ':'); i > 0 {
+		if p, err := strconv.Atoi(override[i+1:]); err == nil && p > 0 && p <= 65535 {
+			return override[:i], p
+		}
+	}
+	return override, defPort
+}

--- a/panel-api/internal/reconciler/dav_override_reconcile_test.go
+++ b/panel-api/internal/reconciler/dav_override_reconcile_test.go
@@ -1,0 +1,105 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// davSeed returns the four default m6 DAV SRV rows a jabali-mail zone starts
+// with (BuildEmailRecords shape), all pointing at mail.example.com.
+func davSeed() []*models.DNSRecord {
+	m6 := dnscompile.EmailRecordsManagedBy
+	mk := func(id, name, content string) *models.DNSRecord {
+		return &models.DNSRecord{ID: id, ZoneID: "z1", Name: name, Type: "SRV", Content: content, Managed: true, ManagedBy: &m6}
+	}
+	return []*models.DNSRecord{
+		mk("cals", "_caldavs._tcp", "1 443 mail.example.com"),
+		mk("cards", "_carddavs._tcp", "1 443 mail.example.com"),
+		mk("cal", "_caldav._tcp", "1 80 mail.example.com"),
+		mk("card", "_carddav._tcp", "1 80 mail.example.com"),
+	}
+}
+
+func davRec(repo *fakeDNSRecordRepo, name string) *models.DNSRecord {
+	for _, r := range repo.records {
+		if r.Name == name && r.Type == "SRV" {
+			return r
+		}
+	}
+	return nil
+}
+
+// GH #1462: an override repoints the SECURE SRV at the external host and drops
+// the insecure :80 row; CardDAV without an override stays on mail.<domain>.
+func TestReconcileDAVOverride_RepointsCalDAV(t *testing.T) {
+	r, repo := newMailReconciler(davSeed()...)
+	zone := &models.DNSZone{ID: "z1", Name: "example.com"}
+	dom := &models.Domain{ID: "d1", EmailEnabled: true, MailProvider: "jabali", CalDAVHost: "nextcloud.example.com"}
+
+	r.reconcileDAVOverrideRecords(context.Background(), zone, dom, nil)
+
+	if got := davRec(repo, "_caldavs._tcp"); got == nil || got.Content != "1 443 nextcloud.example.com" {
+		t.Errorf("_caldavs._tcp = %v, want '1 443 nextcloud.example.com'", got)
+	}
+	if davRec(repo, "_caldav._tcp") != nil {
+		t.Error("insecure _caldav._tcp must be deleted when an override is set")
+	}
+	// CardDAV untouched — still the default, both rows present.
+	if got := davRec(repo, "_carddavs._tcp"); got == nil || got.Content != "1 443 mail.example.com" {
+		t.Errorf("_carddavs._tcp should stay default, got %v", got)
+	}
+	if davRec(repo, "_carddav._tcp") == nil {
+		t.Error("_carddav._tcp default must remain when carddav has no override")
+	}
+}
+
+func TestReconcileDAVOverride_HostPort(t *testing.T) {
+	r, repo := newMailReconciler(davSeed()...)
+	zone := &models.DNSZone{ID: "z1", Name: "example.com"}
+	dom := &models.Domain{ID: "d1", EmailEnabled: true, CardDAVHost: "dav.example.com:8443"}
+
+	r.reconcileDAVOverrideRecords(context.Background(), zone, dom, nil)
+
+	if got := davRec(repo, "_carddavs._tcp"); got == nil || got.Content != "1 8443 dav.example.com" {
+		t.Errorf("_carddavs._tcp = %v, want '1 8443 dav.example.com'", got)
+	}
+}
+
+// Clearing a previously-set override restores the mail.<domain> defaults,
+// including re-creating the insecure :80 row the override had removed.
+func TestReconcileDAVOverride_ClearRestoresDefault(t *testing.T) {
+	m6 := dnscompile.EmailRecordsManagedBy
+	// State after a prior override: secure repointed, insecure gone.
+	seed := []*models.DNSRecord{
+		{ID: "cals", ZoneID: "z1", Name: "_caldavs._tcp", Type: "SRV", Content: "1 443 nextcloud.example.com", Managed: true, ManagedBy: &m6},
+	}
+	r, repo := newMailReconciler(seed...)
+	zone := &models.DNSZone{ID: "z1", Name: "example.com"}
+	dom := &models.Domain{ID: "d1", EmailEnabled: true, CalDAVHost: ""} // cleared
+
+	r.reconcileDAVOverrideRecords(context.Background(), zone, dom, nil)
+
+	if got := davRec(repo, "_caldavs._tcp"); got == nil || got.Content != "1 443 mail.example.com" {
+		t.Errorf("_caldavs._tcp = %v, want restored default", got)
+	}
+	if got := davRec(repo, "_caldav._tcp"); got == nil || got.Content != "1 80 mail.example.com" {
+		t.Errorf("insecure _caldav._tcp = %v, want re-created default", got)
+	}
+}
+
+// A non-jabali (external) mail domain has no m6 DAV rows — the converger must
+// not synthesise any even if an override host is set.
+func TestReconcileDAVOverride_SkipsNonJabali(t *testing.T) {
+	r, repo := newMailReconciler()
+	zone := &models.DNSZone{ID: "z1", Name: "example.com"}
+	dom := &models.Domain{ID: "d1", EmailEnabled: true, MailProvider: "m365", CalDAVHost: "nextcloud.example.com"}
+
+	r.reconcileDAVOverrideRecords(context.Background(), zone, dom, nil)
+
+	if len(repo.records) != 0 {
+		t.Errorf("no DAV rows should be created for a non-jabali domain, got %d", len(repo.records))
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2406,6 +2406,11 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 	// MX/SPF/autodiscover (or none) get pushed to PowerDNS this pass.
 	r.reconcileMailProviderRecords(ctx, zone, domain, srv)
 
+	// GH #1462: repoint the CalDAV/CardDAV SRV records at the domain's
+	// per-domain override host (or restore the mail.<domain> default),
+	// after the provider reconcile has settled the rest of the mail DNS.
+	r.reconcileDAVOverrideRecords(ctx, zone, domain, srv)
+
 	records, err := r.dnsRecords.ListByZoneID(ctx, zone.ID)
 	if err != nil {
 		r.log.Error("list records failed", "zone", zone.Name, "err", err)

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -390,7 +390,8 @@ func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {
 		"redirect_all_to", "redirect_all_type", "page_redirects",
 		"index_priority", "ssl_enabled", "is_quota_suspended", "webmail_enabled",
 		"dmarc_np", "dmarc_testing", "temp_url_enabled",
-		"bot_challenge_exempt", "bot_challenge_include", "updated_at",
+		"bot_challenge_exempt", "bot_challenge_include",
+		"caldav_host", "carddav_host", "updated_at",
 	).Updates(d).Error; err != nil {
 		return translate(err)
 	}

--- a/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
@@ -9,7 +9,7 @@
 // render as static instructions (empty `status` column).
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import { Alert, Button, Popconfirm, Card, Select, Skeleton, Space, Switch, Table, Tag, Typography } from "antd";
+import { Alert, Button, Popconfirm, Card, Input, Select, Skeleton, Space, Switch, Table, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CopyOutlined } from "@icons";
 
@@ -47,6 +47,8 @@ export const DomainEmailSection = ({ domainId }: Props) => {
     webmail_enabled: boolean;
     dmarc_np?: string;
     dmarc_testing?: boolean;
+    caldav_host?: string;
+    carddav_host?: string;
   }>({
     resource: "domains",
     id: domainId,
@@ -94,6 +96,23 @@ export const DomainEmailSection = ({ domainId }: Props) => {
       feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to save DMARC settings");
     } finally {
       setDmarcSaving(false);
+    }
+  };
+
+  // GH #1462: per-domain CalDAV/CardDAV server override. Saved on blur only
+  // when the value actually changed, so tabbing through doesn't PATCH.
+  const [davSaving, setDavSaving] = useState(false);
+  const saveDav = async (patch: { caldav_host?: string; carddav_host?: string }) => {
+    setDavSaving(true);
+    try {
+      await apiClient.patch(`/domains/${domainId}`, patch);
+      qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
+      feedback.message.success("CalDAV/CardDAV settings saved");
+    } catch (err) {
+      const resp = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
+      feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to save CalDAV/CardDAV settings");
+    } finally {
+      setDavSaving(false);
     }
   };
 
@@ -189,6 +208,49 @@ export const DomainEmailSection = ({ domainId }: Props) => {
               Applies to the panel-managed <Typography.Text code>_dmarc</Typography.Text> record; a
               hand-edited DMARC record is left untouched.
             </Typography.Text>
+          </Space>
+        </Card>
+      )}
+
+      {enabled && (
+        <Card size="small" title="CalDAV / CardDAV server (GH #1462)">
+          <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Point calendars and contacts at an external server (e.g. Nextcloud) while mail stays on
+              this server. Leave blank to use <Typography.Text code>mail.{data.domain_name}</Typography.Text>.
+              Enter a hostname, optionally <Typography.Text code>host:port</Typography.Text> (default
+              443). This repoints the <Typography.Text code>_caldavs._tcp</Typography.Text> /{" "}
+              <Typography.Text code>_carddavs._tcp</Typography.Text> SRV records that Thunderbird and
+              Apple Mail use to discover DAV.
+            </Typography.Text>
+            <Space align="center" wrap>
+              <span style={{ minWidth: 130, display: "inline-block" }}>CalDAV host:</span>
+              <Input
+                style={{ minWidth: 300 }}
+                placeholder={`Default: mail.${data.domain_name}`}
+                disabled={davSaving}
+                defaultValue={domain?.caldav_host ?? ""}
+                key={`caldav-${domain?.caldav_host ?? ""}`}
+                onBlur={(e) => {
+                  const v = e.target.value.trim();
+                  if (v !== (domain?.caldav_host ?? "")) void saveDav({ caldav_host: v });
+                }}
+              />
+            </Space>
+            <Space align="center" wrap>
+              <span style={{ minWidth: 130, display: "inline-block" }}>CardDAV host:</span>
+              <Input
+                style={{ minWidth: 300 }}
+                placeholder={`Default: mail.${data.domain_name}`}
+                disabled={davSaving}
+                defaultValue={domain?.carddav_host ?? ""}
+                key={`carddav-${domain?.carddav_host ?? ""}`}
+                onBlur={(e) => {
+                  const v = e.target.value.trim();
+                  if (v !== (domain?.carddav_host ?? "")) void saveDav({ carddav_host: v });
+                }}
+              />
+            </Space>
           </Space>
         </Card>
       )}


### PR DESCRIPTION
## GH #1462

@johnnyq asked to override Stalwart's CalDAV/CardDAV addresses per mail-domain — so a tenant who runs calendars/contacts on Nextcloud but mail on Stalwart can have Thunderbird point DAV at Nextcloud automatically, while mail stays on this server.

## Mechanism

Thunderbird 155+ / Apple Mail discover DAV via **RFC 6764 SRV records** (`_caldavs._tcp` / `_carddavs._tcp`), which today point at `mail.<domain>`. The autoconfig XML carries no DAV block, so the SRV records are the lever. Repoint them at the external host and the client goes straight there.

## Change

- **Model + migration 000290**: `caldav_host` / `carddav_host` `VARCHAR(255) DEFAULT ''` on `domains`. Empty = default (`mail.<domain>`); set = a hostname, optionally `host:port` (default 443).
- **`reconcileDAVOverrideRecords`** (new converger): fully owns the four DAV SRV rows for a jabali-mail domain. Override set → repoints the **secure** (:443) record at the host and **drops the insecure** (:80) one (an external DAV server is HTTPS-only). Override cleared → restores the `mail.<domain>` defaults (re-creating the :80 row). Runs after `reconcileMailProviderRecords`, idempotent, only writes on drift. Skips non-jabali domains (they have no DAV rows).
- **API**: `PATCH /domains/:id` accepts `caldav_host` / `carddav_host`, validated as a bare `hostname[:port]` (`davHostRe`) **before** they reach the space-separated SRV content — a space / scheme / path / out-of-range port is rejected (it's interpolated unquoted into `"weight port target"`). Added both to the domain Update `.Select()` allowlist (the silent-drop scar).
- **UI**: a "CalDAV / CardDAV server" card in the admin domain **Email** section (beside DMARC), saved on blur only when the value changed.

## Test plan

- [x] `go test -race` — new `dav_override_reconcile_test.go` (repoint + drop-insecure, `host:port`, clear-restores-default incl. re-creating :80, skip-non-jabali) and `dav_host_validate_test.go` (accepts host / host:port; rejects single-label, bad port, scheme, path, spaces, internal control chars)
- [x] `go build ./...`, `go vet`, `gofmt`; `tsc -b`; existing admin/domains vitest green
- [x] **Box-verified on the test server**: migration 000290 up+down on the *real* `domains` table shape (no row-size ceiling hit); an existing `_caldavs._tcp` SRV in the identical content format serves correctly via `dig` (`0 1 443 mail.<domain>.`) — the wire format the converger emits
- [ ] **Recommended on deploy**: set an override on a jabali-mail domain, confirm the reconciler repoints `_caldavs._tcp` and drops `_caldav._tcp`, and `dig` shows the external host. (Needs deploying the branch; the converger + wire format are unit- and format-verified.)

## Notes

- **No agent change** — the DAV SRVs are ordinary DNS records pushed through the existing `dns.zone.upsert`. panel-api + panel-ui + migration only.
- Two separate host fields (not one) so a tenant can split CalDAV and CardDAV to different servers; the Nextcloud case just sets both the same.
- Per @johnnyq's follow-up: Thunderbird 155 also fixed the re-prompt-for-credentials-after-discovery issue — no panel change needed for that.
