### PR TITLE
refactor(settings): shared SSH settings EffectPlan module (JAB-295)

### DIFF
--- a/panel-api/cmd/server/settings_cmd.go
+++ b/panel-api/cmd/server/settings_cmd.go
@@ -211,9 +211,9 @@ func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repo
 		fmt.Fprintf(out, "Applying tenant Docker change (%s enabled=%v) — this may take several minutes…\n", call.Method, s.DockerAppsForUsersEnabled)
 		if err := dispatchSettingsAgentCall(ctx, *call); err != nil {
 			// On a failed ENABLE, revert the flag so the DB reflects that host setup
-			// did not happen. settingsops owns the decision (RevertOnEnableFailure);
+			// did not happen. settingsops owns the decision (RevertOnFailure);
 			// the repo write is this adapter's (mirrors the REST revert).
-			if plan.DockerTenant.RevertOnEnableFailure {
+			if plan.DockerTenant.RevertOnFailure {
 				rctx, rcancel := context.WithTimeout(context.Background(), 15*time.Second)
 				if cur, gerr := repo.Get(rctx); gerr == nil && cur != nil {
 					cur.DockerAppsForUsersEnabled = false

--- a/panel-api/cmd/server/settings_cmd_dispatch_test.go
+++ b/panel-api/cmd/server/settings_cmd_dispatch_test.go
@@ -182,7 +182,7 @@ func TestApplySideEffects_PythonDisableNoDispatch(t *testing.T) {
 
 // TestApplySideEffects_DockerTenantRevertOnFailedEnable proves the CLI reverts
 // the persisted flag when a tenant-Docker ENABLE fails — settingsops flags the
-// decision (RevertOnEnableFailure), this adapter runs the repo write.
+// decision (RevertOnFailure), this adapter runs the repo write.
 func TestApplySideEffects_DockerTenantRevertOnFailedEnable(t *testing.T) {
 	stubSettingsDispatch(t, errors.New("unprivileged LXC: userns-remap unavailable"))
 	repo := &recordingRepo{current: &models.ServerSettings{DockerMarketplaceEnabled: true, DockerAppsForUsersEnabled: true}}

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -319,21 +319,18 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 
 	// Optional-module transitions (postgres, docker marketplace + tenant, python,
 	// and the dns/mail/quota/security/ftp loop) are detected from `before` by
-	// settingsops.ModuleEffects below — no per-flag prev* locals needed here.
+	// settingsops.ModuleEffects below; the SSH config + sandbox transitions are
+	// detected from `before` by settingsops.SSHEffects — no per-flag prev* locals
+	// needed for either family.
 	prevHostname := current.Hostname
 	prevPanelBrandText := current.PanelBrandText
 	prevWebadminEnabled := current.StalwartWebadminEnabled
 	prevWebadminCIDRs := current.StalwartWebadminAllowCIDRs
 	prevTimezone := current.Timezone
-	prevSSHPort := current.SSHPort
-	prevSSHPasswordAuth := current.SSHPasswordAuth
-	prevSSHUserPasswordAuth := current.SSHUserPasswordAuth
-	prevSSHSandboxMode := current.SSHSandboxMode
 	prevCrowdsecSensitivity := current.CrowdsecSensitivity
 	prevCrowdsecBouncerMode := current.CrowdsecBouncerMode
 	prevCrowdsecLoginAllowlistEnabled := current.CrowdsecLoginAllowlistEnabled
 	prevCrowdsecLoginAllowlistTTLHours := current.CrowdsecLoginAllowlistTTLHours
-	prevDefaultNspawnImageVersion := current.DefaultNspawnImageVersion
 
 	if req.Hostname != nil {
 		current.Hostname = strings.TrimSpace(*req.Hostname)
@@ -873,15 +870,19 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	// Optional-module lifecycle, continued: docker marketplace, tenant Docker, and
 	// the Python runtime — the same settingsops plan. Tenant Docker additionally
 	// reverts its persisted flag if an ENABLE fails (GH #272 — unprivileged LXC):
-	// the module flags the decision (RevertOnEnableFailure), this adapter runs the
-	// Repo write (dispatchDockerTenant). Python installs on enable only; disable
-	// leaves packages, which the module encodes as a no-op.
+	// the module flags the decision (RevertOnFailure), this adapter runs the Repo
+	// write via the shared dispatchReverting. Python installs on enable only;
+	// disable leaves packages, which the module encodes as a no-op.
 	if h.cfg.Agent != nil {
 		if call := modulePlan.Docker.Call; call != nil {
 			go h.dispatchSettingsCall(*call, "agent docker lifecycle failed")
 		}
 		if call := modulePlan.DockerTenant.Call; call != nil {
-			go h.dispatchDockerTenant(*call, modulePlan.DockerTenant.RevertOnEnableFailure)
+			var revert func(*models.ServerSettings)
+			if modulePlan.DockerTenant.RevertOnFailure {
+				revert = func(cur *models.ServerSettings) { cur.DockerAppsForUsersEnabled = false }
+			}
+			go h.dispatchReverting(*call, "agent docker.tenant_set failed", revert)
 		}
 		if call := modulePlan.Python.Call; call != nil {
 			go h.dispatchSettingsCall(*call, "agent python runtime install failed")
@@ -901,51 +902,49 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		}()
 	}
 
-	// Apply SSH config to the OS via agent if any SSH-affecting field changed.
-	// The agent rewrites both /etc/ssh/sshd_config.d/jabali-sshd.conf (global,
-	// affects root/admin) and /etc/ssh/sshd_config.d/jabali-sftp.conf (M12
-	// Match Group block, affects hosting users), validates with sshd -t,
-	// and reloads sshd. See ADR-0028 for the M12 jabali-sftp design.
-	// Re-apply when ANY SSH-section field is in the request, even if
-	// its value matches the DB row. Without this an operator hitting a
-	// drifted file (DB=1, file=no) couldn't fix it by re-submitting —
-	// `current==prev` short-circuited the agent.Call. With this,
-	// re-saving Server Settings always re-syncs the file. The startup
-	// reconcile in serve.go handles the boot-time case; this handles
-	// the operator-driven re-sync without forcing a toggle off→on.
-	sshFieldTouched := req.SSHPort != nil || req.SSHPasswordAuth != nil || req.SSHUserPasswordAuth != nil
-	if (sshFieldTouched ||
-		current.SSHPort != prevSSHPort ||
-		current.SSHPasswordAuth != prevSSHPasswordAuth ||
-		current.SSHUserPasswordAuth != prevSSHUserPasswordAuth) && h.cfg.Agent != nil {
-		go func() {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if _, err := h.cfg.Agent.Call(bgCtx, "system.set_ssh_config", map[string]any{
-				"port":               current.SSHPort,
-				"password_auth":      current.SSHPasswordAuth,
-				"user_password_auth": current.SSHUserPasswordAuth,
-			}); err != nil {
-				h.cfg.Log.Error("agent set_ssh_config failed", "err", err)
+	// SSH config + sandbox transitions (JAB-295). settingsops.SSHEffects is the
+	// single owner of both agent verbs, their params, timeouts, and the two
+	// distinct detection semantics:
+	//   - system.set_ssh_config rewrites /etc/ssh/sshd_config.d/jabali-sshd.conf
+	//     (global, affects root/admin) + jabali-sftp.conf (M12 Match Group, hosting
+	//     users), validates with `sshd -t`, and reloads (ADR-0028). It is
+	//     touched-based: re-saving ANY ssh field re-syncs the file even when the
+	//     value is unchanged, so an operator can heal a drifted file (DB=1, file=no)
+	//     by re-submitting. The startup reconcile in serve.go covers boot; this
+	//     covers the operator-driven re-sync.
+	//   - system.set_ssh_sandbox_mode writes the mode + default-image files the
+	//     connect wrapper reads on every exec (no reload). It is value-diff: it
+	//     fires only on a genuine change.
+	// AC5: a real change (Kind == Changed) is flagged RevertOnFailure, so a failed
+	// apply reverts the persisted SSH fields to their pre-merge values — the agent
+	// rolls the file back on `sshd -t` failure, and this keeps the DB from claiming
+	// a security state the host never accepted. The revert body is this adapter's
+	// (a repo write against its own handle), driven by the module's decision.
+	sshPlan := settingsops.SSHEffects(&before, current, settingsops.SSHTouched{
+		Config: req.SSHPort != nil || req.SSHPasswordAuth != nil || req.SSHUserPasswordAuth != nil,
+	})
+	if h.cfg.Agent != nil {
+		if call := sshPlan.Config.Call; call != nil {
+			var revert func(*models.ServerSettings)
+			if sshPlan.Config.RevertOnFailure {
+				revert = func(cur *models.ServerSettings) {
+					cur.SSHPort = before.SSHPort
+					cur.SSHPasswordAuth = before.SSHPasswordAuth
+					cur.SSHUserPasswordAuth = before.SSHUserPasswordAuth
+				}
 			}
-		}()
-	}
-
-	// Sandbox mode + default-image flips: write the matching files on
-	// disk so the wrapper picks them up on the next connect. No sshd
-	// reload needed (wrapper reads on every exec).
-	if (current.SSHSandboxMode != prevSSHSandboxMode ||
-		current.DefaultNspawnImageVersion != prevDefaultNspawnImageVersion) && h.cfg.Agent != nil {
-		go func() {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if _, err := h.cfg.Agent.Call(bgCtx, "system.set_ssh_sandbox_mode", map[string]any{
-				"mode":          current.SSHSandboxMode,
-				"default_image": current.DefaultNspawnImageVersion,
-			}); err != nil {
-				h.cfg.Log.Error("agent set_ssh_sandbox_mode failed", "err", err)
+			go h.dispatchReverting(*call, "agent set_ssh_config failed", revert)
+		}
+		if call := sshPlan.Sandbox.Call; call != nil {
+			var revert func(*models.ServerSettings)
+			if sshPlan.Sandbox.RevertOnFailure {
+				revert = func(cur *models.ServerSettings) {
+					cur.SSHSandboxMode = before.SSHSandboxMode
+					cur.DefaultNspawnImageVersion = before.DefaultNspawnImageVersion
+				}
 			}
-		}()
+			go h.dispatchReverting(*call, "agent set_ssh_sandbox_mode failed", revert)
+		}
 	}
 
 	// CrowdSec sensitivity preset: re-apply when either the operator
@@ -1065,27 +1064,30 @@ func (h *serverSettingsHandler) dispatchSettingsCall(call settingsops.AgentCall,
 	}
 }
 
-// dispatchDockerTenant runs the tenant-Docker toggle detached, and — when the
-// module flagged this as an ENABLE that must not leave a false "enabling…" state
-// on failure (GH #272, unprivileged LXC) — reverts the persisted flag so the UI
-// reflects that host setup did not happen. settingsops owns the decision
-// (revertOnFailure); the revert itself (Repo.Get→clear→Upsert) is persistence and
-// stays this adapter's job because it needs the handler's own repo handle. Run
-// it in a goroutine.
-func (h *serverSettingsHandler) dispatchDockerTenant(call settingsops.AgentCall, revertOnFailure bool) {
+// dispatchReverting runs a settings AgentCall detached (like dispatchSettingsCall)
+// and, when revert is non-nil and the call fails, rolls the persisted row back so
+// the DB never claims a state the host rejected. The module owns the decision
+// (whether an effect reverts and in which direction — Effect.RevertOnFailure); the
+// caller supplies revert, which mutates the freshly-read row in place with the
+// fields this effect owns. The revert is a persistence write against the handler's
+// own repo handle, so it cannot be an agent Rollback. Used by tenant Docker
+// (GH #272) and the SSH config + sandbox verbs (JAB-295, AC5). Run in a goroutine;
+// the revert uses its own short-lived context so a call-timeout failure can still
+// persist the rollback.
+func (h *serverSettingsHandler) dispatchReverting(call settingsops.AgentCall, logMsg string, revert func(*models.ServerSettings)) {
 	bgCtx, cancel := context.WithTimeout(context.Background(), call.Timeout)
 	defer cancel()
 	if _, err := h.cfg.Agent.Call(bgCtx, call.Method, call.Params); err != nil {
-		h.cfg.Log.Error("agent docker.tenant_set failed", "params", call.Params, "err", err)
-		if !revertOnFailure {
+		h.cfg.Log.Error(logMsg, "params", call.Params, "err", err)
+		if revert == nil {
 			return
 		}
 		rctx, rcancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer rcancel()
 		if cur, gerr := h.cfg.Repo.Get(rctx); gerr == nil && cur != nil {
-			cur.DockerAppsForUsersEnabled = false
+			revert(cur)
 			if uerr := h.cfg.Repo.Upsert(rctx, cur); uerr != nil {
-				h.cfg.Log.Error("revert docker_apps_for_users after failed enable", "err", uerr)
+				h.cfg.Log.Error("revert settings after failed apply", "method", call.Method, "err", uerr)
 			}
 		}
 	}

--- a/panel-api/internal/api/server_settings_ssh_dispatch_test.go
+++ b/panel-api/internal/api/server_settings_ssh_dispatch_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// This file characterizes the exact SSH agent wire the REST PATCH dispatches:
+// system.set_ssh_config (sshd port + password-auth, touched-based re-sync) and
+// system.set_ssh_sandbox_mode (shell-sandbox mode + default image, value-diff).
+// Every assertion was written and run GREEN against the pre-refactor handler to
+// lock the wire, so the JAB-295 settingsops extraction is proven byte-identical:
+// same verbs, same params, and — critically — the two distinct detection
+// semantics (config re-syncs on any touch even when unchanged; sandbox fires
+// only on a real value change) are preserved.
+
+// --- system.set_ssh_config: touched-based re-sync ---
+
+func TestServerSettingsPatch_SSHConfig_Wire(t *testing.T) {
+	t.Run("port change fires with full param set", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+		m := patchSettings(t, existing, map[string]any{"ssh_port": 2222}, "system.set_ssh_config")
+		require.Equal(t, map[string]any{
+			"port":               float64(2222),
+			"password_auth":      false,
+			"user_password_auth": false,
+		}, moduleCallParams(t, m, "system.set_ssh_config"))
+	})
+	t.Run("password_auth change fires", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+		m := patchSettings(t, existing, map[string]any{"ssh_password_auth": true}, "system.set_ssh_config")
+		require.Equal(t, map[string]any{
+			"port":               float64(22),
+			"password_auth":      true,
+			"user_password_auth": false,
+		}, moduleCallParams(t, m, "system.set_ssh_config"))
+	})
+	t.Run("user_password_auth change fires", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+		m := patchSettings(t, existing, map[string]any{"ssh_user_password_auth": true}, "system.set_ssh_config")
+		require.Equal(t, map[string]any{
+			"port":               float64(22),
+			"password_auth":      false,
+			"user_password_auth": true,
+		}, moduleCallParams(t, m, "system.set_ssh_config"))
+	})
+	// The re-sync semantic: an operator re-saving an unchanged ssh field still
+	// re-applies the file, so a drifted sshd_config can be healed by re-submitting.
+	t.Run("touched but unchanged still re-syncs", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+		m := patchSettings(t, existing, map[string]any{"ssh_port": 22}, "system.set_ssh_config")
+		require.Equal(t, map[string]any{
+			"port":               float64(22),
+			"password_auth":      false,
+			"user_password_auth": false,
+		}, moduleCallParams(t, m, "system.set_ssh_config"))
+	})
+	t.Run("untouched patch does not fire", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+		m := patchSettings(t, existing, map[string]any{"postgres_enabled": false})
+		requireNoCommand(t, m, "system.set_ssh_config")
+	})
+}
+
+// --- system.set_ssh_sandbox_mode: value-diff, no re-sync ---
+
+func TestServerSettingsPatch_SSHSandbox_Wire(t *testing.T) {
+	t.Run("mode change fires with full param set", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHSandboxMode: "bubblewrap", DefaultNspawnImageVersion: "debian-12"}
+		m := patchSettings(t, existing, map[string]any{"ssh_sandbox_mode": "nspawn"}, "system.set_ssh_sandbox_mode")
+		require.Equal(t, map[string]any{
+			"mode":          "nspawn",
+			"default_image": "debian-12",
+		}, moduleCallParams(t, m, "system.set_ssh_sandbox_mode"))
+	})
+	t.Run("image change alone fires", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12"}
+		m := patchSettings(t, existing, map[string]any{"default_nspawn_image_version": "debian-13"}, "system.set_ssh_sandbox_mode")
+		require.Equal(t, map[string]any{
+			"mode":          "nspawn",
+			"default_image": "debian-13",
+		}, moduleCallParams(t, m, "system.set_ssh_sandbox_mode"))
+	})
+	// The value-diff semantic: re-submitting the same sandbox mode does NOT fire
+	// (unlike ssh_config, which re-syncs on any touch).
+	t.Run("same value re-submitted does not fire", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12"}
+		m := patchSettings(t, existing, map[string]any{"ssh_sandbox_mode": "nspawn"})
+		requireNoCommand(t, m, "system.set_ssh_sandbox_mode")
+	})
+	t.Run("untouched patch does not fire", func(t *testing.T) {
+		existing := &models.ServerSettings{ID: 1, SSHPort: 22, SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12"}
+		m := patchSettings(t, existing, map[string]any{"postgres_enabled": false})
+		requireNoCommand(t, m, "system.set_ssh_sandbox_mode")
+	})
+}

--- a/panel-api/internal/api/server_settings_ssh_revert_test.go
+++ b/panel-api/internal/api/server_settings_ssh_revert_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/settingsops"
+)
+
+// countingRepo wraps mockServerSettingsRepo to count Upserts, so a revert test can
+// assert a persisted rollback happened (or, for a re-sync failure, did not).
+type countingRepo struct {
+	*mockServerSettingsRepo
+	upserts int
+}
+
+func (c *countingRepo) Upsert(ctx context.Context, s *models.ServerSettings) error {
+	c.upserts++
+	return c.mockServerSettingsRepo.Upsert(ctx, s)
+}
+
+// revertHandler builds a handler over a counting repo whose persisted row is the
+// post-merge (after) state — the DB has already been written before the SSH
+// dispatch runs. dispatchReverting is exercised SYNCHRONOUSLY (no `go`), so there
+// is no goroutine racing the repo (the shared mock is not mutex-guarded).
+func revertHandler(after *models.ServerSettings, mockAgent agent.AgentInterface) (*serverSettingsHandler, *countingRepo) {
+	cr := &countingRepo{mockServerSettingsRepo: &mockServerSettingsRepo{getResult: after}}
+	h := &serverSettingsHandler{cfg: ServerSettingsHandlerConfig{Repo: cr, Agent: mockAgent, Log: slog.Default()}}
+	return h, cr
+}
+
+// AC5: a failed system.set_ssh_config apply must roll the persisted sshd fields
+// back to their pre-merge values, so the DB never claims a security state the
+// host rejected (the agent already rolled the file back on `sshd -t` failure).
+// Unrelated fields on the row stay at their after values.
+func TestSSHConfigRevert_OnFailedApplyRestoresBeforeFields(t *testing.T) {
+	before := models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+	after := &models.ServerSettings{ID: 1, SSHPort: 2222, SSHPasswordAuth: true, SSHUserPasswordAuth: true, Hostname: "keep.example.com"}
+
+	mockAgent := agent.NewMockClient()
+	mockAgent.OnError("system.set_ssh_config", errors.New("sshd -t rejected config"))
+	h, cr := revertHandler(after, mockAgent)
+
+	revert := func(cur *models.ServerSettings) {
+		cur.SSHPort = before.SSHPort
+		cur.SSHPasswordAuth = before.SSHPasswordAuth
+		cur.SSHUserPasswordAuth = before.SSHUserPasswordAuth
+	}
+	call := settingsops.AgentCall{Method: "system.set_ssh_config", Params: map[string]any{"port": uint16(2222)}, Timeout: 30 * time.Second}
+	h.dispatchReverting(call, "agent set_ssh_config failed", revert)
+
+	require.Equal(t, 1, cr.upserts, "a failed apply must persist exactly one revert")
+	got := cr.getResult
+	require.Equal(t, uint16(22), got.SSHPort, "port reverted to before")
+	require.False(t, got.SSHPasswordAuth, "password_auth reverted to before")
+	require.False(t, got.SSHUserPasswordAuth, "user_password_auth reverted to before")
+	require.Equal(t, "keep.example.com", got.Hostname, "unrelated field must not be touched by the SSH revert")
+}
+
+// AC5: the sandbox revert restores mode + default image, and nothing else.
+func TestSSHSandboxRevert_OnFailedApplyRestoresBeforeFields(t *testing.T) {
+	before := models.ServerSettings{ID: 1, SSHSandboxMode: "bubblewrap", DefaultNspawnImageVersion: "debian-12"}
+	after := &models.ServerSettings{ID: 1, SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-13", Hostname: "keep.example.com"}
+
+	mockAgent := agent.NewMockClient()
+	mockAgent.OnError("system.set_ssh_sandbox_mode", errors.New("agent unreachable"))
+	h, cr := revertHandler(after, mockAgent)
+
+	revert := func(cur *models.ServerSettings) {
+		cur.SSHSandboxMode = before.SSHSandboxMode
+		cur.DefaultNspawnImageVersion = before.DefaultNspawnImageVersion
+	}
+	call := settingsops.AgentCall{Method: "system.set_ssh_sandbox_mode", Params: map[string]any{"mode": "nspawn"}, Timeout: 30 * time.Second}
+	h.dispatchReverting(call, "agent set_ssh_sandbox_mode failed", revert)
+
+	require.Equal(t, 1, cr.upserts)
+	got := cr.getResult
+	require.Equal(t, "bubblewrap", got.SSHSandboxMode, "mode reverted to before")
+	require.Equal(t, "debian-12", got.DefaultNspawnImageVersion, "default image reverted to before")
+	require.Equal(t, "keep.example.com", got.Hostname)
+}
+
+// A touched-but-unchanged re-sync (Kind == Reapply, revert == nil) that fails must
+// NOT write: before == after, so there is nothing to roll back and a pointless
+// Upsert on the drift-heal path is avoided.
+func TestSSHConfigRevert_NilRevertDoesNotWrite(t *testing.T) {
+	after := &models.ServerSettings{ID: 1, SSHPort: 22, SSHPasswordAuth: true}
+
+	mockAgent := agent.NewMockClient()
+	mockAgent.OnError("system.set_ssh_config", errors.New("agent unreachable"))
+	h, cr := revertHandler(after, mockAgent)
+
+	call := settingsops.AgentCall{Method: "system.set_ssh_config", Params: map[string]any{"port": uint16(22)}, Timeout: 30 * time.Second}
+	h.dispatchReverting(call, "agent set_ssh_config failed", nil)
+
+	require.Equal(t, 0, cr.upserts, "a re-sync failure with no value change must not write")
+	require.Equal(t, uint16(22), cr.getResult.SSHPort)
+}
+
+// A successful apply never reverts, even when a revert func is supplied.
+func TestSSHConfigRevert_SuccessDoesNotRevert(t *testing.T) {
+	after := &models.ServerSettings{ID: 1, SSHPort: 2222, SSHPasswordAuth: true}
+
+	mockAgent := agent.NewMockClient()
+	mockAgent.On("system.set_ssh_config", map[string]any{"status": "ok"})
+	h, cr := revertHandler(after, mockAgent)
+
+	revert := func(cur *models.ServerSettings) { cur.SSHPort = 22 }
+	call := settingsops.AgentCall{Method: "system.set_ssh_config", Params: map[string]any{"port": uint16(2222)}, Timeout: 30 * time.Second}
+	h.dispatchReverting(call, "agent set_ssh_config failed", revert)
+
+	require.Equal(t, 0, cr.upserts, "a successful apply must not revert")
+	require.Equal(t, uint16(2222), cr.getResult.SSHPort, "persisted after-state stands")
+}

--- a/panel-api/internal/settingsops/modules.go
+++ b/panel-api/internal/settingsops/modules.go
@@ -135,16 +135,16 @@ func moduleLoopEffect(key string, before, after bool) Effect {
 }
 
 // dockerTenantEffect toggles tenant Docker via docker.tenant_set{enabled}. On the
-// enable direction the effect is flagged RevertOnEnableFailure so the adapter
-// clears the persisted flag if the host setup fails (GH #272 — unprivileged LXC).
+// enable direction the effect is flagged RevertOnFailure so the adapter clears the
+// persisted flag if the host setup fails (GH #272 — unprivileged LXC).
 func dockerTenantEffect(before, after bool) Effect {
 	if before == after {
 		return Effect{Kind: NoOp}
 	}
 	return Effect{
-		Kind:                  Changed,
-		Call:                  &AgentCall{Method: "docker.tenant_set", Params: map[string]any{"enabled": after}, Timeout: dockerTenantTimeout},
-		RevertOnEnableFailure: after, // revert only on a failed ENABLE
+		Kind:            Changed,
+		Call:            &AgentCall{Method: "docker.tenant_set", Params: map[string]any{"enabled": after}, Timeout: dockerTenantTimeout},
+		RevertOnFailure: after, // revert only on a failed ENABLE
 	}
 }
 

--- a/panel-api/internal/settingsops/modules_test.go
+++ b/panel-api/internal/settingsops/modules_test.go
@@ -44,15 +44,15 @@ func TestModuleEffects_DockerMarketplace(t *testing.T) {
 func TestModuleEffects_DockerTenant_RevertOnlyOnEnable(t *testing.T) {
 	enable := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{DockerAppsForUsersEnabled: true})
 	require.Equal(t, &AgentCall{Method: "docker.tenant_set", Params: map[string]any{"enabled": true}, Timeout: 12 * time.Minute}, enable.DockerTenant.Call)
-	require.True(t, enable.DockerTenant.RevertOnEnableFailure, "failed ENABLE must revert the persisted flag")
+	require.True(t, enable.DockerTenant.RevertOnFailure, "failed ENABLE must revert the persisted flag")
 
 	disable := ModuleEffects(&models.ServerSettings{DockerAppsForUsersEnabled: true}, &models.ServerSettings{})
 	require.Equal(t, map[string]any{"enabled": false}, disable.DockerTenant.Call.Params)
-	require.False(t, disable.DockerTenant.RevertOnEnableFailure, "disable must not revert")
+	require.False(t, disable.DockerTenant.RevertOnFailure, "disable must not revert")
 
 	noop := ModuleEffects(&models.ServerSettings{}, &models.ServerSettings{})
 	require.Equal(t, NoOp, noop.DockerTenant.Kind)
-	require.False(t, noop.DockerTenant.RevertOnEnableFailure)
+	require.False(t, noop.DockerTenant.RevertOnFailure)
 }
 
 func TestModuleEffects_Python_EnableOnly(t *testing.T) {

--- a/panel-api/internal/settingsops/nginx.go
+++ b/panel-api/internal/settingsops/nginx.go
@@ -41,20 +41,25 @@ type AgentCall struct {
 // Effect is one settings side effect. Call is non-nil iff Kind != NoOp; an
 // adapter dispatches Call under its own execution policy. Rollback is the
 // compensating call if the apply fails; nil for nginx (the agent's own `nginx -t`
-// gate reverts a bad config, so there is no panel-side rollback). The field is
-// the seam JAB-295 (SSH) will populate.
+// gate reverts a bad config, so there is no panel-side rollback) and nil for SSH
+// too — SSH's compensation is a persisted-row revert (see RevertOnFailure), not an
+// agent call, so the field stays unused (kept for a future verb whose rollback is
+// genuinely a second agent call).
 //
-// RevertOnEnableFailure marks an ENABLE transition whose persisted flag must be
-// cleared if Call fails (tenant Docker on unprivileged LXC — GH #272). The
-// module owns the decision (which module reverts, and only on the enable
-// direction); the adapter owns the execution — reverting the flag is a
-// persistence write against the adapter's own repo handle, not an agent call, so
-// it cannot be expressed as Rollback. Only DockerTenant sets this today.
+// RevertOnFailure marks a transition whose persisted state must be rolled back if
+// Call fails, so the DB never claims a state the host rejected. The module owns
+// the decision (which effects revert, and in which direction); the adapter owns
+// the execution — reverting is a persistence write against the adapter's own repo
+// handle, not an agent call, so it cannot be expressed as Rollback. Tenant Docker
+// sets it on the enable direction (GH #272); SSH config + sandbox set it on any
+// value change (JAB-295, AC5) so a failed apply cannot leave the row claiming an
+// unapplied security state (the agent rolls the file back on `sshd -t` failure,
+// but the panel DB would otherwise keep the new value).
 type Effect struct {
-	Kind                  Kind
-	Call                  *AgentCall
-	Rollback              *AgentCall
-	RevertOnEnableFailure bool
+	Kind            Kind
+	Call            *AgentCall
+	Rollback        *AgentCall
+	RevertOnFailure bool
 }
 
 // NginxTouched reports which nginx field families the adapter merged this
@@ -79,16 +84,18 @@ type NginxPlan struct {
 func NginxEffects(before, after *models.ServerSettings, touched NginxTouched) NginxPlan {
 	return NginxPlan{
 		Tunables: effect(touched.Tunables, "nginx.tunables.apply",
-			nginxTunablesParams(before), nginxTunablesParams(after)),
+			nginxTunablesParams(before), nginxTunablesParams(after), nginxApplyTimeout),
 		Cache: effect(touched.Cache, "nginx.cache.capacity_apply",
-			nginxCacheParams(before), nginxCacheParams(after)),
+			nginxCacheParams(before), nginxCacheParams(after), nginxApplyTimeout),
 	}
 }
 
-// effect builds one Effect: NoOp when the family was not touched, otherwise an
-// AgentCall with the after-params, classified Changed vs Reapply by comparing
-// before/after.
-func effect(touched bool, method string, beforeParams, afterParams map[string]any) Effect {
+// effect builds a touched-based Effect (the nginx / ssh-config re-sync semantics):
+// NoOp when the family was not touched, otherwise an AgentCall with the
+// after-params, classified Changed vs Reapply by comparing before/after. A
+// touched-but-unchanged family is a Reapply — still dispatched, so a re-save
+// re-syncs a drifted file.
+func effect(touched bool, method string, beforeParams, afterParams map[string]any, timeout time.Duration) Effect {
 	if !touched {
 		return Effect{Kind: NoOp}
 	}
@@ -98,7 +105,21 @@ func effect(touched bool, method string, beforeParams, afterParams map[string]an
 	}
 	return Effect{
 		Kind: kind,
-		Call: &AgentCall{Method: method, Params: afterParams, Timeout: nginxApplyTimeout},
+		Call: &AgentCall{Method: method, Params: afterParams, Timeout: timeout},
+	}
+}
+
+// diffEffect builds a value-diff Effect (no touched signal, no re-sync): NoOp iff
+// before == after, otherwise Changed. Used where the adapter has no touched flag
+// and only a genuine value change should dispatch (SSH sandbox mode). There is no
+// Reapply case — an unchanged value simply does not fire.
+func diffEffect(method string, beforeParams, afterParams map[string]any, timeout time.Duration) Effect {
+	if reflect.DeepEqual(beforeParams, afterParams) {
+		return Effect{Kind: NoOp}
+	}
+	return Effect{
+		Kind: Changed,
+		Call: &AgentCall{Method: method, Params: afterParams, Timeout: timeout},
 	}
 }
 

--- a/panel-api/internal/settingsops/ssh.go
+++ b/panel-api/internal/settingsops/ssh.go
@@ -1,0 +1,75 @@
+package settingsops
+
+import (
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// sshApplyTimeout is the per-call agent timeout for both SSH settings verbs
+// (matches the pre-extraction REST goroutine budget of 30s).
+const sshApplyTimeout = 30 * time.Second
+
+// SSHTouched reports whether the adapter merged any ssh-config field this
+// request. Only the config verb is touched-based (a re-save re-syncs a drifted
+// sshd_config even when the value is unchanged — the operator-driven counterpart
+// to the boot-time reconcile in serve.go); the sandbox verb is pure value-diff
+// and needs no touched signal. Kept as adapter input (not re-derived here) so the
+// module preserves the exact re-sync semantics of the handler.
+type SSHTouched struct {
+	Config bool
+}
+
+// SSHPlan is the declarative plan for the SSH settings family: at most one
+// dispatch per verb.
+//
+//   - Config  → system.set_ssh_config (sshd port + password-auth). Touched-based
+//     re-sync; the agent runs `sshd -t` and reloads, rolling the file back on a
+//     bad config.
+//   - Sandbox → system.set_ssh_sandbox_mode (shell-sandbox mode + default image).
+//     Value-diff; the connect wrapper reads the files on every exec, so no reload.
+//
+// Both carry RevertOnFailure when the effect is a real value change (Kind ==
+// Changed): a failed apply must not leave the persisted row claiming an SSH
+// security state the host never accepted (JAB-295 AC5). The agent rolls the file
+// back on `sshd -t` failure, but the panel DB would otherwise keep the new value,
+// so the adapter reverts the matching fields to their pre-merge values. A
+// touched-but-unchanged config re-sync (Kind == Reapply) has nothing to revert —
+// before == after — so it is left unflagged.
+type SSHPlan struct {
+	Config  Effect
+	Sandbox Effect
+}
+
+// SSHEffects derives the SSH settings effect plan from the validated before/after
+// settings and whether any ssh-config field was touched. before is the pre-merge
+// snapshot (old values); after is the merged settings that will be persisted.
+func SSHEffects(before, after *models.ServerSettings, touched SSHTouched) SSHPlan {
+	cfg := effect(touched.Config, "system.set_ssh_config",
+		sshConfigParams(before), sshConfigParams(after), sshApplyTimeout)
+	cfg.RevertOnFailure = cfg.Kind == Changed
+
+	sandbox := diffEffect("system.set_ssh_sandbox_mode",
+		sshSandboxParams(before), sshSandboxParams(after), sshApplyTimeout)
+	sandbox.RevertOnFailure = sandbox.Kind == Changed
+
+	return SSHPlan{Config: cfg, Sandbox: sandbox}
+}
+
+// sshConfigParams is the exact system.set_ssh_config wire (3 keys). This is the
+// single source the REST handler previously copied verbatim.
+func sshConfigParams(s *models.ServerSettings) map[string]any {
+	return map[string]any{
+		"port":               s.SSHPort,
+		"password_auth":      s.SSHPasswordAuth,
+		"user_password_auth": s.SSHUserPasswordAuth,
+	}
+}
+
+// sshSandboxParams is the exact system.set_ssh_sandbox_mode wire (2 keys).
+func sshSandboxParams(s *models.ServerSettings) map[string]any {
+	return map[string]any{
+		"mode":          s.SSHSandboxMode,
+		"default_image": s.DefaultNspawnImageVersion,
+	}
+}

--- a/panel-api/internal/settingsops/ssh_test.go
+++ b/panel-api/internal/settingsops/ssh_test.go
@@ -1,0 +1,106 @@
+package settingsops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// --- system.set_ssh_config: touched-based re-sync ---
+
+func TestSSHEffects_Config_Wire(t *testing.T) {
+	before := &models.ServerSettings{SSHPort: 22, SSHPasswordAuth: false, SSHUserPasswordAuth: false}
+	after := &models.ServerSettings{SSHPort: 2222, SSHPasswordAuth: true, SSHUserPasswordAuth: false}
+	plan := SSHEffects(before, after, SSHTouched{Config: true})
+
+	require.Equal(t, Changed, plan.Config.Kind)
+	require.Equal(t, &AgentCall{
+		Method: "system.set_ssh_config",
+		Params: map[string]any{
+			"port":               uint16(2222),
+			"password_auth":      true,
+			"user_password_auth": false,
+		},
+		Timeout: 30 * time.Second,
+	}, plan.Config.Call)
+	require.True(t, plan.Config.RevertOnFailure, "a real config change must revert on failure (AC5)")
+	require.Nil(t, plan.Config.Rollback, "SSH compensation is a repo revert, not an agent Rollback")
+}
+
+func TestSSHEffects_Config_ReapplyWhenTouchedButUnchanged(t *testing.T) {
+	s := &models.ServerSettings{SSHPort: 22, SSHPasswordAuth: true, SSHUserPasswordAuth: false}
+	plan := SSHEffects(s, s, SSHTouched{Config: true})
+
+	// Touched + unchanged still dispatches (re-sync a drifted sshd_config)...
+	require.Equal(t, Reapply, plan.Config.Kind)
+	require.NotNil(t, plan.Config.Call)
+	// ...but there is nothing to revert (before == after), so it is not flagged.
+	require.False(t, plan.Config.RevertOnFailure, "a no-value-change re-sync has nothing to revert")
+}
+
+func TestSSHEffects_Config_NoOpWhenUntouched(t *testing.T) {
+	before := &models.ServerSettings{SSHPort: 22}
+	after := &models.ServerSettings{SSHPort: 2222} // value differs, but not touched
+	plan := SSHEffects(before, after, SSHTouched{Config: false})
+
+	require.Equal(t, NoOp, plan.Config.Kind)
+	require.Nil(t, plan.Config.Call)
+	require.False(t, plan.Config.RevertOnFailure)
+}
+
+// --- system.set_ssh_sandbox_mode: value-diff, no re-sync ---
+
+func TestSSHEffects_Sandbox_Wire(t *testing.T) {
+	before := &models.ServerSettings{SSHSandboxMode: "bubblewrap", DefaultNspawnImageVersion: "debian-12"}
+	after := &models.ServerSettings{SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12"}
+	plan := SSHEffects(before, after, SSHTouched{})
+
+	require.Equal(t, Changed, plan.Sandbox.Kind)
+	require.Equal(t, &AgentCall{
+		Method: "system.set_ssh_sandbox_mode",
+		Params: map[string]any{
+			"mode":          "nspawn",
+			"default_image": "debian-12",
+		},
+		Timeout: 30 * time.Second,
+	}, plan.Sandbox.Call)
+	require.True(t, plan.Sandbox.RevertOnFailure, "a sandbox mode change must revert on failure (AC5)")
+}
+
+func TestSSHEffects_Sandbox_ImageOnlyChangeFires(t *testing.T) {
+	before := &models.ServerSettings{SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12"}
+	after := &models.ServerSettings{SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-13"}
+	plan := SSHEffects(before, after, SSHTouched{})
+
+	require.Equal(t, Changed, plan.Sandbox.Kind)
+	require.Equal(t, "debian-13", plan.Sandbox.Call.Params["default_image"])
+	require.True(t, plan.Sandbox.RevertOnFailure)
+}
+
+func TestSSHEffects_Sandbox_NoOpWhenUnchanged(t *testing.T) {
+	s := &models.ServerSettings{SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12"}
+	plan := SSHEffects(s, s, SSHTouched{})
+
+	require.Equal(t, NoOp, plan.Sandbox.Kind)
+	require.Nil(t, plan.Sandbox.Call)
+	require.False(t, plan.Sandbox.RevertOnFailure)
+}
+
+// TestSSHEffects_TwoDetectionModesDiffer pins the AC3 distinction: with the SAME
+// before/after (a value that is unchanged), the touched config re-syncs while the
+// value-diff sandbox stays silent. The two verbs must not collapse to one rule.
+func TestSSHEffects_TwoDetectionModesDiffer(t *testing.T) {
+	s := &models.ServerSettings{
+		SSHPort: 22, SSHPasswordAuth: true,
+		SSHSandboxMode: "nspawn", DefaultNspawnImageVersion: "debian-12",
+	}
+	plan := SSHEffects(s, s, SSHTouched{Config: true})
+
+	require.NotNil(t, plan.Config.Call, "touched config re-syncs even when unchanged")
+	require.Equal(t, Reapply, plan.Config.Kind)
+	require.Nil(t, plan.Sandbox.Call, "value-diff sandbox does not fire when unchanged")
+	require.Equal(t, NoOp, plan.Sandbox.Kind)
+}


### PR DESCRIPTION
## Summary

The SSH slice of ADR-0083's `<area>ops` pattern, the third after nginx +
validation (JAB-290) and the optional-module lifecycle (JAB-294). Before this
change the REST PATCH handler carried the `system.set_ssh_config` and
`system.set_ssh_sandbox_mode` dispatch — the verbs, param maps, per-call
timeout, and two subtly different detection rules — written out inline.

New in **`internal/settingsops`** (still no `net/http`, no cobra, no `os.Exit`):

- **`SSHEffects(before, after, SSHTouched) SSHPlan`** — the single owner of both
  SSH agent verbs and, critically, their two distinct detection semantics:
  - **Config** (`system.set_ssh_config`) is **touched-based**: re-saving any ssh
    field re-syncs a possibly-drifted `sshd_config` even when the value is
    unchanged (`Kind == Reapply`). This preserves the operator-driven re-sync the
    handler already did (heal a `DB=1, file=no` drift by re-submitting) and
    complements the boot-time reconcile in `serve.go`.
  - **Sandbox** (`system.set_ssh_sandbox_mode`) is **value-diff**: it fires only
    on a genuine mode / default-image change, never on a same-value re-submit
    (the connect wrapper reads the files on every exec, so there is no re-sync to
    do).
- **`diffEffect()`** — the value-diff constructor for Sandbox. `effect()` is
  generalized with a `timeout` parameter so both families (nginx 60s, SSH 30s)
  share one builder.

## AC5 — a failed apply must not silently leave the row claiming an unapplied security state

The agent already rolls the `sshd_config` file back on a failed `sshd -t`, but
the **panel DB would keep the new value** — so the row would claim, e.g., that
password auth is on while sshd rejected the change. This PR closes that gap: a
real value change (`Kind == Changed`) is flagged **`RevertOnFailure`**, and on a
failed apply the adapter reverts the persisted SSH fields to their pre-merge
values, so the DB matches the file the host actually kept. A no-value re-sync
(`Reapply`) has nothing to revert and is left unflagged.

The tenant-Docker revert (GH #272) and the two SSH reverts are now **one**
adapter helper — `dispatchReverting(call, logMsg, revert)`. The module owns the
decision (`Effect.RevertOnFailure`, and which fields via the caller's closure);
the adapter owns the persistence write against its own repo handle.
`Effect.RevertOnEnableFailure` is renamed **`RevertOnFailure`** to cover both the
enable-only Docker case and the any-change SSH case.

## Adapters

- **REST** (`internal/api/server_settings.go`): derives one `SSHEffects` plan and
  dispatches each non-no-op effect detached, best-effort, with the pre-merge
  `before` snapshot (shared with `ModuleEffects` / `NginxEffects`) driving the
  revert closures. The retired inline SSH goroutines and the `prevSSH*` /
  `prevDefaultNspawnImageVersion` locals are gone; `dispatchDockerTenant` is
  folded into `dispatchReverting`.
- **CLI** (`cmd/server/settings_cmd.go`): unchanged except the `RevertOnFailure`
  rename. **SSH is REST-only** — the CLI exposes no `ssh_*` setters, so, like the
  nginx cache capacity (JAB-290) and the `dns/mail/quota/security/ftp` loop
  (JAB-294), only the REST adapter consumes `SSHEffects`. No new agent verb, no
  wire change.

## Acceptance criteria

- **AC1 — SSH config + sandbox transition detection has one owner:** ✅
  `SSHEffects` owns both verbs and both detection rules; only the REST adapter
  consumes it.
- **AC2 — exact agent commands / params / validation / rollback covered by golden
  tests:** ✅ golden wire per verb (method / params / 30s timeout); sandbox-mode
  validation stays single-owned in `settingsops.Validate`; the `RevertOnFailure`
  rollback decision is golden-tested.
- **AC3 — no-op vs explicitly-touched reapply distinct:** ✅ a dedicated test pins
  it — with the **same** before/after, the touched config re-syncs
  (`Reapply`, `Call != nil`) while the value-diff sandbox stays silent (`NoOp`).
- **AC4 — REST/CLI execution-policy differences stay in adapters:** ✅ the module
  is transport-agnostic; REST dispatches detached best-effort with the revert
  policy, and SSH simply has no CLI surface.
- **AC5 — a failed plan cannot silently leave the persisted setting claiming an
  unapplied security state:** ✅ **with one documented caveat** (see below). On a
  failed apply the persisted SSH fields are reverted to their pre-merge values so
  the DB matches the file the agent kept.

## Caveats for reviewers

- **Timeout-after-success → false revert.** If the agent applies the change but
  the response times out, the panel reverts the DB to `before`: file = *after*,
  DB = *before*. Same class as the existing tenant-Docker revert; the timeout is
  30s on a sub-second op. The **loosen** direction is the one to name: an operator
  turns password auth **on**, the apply lands, the response times out → the DB
  says OFF while sshd accepts passwords. The startup reconcile in `serve.go` heals
  the **config** file on next boot; **sandbox has no reconcile**, so a sandbox
  divergence persists until the next PATCH. Documented, not engineered.
- **Late revert can clobber a later success.** PATCH A (22→2222) fails slowly;
  PATCH C (2222→3333) succeeds first; A's revert then fires, `Repo.Get` sees 3333
  and writes 22 → DB = 22, file = 3333. A CAS guard
  (`if cur.SSHPort != after.SSHPort { skip }`) is the fix if this ever bites; not
  added here.
- **Closure-wiring gap.** The REST glue (`if RevertOnFailure { revert = … }` and
  the exact field list in each closure) is **not** covered by a REST-level test —
  the async dispatch + non-mutex-guarded repo mock would race under `-race` (the
  JAB-294 rule). Coverage is layered instead: the golden test proves the flag, the
  synchronous revert tests prove `dispatchReverting`, and the test closures mirror
  the handler's field lists.
- **`Effect.Rollback` (the JAB-290 seam) stays nil.** SSH's compensation is a repo
  write, not a second agent call — so after two slices the field still has no
  consumer. Flagged for removal in a follow-up; not touched here.

## Test plan

- [x] `internal/settingsops`: golden wire per verb (method / params / 30s
      timeout), `Kind` classification (config NoOp/Changed/Reapply, sandbox
      NoOp/Changed), the `RevertOnFailure` matrix, and the pinned distinction
      that a touched-unchanged config re-syncs while a same-value sandbox stays
      silent.
- [x] `internal/api`: HTTP characterization tests written and run **GREEN against
      the pre-refactor handler** (config re-sync-on-touch, sandbox
      fire-on-change-only, image-only change fires, untouched silent), proving the
      extraction is byte-identical; and **synchronous** revert tests for AC5
      (failed apply restores the pre-merge SSH fields, preserves unrelated fields,
      no write on a no-value re-sync, no revert on success).
- [x] `go build ./...`, `go vet ./...`, full `go test ./...`, gofmt clean,
      `-race` on `settingsops` / `api` / `cmd/server`.
- [x] Rebased onto latest `origin/main`, re-ran the three packages post-rebase.
- No box validation: no new agent verb; the REST wire is proven identical
  green→green; and inducing a real SSH apply failure would mean touching sshd on
  the shared test server (lockout risk) to exercise a path that is a plain panel
  repo write, already proven synchronously.

## Disposition

JAB-295 is a codex arch-audit module-parent, so it stays in **Backlog** per the
convention (a slice ships, the parent stays open) even though all five ACs are
substantively met. Continues the `settingsops` line after JAB-290 and JAB-294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
