### PR TITLE
refactor(databases): dbops owns the whole database deletion path (JAB-275)

### DIFF
--- a/panel-api/cmd/server/db_cmd.go
+++ b/panel-api/cmd/server/db_cmd.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"text/tabwriter"
 	"time"
@@ -34,7 +35,13 @@ func dbopsDeps() dbops.Deps {
 		Packages:       repository.NewPackageRepository(sharedDB),
 		Databases:      repository.NewDatabaseRepository(sharedDB),
 		ServerSettings: repository.NewServerSettingsRepository(sharedDB),
+		// Delete-path collaborators (JAB-275) — the CLI delete now runs the
+		// same attachment refusal + grant teardown the REST handler does.
+		DatabaseGrants: repository.NewDatabaseUserGrantRepository(sharedDB),
+		DatabaseUsers:  repository.NewDatabaseUserRepository(sharedDB),
+		Installs:       repository.NewApplicationInstallRepository(sharedDB),
 		Agent:          sharedAgent,
+		Log:            slog.Default(),
 	}
 }
 
@@ -178,6 +185,12 @@ func mapDBopsErr(err error) error {
 		return err
 	case errors.Is(err, dbops.ErrNotFound):
 		return fmt.Errorf("database not found")
+	case errors.Is(err, dbops.ErrAttached):
+		var attached *dbops.AttachedError
+		if errors.As(err, &attached) {
+			return fmt.Errorf("database is attached to application install %s — delete the app first", attached.InstallID)
+		}
+		return fmt.Errorf("database is attached to an application install — delete the app first")
 	default:
 		return err
 	}

--- a/panel-api/cmd/server/db_cmd_delete_guard_test.go
+++ b/panel-api/cmd/server/db_cmd_delete_guard_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCLIDBDelete_RoutesThroughDbops pins the JAB-275 fix. The operator CLI
+// `jabali db delete` routes the whole deletion path — attachment refusal,
+// engine-correct grant revoke, schema drop, metadata teardown — through the
+// one canonical dbops.Delete the REST handler also uses, and wires every
+// delete-path collaborator so dbops does not fail closed on a nil dep.
+// cmd/server has no DB/agent fixture, so this source-pins the delegation; the
+// deletion behaviour itself is tested in internal/dbops.
+func TestCLIDBDelete_RoutesThroughDbops(t *testing.T) {
+	src, err := os.ReadFile("db_cmd.go")
+	if err != nil {
+		t.Fatalf("read db_cmd.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "dbops.Delete(ctx, dbopsDeps(), dbops.DeleteInput{ID: id})") {
+		t.Fatal("CLI db delete must route through dbops.Delete (JAB-275)")
+	}
+	// The CLI must not hand-roll the drop — dbops owns engine dispatch so a
+	// postgres row never reaches MariaDB (GH #1013).
+	for _, banned := range []string{`"db.drop"`, `"db.postgres.drop_db"`, `"db_user.revoke"`} {
+		if strings.Contains(s, banned) {
+			t.Fatalf("CLI must not issue %s itself — dbops.Delete owns the deletion transcript (JAB-275)", banned)
+		}
+	}
+	// It must wire the delete-path collaborators dbops requires.
+	for _, want := range []string{"DatabaseGrants:", "DatabaseUsers:", "Installs:"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("dbopsDeps missing %q — dbops.Delete fails closed without it (JAB-275)", want)
+		}
+	}
+}

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -369,77 +369,34 @@ func (h *databaseHandler) delete(c *gin.Context) {
 		return
 	}
 
