### PR TITLE
feat(backup): create-from-manifest — restore into a not-yet-existing user (GH #1408)

### DIFF
--- a/panel-api/internal/api/backup_restore_create_test.go
+++ b/panel-api/internal/api/backup_restore_create_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// guardUsersRepo answers FindByEmail (used by the create guard) and nothing
+// else — the guards under test all return before any other repo call.
+type guardUsersRepo struct {
+	repository.UserRepository
+	emailTaken bool
+}
+
+func (g *guardUsersRepo) FindByEmail(context.Context, string) (*models.User, error) {
+	if g.emailTaken {
+		return &models.User{ID: "existing"}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// stubPackages is a non-nil PackageRepository so createUserFromBundle doesn't
+// early-return "unavailable"; its methods are never reached by the guards.
+type stubPackages struct{ repository.PackageRepository }
+
+// GH #1408: create-from-manifest is fed an attacker-controllable bundle. The
+// guards BEFORE userops.Create must reject an admin bundle, a username that
+// isn't the bundle's own (home is name-keyed), a bundle with no email, and an
+// email already in use — without ever creating an account.
+func TestCreateUserFromBundle_Guards(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mk := func(user map[string]any, emailTaken bool) *backupHandler {
+		agent := &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+			if cmd != "backup.inspect_uploaded_tar" {
+				t.Fatalf("guard must only inspect, got agent call %q", cmd)
+			}
+			b, _ := json.Marshal(map[string]any{"user": user})
+			return b, nil
+		}}
+		return &backupHandler{cfg: BackupHandlerConfig{
+			Agent:    agent,
+			Users:    &guardUsersRepo{emailTaken: emailTaken},
+			Packages: stubPackages{},
+		}}
+	}
+	call := func(h *backupHandler, target string) int {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/x", nil)
+		if u, ok := h.createUserFromBundle(c, "/staged.tar.zst", target, nil); ok || u != nil {
+			t.Fatalf("guard must not create a user (ok=%v)", ok)
+		}
+		return w.Code
+	}
+
+	cases := []struct {
+		name   string
+		user   map[string]any
+		target string
+		taken  bool
+		want   int
+	}{
+		{"admin bundle refused", map[string]any{"username": "alice", "email": "a@x.com", "is_admin": true}, "alice", false, http.StatusForbidden},
+		{"username mismatch", map[string]any{"username": "alice", "email": "a@x.com"}, "bob", false, http.StatusBadRequest},
+		{"no email", map[string]any{"username": "alice", "email": ""}, "alice", false, http.StatusBadRequest},
+		{"email already in use", map[string]any{"username": "alice", "email": "a@x.com"}, "alice", true, http.StatusConflict},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := call(mk(tc.user, tc.taken), tc.target); got != tc.want {
+				t.Errorf("status = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/backup_restore_upload.go
+++ b/panel-api/internal/api/backup_restore_upload.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -15,9 +17,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
 
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 )
 
 // backup_restore_upload.go — GH #1408. Admin "restore from an uploaded backup
@@ -43,8 +48,8 @@ const (
 )
 
 var (
-	uploadIDRE               = regexp.MustCompile(`^[A-Za-z0-9_-]{8,128}$`)
-	restoreTargetUsernameRE  = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,31}$`)
+	uploadIDRE              = regexp.MustCompile(`^[A-Za-z0-9_-]{8,128}$`)
+	restoreTargetUsernameRE = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,31}$`)
 )
 
 func restoreUploadAdminTag(userID string) string {
@@ -226,13 +231,41 @@ func (h *backupHandler) restoreUploadInspect(c *gin.Context) {
 		respondAgentError(c, err)
 		return
 	}
-	c.Data(http.StatusOK, "application/json", raw)
+	// GH #1408: annotate whether the bundle's own user already exists (so the UI
+	// offers restore-into-existing vs create-from-backup) and whether this
+	// server can create it (Packages wired).
+	var parsed map[string]any
+	if json.Unmarshal(raw, &parsed) == nil {
+		targetExists := false
+		if u, ok := parsed["user"].(map[string]any); ok {
+			if uname, _ := u["username"].(string); uname != "" {
+				if ex, _ := h.cfg.Users.FindByUsername(c.Request.Context(), uname); ex != nil {
+					targetExists = true
+				}
+			}
+		}
+		parsed["target_exists"] = targetExists
+		parsed["create_supported"] = h.cfg.Packages != nil
+		if out, merr := json.Marshal(parsed); merr == nil {
+			c.Data(http.StatusOK, "application/json", out)
+			return
+		}
+	}
+	c.Data(http.StatusOK, "application/json", raw) // fallback: unparseable → pass through
 }
 
 type restoreUploadApplyRequest struct {
 	UploadID       string   `json:"upload_id"`
 	TargetUsername string   `json:"target_username"`
 	Components     []string `json:"components,omitempty"`
+	// GH #1408 create-from-manifest: when the target user does not exist yet
+	// (fresh-box DR), CreateUser=true creates the account from the bundle
+	// before restoring. The username + email come from the bundle (verified
+	// against the tar, not trusted from the client); PackageID is the admin's
+	// choice (nil = no package = unrestricted resource limits). The account is
+	// always non-admin, and its password is regenerated (recover via link).
+	CreateUser bool    `json:"create_user,omitempty"`
+	PackageID  *string `json:"package_id,omitempty"`
 }
 
 // restoreUploadApply restores the uploaded archive into an EXISTING user.
@@ -261,12 +294,6 @@ func (h *backupHandler) restoreUploadApply(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_target_username"})
 		return
 	}
-	// v1: the target user must already exist (no create-from-manifest).
-	target, uerr := h.cfg.Users.FindByUsername(c.Request.Context(), req.TargetUsername)
-	if uerr != nil || target == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "target_user_not_found", "detail": "create the user first, then restore into it"})
-		return
-	}
 	path := restoreUploadPath(adminID, req.UploadID)
 	if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
 		c.JSON(http.StatusNotFound, gin.H{"error": "upload_not_found"})
