### PR TITLE
refactor(dns): one shared DNS Zone Inventory Module (JAB-299)

### DIFF
--- a/panel-ui/src/components/dns/DNSZoneInventory.test.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.test.tsx
@@ -1,0 +1,145 @@
+// DNSZoneInventory.test.tsx — JAB-299. The shared DNS Zone Inventory Module
+// must honor the audience policy: the admin audience keeps the owner column
+// and admin routes, the tenant audience drops the owner column and uses tenant
+// routes, and the DNSSEC tab receives the audience's owner-visibility policy
+// (AC4 / AC5). The common columns render the same values for both (AC3).
+import { App } from "antd";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DnsZoneInventory,
+  type DnsZoneInventoryAudience,
+  type DnsZoneRow,
+} from "./DNSZoneInventory";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const navigateSpy = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+// DNSSECTable is exercised by its own tests; here we only need to capture the
+// owner-visibility policy the audience hands it (AC5).
+vi.mock("../dnssec/DNSSECTable", () => ({
+  DNSSECTable: ({ showOwner }: { showOwner: boolean }) => (
+    <div data-testid="dnssec-table" data-showowner={String(showOwner)} />
+  ),
+}));
+
+const provisioned: DnsZoneRow = {
+  id: "d1",
+  user_id: "u1234567890",
+  username: "alice",
+  name: "one.tld",
+  provisioned: true,
+  record_count: 3,
+  effective_ttl: 300,
+  dnssec_enabled: true,
+  registrar_expires_at: null,
+};
+
+const notProvisioned: DnsZoneRow = {
+  id: "d2",
+  user_id: "u2",
+  username: "bob",
+  name: "two.tld",
+  provisioned: false,
+  record_count: 0,
+  effective_ttl: null,
+  dnssec_enabled: false,
+  registrar_expires_at: null,
+};
+
+vi.mock("../../hooks/useTableURL", () => ({
+  useTableURL: () => ({
+    items: [provisioned, notProvisioned],
+    total: 2,
+    isLoading: false,
+    isError: false,
+    params: { page: 1, pageSize: 20, q: "", sort: "name", order: "asc" },
+    setParams: vi.fn(),
+  }),
+}));
+
+const adminAudience: DnsZoneInventoryAudience = {
+  showOwner: true,
+  manageRoute: (id) => `/jabali-admin/domains/${id}/dns`,
+  renderEmpty: () => <div>empty</div>,
+  dnssec: { showOwner: true, message: "m", description: "d" },
+  header: { icon: null, title: "DNS Zones" },
+};
+
+const tenantAudience: DnsZoneInventoryAudience = {
+  showOwner: false,
+  manageRoute: (id) => `/jabali-panel/domains/${id}/dns`,
+  renderEmpty: () => <div>empty</div>,
+  dnssec: { showOwner: false, message: "m", description: "d" },
+  header: { icon: null, title: "DNS" },
+};
+
+const renderPage = (audience: DnsZoneInventoryAudience) =>
+  render(
+    <MemoryRouter>
+      <App>
+        <DnsZoneInventory audience={audience} />
+      </App>
+    </MemoryRouter>,
+  );
+
+describe("DnsZoneInventory audience policy (JAB-299)", () => {
+  it("admin audience shows the owner column and routes to admin domains (AC4)", () => {
+    renderPage(adminAudience);
+
+    // Owner column header + owner values are admin-only. antd renders the
+    // sortable header text in more than one node, so assert at least one.
+    expect(screen.getAllByText("dnszonesoverviewpage.owner").length).toBeGreaterThan(0);
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+
+    // Manage Records on the first row navigates to the admin route.
+    fireEvent.click(screen.getAllByText("Manage Records")[0]);
+    expect(navigateSpy).toHaveBeenCalledWith("/jabali-admin/domains/d1/dns");
+  });
+
+  it("tenant audience drops the owner column and routes to tenant domains (AC4)", () => {
+    navigateSpy.mockClear();
+    renderPage(tenantAudience);
+
+    // No owner column, no owner values.
+    expect(screen.queryByText("dnszonesoverviewpage.owner")).not.toBeInTheDocument();
+    expect(screen.queryByText("alice")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByText("Manage Records")[0]);
+    expect(navigateSpy).toHaveBeenCalledWith("/jabali-panel/domains/d1/dns");
+  });
+
+  it("renders provisioning, DNSSEC, and TTL presentation for both rows (AC3)", () => {
+    renderPage(adminAudience);
+
+    expect(screen.getByText("Provisioned")).toBeInTheDocument();
+    expect(screen.getByText("Not provisioned")).toBeInTheDocument();
+    expect(screen.getByText("Signed")).toBeInTheDocument();
+    expect(screen.getByText("Unsigned")).toBeInTheDocument();
+    expect(screen.getByText("300s")).toBeInTheDocument();
+    // effective_ttl null and registrar_expires_at null both render an em dash.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("DNSSEC tab receives showOwner=true for the admin audience (AC5)", () => {
+    renderPage(adminAudience);
+    fireEvent.click(screen.getByText("DNSSEC"));
+    expect(screen.getByTestId("dnssec-table").getAttribute("data-showowner")).toBe("true");
+  });
+
+  it("DNSSEC tab receives showOwner=false for the tenant audience (AC5)", () => {
+    renderPage(tenantAudience);
+    fireEvent.click(screen.getByText("DNSSEC"));
+    expect(screen.getByTestId("dnssec-table").getAttribute("data-showowner")).toBe("false");
+  });
+});

