### PR TITLE
feat(cli): service flags on `jabali domain create` (GH #1449)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1948,10 +1948,13 @@ jabali domain create [flags]
 **Flags:**
 
 - `--doc-root` — Document root (optional, auto-generated if not provided)
+- `--mail` — Mail provider: jabali | none | m365 | google. 'none' for a web/DNS-only domain (default `jabali`)
+- `--manage-dns` — Host this domain's DNS zone on this server. --manage-dns=false when DNS lives elsewhere (external DNS) (default `true`)
 - `--name` — Domain name (required)
 - `--reverse-proxy` — Make this a reverse-proxy domain: allocate a loopback port and proxy '/' to it (GH #1175)
 - `--reverse-proxy-port` — Reverse-proxy to this specific loopback port (GH #1401); 0 = auto-assign from the pool (default `0`)
 - `--user` — User email, username, or ULID (required)
+- `--web-enabled` — Host a website for this domain (vhost + docroot). --web-enabled=false makes a docroot-less DNS-only zone or mail-only domain (default `true`)
 
 #### `jabali domain delete`
 

--- a/panel-api/cmd/server/cli_create.go
+++ b/panel-api/cmd/server/cli_create.go
@@ -217,6 +217,15 @@ type cliDomainInput struct {
 	// ReverseProxyPort (GH #1401): a specific loopback port to proxy to; 0 =
 	// auto-assign from the pool. Validated the same as the HTTP path.
 	ReverseProxyPort int
+	// GH #1449: independent services. WebDisabled → docroot-less (DNS-only /
+	// mail-only), DNSDisabled → external DNS. INVERTED so the zero value keeps
+	// the historic full-service behaviour for any caller that doesn't set them.
+	WebDisabled bool
+	DNSDisabled bool
+	// MailProvider (GH#181) — jabali (default) | none | m365 | google. Empty =
+	// jabali. Lets the CLI create a DNS-only zone (--mail none) or a mail-only
+	// domain (--web-enabled=false, mail jabali).
+	MailProvider string
 }
 
 // createDomainDirect replicates the non-auth side of internal/api/domains.go
@@ -276,21 +285,57 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 		}
 	}
 
+	// GH #1449: resolve the web / mail / dns service matrix before building the
+	// row, mirroring the HTTP createDomainOp.
+	webEnabled := !in.WebDisabled
+	dnsEnabled := !in.DNSDisabled
+	mailProvider := in.MailProvider
+	if mailProvider == "" {
+		mailProvider = models.MailProviderJabali
+	}
+	if !models.ValidMailProvider(mailProvider) {
+		return nil, nil, fmt.Errorf("invalid --mail %q (want jabali|none|m365|google)", mailProvider)
+	}
+	mailEnabled, mailSkipSAN := models.DeriveMailFlags(mailProvider)
+	if !webEnabled && !dnsEnabled && !mailEnabled {
+		return nil, nil, fmt.Errorf("select at least one service: web hosting (--web-enabled), DNS (--manage-dns), or mail (--mail)")
+	}
+
 	docRoot := in.DocRoot
-	if docRoot == "" {
+	if !webEnabled {
+		if in.ReverseProxy {
+			return nil, nil, fmt.Errorf("a reverse-proxy domain requires web hosting")
+		}
+		if strings.TrimSpace(docRoot) != "" {
+			return nil, nil, fmt.Errorf("a web-disabled domain has no document root")
+		}
+		docRoot = "" // docroot-less (DNS-only zone / mail-only domain)
+	} else if docRoot == "" {
 		docRoot = "/home/" + *owner.Username + "/domains/" + in.Name + "/public_html"
+	}
+
+	// DNS-only (web off + no Jabali mail) has nothing to serve over TLS.
+	sslMode := models.SSLModeLE
+	if !webEnabled && !mailEnabled {
+		sslMode = models.SSLModeNone
 	}
 
 	now := time.Now().UTC()
 	d := &models.Domain{
-		ID:         ids.NewULID(),
-		UserID:     ownerID,
-		Name:       in.Name,
-		DocRoot:    docRoot,
-		IsEnabled:  true,
-		SSLEnabled: true,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		ID:           ids.NewULID(),
+		UserID:       ownerID,
+		Name:         in.Name,
+		DocRoot:      docRoot,
+		IsEnabled:    true,
+		WebDisabled:  in.WebDisabled,
+		DNSDisabled:  in.DNSDisabled,
+		MailProvider: mailProvider,
+		EmailEnabled: mailEnabled,
+		SkipAutoSAN:  mailSkipSAN,
+		SSLMode:      sslMode,
+		SSLEnabled:   models.SSLEnabledForMode(sslMode),
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}
 	// GH #1175: reverse-proxy domains draw a loopback port from the shared
 	// allocator BEFORE the insert (owner_id = the ULID above), released if the
@@ -344,7 +389,11 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 	// and the operator can retry via `jabali domain email-enable <name>`
 	// or the Email tab in the UI.
 	var warnings []string
-	if err := initAgent(); err != nil {
+	if mailProvider != models.MailProviderJabali {
+		// External (m365/google) or no mail — nothing to register on Stalwart;
+		// the reconciler publishes the provider's own DNS (or none). A DNS-only
+		// zone (--mail none) must not auto-enable Jabali mail.
+	} else if err := initAgent(); err != nil {
 		warnings = append(warnings, fmt.Sprintf("email auto-enable skipped: agent unavailable (%v)", err))
 	} else {
 		deps := newDomainEmailDepsFromGlobals()

--- a/panel-api/cmd/server/domain_cmd.go
+++ b/panel-api/cmd/server/domain_cmd.go
@@ -94,6 +94,11 @@ func newDomainCreateCmd() *cobra.Command {
 	var name, userID, docRoot string
 	var reverseProxy bool
 	var reverseProxyPort int
+	// GH #1449: independent Web / Mail / DNS services. Web + DNS default ON so
+	// the historic full-service behaviour is unchanged; set false to opt out.
+	var webEnabled = true
+	var manageDNS = true
+	var mailProvider string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -121,6 +126,9 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 				DocRoot:          docRoot,
 				ReverseProxy:     reverseProxy,
 				ReverseProxyPort: reverseProxyPort,
+				WebDisabled:      !webEnabled,
+				DNSDisabled:      !manageDNS,
+				MailProvider:     mailProvider,
 			})
 			if err != nil {
 				return err
@@ -157,6 +165,10 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 	cmd.Flags().StringVar(&docRoot, "doc-root", "", "Document root (optional, auto-generated if not provided)")
 	cmd.Flags().BoolVar(&reverseProxy, "reverse-proxy", false, "Make this a reverse-proxy domain: allocate a loopback port and proxy '/' to it (GH #1175)")
 	cmd.Flags().IntVar(&reverseProxyPort, "reverse-proxy-port", 0, "Reverse-proxy to this specific loopback port (GH #1401); 0 = auto-assign from the pool")
+	// GH #1449: independent Web / Mail / DNS services.
+	cmd.Flags().BoolVar(&webEnabled, "web-enabled", true, "Host a website for this domain (vhost + docroot). --web-enabled=false makes a docroot-less DNS-only zone or mail-only domain")
+	cmd.Flags().BoolVar(&manageDNS, "manage-dns", true, "Host this domain's DNS zone on this server. --manage-dns=false when DNS lives elsewhere (external DNS)")
+	cmd.Flags().StringVar(&mailProvider, "mail", "jabali", "Mail provider: jabali | none | m365 | google. 'none' for a web/DNS-only domain")
 	return cmd
 }
 


### PR DESCRIPTION
## Follow-up to #1449

The HTTP `POST /domains` took the #1449 service flags, but `jabali domain create` (direct-DB CLI) always made a full web + Jabali-mail domain — so the independent-services model wasn't reachable from the CLI. This surfaced deploying #1449 to the test server: the drill had to set `web_disabled` via SQL because the CLI couldn't.

## Change

Three flags on `jabali domain create`, mirroring `createDomainOp`'s matrix:

| flag | default | effect |
|---|---|---|
| `--web-enabled` | true | `WebDisabled = !flag` — docroot-less (DNS-only zone / mail-only domain) when off |
| `--manage-dns` | true | `DNSDisabled = !flag` — external DNS when off |
| `--mail` | jabali | `MailProvider` — `none` for a DNS-only zone |

`createDomainDirect` now resolves web/mail/dns the same way as the HTTP op: derives `EmailEnabled`/`SkipAutoSAN` from the provider, forces `ssl_mode=none` for a DNS-only domain, refuses a domain that hosts nothing, holds reverse-proxy / custom-docroot to web-enabled domains, and only auto-enables Jabali mail when the provider is `jabali` (so `--mail none` never registers a Stalwart domain). **Defaults keep the historic full-service behaviour byte-identical.**

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt`; **`TestCLIReferenceGolden`** regenerated + green
- [x] **Box-verified on the test server** (ran this branch's binary from `/root` against the live DB):
  - `--web-enabled=false --mail none` → row is `web_disabled=1, dns_disabled=0, email_enabled=0, mail_provider=none, ssl_mode=none, doc_root=''` — a clean DNS-only zone, no Stalwart registration
  - `--web-enabled=false --manage-dns=false --mail none` → rejected: *select at least one service*
  - `--web-enabled=false --doc-root …` → rejected: *a web-disabled domain has no document root*
  - test domain deleted, 0 leftovers

## Notes

- No migration, no agent change — panel-api CLI only (reuses the #1449 columns already on main).
