### PR TITLE
feat(backup): full-server container restore — create missing users + per-user metadata rebuild (GH #1408)

### DIFF
--- a/panel-agent/internal/commands/system_fullbackup_extract.go
+++ b/panel-agent/internal/commands/system_fullbackup_extract.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+// system_fullbackup.extract — GH #1408 slice 2 (create-from-manifest for the
+// full-server container). Instead of the agent looping restoreAccountFromTar
+// internally (system.fullbackup.restore_uploaded, which discards each user's
+// metadata + can't create a missing account), the PANEL drives the loop: it
+// extracts the container once, then per selected user runs the SAME per-account
+// path it uses for a single upload — create-if-missing, backup.restore_from_tar,
+// then the panel-side metadata rebuild. This restores full panel state (domains
+// / databases / mailboxes) on a fresh box, works on containers packed by any
+// prior version (identity is read from each inner tar), and reports per-user
+// progress instead of one all-or-nothing socket call.
+//
+// This verb only EXTRACTS (safe plain-tar) to a stage under the uploads root
+// and returns the inner-tar paths; it applies nothing. The stage persists for
+// the panel loop and is removed by system.fullbackup.cleanup_stage.
+
+const fullRestoreStagePrefix = "fullrestore-"
+
+// fullRestoreStageTTL bounds how long an abandoned extraction lingers (a panel
+// crash mid-loop). evictStaleFullRestoreStages reaps older ones on each extract.
+const fullRestoreStageTTL = 24 * time.Hour
+
+type systemFullbackupExtractParams struct {
+	TarPath string `json:"tar_path"`
+}
+
+type extractedContainerUser struct {
+	Username  string `json:"username"`
+	InnerPath string `json:"inner_path"` // under restoreUploadsRoot → valid backup.restore_from_tar input
+}
+
+type systemFullbackupExtractResult struct {
+	Stage       string                   `json:"stage"`
+	RunID       string                   `json:"run_id"`
+	Users       []extractedContainerUser `json:"users"`
+	SystemInner string                   `json:"system_inner,omitempty"` // slice 3 reuse
+}
+
+// evictStaleFullRestoreStages removes fullrestore-* staging dirs older than the
+// TTL — self-heals a panel that crashed between extract and cleanup.
+func evictStaleFullRestoreStages() {
+	matches, _ := filepath.Glob(filepath.Join(restoreUploadsRoot, fullRestoreStagePrefix+"*"))
+	cutoff := time.Now().Add(-fullRestoreStageTTL)
+	for _, m := range matches {
+		if fi, err := os.Stat(m); err == nil && fi.IsDir() && fi.ModTime().Before(cutoff) {
+			_ = os.RemoveAll(m)
+		}
+	}
+}
+
+func systemFullbackupExtractUploadedHandler(_ context.Context, raw json.RawMessage) (any, error) {
+	var p systemFullbackupExtractParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	clean, aerr := fullContainerPathClean(p.TarPath)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if err := hostreserve.CheckReserve("/var/lib/jabali-backups", 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "restore staging is under the host disk reserve: " + err.Error()}
+	}
+	evictStaleFullRestoreStages()
+
+	stage := filepath.Join(restoreUploadsRoot, fullRestoreStagePrefix+randomULID())
+	_ = os.RemoveAll(stage)
+	if err := os.MkdirAll(stage, 0o750); err != nil {
+		return nil, bkInternal("mkdir stage", err)
+	}
+	// NO defer RemoveAll: the stage persists for the panel's per-user loop;
+	// system.fullbackup.cleanup_stage removes it when the loop finishes.
+	if _, err := safeExtractPlainTar(clean, stage); err != nil {
+		_ = os.RemoveAll(stage)
+		return nil, bkInvalidArg("container rejected: " + err.Error())
+	}
+	mb, err := readFileFromPlainTar(clean, "manifest.json")
+	if err != nil {
+		_ = os.RemoveAll(stage)
+		return nil, bkInvalidArg("container has no manifest.json")
+	}
+	var man fullContainerManifest
+	if json.Unmarshal(mb, &man) != nil {
+		_ = os.RemoveAll(stage)
+		return nil, bkInvalidArg("container manifest parse failed")
+	}
+
+	out := systemFullbackupExtractResult{Stage: stage, RunID: man.RunID}
+	for _, e := range man.Entries {
+		if e.Label == "system" {
+			sp := filepath.Join(stage, "system.tar.zst")
+			if fi, serr := os.Stat(sp); serr == nil && fi.Mode().IsRegular() {
+				out.SystemInner = sp
+			}
+			continue
+		}
+		if e.Username == "" {
+			continue
+		}
+		inner := filepath.Join(stage, "users", e.Username+".tar.zst")
+		if fi, serr := os.Stat(inner); serr != nil || !fi.Mode().IsRegular() {
+			continue // inner archive missing from the container — skip; the loop reports it
+		}
+		out.Users = append(out.Users, extractedContainerUser{Username: e.Username, InnerPath: inner})
+	}
+	return out, nil
+}
+
+type systemFullbackupCleanupParams struct {
+	Stage string `json:"stage"`
+}
+
+// systemFullbackupCleanupStageHandler removes one extraction stage. It is a
+// root-privileged RemoveAll, so the target is confined HARD: it must be a clean
+// path whose parent is EXACTLY restoreUploadsRoot and whose basename carries the
+// fullrestore- prefix. Anything else is refused — this can never be steered at
+// an arbitrary directory.
+func systemFullbackupCleanupStageHandler(_ context.Context, raw json.RawMessage) (any, error) {
+	var p systemFullbackupCleanupParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	clean := filepath.Clean(p.Stage)
+	if clean != p.Stage ||
+		filepath.Dir(clean) != restoreUploadsRoot ||
+		!strings.HasPrefix(filepath.Base(clean), fullRestoreStagePrefix) {
+		return nil, bkInvalidArg("refusing to clean a path outside the restore staging root")
+	}
+	if err := os.RemoveAll(clean); err != nil {
+		return nil, bkInternal("cleanup stage", err)
+	}
+	return map[string]any{"cleaned": clean}, nil
+}
+
+func init() {
+	Default.Register("system.fullbackup.extract_uploaded", systemFullbackupExtractUploadedHandler)
+	Default.Register("system.fullbackup.cleanup_stage", systemFullbackupCleanupStageHandler)
+}