--- a/panel-ui/src/components/dns/DNSZoneInventory.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.tsx
@@ -1,0 +1,243 @@
+// DNSZoneInventory — the shared DNS Zone Inventory Module (JAB-299).
+//
+// The admin and tenant DNS landing screens were near-identical copies of the
+// same Card.tabList shell ("Zones" + "DNSSEC"), the same batched /dns/zones
+// query, and the same columns. This module owns all of that; the two route
+// shells (DNSZonesOverviewPage, UserDNSZonesOverviewPage) are thin Adapters
+// that supply an audience policy.
+//
+// The audience policy controls only what genuinely differs between the two:
+// owner-column visibility, the "Manage Records" route prefix, the empty-state
+// action, the DNSSEC owner-visibility + copy, and the page header. Everything
+// else — query state (URL-backed search/sort/page), the whole-list error
+// branch, and the common columns — is shared so the two screens cannot drift.
+import { useTranslation } from "react-i18next";
+import { Alert, Button, Card, Spin, Table, Tag, Tooltip, Typography } from "antd";
+import { useNavigate } from "react-router";
+
+import { useTabParam } from "../../hooks/useTabParam";
+import { columnSearchProps } from "../columnSearch";
+import { DNSSECTable } from "../dnssec/DNSSECTable";
+import { SearchableTableStringQ } from "../SearchableTable";
+import { useTableURL } from "../../hooks/useTableURL";
+import { sorterToParams } from "../../utils/tableSorter";
+
+// DnsZoneRow is one row of the batched GET /dns/zones inventory (JAB-377):
+// the domain plus its provisioning state, record count, and effective TTL,
+// resolved server-side in one request instead of a per-row zone fan-out.
+// `username`/`user_id` are the admin-only owner fields; the tenant inventory
+// never renders them (audience.showOwner === false).
+export interface DnsZoneRow {
+  id: string;
+  user_id: string;
+  username?: string | null;
+  name: string;
+  provisioned: boolean;
+  record_count: number;
+  effective_ttl?: number | null;
+  dnssec_enabled?: boolean;
+  registrar_expires_at?: string | null;
+}
+
+// DnsZoneInventoryAudience is the per-screen policy. Admin passes the
+// owner-visible, admin-routed variant; the tenant passes the owner-free,
+// tenant-routed one. Nothing about the query or the common columns lives here.
+export interface DnsZoneInventoryAudience {
+  // showOwner adds the Owner column to the Zones table and drives the DNSSEC
+  // tab's owner column (AC4 / AC5).
+  showOwner: boolean;
+  // manageRoute builds the "Manage Records" target for a zone row — the only
+  // place the /jabali-admin vs /jabali-panel prefix differs.
+  manageRoute: (zoneId: string) => string;
+  // renderEmpty owns the empty-state: admin offers a create-domain CTA, the
+  // tenant shows a plain Empty. Supplied by the Adapter so it can close over
+  // its own navigate/copy.
+  renderEmpty: () => React.ReactNode;
+  // dnssec copy + owner policy for the DNSSEC tab.
+  dnssec: {
+    showOwner: boolean;
+    message: string;
+    description: string;
+  };
+  // header is the page title strip (icon + text).
+  header: {
+    icon: React.ReactNode;
+    title: string;
+  };
+}
+
+const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  // One batched request (JAB-377): the endpoint returns provisioning state +
+  // record count + effective TTL per row, so there is no per-domain zone fetch
+  // and a transient failure surfaces as an error, not a false "Not provisioned".
+  const query = useTableURL<DnsZoneRow>({
+    resource: "dns/zones",
+    defaultSort: "name",
+    defaultOrder: "asc",
+  });
+
+  // Project AntD's sorter into the URL params so the server does the
+  // ORDER BY. Without an onChange the sort arrows rendered but changed
+  // nothing — the columns declared a server-side sorter and nothing was
+  // listening for it.
+  const handleTableChange: React.ComponentProps<typeof Table<DnsZoneRow>>["onChange"] = (
+    _pagination,
+    _filters,
+    sorter,
+  ) => {
+    const { sort, order } = sorterToParams<DnsZoneRow>(sorter);
+    query.setParams({ sort, order, page: 1 });
+  };
+
+  return (
+    <>
+      <Alert
+        title={t("dnszonesoverviewpage.dns_zones_are_provisioned_automatically_when")}
+        type="info"
+        showIcon
+        style={{ marginBottom: 16 }}
+      />
+      {query.isLoading ? (
+        <Spin />
+      ) : query.isError ? (
+        // A load failure is an error, never rendered as an empty list or a false
+        // "Not provisioned" (JAB-377 — the fan-out swallowed exactly this).
+        <Alert
+          type="error"
+          showIcon
+          message="Failed to load DNS zones"
+          description="The zone inventory could not be loaded. This is usually temporary — retry shortly."
+        />
+      ) : query.items.length === 0 ? (
+        audience.renderEmpty()
+      ) : (
+        <SearchableTableStringQ<DnsZoneRow>
+          onChange={handleTableChange}
+          rowKey="id"
+          loading={query.isLoading}
+          dataSource={query.items}
+          initialSearch={query.params.q}
+          searchPlaceholder="Search by domain name"
+          onSearchChange={(q) => query.setParams({ q, page: 1 })}
+          pagination={{
+            current: query.params.page,
+            pageSize: query.params.pageSize,
+            total: query.total,
+            onChange: (page, pageSize) => query.setParams({ page, pageSize }),
+          }}
+        >
+          <Table.Column<DnsZoneRow>
+            dataIndex="name"
+            title={t("dnszonesoverviewpage.domain_name")}
+            key="name"
+            sorter
+            defaultSortOrder="ascend"
+            {...columnSearchProps<DnsZoneRow>({
+              placeholder: "Search by domain name",
+              currentQ: query.params.q,
+              onSearch: (v) => query.setParams({ q: v, page: 1 }),
+            })}
+          />
+          {audience.showOwner && (
+            <Table.Column<DnsZoneRow>
+              dataIndex="username"
+              title={t("dnszonesoverviewpage.owner")}
+              key="username"
+              sorter
+              render={(username: string | null | undefined, record: DnsZoneRow) =>
+                username ?? record.user_id.substring(0, 8)
+              }
+            />
+          )}
+          <Table.Column<DnsZoneRow>
+            title={t("dnszonesoverviewpage.zone_status")}
+            render={(_, record) =>
+              record.provisioned ? (
+                <Tag color="green">Provisioned</Tag>
+              ) : (
+                <Tag>Not provisioned</Tag>
+              )
+            }
+          />
+          <Table.Column<DnsZoneRow>
+            title={t("dnszonesoverviewpage.records")}
+            render={(_, record) => record.record_count ?? 0}
+          />
+          <Table.Column<DnsZoneRow>
+            title={t("dnszonesoverviewpage.ttl")}
+            render={(_, record) =>
+              record.effective_ttl != null ? `${record.effective_ttl}s` : "—"
+            }
+          />
+          <Table.Column<DnsZoneRow>
+            title={t("dnszonesoverviewpage.dnssec")}
+            dataIndex="dnssec_enabled"
+            render={(enabled: boolean | undefined) =>
+              enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
+            }
+          />
+          <Table.Column<DnsZoneRow>
+            title={t("dnszonesoverviewpage.expiration")}
+            dataIndex="registrar_expires_at"
+            render={(d: string | null | undefined) =>
+              d ? (
+                <Tooltip title={t("dnszonesoverviewpage.domain_registration_expiry_from_whois")}>
+                  {new Date(d).toLocaleDateString()}
+                </Tooltip>
+              ) : (
+                <Typography.Text type="secondary">—</Typography.Text>
+              )
+            }
+          />
+          <Table.Column<DnsZoneRow>
+            title={t("dnszonesoverviewpage.actions")}
+            render={(_, record) => (
+              <Button type="primary" onClick={() => navigate(audience.manageRoute(record.id))}>
+                Manage Records
+              </Button>
+            )}
+          />
+        </SearchableTableStringQ>
+      )}
+    </>
+  );
+};
+
+const DnssecTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => (
+  <>
+    <Alert
+      type="info"
+      showIcon
+      style={{ marginBottom: 16 }}
+      message={audience.dnssec.message}
+      description={audience.dnssec.description}
+    />
+    <DNSSECTable showOwner={audience.dnssec.showOwner} />
+  </>
+);
+
+// DnsZoneInventory is the whole DNS landing screen. Each route shell renders
+// exactly this with its audience policy.
+export const DnsZoneInventory = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
+  const [activeTab, setActiveTab] = useTabParam<"zones" | "dnssec">("zones");
+  return (
+    <div>
+      <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
+        {audience.header.icon} {audience.header.title}
+      </Typography.Title>
+      <Card
+        tabList={[
+          { key: "zones", tab: "Zones" },
+          { key: "dnssec", tab: "DNSSEC" },
+        ]}
+        activeTabKey={activeTab}
+        onTabChange={(k) => setActiveTab(k as "zones" | "dnssec")}
+      >
+        {activeTab === "zones" ? <ZonesTab audience={audience} /> : <DnssecTab audience={audience} />}
+      </Card>
+    </div>
+  );
+};

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
@@ -1,208 +1,40 @@
-// DNSZonesOverviewPage — admin landing for DNS. Card.tabList splits
-// into "Zones" (per-domain provisioning, the batched /dns/zones inventory)
-// and "DNSSEC" (signing state + DS export). Mirrors the UserList tab style —
-// controlled activeTabKey, panel-attached strip.
+// DNSZonesOverviewPage — admin Adapter for the shared DNS Zone Inventory
+// Module (JAB-299). The page owns only the admin audience policy: owner column
+// visible, admin domain routes, a create-domain empty-state CTA, and the
+// owner-visible DNSSEC tab. All list/query/column behavior lives in
+// components/dns/DNSZoneInventory.
 import { useTranslation } from "react-i18next";