@@ -275,6 +302,23 @@ func (h *backupHandler) restoreUploadApply(c *gin.Context) {
 	if h.cfg.Agent == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
 		return
+	}
+
+	target, uerr := h.cfg.Users.FindByUsername(c.Request.Context(), req.TargetUsername)
+	userCreated := false
+	if uerr != nil || target == nil {
+		// GH #1408 create-from-manifest: create the account from the bundle when
+		// the admin opted in (fresh-box DR), else keep the historic 404.
+		if !req.CreateUser {
+			c.JSON(http.StatusNotFound, gin.H{"error": "target_user_not_found", "detail": "user does not exist — enable 'create from backup', or create the user first"})
+			return
+		}
+		newTarget, ok := h.createUserFromBundle(c, path, req.TargetUsername, req.PackageID)
+		if !ok {
+			return // helper wrote the error response
+		}
+		target = newTarget
+		userCreated = true
 	}
 
 	c.Set("audit_target", req.TargetUsername)
@@ -289,9 +333,109 @@ func (h *backupHandler) restoreUploadApply(c *gin.Context) {
 		username:    req.TargetUsername,
 		targetID:    target.ID,
 		components:  req.Components,
+		userCreated: userCreated,
 	})
 
-	c.JSON(http.StatusAccepted, gin.H{"status": "restoring", "upload_id": req.UploadID})
+	c.JSON(http.StatusAccepted, gin.H{"status": "restoring", "upload_id": req.UploadID, "user_created": userCreated})
+}
+
+// createUserFromBundle creates the restore-target account from the uploaded
+// bundle's OWN user metadata (GH #1408 create-from-manifest) for fresh-box DR
+// where the user doesn't exist yet. The username + email are read from the tar
+// here (source of truth — never trusted from the client), the account is ALWAYS
+// non-admin, its package is the admin's choice (nil = unrestricted), and its
+// password is regenerated (the user recovers via a Kratos link — it is never
+// displayed). On any error the helper writes the HTTP response and returns
+// ok=false.
+func (h *backupHandler) createUserFromBundle(c *gin.Context, tarPath, targetUsername string, packageID *string) (*models.User, bool) {
+	ctx := c.Request.Context()
+	if h.cfg.Packages == nil {
+		c.JSON(http.StatusNotImplemented, gin.H{"error": "create_from_bundle_unavailable", "detail": "create-from-backup is not enabled on this server"})
+		return nil, false
+	}
+	// Read the bundle's own user straight from the tar — the client-supplied
+	// target is only a cross-check, never the source of the identity.
+	raw, err := h.cfg.Agent.Call(ctx, "backup.inspect_uploaded_tar", map[string]string{"tar_path": tarPath})
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "inspect_failed", "detail": restoreFailureDetail(err)})
+		return nil, false
+	}
+	var ins struct {
+		User struct {
+			Username string `json:"username"`
+			Email    string `json:"email"`
+			IsAdmin  bool   `json:"is_admin"`
+		} `json:"user"`
+	}
+	if json.Unmarshal(raw, &ins) != nil || ins.User.Username == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bundle_unreadable"})
+		return nil, false
+	}
+	// Home is name-keyed: the account must be the backup's OWN username, or the
+	// home-rsync fails "source missing" downstream. Rename-on-restore is a
+	// separate deferred slice.
+	if ins.User.Username != targetUsername {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "username_mismatch",
+			"detail": "restore into the backup's own username (" + ins.User.Username + ")"})
+		return nil, false
+	}
+	// SECURITY: never create an admin from a bundle (belt beyond the applyUser
+	// refusal — no legitimate account backup is an admin).
+	if ins.User.IsAdmin {
+		c.JSON(http.StatusForbidden, gin.H{"error": "admin_bundle_refused",
+			"detail": "refusing to create an admin account from a backup"})
+		return nil, false
+	}
+	if ins.User.Email == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bundle_no_email",
+			"detail": "the backup carries no user email — create the user manually, then restore into it"})
+		return nil, false
+	}
+	// Don't hijack an existing identity: an email collision is the admin's to
+	// resolve (restore into the existing user, or create manually).
+	if existing, _ := h.cfg.Users.FindByEmail(ctx, ins.User.Email); existing != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "email_taken",
+			"detail": "a user with that email already exists — restore into it instead"})
+		return nil, false
+	}
+
+	pw, perr := randomRestorePassword()
+	if perr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return nil, false
+	}
+	uname := ins.User.Username
+	res, cerr := userops.Create(ctx, userops.Deps{
+		Users:        h.cfg.Users,
+		Packages:     h.cfg.Packages,
+		Agent:        h.cfg.Agent,
+		KratosClient: h.cfg.KratosClient,
+		BcryptCost:   bcrypt.DefaultCost,
+		Log:          h.cfg.Log,
+	}, userops.CreateInput{
+		Email:     ins.User.Email,
+		Password:  pw,
+		Username:  &uname,
+		IsAdmin:   false, // NEVER an admin from a bundle
+		PackageID: packageID,
+	})
+	if cerr != nil {
+		userOpsRESTError(c, cerr) // maps ErrInvalidUsername/Package/Taken/Kratos to HTTP
+		return nil, false
+	}
+	return res.User, true
+}
+
+// randomRestorePassword returns an unguessable password for a create-from-
+// manifest account. It is never returned to the caller — the user signs in via
+// a Kratos recovery link. The fixed prefix guarantees the char-class mix any
+// password policy expects; the suffix is 24 random bytes.
+func randomRestorePassword() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "Jb1!" + base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 type uploadRestoreArgs struct {
@@ -299,6 +443,7 @@ type uploadRestoreArgs struct {
 	outcomePath string
 	username    string
 	targetID    string
+	userCreated bool
 	components  []string
 }
 
@@ -315,7 +460,14 @@ func (h *backupHandler) runUploadRestore(a uploadRestoreArgs) {
 		"components":      a.components,
 	})
 	if err != nil {
-		writeRestoreUploadOutcome(a.outcomePath, "failed", nil, nil, restoreFailureDetail(err))
+		detail := restoreFailureDetail(err)
+		if a.userCreated {
+			// GH #1408: the account was created before the restore ran — leave it
+			// (deleting is the destructive path). A retry re-uploads and restores
+			// into the now-existing user, no create needed.
+			detail += " — note: the account was created; re-upload and restore into the now-existing user"
+		}
+		writeRestoreUploadOutcome(a.outcomePath, "failed", nil, nil, detail)
 		_ = os.Remove(a.path) // terminal failure — don't strand a huge tar
 		return
 	}
