### PR TITLE
feat(nav): side-nav badge counts for tenant + admin (GH #1478)

### DIFF
--- a/panel-api/internal/api/me_nav_counts.go
+++ b/panel-api/internal/api/me_nav_counts.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// me_nav_counts.go — GH #1478 side-nav badge counts.
+//
+// One lightweight aggregate endpoint per side so the nav fetches all its
+// badge numbers in a single call rather than firing a list query per item:
+//   GET /me/nav-counts     — the caller's own resource counts (tenant nav)
+//   GET /admin/nav-counts  — fleet-wide counts (admin nav; RequireAdmin)
+//
+// Web/Mail/DNS follow the GH #1449 service flags (web-enabled / mail-enabled /
+// dns-hosted domains). The counts are cheap aggregates; the UI caches the
+// result and refreshes on a short interval, so this is not a hot path.
+
+// NavCountsConfig wires the badge-count endpoints.
+type NavCountsConfig struct {
+	Counts repository.NavCountsRepository
+}
+
+type navCountsHandler struct{ cfg NavCountsConfig }
+
+// RegisterNavCountsRoutes mounts the tenant + admin badge-count endpoints on an
+// authenticated group. The admin route additionally requires admin.
+func RegisterNavCountsRoutes(g *gin.RouterGroup, cfg NavCountsConfig) {
+	h := &navCountsHandler{cfg: cfg}
+	g.GET("/me/nav-counts", h.me)
+	g.GET("/admin/nav-counts", middleware.RequireAdmin(), h.admin)
+}
+
+func (h *navCountsHandler) me(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+	counts, err := h.cfg.Counts.ForUser(c.Request.Context(), claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, counts)
+}
+
+func (h *navCountsHandler) admin(c *gin.Context) {
+	counts, err := h.cfg.Counts.Global(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, counts)
+}

--- a/panel-api/internal/api/me_nav_counts_test.go
+++ b/panel-api/internal/api/me_nav_counts_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeNavCountsRepo struct {
+	user, global repository.NavCounts
+	sawGlobal    bool
+}
+
+func (f *fakeNavCountsRepo) ForUser(_ context.Context, _ string) (repository.NavCounts, error) {
+	return f.user, nil
+}
+func (f *fakeNavCountsRepo) Global(_ context.Context) (repository.NavCounts, error) {
+	f.sawGlobal = true
+	return f.global, nil
+}
+
+func navCountsRouter(t *testing.T, userID string, admin bool, repo repository.NavCountsRepository) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: admin})
+		c.Next()
+	})
+	RegisterNavCountsRoutes(r.Group("/api/v1"), NavCountsConfig{Counts: repo})
+	return r
+}
+
+func TestNavCounts_Me(t *testing.T) {
+	repo := &fakeNavCountsRepo{user: repository.NavCounts{
+		WebDomains: 3, MailDomains: 2, DNSZones: 3, Databases: 5, FTPAccounts: 1, Backups: 4, CronJobs: 2,
+	}}
+	r := navCountsRouter(t, "u1", false, repo)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/me/nav-counts", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var got repository.NavCounts
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if got != repo.user {
+		t.Errorf("me counts = %+v, want %+v", got, repo.user)
+	}
+}
+
+func TestNavCounts_AdminRequiresAdmin(t *testing.T) {
+	repo := &fakeNavCountsRepo{global: repository.NavCounts{WebDomains: 99}}
+
+	// Non-admin → 403, and Global must NOT be queried.
+	r := navCountsRouter(t, "u1", false, repo)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/admin/nav-counts", nil))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("non-admin want 403, got %d", w.Code)
+	}
+	if repo.sawGlobal {
+		t.Error("Global() must not run for a non-admin caller")
+	}
+
+	// Admin → 200 + global counts.
+	ra := navCountsRouter(t, "admin1", true, repo)
+	wa := httptest.NewRecorder()
+	ra.ServeHTTP(wa, httptest.NewRequest(http.MethodGet, "/api/v1/admin/nav-counts", nil))
+	if wa.Code != http.StatusOK {
+		t.Fatalf("admin want 200, got %d: %s", wa.Code, wa.Body.String())
+	}
+	var got repository.NavCounts
+	if err := json.Unmarshal(wa.Body.Bytes(), &got); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if got.WebDomains != 99 {
+		t.Errorf("admin global web_domains = %d, want 99", got.WebDomains)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3896,6 +3896,20 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/nav-counts:
+    get:
+      tags: [Me]
+      summary: Resource counts for the caller's side-nav badges (GH #1478)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/nav-counts:
+    get:
+      tags: [Admin]
+      summary: Fleet-wide resource counts for the admin side-nav badges (GH #1478)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/disk-usage/files:
     get:
       tags: [Me]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -598,6 +598,11 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			MailStats: repository.NewMailStatsRepository(deps.DB),
 			Agent:     deps.Agent,
 		})