-import { useTabParam } from "../../../hooks/useTabParam";
-import { Alert, Button, Card, Spin, Table, Tag, Tooltip, Typography } from "antd";
-import { ServerOutlined } from "@icons";
 import { useNavigate } from "react-router";
+import { ServerOutlined } from "@icons";
 
-import { columnSearchProps } from "../../../components/columnSearch";
-import { DNSSECTable } from "../../../components/dnssec/DNSSECTable";
-import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
-import { useTableURL } from "../../../hooks/useTableURL";
-import { sorterToParams } from "../../../utils/tableSorter";
+import {
+  DnsZoneInventory,
+  type DnsZoneInventoryAudience,
+} from "../../../components/dns/DNSZoneInventory";
 
-// DnsZoneRow is one row of the batched GET /dns/zones inventory (JAB-377):
-// the domain plus its provisioning state, record count, and effective TTL,
-// resolved server-side in one request instead of a per-row zone fan-out.
-interface DnsZoneRow {
-  id: string;
-  user_id: string;
-  username?: string | null;
-  name: string;
-  provisioned: boolean;
-  record_count: number;
-  effective_ttl?: number | null;
-  dnssec_enabled?: boolean;
-  registrar_expires_at?: string | null;
-}
-
-const ZonesTab = () => {
+export const DNSZonesOverviewPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  // One batched request (JAB-377): the endpoint returns provisioning state +
-  // record count + effective TTL per row, so there is no per-domain zone fetch
-  // and a transient failure surfaces as an error, not a false "Not provisioned".
-  const query = useTableURL<DnsZoneRow>({
-    resource: "dns/zones",
-    defaultSort: "name",
-    defaultOrder: "asc",
-  });
-
-  // Project AntD's sorter into the URL params so the server does the
-  // ORDER BY. Without an onChange the sort arrows rendered but changed
-  // nothing — the columns declared a server-side sorter and nothing was
-  // listening for it.
-  const handleTableChange: React.ComponentProps<typeof Table<DnsZoneRow>>["onChange"] = (
-    _pagination,
-    _filters,
-    sorter,
-  ) => {
-    const { sort, order } = sorterToParams<DnsZoneRow>(sorter);
-    query.setParams({ sort, order, page: 1 });
+  const audience: DnsZoneInventoryAudience = {
+    showOwner: true,
+    manageRoute: (id) => `/jabali-admin/domains/${id}/dns`,
+    renderEmpty: () => (
+      <EmptyWithCTA
+        description={t("dnszonesoverviewpage.no_dns_zones_yet_create_a_domain_to_manage_i")}
+        ctaLabel="Create domain"
+        onCta={() => navigate("/jabali-admin/domains/create")}
+      />
+    ),
+    dnssec: {
+      showOwner: true,
+      message: "Sign zones with DNSSEC. Enable per-domain, then publish the DS record at the registrar.",
+      description:
+        "Signing is best-effort NSEC3 with ECDSAP256SHA256 (RFC 8624). Keys are managed by PowerDNS via pdnsutil.",
+    },
+    header: { icon: <ServerOutlined />, title: "DNS Zones" },
   };
 
-  return (
-    <>
-      <Alert
-        title={t("dnszonesoverviewpage.dns_zones_are_provisioned_automatically_when")}
-        type="info"
-        showIcon
-        style={{ marginBottom: 16 }}
-      />
-      {query.isLoading ? (
-        <Spin />
-      ) : query.isError ? (
-        // A load failure is an error, never rendered as an empty list or a false
-        // "Not provisioned" (JAB-377 — the fan-out swallowed exactly this).
-        <Alert
-          type="error"
-          showIcon
-          message="Failed to load DNS zones"
-          description="The zone inventory could not be loaded. This is usually temporary — retry shortly."
-        />
-      ) : query.items.length === 0 ? (
-        <EmptyWithCTA description={t("dnszonesoverviewpage.no_dns_zones_yet_create_a_domain_to_manage_i")} ctaLabel="Create domain" onCta={() => navigate("/jabali-admin/domains/create")} />
-      ) : (
-        <SearchableTableStringQ<DnsZoneRow>
-          onChange={handleTableChange}
-          rowKey="id"
-          loading={query.isLoading}
-          dataSource={query.items}
-          initialSearch={query.params.q}
-          searchPlaceholder="Search by domain name"
-          onSearchChange={(q) => query.setParams({ q, page: 1 })}
-          pagination={{
-            current: query.params.page,
-            pageSize: query.params.pageSize,
-            total: query.total,
-            onChange: (page, pageSize) => query.setParams({ page, pageSize }),
-          }}
-        >
-          <Table.Column<DnsZoneRow>
-            dataIndex="name"
-            title={t("dnszonesoverviewpage.domain_name")}
-            key="name"
-            sorter
-            defaultSortOrder="ascend"
-            {...columnSearchProps<DnsZoneRow>({
-              placeholder: "Search by domain name",
-              currentQ: query.params.q,
-              onSearch: (v) => query.setParams({ q: v, page: 1 }),
-            })}
-          />
-          <Table.Column<DnsZoneRow>
-            dataIndex="username"
-            title={t("dnszonesoverviewpage.owner")}
-            key="username"
-            sorter
-            render={(username: string | null | undefined, record: DnsZoneRow) =>
-              username ?? record.user_id.substring(0, 8)
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("dnszonesoverviewpage.zone_status")}
-            render={(_, record) =>
-              record.provisioned ? (
-                <Tag color="green">Provisioned</Tag>
-              ) : (
-                <Tag>Not provisioned</Tag>
-              )
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("dnszonesoverviewpage.records")}
-            render={(_, record) => record.record_count ?? 0}
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("dnszonesoverviewpage.ttl")}
-            render={(_, record) =>
-              record.effective_ttl != null ? `${record.effective_ttl}s` : "—"
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("dnszonesoverviewpage.dnssec")}
-            dataIndex="dnssec_enabled"
-            render={(enabled: boolean | undefined) =>
-              enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("dnszonesoverviewpage.expiration")}
-            dataIndex="registrar_expires_at"
-            render={(d: string | null | undefined) =>
-              d ? (
-                <Tooltip title={t("dnszonesoverviewpage.domain_registration_expiry_from_whois")}>
-                  {new Date(d).toLocaleDateString()}
-                </Tooltip>
-              ) : (
-                <Typography.Text type="secondary">—</Typography.Text>
-              )
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("dnszonesoverviewpage.actions")}
-            render={(_, record) => (
-              <Button
-                type="primary"
-                onClick={() =>
-                  navigate(`/jabali-admin/domains/${record.id}/dns`)
-                }
-              >
-                Manage Records
-              </Button>
-            )}
-          />
-        </SearchableTableStringQ>
-      )}
-    </>
-  );
-};
-
-const DNSSECTab = () => (
-  <>
-    <Alert
-      type="info"
-      showIcon
-      style={{ marginBottom: 16 }}
-      message="Sign zones with DNSSEC. Enable per-domain, then publish the DS record at the registrar."
-      description="Signing is best-effort NSEC3 with ECDSAP256SHA256 (RFC 8624). Keys are managed by PowerDNS via pdnsutil."
-    />
-    <DNSSECTable showOwner />
-  </>
-);
-
-export const DNSZonesOverviewPage = () => {
-  const [activeTab, setActiveTab] = useTabParam<"zones" | "dnssec">("zones");
-  return (
-    <div>
-      <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
-        <ServerOutlined /> DNS Zones
-      </Typography.Title>
-      <Card
-        tabList={[
-          { key: "zones", tab: "Zones" },
-          { key: "dnssec", tab: "DNSSEC" },
-        ]}
-        activeTabKey={activeTab}
-        onTabChange={(k) => setActiveTab(k as "zones" | "dnssec")}
-      >
-        {activeTab === "zones" ? <ZonesTab /> : <DNSSECTab />}
-      </Card>
-    </div>
-  );
+  return <DnsZoneInventory audience={audience} />;
 };

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
@@ -1,196 +1,36 @@
-// UserDNSZonesOverviewPage — tenant landing for DNS. Card.tabList
-// pattern matches admin DNS + UserList — controlled activeTabKey,
-// panel-attached strip. The Zones tab is the batched /dns/zones inventory.
+// UserDNSZonesOverviewPage — tenant Adapter for the shared DNS Zone Inventory
+// Module (JAB-299). The page owns only the tenant audience policy: no owner
+// column, tenant domain routes, a plain empty state, and the owner-free DNSSEC
+// tab. All list/query/column behavior lives in components/dns/DNSZoneInventory.
 import { useTranslation } from "react-i18next";