--- a/panel-agent/internal/commands/system_fullbackup_extract_test.go
+++ b/panel-agent/internal/commands/system_fullbackup_extract_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// GH #1408 slice 2: cleanup_stage is a root-privileged RemoveAll. It must refuse
+// any path that isn't a fullrestore- stage directly under the uploads root — no
+// traversal, no sibling dir, no nested path, no other-root path.
+func TestSystemFullbackupCleanupStage_RefusesOutOfRoot(t *testing.T) {
+	bad := []string{
+		"/etc",
+		"/",
+		restoreUploadsRoot,                              // the root itself (no fullrestore- prefix)
+		restoreUploadsRoot + "/notfullrestore",          // wrong prefix
+		restoreUploadsRoot + "/../etc",                  // traversal (clean != input)
+		restoreUploadsRoot + "/fullrestore-x/sub",       // nested (parent != root)
+		"/tmp/fullrestore-x",                            // right prefix, wrong root
+		restoreUploadsRoot + "/rup-abc.tar.zst",         // an upload, not a stage
+		"",                                              // empty
+	}
+	for _, p := range bad {
+		raw, _ := json.Marshal(map[string]string{"stage": p})
+		if _, err := systemFullbackupCleanupStageHandler(context.Background(), raw); err == nil {
+			t.Errorf("cleanup_stage must REFUSE %q", p)
+		}
+	}
+}