+		// GH #1478: side-nav badge counts — GET /me/nav-counts (tenant) +
+		// GET /admin/nav-counts (admin). One aggregate call per side.
+		api.RegisterNavCountsRoutes(v1, api.NavCountsConfig{
+			Counts: repository.NewNavCountsRepository(deps.DB),
+		})
 		// JAB-171 phase 3b — tenant-facing notification channels + routing.
 		// Gated behind ServerSettings.TenantNotificationsEnabled (default OFF,
 		// no admin toggle until phase 4 lands the SSRF guard + email-verify),

--- a/panel-api/internal/repository/nav_counts_repository.go
+++ b/panel-api/internal/repository/nav_counts_repository.go
@@ -1,0 +1,102 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// NavCounts holds the resource counts the side-nav badges show (GH #1478).
+// Web/Mail/DNS follow the GH #1449 service flags: Web = web-enabled domains,
+// Mail = jabali-mail-enabled domains, DNS = domains whose zone the panel hosts
+// (a domain has a managed zone iff dns is enabled, so this doubles as the DNS
+// Zones count without a join). Backups counts retained account backups only.
+type NavCounts struct {
+	WebDomains  int64 `json:"web_domains"`
+	MailDomains int64 `json:"mail_domains"`
+	DNSZones    int64 `json:"dns_zones"`
+	Databases   int64 `json:"databases"`
+	FTPAccounts int64 `json:"ftp_accounts"`
+	Backups     int64 `json:"backups"`
+	CronJobs    int64 `json:"cron_jobs"`
+}
+
+// NavCountsRepository aggregates the side-nav badge counts. Kept as its own
+// small repo (rather than adding methods to seven existing interfaces + their
+// mocks) so the counts live in one place and the handler mocks one dependency.
+type NavCountsRepository interface {
+	// ForUser returns the counts scoped to one owner (tenant nav).
+	ForUser(ctx context.Context, userID string) (NavCounts, error)
+	// Global returns the fleet-wide counts (admin nav).
+	Global(ctx context.Context) (NavCounts, error)
+}
+
+type navCountsRepo struct{ db *gorm.DB }
+
+// NewNavCountsRepository builds the badge-count aggregator.
+func NewNavCountsRepository(db *gorm.DB) NavCountsRepository { return &navCountsRepo{db: db} }
+
+func (r *navCountsRepo) ForUser(ctx context.Context, userID string) (NavCounts, error) {
+	return r.compute(ctx, userID, false)
+}
+
+func (r *navCountsRepo) Global(ctx context.Context) (NavCounts, error) {
+	return r.compute(ctx, "", true)
+}
+
+// compute runs the counts. global=true drops the user_id filter. Each COUNT is
+// a cheap indexed aggregate; the three domain counts share one query.
+func (r *navCountsRepo) compute(ctx context.Context, userID string, global bool) (NavCounts, error) {
+	var out NavCounts
+	// user_id scoping applied unless global.
+	scope := func(q *gorm.DB) *gorm.DB {
+		if global {
+			return q
+		}
+		return q.Where("user_id = ?", userID)
+	}
+
+	// Domains: web / mail / dns in a single pass (GH #1449 flags).
+	var dom struct {
+		Web  int64 `gorm:"column:web"`
+		Mail int64 `gorm:"column:mail"`
+		DNS  int64 `gorm:"column:dns"`
+	}
+	if err := scope(r.db.WithContext(ctx).Model(&models.Domain{})).
+		Select("COALESCE(SUM(web_disabled = 0),0) AS web, " +
+			"COALESCE(SUM(email_enabled = 1),0) AS mail, " +
+			"COALESCE(SUM(dns_disabled = 0),0) AS dns").
+		Scan(&dom).Error; err != nil {
+		return out, translate(err)
+	}
+	out.WebDomains, out.MailDomains, out.DNSZones = dom.Web, dom.Mail, dom.DNS
+
+	if err := scope(r.db.WithContext(ctx).Model(&models.Database{})).Count(&out.Databases).Error; err != nil {
+		return out, translate(err)
+	}
+	if err := scope(r.db.WithContext(ctx).Model(&models.FtpAccount{})).Count(&out.FTPAccounts).Error; err != nil {
+		return out, translate(err)
+	}
+	if err := scope(r.db.WithContext(ctx).Model(&models.CronJob{})).Count(&out.CronJobs).Error; err != nil {
+		return out, translate(err)
+	}
+
+	// Backups: retained account backups only (mirrors CountRetainedForUser —
+	// exclude failed/deleted job rows so the badge matches the Backups list).
+	bq := r.db.WithContext(ctx).Model(&models.BackupJob{}).
+		Where("kind = ? AND status IN ?", models.BackupJobKindAccountBackup,
+			[]string{
+				models.BackupJobStatusQueued, models.BackupJobStatusRunning,
+				models.BackupJobStatusSucceeded, models.BackupJobStatusPartial,
+			})
+	if !global {
+		bq = bq.Where("user_id = ?", userID)
+	}
+	if err := bq.Count(&out.Backups).Error; err != nil {
+		return out, translate(err)
+	}
+
+	return out, nil
+}