-import { useTabParam } from "../../../hooks/useTabParam";
-import { Alert, Button, Card, Empty, Spin, Table, Tag, Tooltip, Typography } from "antd";
+import { Empty } from "antd";
 import { CloudServerOutlined } from "@icons";
-import { useNavigate } from "react-router";
 
-import { columnSearchProps } from "../../../components/columnSearch";
-import { DNSSECTable } from "../../../components/dnssec/DNSSECTable";
-import { SearchableTableStringQ } from "../../../components/SearchableTable";
-import { useTableURL } from "../../../hooks/useTableURL";
-import { sorterToParams } from "../../../utils/tableSorter";
-
-// DnsZoneRow is one row of the batched GET /dns/zones inventory (JAB-377):
-// the domain plus its provisioning state, record count, and effective TTL,
-// resolved server-side in one request instead of a per-row zone fan-out.
-interface DnsZoneRow {
-  id: string;
-  user_id: string;
-  name: string;
-  provisioned: boolean;
-  record_count: number;
-  effective_ttl?: number | null;
-  dnssec_enabled?: boolean;
-  registrar_expires_at?: string | null;
-}
-
-const ZonesTab = () => {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-
-  // One batched request (JAB-377): the endpoint returns provisioning state +
-  // record count + effective TTL per row, so there is no per-domain zone fetch
-  // and a transient failure surfaces as an error, not a false "Not provisioned".
-  const query = useTableURL<DnsZoneRow>({
-    resource: "dns/zones",
-    defaultSort: "name",
-    defaultOrder: "asc",
-  });
-
-  // Project AntD's sorter into the URL params so the server does the
-  // ORDER BY. Without an onChange the sort arrows rendered but changed
-  // nothing — the columns declared a server-side sorter and nothing was
-  // listening for it.
-  const handleTableChange: React.ComponentProps<typeof Table<DnsZoneRow>>["onChange"] = (
-    _pagination,
-    _filters,
-    sorter,
-  ) => {
-    const { sort, order } = sorterToParams<DnsZoneRow>(sorter);
-    query.setParams({ sort, order, page: 1 });
-  };
-
-  return (
-    <>
-      <Alert
-        title={t("userdnszonesoverviewpage.dns_zones_are_provisioned_automatically_when")}
-        type="info"
-        showIcon
-        style={{ marginBottom: 16 }}
-      />
-      {query.isLoading ? (
-        <Spin />
-      ) : query.isError ? (
-        // A load failure is an error, never rendered as an empty list or a false
-        // "Not provisioned" (JAB-377 — the fan-out swallowed exactly this).
-        <Alert
-          type="error"
-          showIcon
-          message="Failed to load DNS zones"
-          description="The zone inventory could not be loaded. This is usually temporary — retry shortly."
-        />
-      ) : query.items.length === 0 ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userdnszonesoverviewpage.no_domains_found")} />
-      ) : (
-        <SearchableTableStringQ<DnsZoneRow>
-          onChange={handleTableChange}
-          rowKey="id"
-          loading={query.isLoading}
-          dataSource={query.items}
-          initialSearch={query.params.q}
-          searchPlaceholder="Search by domain name"
-          onSearchChange={(q) => query.setParams({ q, page: 1 })}
-          pagination={{
-            current: query.params.page,
-            pageSize: query.params.pageSize,
-            total: query.total,
-            onChange: (page, pageSize) => query.setParams({ page, pageSize }),
-          }}
-        >
-          <Table.Column<DnsZoneRow>
-            dataIndex="name"
-            title={t("userdnszonesoverviewpage.domain_name")}
-            key="name"
-            sorter
-            defaultSortOrder="ascend"
-            {...columnSearchProps<DnsZoneRow>({
-              placeholder: "Search by domain name",
-              currentQ: query.params.q,
-              onSearch: (v) => query.setParams({ q: v, page: 1 }),
-            })}
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("userdnszonesoverviewpage.zone_status")}
-            render={(_, record) =>
-              record.provisioned ? (
-                <Tag color="green">Provisioned</Tag>
-              ) : (
-                <Tag>Not provisioned</Tag>
-              )
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("userdnszonesoverviewpage.records")}
-            render={(_, record) => record.record_count ?? 0}
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("userdnszonesoverviewpage.ttl")}
-            render={(_, record) =>
-              record.effective_ttl != null ? `${record.effective_ttl}s` : "—"
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("userdnszonesoverviewpage.dnssec")}
-            dataIndex="dnssec_enabled"
-            render={(enabled: boolean | undefined) =>
-              enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("userdnszonesoverviewpage.expiration")}
-            dataIndex="registrar_expires_at"
-            render={(d: string | null | undefined) =>
-              d ? (
-                <Tooltip title={t("userdnszonesoverviewpage.domain_registration_expiry_from_whois")}>
-                  {new Date(d).toLocaleDateString()}
-                </Tooltip>
-              ) : (
-                <Typography.Text type="secondary">—</Typography.Text>
-              )
-            }
-          />
-          <Table.Column<DnsZoneRow>
-            title={t("userdnszonesoverviewpage.actions")}
-            render={(_, record) => (
-              <Button
-                type="primary"
-                onClick={() =>
-                  navigate(`/jabali-panel/domains/${record.id}/dns`)
-                }
-              >
-                Manage Records
-              </Button>
-            )}
-          />
-        </SearchableTableStringQ>
-      )}
-    </>
-  );
-};
-
-const DNSSECTab = () => (
-  <>
-    <Alert
-      type="info"
-      showIcon
-      style={{ marginBottom: 16 }}
-      message="Protect your domain with DNSSEC."
-      description="Enable signing here, then copy the DS record to your registrar to complete the chain of trust."
-    />
-    <DNSSECTable showOwner={false} />
-  </>
-);
+import {
+  DnsZoneInventory,
+  type DnsZoneInventoryAudience,
+} from "../../../components/dns/DNSZoneInventory";
 
 export const UserDNSZonesOverviewPage = () => {
-  const [activeTab, setActiveTab] = useTabParam<"zones" | "dnssec">("zones");
-  return (
-    <div>
-      <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
-        <CloudServerOutlined /> DNS
-      </Typography.Title>
-      <Card
-        tabList={[
-          { key: "zones", tab: "Zones" },
-          { key: "dnssec", tab: "DNSSEC" },
-        ]}
-        activeTabKey={activeTab}
-        onTabChange={(k) => setActiveTab(k as "zones" | "dnssec")}
-      >
-        {activeTab === "zones" ? <ZonesTab /> : <DNSSECTab />}
-      </Card>
-    </div>
-  );
+  const { t } = useTranslation();
+
+  const audience: DnsZoneInventoryAudience = {
+    showOwner: false,
+    manageRoute: (id) => `/jabali-panel/domains/${id}/dns`,
+    renderEmpty: () => (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description={t("userdnszonesoverviewpage.no_domains_found")}
+      />
+    ),
+    dnssec: {
+      showOwner: false,
+      message: "Protect your domain with DNSSEC.",
+      description:
+        "Enable signing here, then copy the DS record to your registrar to complete the chain of trust.",
+    },
+    header: { icon: <CloudServerOutlined />, title: "DNS" },
+  };
+
+  return <DnsZoneInventory audience={audience} />;
 };