@@ -333,6 +485,13 @@ func (h *backupHandler) runUploadRestore(a uploadRestoreArgs) {
 	// before applying — otherwise the rows attach to a non-existent user.
 	metaErrs := h.applyRestoreMetadataForUser(ctx, result.Metadata, a.targetID)
 	result.Warnings = append(result.Warnings, metaErrs...)
+
+	// GH #1408: when we created the account for this DR restore, tell the admin
+	// how the user signs in (their password was regenerated, not restored).
+	if a.userCreated {
+		result.Warnings = append(result.Warnings,
+			"Account "+a.username+" was created from the backup with a regenerated password — send a recovery link: jabali user password "+a.username+" --link")
+	}
 
 	// The archive is consumed — drop it so a downloaded backup with real data
 	// doesn't linger in the uploads dir.

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -41,6 +41,11 @@ type BackupHandlerConfig struct {
 	Jobs           repository.BackupJobRepository
 	Destinations   repository.BackupDestinationRepository
 	Users          repository.UserRepository
+	// Packages backs create-from-manifest (GH #1408): when a restore-from-
+	// upload targets a user that doesn't exist yet, the account is created via
+	// userops.Create with the admin-chosen package. Optional: nil disables the
+	// create path (the restore then 404s "create the user first").
+	Packages       repository.PackageRepository
 	Databases      repository.DatabaseRepository
 	DatabaseUsers  repository.DatabaseUserRepository
 	DatabaseGrants repository.DatabaseUserGrantRepository

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1145,6 +1145,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Jobs:           deps.BackupJobs,
 				Destinations:   deps.BackupDestinations,
 				Users:          deps.Users,
+				Packages:       deps.Packages, // GH #1408 create-from-manifest
 				Databases:      deps.Databases,
 				DatabaseUsers:  deps.DatabaseUsers,
 				DatabaseGrants: deps.DatabaseUserGrants,

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -481,6 +481,11 @@ export async function restoreDatabaseUploadAuto(
 export interface UploadedBackupInfo {
   user: { id: string; username: string; email?: string; is_admin?: boolean };
   components: string[];
+  // GH #1408 create-from-manifest: target_exists is false when the bundle's own
+  // user isn't on this box yet (fresh-box DR); create_supported is true when the
+  // server can create it (Packages wired). Both optional for old responses.
+  target_exists?: boolean;
+  create_supported?: boolean;
 }
 
 // uploadBackupArchiveChunked streams a downloaded account backup .tar to the
@@ -561,10 +566,18 @@ export async function applyUploadedBackupRestore(
   targetUsername: string,
   components: string[],
   base = "/admin/backups", // GH #1408: "/me/backups" forces target = the caller
+  // GH #1408 create-from-manifest: when the target user doesn't exist yet,
+  // createUser creates it from the bundle (admin only) with the chosen package.
+  opts?: { createUser?: boolean; packageId?: string | null },
 ): Promise<UploadedBackupRestoreResult> {
   await apiClient.post(
     `${base}/restore-upload/apply`,
-    { upload_id: uploadId, target_username: targetUsername, components },
+    {
+      upload_id: uploadId,
+      target_username: targetUsername,
+      components,
+      ...(opts?.createUser ? { create_user: true, package_id: opts.packageId ?? null } : {}),
+    },
   );
   const deadline = Date.now() + 65 * 60 * 1000; // matches the server's 60-min cap
   for (;;) {

--- a/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
@@ -11,6 +11,7 @@ import {
   Drawer,
   Input,
   Progress,
+  Select,
   Space,
   Typography,
   Upload,
@@ -24,6 +25,7 @@ import {
   type UploadedBackupInfo,
   type UploadedBackupRestoreResult,
 } from "../../../apiClient";
+import { useListQuery } from "../../../hooks/useQueries";
 import { extractApiError } from "../../../apiErrors";
 
 const COMPONENT_LABELS: Record<string, string> = {
@@ -57,6 +59,10 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
   const [targetUser, setTargetUser] = useState("");
   const [result, setResult] = useState<UploadedBackupRestoreResult | null>(null);
+  // GH #1408 create-from-manifest: when the bundle's user isn't on this box yet.
+  const [createUser, setCreateUser] = useState(false);
+  const [packageId, setPackageId] = useState<string | null>(null);
+  const { items: packages } = useListQuery<{ id: string; name: string }>({ resource: "packages" });
 
   const reset = () => {
     setFile(null);
@@ -67,6 +73,8 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
     setSelected([]);
     setTargetUser("");
     setResult(null);
+    setCreateUser(false);
+    setPackageId(null);
   };
 
   const close = () => {
@@ -94,7 +102,9 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
         ? meta.components.filter((c) => OWNER_COMPONENTS.includes(c))
         : meta.components;
       setSelected(offered);
-      setTargetUser(meta.user.username); // v1: restore into the same username
+      setTargetUser(meta.user.username); // restore into the same username (home is name-keyed)
+      // GH #1408: offer create-from-backup when the bundle's user isn't here yet.
+      setCreateUser(!ownerMode && meta.target_exists === false && meta.create_supported === true);
       setPhase("ready");
     } catch (err) {
       feedback.message.error(extractApiError(err, "Upload / inspect failed"));
@@ -110,7 +120,13 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
     // empty "applying" state doesn't look like nothing happened (GH #1408).
     feedback.message.info("Restore started — running in the background");
     try {
-      const r = await applyUploadedBackupRestore(uploadId, targetUser, selected, base);
+      const r = await applyUploadedBackupRestore(
+        uploadId,
+        targetUser,
+        selected,
+        base,
+        createUser ? { createUser: true, packageId } : undefined,
+      );
       setResult(r);
       setPhase("done");
       const n = r.applied?.length ?? 0;
@@ -142,9 +158,9 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
           ) : (
             <>
               Upload a backup archive you downloaded earlier (the per-account{" "}
-              <code>.tar</code>) and restore it into an existing user — useful for
-              disaster recovery or moving a user to a new server. Create the target
-              user first if it doesn&apos;t exist yet.
+              <code>.tar</code>) and restore it — useful for disaster recovery or
+              moving a user to a new server. If the user doesn&apos;t exist yet,
+              the panel can create it from the backup.
             </>
           )}
         </Typography.Paragraph>
@@ -196,7 +212,41 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
               message={`Backup of ${info.user.username}`}
               description={info.user.email || undefined}
             />
-            {!ownerMode && (
+            {!ownerMode && info.target_exists === false ? (
+              info.create_supported ? (
+                // GH #1408 create-from-manifest: the bundle's user isn't here yet.
+                <div>
+                  <Alert
+                    type="info"
+                    showIcon
+                    message={`User "${info.user.username}" doesn't exist yet — it will be created from this backup`}
+                    description="A new non-admin account is created with this username and email, then the backup is restored into it. Its password is regenerated (not restored) — send the user a recovery link after the restore."
+                  />
+                  <div style={{ marginTop: 8 }}>
+                    <Typography.Text strong>Package</Typography.Text>
+                    <Select
+                      allowClear
+                      value={packageId ?? undefined}
+                      onChange={(v) => setPackageId(v ?? null)}
+                      placeholder="No package (unrestricted limits)"
+                      style={{ width: "100%", marginTop: 4 }}
+                      disabled={phase !== "ready"}
+                      options={(packages ?? []).map((p) => ({ label: p.name, value: p.id }))}
+                    />
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      No package = unrestricted resource limits. Pick a package to cap the new account.
+                    </Typography.Text>
+                  </div>
+                </div>
+              ) : (
+                <Alert
+                  type="warning"
+                  showIcon
+                  message={`User "${info.user.username}" doesn't exist`}
+                  description="This server can't create it from the backup — create the user manually first, then re-run the restore."
+                />
+              )
+            ) : !ownerMode ? (
               <div>
                 <Typography.Text strong>Restore into user</Typography.Text>
                 <Input
@@ -207,11 +257,10 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
                   disabled={phase !== "ready"}
                 />
                 <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                  Must be an existing user. Restore into the same username the
-                  backup came from.
+                  Restore into the same username the backup came from.
                 </Typography.Text>
               </div>
-            )}
+            ) : null}
             <div>
               <Typography.Text strong>Components</Typography.Text>
               <Checkbox.Group
@@ -246,14 +295,22 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
                 type="primary"
                 danger
                 loading={phase === "applying"}
-                disabled={phase === "applying" || !targetUser || selected.length === 0}
+                disabled={
+                  phase === "applying" ||
+                  !targetUser ||
+                  selected.length === 0 ||
+                  // create needed but this server can't create the user
+                  (!ownerMode && info.target_exists === false && !info.create_supported)
+                }
                 onClick={apply}
               >
                 {phase === "applying"
                   ? "Restoring…"
                   : ownerMode
                     ? "Restore into my account"
-                    : `Restore into ${targetUser || "user"}`}
+                    : createUser
+                      ? `Create ${targetUser} & restore`
+                      : `Restore into ${targetUser || "user"}`}
               </Button>
             )}
           </>


### PR DESCRIPTION
## GH #1408 (slice: create-from-manifest)

Fresh-box disaster recovery: an admin uploads a per-account backup and restores it, but the target user **doesn't exist yet**. Until now the restore 404'd ("create the user first"). Create it from the bundle instead.

Builds on the security fix #1521 (bundle-identity mint gate).

## Change (panel-only — no agent change, no migration)

`POST /admin/backups/restore-upload/apply` gains `create_user` + `package_id`. When the target user is absent and `create_user` is set, `createUserFromBundle`:
- reads the bundle's **own** user straight from the tar (agent `inspect` — never trusted from the client);
- creates the account via the shared `userops.Create`, with:
  - **username = the bundle's username** (home is name-keyed; a mismatch is rejected — rename-on-restore is a separate deferred slice);
  - **email = the bundle's email** (collision → 409, don't hijack an identity);
  - **`IsAdmin = false` always** (belt beyond #1521's `applyUser` refusal);
  - **package = the admin's choice** (nil = unrestricted — the UI says so, #282);
  - **password regenerated, never displayed** (recover via a Kratos link);
- then runs the normal restore + metadata rebuild, remapped to the new user.

On restore failure the account is **left** (a retry restores into the now-existing user); the outcome marker says so.

`inspect` now annotates `target_exists` + `create_supported` so the UI offers restore-into-existing vs create-from-backup, and disables create when the server can't (Packages unwired). The admin **Restore-from-Upload drawer** shows a "will be created" panel with a package picker + the regenerated-password note; the direct-IP large-upload warning already rides in this drawer.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt`; `TestOpenAPICoverage` green; `tsc -b`; admin/backups vitest
- [x] New `backup_restore_create_test.go` guards (all reject **before** any account is created): admin bundle → 403, username≠bundle → 400, missing email → 400, email-in-use → 409
- [x] The create path is the shared, already-tested `userops.Create` (POSIX + Kratos + package); the security-critical bundle-trust guards are #1521 + these
- [x] Verified build + tests in an **isolated worktree** (this landed alongside concurrent work on the shared checkout)
- [ ] Full create+restore e2e on a live box needs an authenticated admin Kratos session (the standing #1408 e2e limitation) — offered separately

## Deferred (unchanged)

Rename-on-restore / restore-into-a-different username; key-gated original credentials; system-config restore from upload (its own slice).