--- a/panel-api/internal/api/backup_restore_upload.go
+++ b/panel-api/internal/api/backup_restore_upload.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -347,18 +348,36 @@ func (h *backupHandler) restoreUploadApply(c *gin.Context) {
 // password is regenerated (the user recovers via a Kratos link — it is never
 // displayed). On any error the helper writes the HTTP response and returns
 // ok=false.
-func (h *backupHandler) createUserFromBundle(c *gin.Context, tarPath, targetUsername string, packageID *string) (*models.User, bool) {
-	ctx := c.Request.Context()
-	if h.cfg.Packages == nil {
-		c.JSON(http.StatusNotImplemented, gin.H{"error": "create_from_bundle_unavailable", "detail": "create-from-backup is not enabled on this server"})
-		return nil, false
+// createBundleError carries the HTTP shape for a create-from-bundle guard
+// failure so the gin wrapper renders it verbatim while the detached full-server
+// loop (no gin.Context) can read the reason for its per-user marker line.
+type createBundleError struct {
+	status int
+	code   string
+	detail string
+}
+
+func (e *createBundleError) Error() string {
+	if e.detail != "" {
+		return e.code + ": " + e.detail
 	}
-	// Read the bundle's own user straight from the tar — the client-supplied
-	// target is only a cross-check, never the source of the identity.
+	return e.code
+}
+
+// resolveOrCreateUserFromTar reads the bundle's OWN user straight from the tar
+// (agent inspect — never trusted from the client) and creates a NON-ADMIN
+// account for it (GH #1408 create-from-manifest). Context-free so the detached
+// full-server restore loop can call it per user. Guard failures return a
+// *createBundleError; a userops.Create failure is returned verbatim (the gin
+// wrapper maps it via userOpsRESTError). The client-supplied targetUsername is
+// only a cross-check — home is name-keyed, so it must equal the bundle username.
+func (h *backupHandler) resolveOrCreateUserFromTar(ctx context.Context, tarPath, targetUsername string, packageID *string) (*models.User, error) {
+	if h.cfg.Packages == nil {
+		return nil, &createBundleError{http.StatusNotImplemented, "create_from_bundle_unavailable", "create-from-backup is not enabled on this server"}
+	}
 	raw, err := h.cfg.Agent.Call(ctx, "backup.inspect_uploaded_tar", map[string]string{"tar_path": tarPath})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "inspect_failed", "detail": restoreFailureDetail(err)})
-		return nil, false
+		return nil, &createBundleError{http.StatusBadGateway, "inspect_failed", restoreFailureDetail(err)}
 	}
 	var ins struct {
 		User struct {
@@ -368,41 +387,28 @@ func (h *backupHandler) createUserFromBundle(c *gin.Context, tarPath, targetUser
 		} `json:"user"`
 	}
 	if json.Unmarshal(raw, &ins) != nil || ins.User.Username == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bundle_unreadable"})
-		return nil, false
+		return nil, &createBundleError{http.StatusBadRequest, "bundle_unreadable", ""}
 	}
-	// Home is name-keyed: the account must be the backup's OWN username, or the
-	// home-rsync fails "source missing" downstream. Rename-on-restore is a
-	// separate deferred slice.
 	if ins.User.Username != targetUsername {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username_mismatch",
-			"detail": "restore into the backup's own username (" + ins.User.Username + ")"})
-		return nil, false
+		return nil, &createBundleError{http.StatusBadRequest, "username_mismatch", "restore into the backup's own username (" + ins.User.Username + ")"}
 	}
 	// SECURITY: never create an admin from a bundle (belt beyond the applyUser
 	// refusal — no legitimate account backup is an admin).
 	if ins.User.IsAdmin {
-		c.JSON(http.StatusForbidden, gin.H{"error": "admin_bundle_refused",
-			"detail": "refusing to create an admin account from a backup"})
-		return nil, false
+		return nil, &createBundleError{http.StatusForbidden, "admin_bundle_refused", "refusing to create an admin account from a backup"}
 	}
 	if ins.User.Email == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bundle_no_email",
-			"detail": "the backup carries no user email — create the user manually, then restore into it"})
-		return nil, false
+		return nil, &createBundleError{http.StatusBadRequest, "bundle_no_email", "the backup carries no user email — create the user manually, then restore into it"}
 	}
 	// Don't hijack an existing identity: an email collision is the admin's to
 	// resolve (restore into the existing user, or create manually).
 	if existing, _ := h.cfg.Users.FindByEmail(ctx, ins.User.Email); existing != nil {
-		c.JSON(http.StatusConflict, gin.H{"error": "email_taken",
-			"detail": "a user with that email already exists — restore into it instead"})
-		return nil, false
+		return nil, &createBundleError{http.StatusConflict, "email_taken", "a user with that email already exists — restore into it instead"}
 	}
 
 	pw, perr := randomRestorePassword()
 	if perr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return nil, false
+		return nil, &createBundleError{http.StatusInternalServerError, "internal", ""}
 	}
 	uname := ins.User.Username
 	res, cerr := userops.Create(ctx, userops.Deps{
@@ -420,10 +426,26 @@ func (h *backupHandler) createUserFromBundle(c *gin.Context, tarPath, targetUser
 		PackageID: packageID,
 	})
 	if cerr != nil {
-		userOpsRESTError(c, cerr) // maps ErrInvalidUsername/Package/Taken/Kratos to HTTP
+		return nil, cerr
+	}
+	return res.User, nil
+}
+
+// createUserFromBundle is the gin wrapper over resolveOrCreateUserFromTar for
+// the single-account apply handler: on error it writes the HTTP response and
+// returns ok=false.
+func (h *backupHandler) createUserFromBundle(c *gin.Context, tarPath, targetUsername string, packageID *string) (*models.User, bool) {
+	u, err := h.resolveOrCreateUserFromTar(c.Request.Context(), tarPath, targetUsername, packageID)
+	if err != nil {
+		var ce *createBundleError
+		if errors.As(err, &ce) {
+			c.JSON(ce.status, gin.H{"error": ce.code, "detail": ce.detail})
+		} else {
+			userOpsRESTError(c, err) // userops sentinels → HTTP
+		}
 		return nil, false
 	}
-	return res.User, true
+	return u, true
 }
 
 // randomRestorePassword returns an unguessable password for a create-from-

--- a/panel-api/internal/api/system_fullbackup.go
+++ b/panel-api/internal/api/system_fullbackup.go
@@ -3,16 +3,21 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
@@ -252,6 +257,30 @@ func (h *backupHandler) fullRestoreInspect(c *gin.Context) {
 		respondAgentError(c, err)
 		return
 	}