### PR DESCRIPTION
## What

The admin and tenant DNS landing screens (`DNSZonesOverviewPage`,
`UserDNSZonesOverviewPage`) were near-identical copies of the same
`Card.tabList` shell ("Zones" + "DNSSEC"), the same batched `/dns/zones` query,
and the same columns — the classic drift trap where a column or a formatting
fix lands on one screen and not the other.

This extracts the whole screen into `components/dns/DNSZoneInventory`. The two
route shells become thin Adapters that supply an **audience policy**; the Module
owns the URL-backed query state, the whole-list error branch, and the common
columns. The audience policy carries only the six things that genuinely differ:

- owner-column visibility (admin shows Owner + owner data; tenant omits it)
- the "Manage Records" route prefix (`/jabali-admin` vs `/jabali-panel`)
- the empty-state action (admin's create-domain CTA vs the tenant's plain `Empty`)
- the DNSSEC tab's owner-visibility policy and copy
- the page header (icon + title)

## Acceptance criteria (JAB-299)

- **Search, sort, pagination shared and URL-backed** — MET, and *preserved* not
  added: `useTableURL` already URL-backs `q`/`sort`/`order`/`page` in both
  screens today; it now lives once in the Module. (The admin Owner column's sort
  arrow inherits the server's existing behavior — `username` is a post-query
  batch join on `/dns/zones`, not a sortable domain column, so owner-sort is a
  pre-existing no-op, unchanged here.)