-	// Guard: wordpress_installs.db_id is RESTRICT. Surface a 409 with
-	// the install id so the caller knows what to tear down first.
-	if h.cfg.WordPressInstalls != nil {
-		wp, wErr := h.cfg.WordPressInstalls.FindByDBID(ctx, d.ID)
-		if wErr != nil && !isNotFound(wErr) {
-			slog.ErrorContext(ctx, "databases.delete: wp in-use probe failed", "err", wErr, "db_id", d.ID)
+	// The complete deletion path — attachment refusal, engine-correct grant
+	// revoke, schema drop, and metadata teardown, all in the fail-safe phase
+	// order — lives in dbops so this handler and the `jabali db delete` CLI
+	// cannot drift (JAB-275). This handler owns only authorization (above),
+	// dependency wiring, and status-code mapping.
+	if err := dbops.Delete(ctx, dbops.Deps{
+		Databases:      h.cfg.Databases,
+		DatabaseGrants: h.cfg.DatabaseGrants,
+		DatabaseUsers:  h.cfg.DatabaseUsers,
+		Installs:       h.cfg.WordPressInstalls,
+		Agent:          h.cfg.Agent,
+		Log:            slog.Default(),
+	}, dbops.DeleteInput{ID: d.ID}); err != nil {
+		var attached *dbops.AttachedError
+		switch {
+		case errors.As(err, &attached):
+			// application_installs.db_id is ON DELETE CASCADE — dropping the
+			// database would silently delete the install row, so refuse and
+			// name the install to tear down first.
+			c.JSON(http.StatusConflict, gin.H{"error": "in_use_by_wordpress", "wordpress_id": attached.InstallID})
+		case errors.Is(err, dbops.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		case errors.Is(err, dbops.ErrAgentFailed):
+			respondAgentErr(c, "agent_failed", err)
+		default:
+			slog.ErrorContext(ctx, "databases.delete: dbops.Delete failed", "err", err, "db_id", d.ID)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-			return
 		}
-		if wp != nil {
-			c.JSON(http.StatusConflict, gin.H{"error": "in_use_by_wordpress", "wordpress_id": wp.ID})
-			return
-		}
-	}
-
-	if h.cfg.Agent == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-
-	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	// Cascade grants: database_user_grants.database_id is RESTRICT, so the
-	// final row delete would 500 if any grant is left behind. Revoke on the
-	// MariaDB side first (idempotent since b723fe1), then drop the panel row.
-	if h.cfg.DatabaseGrants != nil {
-		grants, gErr := h.cfg.DatabaseGrants.ListByDatabaseID(ctx, d.ID)
-		if gErr != nil {
-			slog.ErrorContext(ctx, "databases.delete: list grants failed", "err", gErr, "db_id", d.ID)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-			return
-		}
-		for _, g := range grants {
-			var username string
-			if h.cfg.DatabaseUsers != nil {
-				if u, uErr := h.cfg.DatabaseUsers.FindByID(ctx, g.DatabaseUserID); uErr == nil && u != nil {
-					username = u.Username
-				}
-			}
-			if username != "" {
-				if _, rErr := h.cfg.Agent.Call(agentCtx, "db_user.revoke", map[string]any{
-					"db_name":      d.Name,
-					"db_user_name": username,
-				}); rErr != nil {
-					slog.WarnContext(ctx, "databases.delete: revoke failed (best-effort)", "err", rErr, "db", d.Name, "user", username)
-				}
-			}
-			if dErr := h.cfg.DatabaseGrants.Delete(ctx, g.ID); dErr != nil {
-				slog.ErrorContext(ctx, "databases.delete: grant row delete failed", "err", dErr, "grant_id", g.ID)
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-				return
-			}
-		}
-	}
-
-	// Drop the database on the engine the row was created with.
-	// d.Name is the full prefixed name.
-	dropCmd := "db.drop"
-	if d.Engine == "postgres" {
-		dropCmd = "db.postgres.drop_db"
-	}
-	if _, err := h.cfg.Agent.Call(agentCtx, dropCmd, map[string]any{"db_name": d.Name}); err != nil {
-		slog.ErrorContext(ctx, "databases.delete: agent drop failed", "err", err, "db_name", d.Name, "engine", d.Engine)
-		respondAgentErr(c, "agent_failed", err)
-		return
-	}
-
-	if err := h.cfg.Databases.Delete(ctx, d.ID); err != nil {
-		slog.ErrorContext(ctx, "databases.delete: row delete failed", "err", err, "db_id", d.ID)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
 

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -188,7 +188,9 @@ func (m *mockUserRepo) Update(ctx context.Context, u *models.User) error {
 	return nil
 }
 
-func (m *mockUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+func (m *mockUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error {
+	return nil
+}
 
 func (m *mockUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
@@ -323,11 +325,13 @@ func databaseRouter(userID string, isAdmin bool) (*gin.Engine, *mockDatabaseRepo
 	}
 
 	RegisterDatabaseRoutes(v1, DatabaseHandlerConfig{
-		Databases:     dbRepo,
-		DatabaseUsers: &mockDatabaseUserRepo{},
-		Users:         userRepo,
-		Packages:      pkgRepo,
-		Agent:         &mockAgent{},
+		Databases:         dbRepo,
+		DatabaseUsers:     &mockDatabaseUserRepo{},
+		DatabaseGrants:    &mockDatabaseGrantRepo{},
+		WordPressInstalls: &mockWordPressInstallRepo{},
+		Users:             userRepo,
+		Packages:          pkgRepo,
+		Agent:             &mockAgent{},
 	})
 
 	return r, dbRepo
@@ -377,11 +381,13 @@ func databaseRouterWithAgent(userID string, isAdmin bool, agent *mockAgent) (*gi
 	}
 
 	cfg := DatabaseHandlerConfig{
-		Databases:     dbRepo,
-		DatabaseUsers: &mockDatabaseUserRepo{},
-		Users:         userRepo,
-		Packages:      pkgRepo,
-		Agent:         agent,
+		Databases:         dbRepo,
+		DatabaseUsers:     &mockDatabaseUserRepo{},
+		DatabaseGrants:    &mockDatabaseGrantRepo{},
+		WordPressInstalls: &mockWordPressInstallRepo{},
+		Users:             userRepo,
+		Packages:          pkgRepo,
+		Agent:             agent,
 	}
 	RegisterDatabaseRoutes(v1, cfg)
 
@@ -700,6 +706,49 @@ func TestDatabaseDeleteAgentFailure(t *testing.T) {
 	var resp map[string]interface{}
 	json.NewDecoder(w.Body).Decode(&resp)
 	assert.Equal(t, "agent_failed", resp["error"])
+}
+
+// JAB-275: deleting a database that still backs an application install must be
+// refused with 409 in_use_by_wordpress + the install id, BEFORE any agent
+// mutation. application_installs.db_id is ON DELETE CASCADE, so a drop would
+// silently delete the install row — the attachment probe stops it at the door.
+func TestDatabaseDeleteAttachedInstallReturns409ZeroMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "user1", IsAdmin: false})
+		c.Next()
+	})
+
+	dbRepo := &mockDatabaseRepo{databases: []models.Database{
+		{ID: "id1", UserID: "user1", Name: "alice_blog", Engine: "mariadb"},
+	}}
+	wpRepo := &mockWordPressInstallRepo{installs: map[string]*models.WordPressInstall{
+		"app1": {ID: "app1", DBID: models.DBIDPtr("id1")},
+	}}
+	agent := &mockAgent{}
+
+	RegisterDatabaseRoutes(v1, DatabaseHandlerConfig{
+		Databases:         dbRepo,
+		DatabaseUsers:     &mockDatabaseUserRepo{},
+		DatabaseGrants:    &mockDatabaseGrantRepo{},
+		WordPressInstalls: wpRepo,
+		Users:             &mockUserRepo{users: map[string]*models.User{"user1": {ID: "user1", Username: stringPtr("alice")}}},
+		Packages:          &mockPackageRepo{},
+		Agent:             agent,
+	})
+
+	req := httptest.NewRequest("DELETE", "/api/v1/databases/id1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	assert.Equal(t, "in_use_by_wordpress", resp["error"])
+	assert.Equal(t, "app1", resp["wordpress_id"])
+	assert.Equal(t, 0, agent.callCount, "an attached database must never reach the agent")
 }
 
 func TestDatabaseDeleteUnauthenticated(t *testing.T) {

--- a/panel-api/internal/backupmetadata/apply.go
+++ b/panel-api/internal/backupmetadata/apply.go
@@ -554,7 +554,17 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 	// so the operator gets a definitive login status instead of a swallowed
 	// warning, and a fresh (password-less) identity is minted when none
 	// exists so a recovery link can actually be issued.
-	if d.KratosClient != nil && m.User.Email != "" {
+	//
+	// SECURITY (GH #1408): gated on `created`. The email + is_admin + password
+	// hash read here are bundle-controlled, and the restore-from-UPLOAD path
+	// remaps only user.id — not the email — into an EXISTING target user
+	// (created=false). Ungated, an uploaded tar carrying an attacker's email +
+	// is_admin=true + a known hash would MINT a matching (admin) Kratos identity
+	// on this box: privilege escalation. We only ever mint/verify for a user we
+	// just created this run (a trusted same-box snapshot or a sanitized
+	// create-from-manifest, both non-admin per applyUser); an
+	// upload-into-existing-user restore never touches Kratos here.
+	if created && d.KratosClient != nil && m.User.Email != "" {
 		username := ""
 		if m.User.Username != nil {
 			username = *m.User.Username
@@ -608,6 +618,16 @@ func applyUser(ctx context.Context, m *internalbackup.AccountMetadata, d Deps, n
 		return false, nil
 	} else if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		return false, fmt.Errorf("lookup: %w", err)
+	}
+	// SECURITY (GH #1408): refuse to CREATE an admin user from a backup bundle.
+	// An account backup is only ever a non-admin tenant (admins host nothing and
+	// are never account-backed-up), so is_admin=true here is a malformed or
+	// crafted bundle — and creating an admin from an attacker-controllable
+	// uploaded tar is a privilege-escalation. The row is only reached on the
+	// CREATE path (an existing user no-ops above), so a legitimate
+	// same-box/#954 restore of a non-admin is unaffected.
+	if m.User.IsAdmin {
+		return false, errors.New("refusing to create an admin user from a backup bundle")
 	}
 	pwd := m.User.PasswordHash
 	if pwd == "" {

--- a/panel-api/internal/backupmetadata/apply_security_test.go
+++ b/panel-api/internal/backupmetadata/apply_security_test.go
@@ -1,0 +1,92 @@
+package backupmetadata
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// createGuardUsersRepo forces the applyUser CREATE path (FindByID → not found)
+// and records whether a user row was inserted.
+type createGuardUsersRepo struct {
+	repository.UserRepository
+	created int
+}
+
+func (r *createGuardUsersRepo) FindByID(context.Context, string) (*models.User, error) {
+	return nil, repository.ErrNotFound
+}
+func (r *createGuardUsersRepo) Create(context.Context, *models.User) error {
+	r.created++
+	return nil
+}
+
+// recordingKratos records every identity it is asked to mint. IdentityIDByEmail
+// returns "" (no identity for the bundle email) so the step-9 mint branch would
+// fire if it were reachable.
+type recordingKratos struct {
+	mints int
+}
+
+func (k *recordingKratos) CreateIdentityWithPassword(context.Context, kratosclient.AdminTraits, string) (string, error) {
+	k.mints++
+	return "id-minted", nil
+}
+func (k *recordingKratos) ImportIdentities(context.Context, []kratosclient.ExportedIdentity) error {
+	return nil
+}
+func (k *recordingKratos) IdentityIDByEmail(context.Context, string) (string, error) {
+	return "", nil
+}
+func (k *recordingKratos) IdentityHasPassword(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+// GH #1408: a backup bundle claiming is_admin=true must NOT create an admin
+// user — a crafted uploaded tar would otherwise mint an admin account.
+func TestApply_RefusesAdminBundle(t *testing.T) {
+	users := &createGuardUsersRepo{}
+	meta := &internalbackup.AccountMetadata{
+		User: internalbackup.MetadataUser{ID: "u-evil", Email: "attacker@evil.com", IsAdmin: true},
+	}
+	r := Apply(context.Background(), meta, Deps{Users: users})
+
+	if users.created != 0 {
+		t.Fatalf("no user may be created from an admin bundle, got %d", users.created)
+	}
+	found := false
+	for _, e := range r.Errors {
+		if strings.Contains(e, "refusing to create an admin") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want an admin-refusal error, got %v", r.Errors)
+	}
+}
+
+// GH #1408: the restore-from-UPLOAD path remaps only user.id into an EXISTING
+// target (created=false). The bundle's email + is_admin + password hash are
+// attacker-controllable, so step 9 must NOT mint a Kratos identity from them —
+// otherwise an uploaded tar could create a matching (admin) login on this box.
+func TestApply_NoKratosMintForExistingUser(t *testing.T) {
+	kratos := &recordingKratos{}
+	// a realistic-length bcrypt hash so the (guarded) mint branch would qualify
+	bcrypt := "$2a$10$" + strings.Repeat("a", 53)
+	meta := &internalbackup.AccountMetadata{
+		User: internalbackup.MetadataUser{ID: "u1", Email: "attacker@evil.com", PasswordHash: bcrypt, IsAdmin: true},
+	}
+	// existingUsersRepo → applyUser no-ops (created=false), like a real
+	// upload-into-existing-user restore.
+	r := Apply(context.Background(), meta, Deps{Users: existingUsersRepo{}, KratosClient: kratos})
+
+	if kratos.mints != 0 {
+		t.Errorf("step 9 must not mint an identity for a pre-existing user (created=false); minted %d", kratos.mints)
+	}
+	_ = r
+}

--- a/panel-api/internal/dbops/dbops.go
+++ b/panel-api/internal/dbops/dbops.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"time"
 
@@ -34,14 +35,35 @@ type AgentCaller interface {
 	Call(ctx context.Context, method string, params any) (json.RawMessage, error)
 }
 
-// Deps wires the four collaborator repos + the agent. Every field
-// is required; zero values cause Create/Delete to return ErrDeps.
+// Deps wires the collaborator repos + the agent.
+//
+// Create needs Users, Packages, Databases and Agent (plus ServerSettings
+// for the postgres gate). Delete additionally needs DatabaseGrants,
+// DatabaseUsers and Installs so the deletion path owns attachment
+// detection and grant teardown itself, rather than leaving those to
+// whichever Adapter happened to remember them (JAB-275). A nil repo that
+// an operation needs is ErrDeps — fail closed, never a silent skip of the
+// attachment or grant step.
 type Deps struct {
 	Users          repository.UserRepository
 	Packages       repository.PackageRepository
 	Databases      repository.DatabaseRepository
 	ServerSettings repository.ServerSettingsRepository
+	// Delete-path collaborators.
+	DatabaseGrants repository.DatabaseUserGrantRepository
+	DatabaseUsers  repository.DatabaseUserRepository
+	Installs       repository.ApplicationInstallRepository
 	Agent          AgentCaller
+	// Log is optional; when set, Delete records best-effort failures (a
+	// grant revoke that did not take) that do not abort the operation.
+	Log *slog.Logger
+}
+
+// logWarn guards the optional logger.
+func logWarn(d Deps, msg string, args ...any) {
+	if d.Log != nil {
+		d.Log.Warn(msg, args...)
+	}
 }
 
 // CreateInput is the shared input shape. Both callers (REST + CLI)
@@ -82,7 +104,25 @@ var (
 	ErrAgentFailed    = errors.New("dbops: agent dispatch failed")
 	ErrInternal       = errors.New("dbops: internal error")
 	ErrNotFound       = errors.New("dbops: database not found")
+	// ErrAttached reports that the database still backs an application
+	// install and must not be dropped until the app is torn down. Since
+	// application_installs.db_id is ON DELETE CASCADE (migration 000107),
+	// dropping the database row would silently delete the install row with
+	// it — so the deletion path refuses up front. Match with errors.Is;
+	// use errors.As on *AttachedError to recover the install id.
+	ErrAttached = errors.New("dbops: database is attached to an application install")
 )
+
+// AttachedError carries the blocking install's id so an Adapter can tell
+// the caller what to tear down first (REST surfaces it as the 409
+// in_use_by_wordpress body). It satisfies errors.Is(err, ErrAttached).
+type AttachedError struct{ InstallID string }
+
+func (e *AttachedError) Error() string {
+	return fmt.Sprintf("dbops: database is attached to application install %s", e.InstallID)
+}
+func (e *AttachedError) Is(target error) bool { return target == ErrAttached }
+func (e *AttachedError) Unwrap() error        { return ErrAttached }
 
 // Create materialises a database and inserts the panel-side row.
 // Returns the persisted *models.Database on success.
@@ -90,13 +130,13 @@ var (
 // Pipeline (matches the pre-M41 REST handler exactly so the
 // behavioural change set is "REST + CLI now share code", not
 // "REST + CLI behave subtly differently"):
-//   1. validate input + load user
-//   2. compute final prefixed name
-//   3. quota check via package.MaxDatabases
-//   4. collision check on (user_id, finalName)
-//   5. engine gate (postgres requires server_settings)
-//   6. agent.db.create / db.postgres.create_db
-//   7. insert databases row
+//  1. validate input + load user
+//  2. compute final prefixed name
+//  3. quota check via package.MaxDatabases
+//  4. collision check on (user_id, finalName)
+//  5. engine gate (postgres requires server_settings)
+//  6. agent.db.create / db.postgres.create_db
+//  7. insert databases row
 func Create(ctx context.Context, d Deps, in CreateInput) (*models.Database, error) {
 	if d.Users == nil || d.Packages == nil || d.Databases == nil || d.Agent == nil {
 		return nil, ErrDeps
@@ -207,17 +247,34 @@ func Create(ctx context.Context, d Deps, in CreateInput) (*models.Database, erro
 	return row, nil
 }
 
-// Delete drops the agent-side schema then the panel-side row.
-// Errors before agent dispatch return ErrNotFound / ErrDeps;
-// agent failures wrap ErrAgentFailed; row delete failure wraps
-// ErrInternal. Caller surfaces appropriately.
+// Delete owns the complete database deletion path so the REST handler and
+// the operator CLI produce the same transcript (JAB-275). It runs in three
+// strictly ordered phases so no failure can half-tear-down the database:
+//
+//	Phase 0 — refuse (zero mutation): load the row, refuse with ErrAttached
+//	  if an application install still backs it, then load its grants.
+//	Phase 1 — host: revoke each grant on the engine (best effort, matching
+//	  the pre-JAB-275 REST handler), then drop the schema on the engine the
+//	  row was created with. Any drop failure returns ErrAgentFailed with the
+//	  database row and all management metadata still intact, so the row stays
+//	  the addressable handle and a retry is safe (db.drop / db.postgres.drop_db
+//	  are DROP ... IF EXISTS, idempotent on a name that is already gone).
+//	Phase 2 — metadata: delete the grant rows, then the database row. This
+//	  runs only after the host drop succeeded; a failure here leaves the row
+//	  in place for a durable retry.
+//
+// Engine dispatch is by row.Engine, never a hard-coded command, so a
+// postgres row never reaches MariaDB (GH #1013).
 func Delete(ctx context.Context, d Deps, in DeleteInput) error {
-	if d.Databases == nil || d.Agent == nil {
+	if d.Databases == nil || d.Agent == nil ||
+		d.DatabaseGrants == nil || d.DatabaseUsers == nil || d.Installs == nil {
 		return ErrDeps
 	}
 	if in.ID == "" {
 		return fmt.Errorf("%w: id required", ErrNotFound)
 	}
+
+	// Phase 0 — refuse, zero mutation.
 	row, err := d.Databases.FindByID(ctx, in.ID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
@@ -225,16 +282,55 @@ func Delete(ctx context.Context, d Deps, in DeleteInput) error {
 		}
 		return fmt.Errorf("%w: find: %v", ErrInternal, err)
 	}
+	inst, iErr := d.Installs.FindByDBID(ctx, row.ID)
+	if iErr != nil && !errors.Is(iErr, repository.ErrNotFound) {
+		return fmt.Errorf("%w: install probe: %v", ErrInternal, iErr)
+	}
+	if inst != nil {
+		return &AttachedError{InstallID: inst.ID}
+	}
+	grants, err := d.DatabaseGrants.ListByDatabaseID(ctx, row.ID)
+	if err != nil {
+		return fmt.Errorf("%w: list grants: %v", ErrInternal, err)
+	}
+
+	// Phase 1 — host mutations.
+	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	for _, g := range grants {
+		u, uErr := d.DatabaseUsers.FindByID(ctx, g.DatabaseUserID)
+		if uErr != nil || u == nil || u.Username == "" {
+			continue
+		}
+		// db_user.revoke is load-bearing: MariaDB DROP DATABASE does NOT drop
+		// the privileges granted on that database (they persist in mysql.db),
+		// so the revoke is the only thing that cleans them. It is best effort
+		// only in that a failure must not strand the drop — the database row
+		// stays the retryable handle, and a re-run re-revokes (revoke is
+		// idempotent). A failure is logged, never swallowed.
+		if _, rErr := d.Agent.Call(agentCtx, "db_user.revoke", map[string]any{
+			"db_name":      row.Name,
+			"db_user_name": u.Username,
+		}); rErr != nil {
+			logWarn(d, "dbops.Delete: grant revoke failed (best-effort; database row retained for retry)",
+				"db", row.Name, "db_user", u.Username, "err", rErr)
+		}
+	}
 	cmdName := "db.drop"
 	if row.Engine == "postgres" {
 		cmdName = "db.postgres.drop_db"
 	}
-	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	if _, err := d.Agent.Call(agentCtx, cmdName, map[string]any{
 		"db_name": row.Name,
 	}); err != nil {
 		return fmt.Errorf("%w: %v", ErrAgentFailed, err)
+	}
+
+	// Phase 2 — metadata cleanup, durably retryable.
+	for _, g := range grants {
+		if dErr := d.DatabaseGrants.Delete(ctx, g.ID); dErr != nil {
+			return fmt.Errorf("%w: delete grant %s: %v", ErrInternal, g.ID, dErr)
+		}
 	}
 	if err := d.Databases.Delete(ctx, row.ID); err != nil {
 		return fmt.Errorf("%w: delete row: %v", ErrInternal, err)

--- a/panel-api/internal/dbops/dbops_test.go
+++ b/panel-api/internal/dbops/dbops_test.go
@@ -1,0 +1,209 @@
+package dbops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- recording fakes (JAB-275 delete-path transcript) ---
+
+// recAgent records every command it is asked to run, in order, and can be
+// told to fail one specific command. This is how the tests assert the exact
+// ordered transcript both Adapters now share.
+type recAgent struct {
+	calls  []string
+	failOn string
+}
+
+func (a *recAgent) Call(_ context.Context, command string, _ any) (json.RawMessage, error) {
+	a.calls = append(a.calls, command)
+	if command == a.failOn {
+		return nil, errors.New(command + " boom")
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type recDatabases struct {
+	repository.DatabaseRepository
+	row     *models.Database
+	deleted []string
+}
+
+func (r *recDatabases) FindByID(_ context.Context, id string) (*models.Database, error) {
+	if r.row == nil || r.row.ID != id {
+		return nil, repository.ErrNotFound
+	}
+	return r.row, nil
+}
+func (r *recDatabases) Delete(_ context.Context, id string) error {
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+type recGrants struct {
+	repository.DatabaseUserGrantRepository
+	grants  []models.DatabaseUserGrant
+	deleted []string
+}
+
+func (r *recGrants) ListByDatabaseID(_ context.Context, _ string) ([]models.DatabaseUserGrant, error) {
+	return r.grants, nil
+}
+func (r *recGrants) Delete(_ context.Context, id string) error {
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+type recUsers struct {
+	repository.DatabaseUserRepository
+	byID map[string]*models.DatabaseUser
+}
+
+func (r *recUsers) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
+	if u, ok := r.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type recInstalls struct {
+	repository.ApplicationInstallRepository
+	install *models.ApplicationInstall // non-nil → the db is attached
+}
+
+func (r *recInstalls) FindByDBID(_ context.Context, _ string) (*models.ApplicationInstall, error) {
+	if r.install != nil {
+		return r.install, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// depsFor builds a fully wired Deps around the given fakes.
+func depsFor(ag AgentCaller, dbs *recDatabases, grants *recGrants, users *recUsers, installs *recInstalls) Deps {
+	return Deps{
+		Databases:      dbs,
+		DatabaseGrants: grants,
+		DatabaseUsers:  users,
+		Installs:       installs,
+		Agent:          ag,
+	}
+}
+
+func mariaRow() *models.Database {
+	return &models.Database{ID: "db1", UserID: "u1", Name: "alice_blog", Engine: "mariadb"}
+}
+
+// Happy path pins the shared transcript: revoke each grant's engine user,
+// drop the schema, then delete the grant rows and the database row. Both the
+// REST handler and the CLI now call this one function, so proving the order
+// once proves it for both (AC5).
+func TestDelete_HappyPath_Transcript(t *testing.T) {
+	ag := &recAgent{}
+	dbs := &recDatabases{row: mariaRow()}
+	grants := &recGrants{grants: []models.DatabaseUserGrant{{ID: "g1", DatabaseID: "db1", DatabaseUserID: "du1"}}}
+	users := &recUsers{byID: map[string]*models.DatabaseUser{"du1": {ID: "du1", Username: "alice_app"}}}
+
+	if err := Delete(context.Background(), depsFor(ag, dbs, grants, users, &recInstalls{}), DeleteInput{ID: "db1"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	want := []string{"db_user.revoke", "db.drop"}
+	if len(ag.calls) != len(want) {
+		t.Fatalf("agent transcript: got %v want %v", ag.calls, want)
+	}
+	for i := range want {
+		if ag.calls[i] != want[i] {
+			t.Fatalf("agent transcript[%d]: got %q want %q (full %v)", i, ag.calls[i], want[i], ag.calls)
+		}
+	}
+	if len(grants.deleted) != 1 || grants.deleted[0] != "g1" {
+		t.Fatalf("grant rows not deleted: %v", grants.deleted)
+	}
+	if len(dbs.deleted) != 1 || dbs.deleted[0] != "db1" {
+		t.Fatalf("db row not deleted: %v", dbs.deleted)
+	}
+}
+
+// Engine dispatch is by the row's engine — a postgres row must reach
+// db.postgres.drop_db, never db.drop (GH #1013).
+func TestDelete_Postgres_UsesPostgresDropCmd(t *testing.T) {
+	ag := &recAgent{}
+	dbs := &recDatabases{row: &models.Database{ID: "db1", Name: "alice_pg", Engine: "postgres"}}
+	if err := Delete(context.Background(), depsFor(ag, dbs, &recGrants{}, &recUsers{}, &recInstalls{}), DeleteInput{ID: "db1"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(ag.calls) != 1 || ag.calls[0] != "db.postgres.drop_db" {
+		t.Fatalf("postgres drop cmd: got %v want [db.postgres.drop_db]", ag.calls)
+	}
+}
+
+// An attached database must be refused before any mutation — no agent call,
+// no grant delete, no row delete — and the error must carry the install id.
+func TestDelete_Attached_RefusesZeroMutation(t *testing.T) {
+	ag := &recAgent{}
+	dbs := &recDatabases{row: mariaRow()}
+	grants := &recGrants{grants: []models.DatabaseUserGrant{{ID: "g1", DatabaseUserID: "du1"}}}
+	installs := &recInstalls{install: &models.ApplicationInstall{ID: "app1"}}
+
+	err := Delete(context.Background(), depsFor(ag, dbs, grants, &recUsers{}, installs), DeleteInput{ID: "db1"})
+	if !errors.Is(err, ErrAttached) {
+		t.Fatalf("want ErrAttached, got %v", err)
+	}
+	var ae *AttachedError
+	if !errors.As(err, &ae) || ae.InstallID != "app1" {
+		t.Fatalf("want AttachedError carrying app1, got %v", err)
+	}
+	if len(ag.calls) != 0 || len(grants.deleted) != 0 || len(dbs.deleted) != 0 {
+		t.Fatalf("attached db mutated something: agent=%v grants=%v dbs=%v", ag.calls, grants.deleted, dbs.deleted)
+	}
+}
+
+// A failed schema drop must retain the database row AND its grant metadata,
+// so the row stays the addressable handle for a retry (AC "Agent failure
+// retains the database and all management metadata").
+func TestDelete_AgentDropFailure_RetainsRowAndMetadata(t *testing.T) {
+	ag := &recAgent{failOn: "db.drop"}
+	dbs := &recDatabases{row: mariaRow()}
+	grants := &recGrants{grants: []models.DatabaseUserGrant{{ID: "g1", DatabaseUserID: "du1"}}}
+	users := &recUsers{byID: map[string]*models.DatabaseUser{"du1": {ID: "du1", Username: "alice_app"}}}
+
+	err := Delete(context.Background(), depsFor(ag, dbs, grants, users, &recInstalls{}), DeleteInput{ID: "db1"})
+	if !errors.Is(err, ErrAgentFailed) {
+		t.Fatalf("want ErrAgentFailed, got %v", err)
+	}
+	if len(grants.deleted) != 0 {
+		t.Fatalf("grant metadata deleted despite drop failure: %v", grants.deleted)
+	}
+	if len(dbs.deleted) != 0 {
+		t.Fatalf("db row deleted despite drop failure: %v", dbs.deleted)
+	}
+}
+
+// Every delete-path collaborator is required: a nil one is ErrDeps, never a
+// silent skip of the attachment or grant step.
+func TestDelete_MissingDeps_ErrDeps(t *testing.T) {
+	full := depsFor(&recAgent{}, &recDatabases{row: mariaRow()}, &recGrants{}, &recUsers{}, &recInstalls{})
+	for name, mutate := range map[string]func(*Deps){
+		"grants":   func(d *Deps) { d.DatabaseGrants = nil },
+		"users":    func(d *Deps) { d.DatabaseUsers = nil },
+		"installs": func(d *Deps) { d.Installs = nil },
+		"agent":    func(d *Deps) { d.Agent = nil },
+	} {
+		d := full
+		mutate(&d)
+		if err := Delete(context.Background(), d, DeleteInput{ID: "db1"}); !errors.Is(err, ErrDeps) {
+			t.Fatalf("nil %s: want ErrDeps, got %v", name, err)
+		}
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	d := depsFor(&recAgent{}, &recDatabases{row: mariaRow()}, &recGrants{}, &recUsers{}, &recInstalls{})
+	if err := Delete(context.Background(), d, DeleteInput{ID: "missing"}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

Deepen `internal/dbops` so the Database Lifecycle Module owns the **complete**
database deletion path, and route both the REST handler
(`internal/api/databases.go`) and the operator CLI (`jabali db delete`,
`cmd/server/db_cmd.go`) through it. The deletion slice of ADR-0083's
`<area>ops` line.

## The bug

Only the REST handler guarded a delete: it refused when an application install
still backed the database, and it revoked + cleared grants first. The shared
`dbops.Delete` did neither — it just dropped the schema and deleted the row —
and the CLI called exactly that. So `jabali db delete` on a database that still
backs an application install would drop it, and because
`application_installs.db_id` is `ON DELETE CASCADE` (migration 000107), the
install row was **silently deleted with it**. A CLI delete of a database with
grants could also fail part-way through.

## Phase-ordered deletion

`dbops.Delete` now runs three strictly ordered phases so no failure can
half-tear-down the database:

- **Phase 0 — refuse (zero mutation):** load the row; refuse with `ErrAttached`
  (carrying the blocking install id) if an install still backs it; then load
  the grants.
- **Phase 1 — host:** revoke each grant on the engine, then drop the schema by
  `row.Engine` (`db.drop` / `db.postgres.drop_db`, never hard-coded, so a
  postgres row never reaches MariaDB — GH #1013). A drop failure returns
  `ErrAgentFailed` with the row and all grant metadata intact; the row stays
  the addressable handle and a retry is safe (both drops are `DROP ... IF
  EXISTS`).
- **Phase 2 — metadata:** delete the grant rows, then the database row — only
  after a successful drop, durably retryable if it fails.

## Adapter reconciliation

| step | old REST | old CLI (`dbops.Delete`) | canonical (dbops now) |
|------|----------|--------------------------|-----------------------|
| attached-install check | 409 via WP-install probe | **none** — silently CASCADE-deleted the install | refuse with `ErrAttached` before any mutation |
| grant engine-revoke | yes, before drop | **none** | yes, in phase 1 (logged on failure) |
| grant row cleanup | before drop (partial-removal risk on drop failure) | none | after a successful drop (phase 2) |
| engine dispatch | by engine | by engine | by engine |
| drop-failure policy | keep row | keep row | keep row + all grant metadata |

REST keeps its wire shape: 409 `{"error":"in_use_by_wordpress","wordpress_id":
<install id>}` for an attached database (now sourced from `ErrAttached`), 404
`not_found`, 502 `agent_failed`, 500 `internal`. The CLI maps `ErrAttached` to
a "delete the app first" message.

`dbops.Delete` requires its delete-path collaborators (`DatabaseGrants`,
`DatabaseUsers`, `Installs`) — a nil one is `ErrDeps`, never a silent skip of
the attachment or grant step. Production already wires them
(`internal/app/app.go`); the CLI now does too.

## Scope / non-goals

- **AC6 (account + application teardown) is deliberately deferred.** Application
  teardown (`app_delete.go`) deletes a database that is attached to the very app
  being deleted, so it needs an additive "detaching app" mode on the lifecycle
  op rather than the unconditional attachment refusal added here — a follow-up
  slice. Account teardown (`userops`) already dispatches by engine (GH #1013
  fixed), so it is not regressed.
- `db_user.revoke` is a MariaDB verb and fires for postgres rows too, exactly as
  the old REST handler did — engine grant cleanup for postgres is unchanged
  parity, not fixed by this slice. "Correct Agent command" here is about the
  drop.

## Test plan

- [x] `internal/dbops`: shared delete transcript (revoke → drop → delete grant
      rows → delete db row), postgres engine dispatch, attached-database refusal
      with zero mutation and the install id on the error, drop-failure retains
      the row and all grant metadata, every delete-path dep required
      (`ErrDeps`), not-found.
- [x] `internal/api`: existing `databaseHandler` delete tests unchanged in
      intent (routers now wire the install + grant fakes) + a new test that an
      attached database returns 409 `in_use_by_wordpress` with the install id
      and makes **zero** agent calls.
- [x] `cmd/server`: a source guard that the CLI delete routes through
      `dbops.Delete`, issues no `db.drop` / `db.postgres.drop_db` /
      `db_user.revoke` itself, and wires the delete-path collaborators.
- [x] `go build ./...`, `go vet`, `go test -race ./internal/dbops/
      ./internal/api/ ./cmd/server/` all clean; gofmt clean; `internal/userops`
      still green (account teardown untouched).

## Note

The FK on-delete semantics (`application_installs.db_id` and
`database_user_grants.database_id` both `CASCADE` as of migration 000107) were
confirmed from the migration history — no live-schema tool was available in this
session — which also corrected two stale "RESTRICT" comments in the old REST
handler. No box run: no migration, agent, or reconciler surface, and the phase
order is fully exercised by fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