+	// GH #1408 slice 2: annotate which container users already exist (so the UI
+	// can offer create-missing) and whether the server can create them.
+	var parsed map[string]any
+	if json.Unmarshal(raw, &parsed) == nil {
+		if us, ok := parsed["users"].([]any); ok {
+			status := make([]map[string]any, 0, len(us))
+			for _, x := range us {
+				uname, _ := x.(string)
+				exists := false
+				if uname != "" {
+					if ex, _ := h.cfg.Users.FindByUsername(c.Request.Context(), uname); ex != nil {
+						exists = true
+					}
+				}
+				status = append(status, map[string]any{"username": uname, "exists": exists})
+			}
+			parsed["user_status"] = status
+		}
+		parsed["create_supported"] = h.cfg.Packages != nil
+		if out, merr := json.Marshal(parsed); merr == nil {
+			c.Data(http.StatusOK, "application/json", out)
+			return
+		}
+	}
 	c.Data(http.StatusOK, "application/json", raw)
 }
 
@@ -259,6 +288,12 @@ type fullRestoreApplyRequest struct {
 	UploadID      string   `json:"upload_id"`
 	Usernames     []string `json:"usernames"`
 	IncludeSystem bool     `json:"include_system"`
+	// GH #1408 slice 2 create-from-manifest: create any selected user that isn't
+	// on this box yet (fresh-box DR), from that user's own inner-tar metadata.
+	// One PackageID is applied to every created account (v1). Non-admin, password
+	// regenerated — same guards as the single-account create.
+	CreateMissing bool    `json:"create_missing,omitempty"`
+	PackageID     *string `json:"package_id,omitempty"`
 }
 
 // fullRestoreApply handles POST /admin/system/full-restore-upload/apply — restores
@@ -289,41 +324,133 @@ func (h *backupHandler) fullRestoreApply(c *gin.Context) {
 	marker := fullRestoreMarkerPath(adminID, req.UploadID)
 	writeFullBackupOutcome(marker, fullBackupOutcome{Status: "restoring"})
 
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
-		defer cancel()
-		raw, cerr := h.cfg.Agent.Call(ctx, "system.fullbackup.restore_uploaded", map[string]any{
-			"tar_path":       path,
-			"usernames":      req.Usernames,
-			"include_system": req.IncludeSystem,
-		})
-		if cerr != nil {
-			writeFullBackupOutcome(marker, fullBackupOutcome{Status: "failed", Error: restoreFailureDetail(cerr)})
-			return
-		}
-		// The container is consumed — drop it.
-		_ = os.Remove(path)
-		var res struct {
-			Users []struct {
-				Username string   `json:"username"`
-				Applied  []string `json:"applied"`
-				Error    string   `json:"error"`
-			} `json:"users"`
-			Skipped []string `json:"skipped"`
-		}
-		_ = json.Unmarshal(raw, &res)
-		packed := make([]string, 0, len(res.Users))
-		for _, u := range res.Users {
-			if u.Error != "" {
-				packed = append(packed, u.Username+": "+u.Error)
-			} else {
-				packed = append(packed, u.Username+": restored "+strconv.Itoa(len(u.Applied))+" item(s)")
-			}
-		}
-		writeFullBackupOutcome(marker, fullBackupOutcome{Status: "done", Packed: packed, Skipped: res.Skipped})
-	}()
+	go h.runFullRestore(path, marker, req)
 
 	c.JSON(http.StatusAccepted, gin.H{"status": "restoring", "upload_id": req.UploadID})
