### PR TITLE
fix(backup): don't mint a Kratos identity from uploaded-bundle fields (GH #1408)

### DIFF
--- a/panel-api/internal/backupmetadata/apply.go
+++ b/panel-api/internal/backupmetadata/apply.go
@@ -554,7 +554,17 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 	// so the operator gets a definitive login status instead of a swallowed
 	// warning, and a fresh (password-less) identity is minted when none
 	// exists so a recovery link can actually be issued.
-	if d.KratosClient != nil && m.User.Email != "" {
+	//
+	// SECURITY (GH #1408): gated on `created`. The email + is_admin + password
+	// hash read here are bundle-controlled, and the restore-from-UPLOAD path
+	// remaps only user.id — not the email — into an EXISTING target user
+	// (created=false). Ungated, an uploaded tar carrying an attacker's email +
+	// is_admin=true + a known hash would MINT a matching (admin) Kratos identity
+	// on this box: privilege escalation. We only ever mint/verify for a user we
+	// just created this run (a trusted same-box snapshot or a sanitized
+	// create-from-manifest, both non-admin per applyUser); an
+	// upload-into-existing-user restore never touches Kratos here.
+	if created && d.KratosClient != nil && m.User.Email != "" {
 		username := ""
 		if m.User.Username != nil {
 			username = *m.User.Username
@@ -608,6 +618,16 @@ func applyUser(ctx context.Context, m *internalbackup.AccountMetadata, d Deps, n
 		return false, nil
 	} else if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		return false, fmt.Errorf("lookup: %w", err)
+	}
+	// SECURITY (GH #1408): refuse to CREATE an admin user from a backup bundle.
+	// An account backup is only ever a non-admin tenant (admins host nothing and
+	// are never account-backed-up), so is_admin=true here is a malformed or
+	// crafted bundle — and creating an admin from an attacker-controllable
+	// uploaded tar is a privilege-escalation. The row is only reached on the
+	// CREATE path (an existing user no-ops above), so a legitimate
+	// same-box/#954 restore of a non-admin is unaffected.
+	if m.User.IsAdmin {
+		return false, errors.New("refusing to create an admin user from a backup bundle")
 	}
 	pwd := m.User.PasswordHash
 	if pwd == "" {

--- a/panel-api/internal/backupmetadata/apply_security_test.go
+++ b/panel-api/internal/backupmetadata/apply_security_test.go
@@ -1,0 +1,92 @@
+package backupmetadata
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// createGuardUsersRepo forces the applyUser CREATE path (FindByID → not found)
+// and records whether a user row was inserted.
+type createGuardUsersRepo struct {
+	repository.UserRepository
+	created int
+}
+
+func (r *createGuardUsersRepo) FindByID(context.Context, string) (*models.User, error) {
+	return nil, repository.ErrNotFound
+}
+func (r *createGuardUsersRepo) Create(context.Context, *models.User) error {
+	r.created++
+	return nil
+}
+
+// recordingKratos records every identity it is asked to mint. IdentityIDByEmail
+// returns "" (no identity for the bundle email) so the step-9 mint branch would
+// fire if it were reachable.
+type recordingKratos struct {
+	mints int
+}
+
+func (k *recordingKratos) CreateIdentityWithPassword(context.Context, kratosclient.AdminTraits, string) (string, error) {
+	k.mints++
+	return "id-minted", nil
+}
+func (k *recordingKratos) ImportIdentities(context.Context, []kratosclient.ExportedIdentity) error {
+	return nil
+}
+func (k *recordingKratos) IdentityIDByEmail(context.Context, string) (string, error) {
+	return "", nil
+}
+func (k *recordingKratos) IdentityHasPassword(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+// GH #1408: a backup bundle claiming is_admin=true must NOT create an admin
+// user — a crafted uploaded tar would otherwise mint an admin account.
+func TestApply_RefusesAdminBundle(t *testing.T) {
+	users := &createGuardUsersRepo{}
+	meta := &internalbackup.AccountMetadata{
+		User: internalbackup.MetadataUser{ID: "u-evil", Email: "attacker@evil.com", IsAdmin: true},
+	}
+	r := Apply(context.Background(), meta, Deps{Users: users})
+
+	if users.created != 0 {
+		t.Fatalf("no user may be created from an admin bundle, got %d", users.created)
+	}
+	found := false
+	for _, e := range r.Errors {
+		if strings.Contains(e, "refusing to create an admin") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want an admin-refusal error, got %v", r.Errors)
+	}
+}
+
+// GH #1408: the restore-from-UPLOAD path remaps only user.id into an EXISTING
+// target (created=false). The bundle's email + is_admin + password hash are
+// attacker-controllable, so step 9 must NOT mint a Kratos identity from them —
+// otherwise an uploaded tar could create a matching (admin) login on this box.
+func TestApply_NoKratosMintForExistingUser(t *testing.T) {
+	kratos := &recordingKratos{}
+	// a realistic-length bcrypt hash so the (guarded) mint branch would qualify
+	bcrypt := "$2a$10$" + strings.Repeat("a", 53)
+	meta := &internalbackup.AccountMetadata{
+		User: internalbackup.MetadataUser{ID: "u1", Email: "attacker@evil.com", PasswordHash: bcrypt, IsAdmin: true},
+	}
+	// existingUsersRepo → applyUser no-ops (created=false), like a real
+	// upload-into-existing-user restore.
+	r := Apply(context.Background(), meta, Deps{Users: existingUsersRepo{}, KratosClient: kratos})
+
+	if kratos.mints != 0 {
+		t.Errorf("step 9 must not mint an identity for a pre-existing user (created=false); minted %d", kratos.mints)
+	}
+	_ = r
+}


### PR DESCRIPTION
## Security fix (found while extending #1408)

`backupmetadata.Apply`'s step-9 login-verification block minted a Kratos identity for `m.User.Email` whenever the box had none — using the bundle's `is_admin` trait and password hash. The restore-**from-upload** path (shipped in #1445) remaps only `user.id` into an existing target user, so the bundle's email / `is_admin` / password-hash reach `Apply` unchanged. Since the uploaded archive is attacker-controllable, a crafted bundle could mint a matching **admin-trait** login on the restoring box — a privilege-escalation class.

## Fix (defence in depth)

- **Gate the step-9 mint/verify on `created`** (returned by `applyUser`). We only ever touch Kratos for a user we actually created this run — a trusted same-box snapshot or a sanitized create-from-manifest (both non-admin). An upload-into-existing-user restore (`created=false`) never mints from bundle-supplied fields.
- **Refuse to CREATE an admin user from a bundle** in `applyUser`. An account backup is only ever a non-admin tenant (admins host nothing and are never account-backed-up), so `is_admin=true` is malformed/crafted. This closes the class on every restore path, including the #954 migration path.

A legitimate non-admin snapshot / DR restore is unaffected (that path still creates the user + mints its identity as before).

## Test plan

- [x] New `apply_security_test.go`: admin-bundle → refusal + no user row created; pre-existing-user restore (`created=false`) with a recording Kratos mock → **zero** identity mints even with `is_admin=true` + a valid-length hash + a foreign email
- [x] `go test -race ./internal/backupmetadata/... ./internal/api/...` green (no existing restore/migration test regressed); `gofmt` clean

No migration, no agent change — panel-api only. Merge-worthy on its own; the create-from-manifest work builds on it.