- **Provisioning / record count / TTL / expiration / DNSSEC presentation stay
  correct** — MET; the common columns are byte-preserved and covered by the new
  test.
- **Admin retains owner data + admin routes; tenant owner-free + tenant routes**
  — MET via the audience policy; asserted for both audiences in the test.
- **DNSSEC receives the correct owner-visibility policy** — MET
  (`audience.dnssec.showOwner`); the test mocks `DNSSECTable` and asserts
  `showOwner` true/false per audience.
- **Both route shells become thin Adapters** — MET; each page is now an audience
  object plus `<DnsZoneInventory audience={…} />`.

## AC2 is superseded, not implemented

The original AC2 ("each visible zone receives one status request; one failed
lookup degrades only that row") predates **#1300 (JAB-377)**, which deliberately
replaced the per-row status fan-out with one batched `GET /dns/zones` request so
a transient failure surfaces as an error instead of a false "Not provisioned".
Reintroducing a per-row fan-out to satisfy the stale wording would regress
#1300. The JAB-377 comments are kept verbatim in the Module so the batched
design is not "fixed" back into a fan-out.

## Notes for reviewers

- **i18n:** the Module reuses the existing `dnszonesoverviewpage.*` keys (already
  translated in all 14 locale files). The tenant's old
  `userdnszonesoverviewpage.*` keys for the common columns / alert / tooltip
  orphan but are harmless — no test enforces key usage, and the tenant's own
  `no_domains_found` key still resolves via its Adapter's empty state. Cleaning
  the orphans is out of scope (14 locale files, would collide with other
  worktrees).
- **Zero intended behavior change.** UI-only, no live/agent/reconciler surface —
  no box verification; `tsc -b` + vitest + `vite build` is proportionate.
- `App.tsx` is untouched — the two export names and paths are unchanged, so the
  lazy imports still resolve.
- The `antd: Alert message deprecated → title` warning in the test stderr is
  pre-existing on the DNSSEC tab (the `message`/`description` props were carried
  forward unchanged); not introduced here.

## Test plan

- [x] `npx vitest run src/components/dns/DNSZoneInventory.test.tsx` — 5/5:
      both audiences (owner column present/absent, admin vs tenant Manage-Records
      route), DNSSEC `showOwner` policy, provisioning/DNSSEC/TTL presentation
- [x] `npx tsc -b` clean
- [x] `npx vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