+}
+
+// runFullRestore is the detached full-server restore loop (GH #1408 slice 2).
+// The PANEL drives it: extract the container once (agent), then per selected
+// user resolve-or-create the account and restore its inner tar via the SAME
+// per-account path (backup.restore_from_tar + panel metadata rebuild),
+// reporting per-user progress. Panel-driven so it reuses create-from-manifest,
+// rebuilds full panel state, and works on any prior container (identity is read
+// from each inner tar). The extraction stage is always cleaned up.
+func (h *backupHandler) runFullRestore(containerPath, marker string, req fullRestoreApplyRequest) {
+	// Scale the ceiling with the work: one account restore fit in ~an hour, a
+	// whole box does not. Size from the explicit selection when given, else the
+	// "all users" case gets a generous fixed ceiling.
+	budget := 6 * time.Hour
+	if n := len(req.Usernames); n > 0 {
+		budget = 20*time.Minute + time.Duration(n)*40*time.Minute
+		if budget > 6*time.Hour {
+			budget = 6 * time.Hour
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	raw, cerr := h.cfg.Agent.Call(ctx, "system.fullbackup.extract_uploaded", map[string]any{"tar_path": containerPath})
+	if cerr != nil {
+		detail := restoreFailureDetail(cerr)
+		var ae *agentwire.AgentError
+		if errors.As(cerr, &ae) && ae.Code == agent.CodeUnknownCommand {
+			// Fail closed on an old agent — never fall back to the legacy
+			// restore_uploaded, which silently produces the no-metadata behaviour
+			// this slice fixes.
+			detail = "this restore needs the updated agent (system.fullbackup.extract_uploaded) — update the panel-agent on this server, then retry"
+		}
+		writeFullBackupOutcome(marker, fullBackupOutcome{Status: "failed", Error: detail})
+		return
+	}
+	var ex struct {
+		Stage string `json:"stage"`
+		Users []struct {
+			Username  string `json:"username"`
+			InnerPath string `json:"inner_path"`
+		} `json:"users"`
+	}
+	if json.Unmarshal(raw, &ex) != nil || ex.Stage == "" {
+		writeFullBackupOutcome(marker, fullBackupOutcome{Status: "failed", Error: "container extract returned no staging dir"})
+		return
+	}
+	// Drop the container tar now — no need to hold container + inners together.
+	_ = os.Remove(containerPath)
+	// Always remove the extraction stage when the loop finishes.
+	defer func() {
+		cctx, cc := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cc()
+		_, _ = h.cfg.Agent.Call(cctx, "system.fullbackup.cleanup_stage", map[string]any{"stage": ex.Stage})
+	}()
+
+	want := map[string]bool{}
+	for _, u := range req.Usernames {
+		want[u] = true
+	}
+
+	var packed, skipped []string
+	for _, u := range ex.Users {
+		// Flush progress-so-far before each account so a poller sees movement even
+		// when the users ahead only produced failure/skip lines.
+		writeFullBackupOutcome(marker, fullBackupOutcome{Status: "restoring", Packed: packed, Skipped: skipped})
+		if len(want) > 0 && !want[u.Username] {
+			skipped = append(skipped, u.Username)
+			continue
+		}
+		if !restoreTargetUsernameRE.MatchString(u.Username) {
+			packed = append(packed, u.Username+": invalid username — skipped")
+			continue
+		}
+		target, terr := h.cfg.Users.FindByUsername(ctx, u.Username)
+		userCreated := false
+		if terr != nil || target == nil {
+			if !req.CreateMissing {
+				packed = append(packed, u.Username+": user does not exist — enable 'create missing users' or create it first")
+				continue
+			}
+			// create-from-manifest for this user, from its OWN inner tar (a
+			// mismatched inner manifest fails the username guard before creating).
+			nt, cberr := h.resolveOrCreateUserFromTar(ctx, u.InnerPath, u.Username, req.PackageID)
+			if cberr != nil {
+				packed = append(packed, u.Username+": "+cberr.Error())
+				continue
+			}
+			target, userCreated = nt, true
+		}
+		rraw, rerr := h.cfg.Agent.Call(ctx, "backup.restore_from_tar", map[string]any{
+			"job_id":          ids.NewULID(),
+			"tar_path":        u.InnerPath,
+			"target_username": u.Username,
+		})
+		if rerr != nil {
+			line := u.Username + ": " + restoreFailureDetail(rerr)
+			if userCreated {
+				line += " (account created; a retry restores into it)"
+			}
+			packed = append(packed, line)
+			continue
+		}
+		var rr struct {
+			Applied  []string        `json:"applied"`
+			Metadata json.RawMessage `json:"metadata"`
+		}
+		_ = json.Unmarshal(rraw, &rr)
+		metaErrs := h.applyRestoreMetadataForUser(ctx, rr.Metadata, target.ID)
+		line := u.Username + ": restored " + strconv.Itoa(len(rr.Applied)) + " item(s)"
+		if userCreated {
+			line += " (account created — send a recovery link: jabali user password " + u.Username + " --link)"
+		}
+		if len(metaErrs) > 0 {
+			line += "; metadata: " + strings.Join(metaErrs, "; ")
+		}
+		packed = append(packed, line)
+	}
+
+	note := ""
+	if req.IncludeSystem {
+		note = "system restore is not applied from the panel — run the system_restore CLI on the box"
+	}
+	writeFullBackupOutcome(marker, fullBackupOutcome{Status: "done", Packed: packed, Skipped: skipped, Error: note})
 }
 
 // fullRestoreStatus handles GET /admin/system/full-restore-upload/status?upload_id=…

--- a/panel-api/internal/api/system_fullbackup_restore_test.go
+++ b/panel-api/internal/api/system_fullbackup_restore_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fullRestoreUsers: "alice" exists, everyone else is missing.
+type fullRestoreUsers struct {
+	repository.UserRepository
+}
+
+func (fullRestoreUsers) FindByUsername(_ context.Context, name string) (*models.User, error) {
+	if name == "alice" {
+		u := "alice"
+		return &models.User{ID: "UA", Username: &u}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func fullMarker(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "marker.json")
+}
+
+func readFullOutcome(t *testing.T, path string) fullBackupOutcome {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var o fullBackupOutcome
+	if err := json.Unmarshal(b, &o); err != nil {
+		t.Fatalf("marker json: %v", err)
+	}
+	return o
+}
+
+// GH #1408 slice 2: an agent that predates extract_uploaded must FAIL CLOSED —
+// never silently fall back to the no-metadata legacy path.
+func TestRunFullRestore_FailClosedOnOldAgent(t *testing.T) {
+	ag := &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		if cmd == "system.fullbackup.extract_uploaded" {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeUnknownCommand, Message: "unknown command"}
+		}
+		return nil, fmt.Errorf("unexpected agent call %q", cmd)
+	}}
+	h := &backupHandler{cfg: BackupHandlerConfig{Agent: ag, Users: fullRestoreUsers{}}}
+	marker := fullMarker(t)
+	h.runFullRestore("/x/container.tar.zst", marker, fullRestoreApplyRequest{})
+
+	o := readFullOutcome(t, marker)
+	if o.Status != "failed" || !strings.Contains(o.Error, "updated agent") {
+		t.Fatalf("want failed + 'updated agent', got %+v", o)
+	}
+}
+
+// A selected user that doesn't exist is SKIPPED (not restored) when
+// create-missing is off; the extraction stage is always cleaned up.
+func TestRunFullRestore_MissingUserGateAndCleanup(t *testing.T) {
+	cleaned := false
+	restored := false
+	ag := &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		switch cmd {
+		case "system.fullbackup.extract_uploaded":
+			return json.RawMessage(`{"stage":"/var/lib/jabali-uploads/fullrestore-X","users":[` +
+				`{"username":"alice","inner_path":"/var/lib/jabali-uploads/fullrestore-X/users/alice.tar.zst"},` +
+				`{"username":"bob","inner_path":"/var/lib/jabali-uploads/fullrestore-X/users/bob.tar.zst"}]}`), nil
+		case "backup.restore_from_tar":
+			restored = true
+			return json.RawMessage(`{"applied":["home → /home/alice"]}`), nil
+		case "system.fullbackup.cleanup_stage":
+			cleaned = true
+			return json.RawMessage(`{"cleaned":"x"}`), nil
+		}
+		return nil, fmt.Errorf("unexpected agent call %q", cmd)
+	}}
+	h := &backupHandler{cfg: BackupHandlerConfig{Agent: ag, Users: fullRestoreUsers{}}}
+	marker := fullMarker(t)
+	// Only bob selected, create-missing OFF → bob is skipped-not-created, and no
+	// account is ever created (Packages nil would 501 the create path anyway).
+	h.runFullRestore("/x/container.tar.zst", marker, fullRestoreApplyRequest{
+		Usernames: []string{"bob"}, CreateMissing: false,
+	})
+
+	o := readFullOutcome(t, marker)
+	if o.Status != "done" {
+		t.Fatalf("want done, got %+v", o)
+	}
+	joined := strings.Join(o.Packed, " | ")
+	if !strings.Contains(joined, "bob: user does not exist") {
+		t.Errorf("bob must be reported as missing-not-created, got %q", joined)
+	}
+	// alice not selected → skipped, never restored.
+	if restored {
+		t.Error("no user was selected for restore; restore_from_tar must not run")
+	}
+	sk := strings.Join(o.Skipped, ",")
+	if !strings.Contains(sk, "alice") {
+		t.Errorf("unselected alice must be skipped, got skipped=%q", sk)
+	}
+	if !cleaned {
+		t.Error("the extraction stage must be cleaned up")
+	}
+}

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -611,10 +611,19 @@ interface RestoreUploadStatus {
 
 // === GH #1408 phase 2: restore from an uploaded full-server container ===
 
+export interface FullContainerUserStatus {
+  username: string;
+  exists: boolean;
+}
+
 export interface FullContainerInfo {
   run_id: string;
   users: string[];
   has_system: boolean;
+  // GH #1408 slice 2: per-user existence + whether the server can create the
+  // missing ones (Packages wired). Older panels omit these.
+  user_status?: FullContainerUserStatus[];
+  create_supported?: boolean;
 }
 
 export async function inspectFullServerContainer(
@@ -640,11 +649,16 @@ export async function applyFullServerRestore(
   uploadId: string,
   usernames: string[],
   includeSystem: boolean,
+  // GH #1408 slice 2: create the container's missing users before restoring
+  // (non-admin bundles only), optionally onto a chosen package.
+  opts?: { createMissing?: boolean; packageId?: string | null },
 ): Promise<FullRestoreResult> {
   await apiClient.post("/admin/system/full-restore-upload/apply", {
     upload_id: uploadId,
     usernames,
     include_system: includeSystem,
+    create_missing: opts?.createMissing ?? false,
+    package_id: opts?.packageId ?? null,
   });
   const deadline = Date.now() + 65 * 60 * 1000;
   for (;;) {

--- a/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
@@ -2,19 +2,21 @@
 // SERVER container: upload the one-file archive produced by "Package & download",
 // pick which users to restore, and each is restored exactly like a normal
 // account restore. System restore is intentionally left to the CLI.
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Alert,
   Button,
   Checkbox,
   Drawer,
   Progress,
+  Select,
   Space,
   Typography,
   Upload,
 } from "antd";
 import { InboxOutlined } from "@icons";
 import { feedback } from "../../../lib/feedback";
+import { useSelectQuery } from "../../../hooks/useSelectQuery";
 import {
   applyFullServerRestore,
   inspectFullServerContainer,
@@ -23,6 +25,8 @@ import {
   type FullRestoreResult,
 } from "../../../apiClient";
 import { extractApiError } from "../../../apiErrors";
+
+type HostingPackage = { id: string; name: string };
 
 interface Props {
   open: boolean;
@@ -38,7 +42,22 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
   const [info, setInfo] = useState<FullContainerInfo | null>(null);
   const [uploadId, setUploadId] = useState<string | null>(null);
   const [users, setUsers] = useState<string[]>([]);
+  const [createMissing, setCreateMissing] = useState(false);
+  const [packageId, setPackageId] = useState<string | null>(null);
   const [result, setResult] = useState<FullRestoreResult | null>(null);
+
+  // Which container users don't yet exist on this server (from inspect). Older
+  // panels omit user_status → treat existence as unknown (no create UI).
+  const missingSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const st of info?.user_status ?? []) {
+      if (!st.exists) s.add(st.username);
+    }
+    return s;
+  }, [info]);
+  // Missing users the admin actually selected — the ones that need creating.
+  const selectedMissing = users.filter((u) => missingSet.has(u));
+  const canCreate = (info?.create_supported ?? false) && selectedMissing.length > 0;
 
   const reset = () => {
     setFile(null);
@@ -47,6 +66,8 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
     setInfo(null);
     setUploadId(null);
     setUsers([]);
+    setCreateMissing(false);
+    setPackageId(null);
     setResult(null);
   };
   const close = () => {
@@ -77,7 +98,10 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
     setPhase("applying");
     feedback.message.info("Restore started — running in the background");
     try {
-      const r = await applyFullServerRestore(uploadId, users, false);
+      const r = await applyFullServerRestore(uploadId, users, false, {
+        createMissing: canCreate && createMissing,
+        packageId: canCreate && createMissing ? packageId : null,
+      });
       setResult(r);
       setPhase("done");
       feedback.message.success("Full server restore finished — see details");
@@ -99,7 +123,8 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           Upload a Full Server backup archive (from “Package &amp; download”) and
           restore the accounts it contains. Each user is restored just like a
-          normal account restore. Create any missing users first.
+          normal account restore. Accounts that don&apos;t exist yet can be
+          created for you.
         </Typography.Paragraph>
 
         {(phase === "pick" || phase === "uploading") && (
@@ -143,9 +168,60 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
                 value={users}
                 onChange={(v) => setUsers(v as string[])}
                 style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 4 }}
-                options={info.users.map((u) => ({ label: u, value: u }))}
+                options={info.users.map((u) => ({
+                  label: missingSet.has(u) ? (
+                    <span>
+                      {u}{" "}
+                      <Typography.Text type="warning" style={{ fontSize: 12 }}>
+                        (not on this server)
+                      </Typography.Text>
+                    </span>
+                  ) : (
+                    u
+                  ),
+                  value: u,
+                }))}
               />
             </div>
+
+            {canCreate && (
+              <div>
+                <Checkbox
+                  checked={createMissing}
+                  onChange={(e) => setCreateMissing(e.target.checked)}
+                  disabled={phase !== "ready"}
+                >
+                  Create the {selectedMissing.length} missing account(s):{" "}
+                  <Typography.Text code>{selectedMissing.join(", ")}</Typography.Text>
+                </Checkbox>
+                {createMissing && (
+                  <div style={{ marginTop: 8 }}>
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      Hosting package for the new accounts
+                    </Typography.Text>
+                    <PackageSelect value={packageId} onChange={setPackageId} disabled={phase !== "ready"} />
+                    <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginTop: 4 }}>
+                      New accounts get a random password (set one afterwards) and
+                      the identity/limits from the backup are never trusted —
+                      admin accounts in the backup are refused.
+                    </Typography.Text>
+                  </div>
+                )}
+              </div>
+            )}
+            {selectedMissing.length > 0 && !createMissing && (
+              <Alert
+                type="warning"
+                showIcon
+                message="Some selected accounts don't exist yet"
+                description={
+                  info.create_supported
+                    ? "Tick “Create the missing account(s)” above, or create them first — otherwise they're skipped."
+                    : "Create them first — otherwise they're skipped."
+                }
+              />
+            )}
+
             <Alert
               type="warning"
               showIcon
@@ -198,5 +274,29 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
         )}
       </Space>
     </Drawer>