--- a/panel-ui/src/hooks/useNavCounts.ts
+++ b/panel-ui/src/hooks/useNavCounts.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../apiClient";
+
+// GH #1478: side-nav badge counts. One aggregate call per side
+// (GET /me/nav-counts | GET /admin/nav-counts) rather than a list query per
+// nav item.
+export type NavCounts = {
+  web_domains: number;
+  mail_domains: number;
+  dns_zones: number;
+  databases: number;
+  ftp_accounts: number;
+  backups: number;
+  cron_jobs: number;
+};
+
+// navCountForKey maps a nav item's `key` (src/nav.ts) to the matching count
+// field, so the layout doesn't hard-code the mapping inline. Returns undefined
+// for nav items that don't carry a badge.
+export function navCountForKey(counts: NavCounts | undefined, key: string): number | undefined {
+  if (!counts) return undefined;
+  switch (key) {
+    case "domains":
+      return counts.web_domains;
+    case "mail":
+      return counts.mail_domains;
+    case "dns":
+      return counts.dns_zones;
+    case "databases":
+      return counts.databases;
+    case "ftp-accounts":
+      return counts.ftp_accounts;
+    case "backups":
+      return counts.backups;
+    case "cron":
+      return counts.cron_jobs;
+    default:
+      return undefined;
+  }
+}
+
+export function useNavCounts(scope: "me" | "admin") {
+  return useQuery<NavCounts>({
+    queryKey: ["nav-counts", scope],
+    queryFn: async () => {
+      const { data } = await apiClient.get<NavCounts>(`/${scope}/nav-counts`);
+      return data;
+    },
+    // Counts change rarely relative to nav renders; a short stale window keeps
+    // the badges live without a request on every page change.
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -9,6 +9,8 @@ import { Drawer, Grid, Layout, Menu, Tooltip, theme } from "antd";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
 import { useServerCapabilities } from "../hooks/useServerCapabilities";
+import { useNavCounts, navCountForKey } from "../hooks/useNavCounts";
+import { navLabelWithBadge } from "./navBadge";
 import { DRStandbyBanner } from "../components/DRStandbyBanner";
 import { JabaliFooter } from "../components/JabaliFooter";
 import { JabaliHeader } from "../components/JabaliHeader";
@@ -40,6 +42,8 @@ export function AdminLayout() {
   // via Server Settings -> Apps. /me/server-capabilities is cached
   // per-session; UI ergonomics outweigh staleness here.
   const { data: caps } = useServerCapabilities();
+  // GH #1478: side-nav badge counts (fleet-wide / admin scope).
+  const { data: navCounts } = useNavCounts("admin");
   // M353 Phase 1 (GH #353): hide a module's nav entry when it's disabled.
   // Module flags default on (undefined/loading = shown) so an upgraded install
   // and the brief pre-caps render never flash-hide a real feature.
@@ -85,12 +89,15 @@ export function AdminLayout() {
         // when an item has no description. DESKTOP ONLY (GH #1066): on touch the
         // tooltip swallows the first tap — the user has to tap twice to navigate.
         // The mobile Drawer shows full labels, so the tooltip adds nothing there.
-        label: isDesktop && n.description ? (
-          <Tooltip title={t(n.description)} placement="right" mouseEnterDelay={0.4}>
-            <span>{t(n.label)}</span>
-          </Tooltip>
-        ) : (
-          t(n.label)
+        label: navLabelWithBadge(
+          isDesktop && n.description ? (
+            <Tooltip title={t(n.description)} placement="right" mouseEnterDelay={0.4}>
+              <span>{t(n.label)}</span>
+            </Tooltip>
+          ) : (
+            t(n.label)
+          ),
+          navCountForKey(navCounts, n.key),
         ),
         onClick: () => {
           navigate(n.path);

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -20,6 +20,8 @@ import { BreadcrumbProvider } from "../components/admin/BreadcrumbContext";
 import { RouteBreadcrumb } from "../components/admin/RouteBreadcrumb";
 import { useThemeMode } from "../theme/ThemeModeContext";
 import { useServerCapabilities } from "../hooks/useServerCapabilities";
+import { useNavCounts, navCountForKey } from "../hooks/useNavCounts";
+import { navLabelWithBadge } from "./navBadge";
 import { QuickStartModal } from "./user/QuickStartModal";
 
 const { Sider, Content } = Layout;
@@ -41,6 +43,8 @@ export function UserLayout() {
   // hide its sidebar entry until an admin enables it (GH #229). The same
   // cached capability gates the route itself (CapabilityRoute, gap-audit #1).
   const { data: caps } = useServerCapabilities();
+  // GH #1478: side-nav badge counts (tenant scope).
+  const { data: navCounts } = useNavCounts("me");
   // nav.label holds an i18n key (see src/locales/en/common.json).
   const { t } = useTranslation();
   const visibleNav = userNav.filter((n) => {
@@ -95,7 +99,7 @@ export function UserLayout() {
         items={visibleNav.map((n) => ({
           key: n.key,
           icon: n.icon,
-          label: t(n.label),
+          label: navLabelWithBadge(t(n.label), navCountForKey(navCounts, n.key)),
           onClick: () => {
             navigate(n.path);
             setDrawerOpen(false);

--- a/panel-ui/src/shells/navBadge.tsx
+++ b/panel-ui/src/shells/navBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "antd";
+import type { ReactNode } from "react";
+
+// GH #1478: render a side-nav item's label with a trailing count badge.
+// Returns the bare label (no badge) when the count is undefined (still loading
+// or not a badged item) or 0, so the nav stays clean until there's something to
+// show. The badge is muted (gray) so it reads as a count, not an alert.
+export function navLabelWithBadge(label: ReactNode, count: number | undefined): ReactNode {
+  if (count == null || count <= 0) return label;
+  return (
+    <span
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 8,
+      }}
+    >
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{label}</span>
+      <Badge
+        count={count}
+        overflowCount={999}
+        style={{
+          backgroundColor: "#e5e7eb",
+          color: "#374151",
+          boxShadow: "none",
+          fontWeight: 500,
+        }}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
## GH #1478

@johnnyq asked for count badges next to the side-nav items (tenant + admin): Web Domains, Mail Domains, DNS Zones, Databases, FTP Accounts, Backups, Cron.

## Approach

**One aggregate endpoint per side** rather than firing a list query per nav item:
- `GET /me/nav-counts` — the caller's own counts (tenant nav)
- `GET /admin/nav-counts` — fleet-wide counts (admin nav; `RequireAdmin`)

Backed by a dedicated **`NavCountsRepository`** so the counts live in one place — no new method on seven existing repo interfaces and their mocks (the "iface method breaks mocks tree-wide" trap). Web/Mail/DNS follow the **GH #1449** service flags — web-enabled / mail-enabled / dns-hosted domains, computed in one `SUM(...)` pass — so "DNS Zones" doubles as the count of domains whose zone we host without a join. Backups counts **retained account backups** only (mirrors `CountRetainedForUser`, excluding failed/deleted job rows).

**Frontend:** a `useNavCounts` hook (60s stale, refetch on focus) + a shared `navLabelWithBadge` helper; `UserLayout` and `AdminLayout` render a muted count badge on the mapped nav keys, hidden while loading or when the count is 0. Admin nav badges the items that map to global counts (domains/mail/dns/backups/cron); tenant nav badges all seven.

## Test plan

- [x] `go test -race` — handler test: `/me/nav-counts` returns the tenant counts; `/admin/nav-counts` is 403 for a non-admin (and `Global()` is not even queried) and 200 + global counts for an admin
- [x] `go build ./...`, `gofmt`; `tsc -b`; **all 151 shell vitest specs green** (layout changes break nothing)
- [x] **Box-checked the domain-services aggregate on the test server's MariaDB**: `SUM(web_disabled=0)/SUM(email_enabled=1)/SUM(dns_disabled=0)` with `COALESCE(...,0)` → scoped `2/2/3`, global `3/3/4`, zero-rows `0` (not NULL) — the one non-trivial query; the rest are plain `COUNT(*) WHERE user_id`
- [ ] **Visual check on deploy**: badges render on both navs with live counts (hook + helper are tsc-clean; count logic validated)

## Notes

- **No migration** — reuses the `web_disabled` / `dns_disabled` / `email_enabled` columns already on main (#1449/#1462). **No agent change.** panel-api + panel-ui only.
- The badge shows in the expanded sider label; a collapsed (icon-only) sider hides it (antd hides the label) — matching how the rest of the nav labels behave.