+  );
+}
+
+function PackageSelect(props: {
+  value: string | null;
+  onChange: (v: string | null) => void;
+  disabled?: boolean;
+}) {
+  const { options, isLoading } = useSelectQuery<HostingPackage>({
+    resource: "packages",
+    labelField: "name",
+    valueField: "id",
+  });
+  return (
+    <Select
+      placeholder="Select a package (optional)"
+      allowClear
+      style={{ width: "100%", marginTop: 4 }}
+      loading={isLoading}
+      disabled={props.disabled}
+      options={[{ label: "No package", value: null }, ...options]}
+      value={props.value}
+      onChange={(v: string | null) => props.onChange(v ?? null)}
+    />
   );
 }


### PR DESCRIPTION
Slice 2 of the "restore from an uploaded backup archive" work (GH #1408). **Stacked on #1523** (create-from-manifest) — review/merge that first; this PR's diff is against that branch and will be retargeted to `main` once #1523 lands.

## What this adds
Restore from an uploaded **Full Server container** (the one-file archive from "Package & download"), entirely **panel-driven** so it reuses the per-account create-from-manifest path and rebuilds full panel state for each user — instead of the old legacy path that applied no metadata.

### Agent — two new verbs
- `system.fullbackup.extract_uploaded` — extracts the plain container tar into a **confined stage** (`fullrestore-<ULID>` directly under `/var/lib/jabali-uploads`), reads `manifest.json`, and returns each inner per-account tar path (+ the system inner, when the manifest declares one). No auto-cleanup — the panel drives the per-user loop. `tar_path` is confined under the uploads root (clean path, prefix check, no symlink), matching `restore_from_tar`.
- `system.fullbackup.cleanup_stage` — a root-privileged `RemoveAll` confined **hard**: only a `fullrestore-` dir whose parent is *exactly* the uploads root. Refuses traversal, the root itself, sibling, and nested paths. Stale stages older than 24h are evicted at each extract (survives a panel crash mid-loop).

### Panel — `runFullRestore` (detached)
- Extract once, then per **selected** user: find-or-create the account and restore its inner tar via the **same** `backup.restore_from_tar` + metadata rebuild used for a single account, remapping metadata `user.id` to the local target.
- Missing users are created only when `create_missing` is set (fresh-box DR), from **each user's own inner-tar manifest** — a mismatched inner manifest fails the username guard before any account is created; **admin bundles are refused**; the identity/package/password in the bundle are never trusted (random password; operator sends a recovery link).
- **Fails closed** on an old agent (unknown `extract_uploaded`) rather than silently falling back to the no-metadata legacy path.
- Timeout scales with the selection (20m + 40m/user, capped 6h); progress marker flushed each iteration so failure/skip lines show movement; the extraction stage is always cleaned up.
- Container inspect now annotates each user with `target_exists` + whether the server can create the missing ones.

### UI — `RestoreFullServerDrawer`
Flags users not on this server, offers a **create-missing** checkbox + hosting-package picker (with the "random password / identity not trusted / admins refused" note), and warns when selected users are missing and won't be created.

### Refactor
`createUserFromBundle` split into a context-free `resolveOrCreateUserFromTar` core reused by both the single-account and full-container loops.

## Design notes
- **No step-up on this apply, by design.** It restores *accounts* (system restore stays CLI). The sibling single-account apply deliberately dropped step-up after #1448 (the mid-flow Kratos redirect lost the flow); a per-account restore is ordinary admin work. Step-up lands on the system-config restore (a later slice) via a pre-upload pre-check, not a mid-apply break.
- Container upload reuses the already body-limit-exempt `/admin/backups/restore-upload` chunk route.

## Test plan
- [x] `go build ./...` (panel-api + panel-agent), `go vet`, `gofmt` clean
- [x] `go test -race` panel-agent/internal/commands + panel-api/internal/api
- [x] New unit tests: cleanup_stage out-of-root confinement (agent); fail-closed-on-old-agent, missing-user create-gate, unselected-skip, stage-cleanup (panel loop)
- [x] `tsc -b` clean (panel-ui)
- [x] **Box drill on test server** (.60), real agent binary, throwaway instance — extract splits a 2-user+system container correctly (stage under `fullrestore-`, both inner tars + system_inner returned); cleanup_stage refuses `/etc`, the uploads root, and a nested path; removes the real stage. ALL PASS.
- [ ] Fleet agent redeploy owed (new agent verbs) before this reaches boxes.