### PR TITLE
refactor(quickstart): one shared Quick Start Guide Module (JAB-297)

### DIFF
--- a/panel-ui/src/components/quickstart/QuickStartGuide.test.tsx
+++ b/panel-ui/src/components/quickstart/QuickStartGuide.test.tsx
@@ -1,0 +1,199 @@
+// QuickStartGuide.test.tsx — JAB-297. The shared Quick Start Module owns the
+// display policy, the late-response cancel guard, and persistence; the two
+// shells only supply an audience. These are the behavioral ACs:
+//   AC1 — missing preference opens; dismissed ("1") stays closed; a failed
+//         lookup stays closed.
+//   AC2 — a response that arrives after the request is superseded/unmounted is
+//         ignored (the cancelled flag).
+//   AC3 — "I'll read later" persists nothing; "Never show again" writes the
+//         audience's own preference key.
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QuickStartGuide, type QuickStartAudience } from "./QuickStartGuide";
+import { QuickStartModal as AdminQuickStart } from "../../shells/admin/QuickStartModal";
+import { QuickStartModal as UserQuickStart } from "../../shells/user/QuickStartModal";
+
+// apiClient is the only side-effecting seam; control it per test.
+const { getMock, putMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  putMock: vi.fn(),
+}));
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: getMock, put: putMock },
+}));
+
+// A signed-in user is required for the effect to fire; the id value is opaque.
+vi.mock("../../auth/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+const audience = (prefKey = "quickstart_test"): QuickStartAudience => ({
+  prefKey,
+  steps: [
+    {
+      number: 1,
+      title: "First Step",
+      desc: "do the first thing",
+      href: "/first",
+      color: "#2563eb",
+    },
+  ],
+  renderSupport: (close) => (
+    <a href="https://example.com/docs" onClick={close}>
+      docs link
+    </a>
+  ),
+});
+
+const renderGuide = (a: QuickStartAudience = audience()) =>
+  render(
+    <MemoryRouter>
+      <QuickStartGuide audience={a} />
+    </MemoryRouter>,
+  );
+
+// Flush the get().then() microtask chain and any resulting state update.
+const flush = () => act(async () => { await Promise.resolve(); });
+
+beforeEach(() => {
+  getMock.mockReset();
+  putMock.mockReset();
+  putMock.mockResolvedValue({});
+});
+
+describe("QuickStartGuide display policy (AC1)", () => {
+  it("opens when the preference is missing", async () => {
+    getMock.mockResolvedValue({ data: { prefs: {} } });
+    renderGuide();
+    expect(await screen.findByText(/Welcome to Jabali Panel/)).toBeInTheDocument();
+    // The audience's own step content renders inside the open guide.
+    expect(screen.getByText("First Step")).toBeInTheDocument();
+  });
+
+  it("stays closed when the preference is already dismissed", async () => {
+    getMock.mockResolvedValue({ data: { prefs: { quickstart_test: "1" } } });
+    renderGuide();
+    await flush();
+    expect(screen.queryByText(/Welcome to Jabali Panel/)).not.toBeInTheDocument();
+  });
+
+  it("stays closed when the lookup fails", async () => {
+    getMock.mockRejectedValue(new Error("network down"));
+    renderGuide();
+    await flush();
+    expect(screen.queryByText(/Welcome to Jabali Panel/)).not.toBeInTheDocument();
+  });
+});
+
+describe("QuickStartGuide late-response guard (AC2)", () => {
+  it("ignores a response that resolves after unmount", async () => {
+    let resolveGet!: (v: unknown) => void;
+    getMock.mockReturnValue(
+      new Promise((r) => {
+        resolveGet = r;
+      }),
+    );
+    const { unmount } = renderGuide();
+    unmount();
+    // Resolving with "missing preference" would open the guide were it not
+    // cancelled; after unmount it must be a no-op that does not throw.
+    await act(async () => {
+      resolveGet({ data: { prefs: {} } });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/Welcome to Jabali Panel/)).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale response after the request is superseded", async () => {
+    // First request hangs; a prefKey change supersedes it (cleanup → cancelled)
+    // and fires a second request whose "dismissed" answer keeps the guide shut.
+    let resolveStale!: (v: unknown) => void;
+    getMock.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveStale = r;
+        }),
+    );
+    getMock.mockResolvedValue({ data: { prefs: { second_key: "1" } } });
+
+    const { rerender } = renderGuide(audience("first_key"));
+    rerender(
+      <MemoryRouter>
+        <QuickStartGuide audience={audience("second_key")} />
+      </MemoryRouter>,
+    );
+    await flush();
+
+    // The stale answer says "missing preference" (would open under first_key);
+    // the guard must ignore it because that request was cancelled.
+    await act(async () => {
+      resolveStale({ data: { prefs: {} } });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/Welcome to Jabali Panel/)).not.toBeInTheDocument();
+  });
+});
+
+describe("QuickStartGuide persistence (AC3)", () => {
+  it("'I'll read later' closes without persisting", async () => {
+    getMock.mockResolvedValue({ data: { prefs: {} } });
+    renderGuide();
+    await screen.findByText(/Welcome to Jabali Panel/);
+    fireEvent.click(screen.getByText(/read later/));
+    // The whole point of "read later" is that it persists nothing (both footer
+    // buttons close the guide; only "Never show again" writes a preference).
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("'Never show again' persists the audience's own preference key", async () => {
+    getMock.mockResolvedValue({ data: { prefs: {} } });
+    renderGuide(audience("quickstart_admin"));
+    await screen.findByText(/Welcome to Jabali Panel/);
+    fireEvent.click(screen.getByText(/Never show again/));
+    expect(putMock).toHaveBeenCalledWith("/me/ui-prefs/quickstart_admin", {
+      value: "1",
+    });
+  });
+});
+
+// AC4 — the real shell Adapters must keep their own copy, destinations, and
+// support variant. The apiClient / AuthContext mocks above resolve by module
+// id, so they cover each adapter's transitive imports too.
+describe("shell adapters preserve their audience (AC4)", () => {
+  it("admin: admin steps, admin routes, Support link + docs emoji", async () => {
+    getMock.mockResolvedValue({ data: { prefs: {} } });
+    render(
+      <MemoryRouter>
+        <AdminQuickStart />
+      </MemoryRouter>,
+    );
+    await screen.findByText(/Welcome to Jabali Panel/);
+    expect(screen.getByText("Server Settings").closest("a")).toHaveAttribute(
+      "href",
+      "/jabali-admin/settings",
+    );
+    expect(screen.getByText("Support").closest("a")).toHaveAttribute(
+      "href",
+      "/jabali-admin/support",
+    );
+    expect(screen.getByLabelText("docs")).toBeInTheDocument();
+  });
+
+  it("tenant: tenant steps, tenant routes, docs-only support", async () => {
+    getMock.mockResolvedValue({ data: { prefs: {} } });
+    render(
+      <MemoryRouter>
+        <UserQuickStart />
+      </MemoryRouter>,
+    );
+    await screen.findByText(/Welcome to Jabali Panel/);
+    expect(
+      screen.getByText("Personal API Tokens").closest("a"),
+    ).toHaveAttribute("href", "/jabali-panel/api-tokens");
+    // No admin-style Support link, no 📖 emoji — docs-only.
+    expect(screen.queryByText("Support")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("docs")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/components/quickstart/QuickStartGuide.tsx
+++ b/panel-ui/src/components/quickstart/QuickStartGuide.tsx
@@ -1,0 +1,218 @@
+// QuickStartGuide — shared first-login welcome + quick-start guide Module.
+// The admin and tenant shells were byte-identical here except for three
+// things: the preference key, the step definitions, and the support callout.
+// Those deltas live in the per-shell audience (see QuickStartAudience); the
+// Module owns loading, cancellation, the display policy, persistence,
+// navigation, and layout so the two shells cannot drift.
+import { useEffect, useState, type ReactNode } from "react";
+import { Button, Modal, theme, Typography } from "antd";
+import { CheckOutlined, ClockCircleOutlined } from "@icons";
+import { Link } from "react-router";
+
+import { useAuth } from "../../auth/AuthContext";
+import { apiClient } from "../../apiClient";
+
+export interface QuickStartStep {
+  number: number;
+  title: string;
+  desc: string;
+  href: string;
+  color: string; // accent for the number badge
+}
+
+export interface QuickStartAudience {
+  // Server-side dismissal key, per shell (e.g. "quickstart_admin").
+  prefKey: string;
+  // The six landing destinations for this shell.
+  steps: QuickStartStep[];
+  // The support callout's inner content — icon + copy + optional emoji.
+  // The admin variant links to Support and shows a 📖; the tenant variant is
+  // docs-only. `close` is passed so an in-app link can close the modal on
+  // navigate. Kept as a render prop so each shell preserves its exact copy,
+  // destinations, and support variant.
+  renderSupport: (close: () => void) => ReactNode;
+}
+
+const hexAlpha = (hex: string, alpha: number) => {
+  const n = parseInt(hex.slice(1), 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+export function QuickStartGuide({ audience }: { audience: QuickStartAudience }) {
+  const { token } = theme.useToken();
+  const borderBase = token.colorBorderSecondary;
+  const borderHover = token.colorBorder;
+  const bgSubtle = token.colorFillTertiary;
+  const bgSubtleHover = token.colorFillSecondary;
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    let cancelled = false;
+    // Server-side dismissal (GH #218) so it survives browsers that clear
+    // storage on close. On error, leave the modal closed — don't pester.
+    apiClient
+      .get<{ prefs: Record<string, string> }>("/me/ui-prefs")
+      .then(({ data }) => {
+        if (!cancelled && data.prefs?.[audience.prefKey] !== "1") setOpen(true);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id, audience.prefKey]);
+
+  const close = () => setOpen(false);
+
+  const dismissForever = () => {
+    setOpen(false);
+    // Fire-and-forget persist; failure just means it may reappear later.
+    apiClient.put(`/me/ui-prefs/${audience.prefKey}`, { value: "1" }).catch(() => {});
+  };
+
+  return (
+    <Modal
+      title={
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "nowrap", minWidth: 0 }}>
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 10,
+              background: hexAlpha("#3b82f6", 0.18),
+              color: "#3b82f6",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 20,
+              flexShrink: 0,
+            }}
+          >
+            <span role="img" aria-label="jabali">
+              🐃
+            </span>
+          </div>
+          <Typography.Title level={4} style={{ margin: 0, minWidth: 0, fontSize: "clamp(16px, 4.5vw, 22px)" }}>
+            Welcome to Jabali Panel!{" "}
+            <span role="img" aria-label="wave">
+              👋
+            </span>
+          </Typography.Title>
+        </div>
+      }
+      open={open}
+      onCancel={close}
+      width={960}
+      style={{ maxWidth: "calc(100vw - 32px)" }}
+      styles={{ wrapper: { padding: "16px" } }}
+      destroyOnClose
+      centered
+      footer={[
+        <Button key="later" icon={<ClockCircleOutlined />} onClick={close}>
+          I&apos;ll read later
+        </Button>,
+        <Button
+          key="never"
+          type="primary"
+          icon={<CheckOutlined />}
+          onClick={dismissForever}
+        >
+          Never show again
+        </Button>,
+      ]}
+    >
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 20 }}>
+        Glad to have you here. A short tour of what to do first — click any
+        item to jump straight to it:
+      </Typography.Paragraph>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          gap: 12,
+        }}
+      >
+        {audience.steps.map((step) => {
+          return (
+            <Link
+              key={step.number}
+              to={step.href}
+              onClick={close}
+              style={{
+                display: "block",
+                padding: "14px 16px",
+                overflow: "hidden",
+                borderRadius: 12,
+                border: `1px solid ${borderBase}`,
+                background: bgSubtle,
+                color: "inherit",
+                textDecoration: "none",
+                transition: "background 0.15s, border-color 0.15s",
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.background =
+                  bgSubtleHover;
+                (e.currentTarget as HTMLAnchorElement).style.borderColor =
+                  borderHover;
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.background =
+                  bgSubtle;
+                (e.currentTarget as HTMLAnchorElement).style.borderColor =
+                  borderBase;
+              }}
+            >
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  background: step.color,
+                  color: "white",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 15,
+                  fontWeight: 700,
+                  float: "left",
+                  marginRight: 14,
+                  marginBottom: 4,
+                }}
+              >
+                {step.number}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <Typography.Text strong style={{ fontSize: 16, display: "block" }}>
+                  {step.title}
+                </Typography.Text>
+                <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+                  {step.desc}
+                </Typography.Text>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      <div
+        style={{
+          marginTop: 20,
+          padding: "16px 18px",
+          borderRadius: 12,
+          background: hexAlpha("#3b82f6", 0.08),
+          border: "1px solid " + hexAlpha("#3b82f6", 0.25),
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+        }}
+      >
+        {audience.renderSupport(close)}
+      </div>
+    </Modal>
+  );
+}

--- a/panel-ui/src/shells/admin/QuickStartModal.tsx
+++ b/panel-ui/src/shells/admin/QuickStartModal.tsx
@@ -1,42 +1,25 @@
-// QuickStartModal — first-login welcome + quick-start guide for the
-// admin shell. Per-admin localStorage dismiss; "I'll read later" only
-// closes for the session, "Never show again" persists.
-import { useEffect, useState, type ComponentType, type CSSProperties } from "react";
-import { Button, Modal, theme, Typography } from "antd";
-import {
-  AppstoreAddOutlined,
-  CheckOutlined,
-  ClockCircleOutlined,
-  DatabaseOutlined,
-  GlobalOutlined,
-  InboxOutlined,
-  QuestionCircleOutlined,
-  SafetyOutlined,
-  TeamOutlined,
-} from "@icons";
+// QuickStartModal — admin-shell adapter for the shared QuickStartGuide.
+// Supplies the admin audience: preference key, the six admin destinations,
+// and the admin support callout (Support link + docs + 📖). All loading,
+// dismissal, and layout live in the Module.
+import { Typography } from "antd";
+import { QuestionCircleOutlined } from "@icons";
 import { Link } from "react-router";
 
-import { useAuth } from "../../auth/AuthContext";
-import { apiClient } from "../../apiClient";
+import {
+  QuickStartGuide,
+  type QuickStartAudience,
+  type QuickStartStep,
+} from "../../components/quickstart/QuickStartGuide";
 
 const PREF_KEY = "quickstart_admin";
 
-interface Step {
-  number: number;
-  title: string;
-  desc: string;
-  href: string;
-  icon: ComponentType<{ style?: CSSProperties }>;
-  color: string; // accent for icon tile + number badge
-}
-
-const STEPS: Step[] = [
+const STEPS: QuickStartStep[] = [
   {
     number: 1,
     title: "Server Settings",
     desc: "Set your hostname, primary IPs, and nameservers (ns1/ns2).",
     href: "/jabali-admin/settings",
-    icon: DatabaseOutlined,
     color: "#2563eb", // blue
   },
   {
@@ -44,7 +27,6 @@ const STEPS: Step[] = [
     title: "Hosting Packages",
     desc: "Define disk/bandwidth quota, PHP version, and resource limits for tenants.",
     href: "/jabali-admin/packages",
-    icon: InboxOutlined,
     color: "#10b981", // green
   },
   {
@@ -52,7 +34,6 @@ const STEPS: Step[] = [
     title: "Users",
     desc: "Create your first tenant account.",
     href: "/jabali-admin/users",
-    icon: TeamOutlined,
     color: "#a855f7", // purple
   },
   {
@@ -60,7 +41,6 @@ const STEPS: Step[] = [
     title: "Domains",
     desc: "Add a domain — vhost, DNS zone, and SSL provision automatically.",
     href: "/jabali-admin/domains",
-    icon: GlobalOutlined,
     color: "#f59e0b", // amber
   },
   {
@@ -68,7 +48,6 @@ const STEPS: Step[] = [
     title: "SSL Manager",
     desc: "Let's Encrypt issues automatically. Track + retry from here.",
     href: "/jabali-admin/ssl",
-    icon: SafetyOutlined,
     color: "#22c55e", // emerald
   },
   {
@@ -76,216 +55,44 @@ const STEPS: Step[] = [
     title: "Applications",
     desc: "1-click install WordPress and other apps for any user.",
     href: "/jabali-admin/applications",
-    icon: AppstoreAddOutlined,
     color: "#3b82f6", // bright blue
   },
 ];
 
-const hexAlpha = (hex: string, alpha: number) => {
-  const n = parseInt(hex.slice(1), 16);
-  const r = (n >> 16) & 0xff;
-  const g = (n >> 8) & 0xff;
-  const b = n & 0xff;
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+const AUDIENCE: QuickStartAudience = {
+  prefKey: PREF_KEY,
+  steps: STEPS,
+  renderSupport: (close) => (
+    <>
+      <QuestionCircleOutlined
+        style={{ fontSize: 24, color: "#3b82f6", flexShrink: 0 }}
+      />
+      <Typography.Text style={{ flex: 1 }}>
+        Stuck? Use{" "}
+        <Link to="/jabali-admin/support" onClick={close}>
+          Support
+        </Link>{" "}
+        or read the docs at{" "}
+        <a
+          href="https://jabali-panel.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          jabali-panel.com
+        </a>
+        .
+      </Typography.Text>
+      <span
+        role="img"
+        aria-label="docs"
+        style={{ fontSize: 28, flexShrink: 0 }}
+      >
+        📖
+      </span>
+    </>
+  ),
 };
 
 export function QuickStartModal() {
-  const { token } = theme.useToken();
-  const borderBase = token.colorBorderSecondary;
-  const borderHover = token.colorBorder;
-  const bgSubtle = token.colorFillTertiary;
-  const bgSubtleHover = token.colorFillSecondary;
-  const { user } = useAuth();
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    if (!user?.id) return;
-    let cancelled = false;
-    // Server-side dismissal (GH #218) so it survives browsers that clear
-    // storage on close. On error, leave the modal closed — don't pester.
-    apiClient
-      .get<{ prefs: Record<string, string> }>("/me/ui-prefs")
-      .then(({ data }) => {
-        if (!cancelled && data.prefs?.[PREF_KEY] !== "1") setOpen(true);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [user?.id]);
-
-  const close = () => setOpen(false);
-
-  const dismissForever = () => {
-    setOpen(false);
-    // Fire-and-forget persist; failure just means it may reappear later.
-    apiClient.put(`/me/ui-prefs/${PREF_KEY}`, { value: "1" }).catch(() => {});
-  };
-
-  return (
-    <Modal
-      title={
-        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "nowrap", minWidth: 0 }}>
-          <div
-            style={{
-              width: 40,
-              height: 40,
-              borderRadius: 10,
-              background: hexAlpha("#3b82f6", 0.18),
-              color: "#3b82f6",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 20,
-              flexShrink: 0,
-            }}
-          >
-            <span role="img" aria-label="jabali">
-              🐃
-            </span>
-          </div>
-          <Typography.Title level={4} style={{ margin: 0, minWidth: 0, fontSize: "clamp(16px, 4.5vw, 22px)" }}>
-            Welcome to Jabali Panel!{" "}
-            <span role="img" aria-label="wave">
-              👋
-            </span>
-          </Typography.Title>
-        </div>
-      }
-      open={open}
-      onCancel={close}
-      width={960}
-      style={{ maxWidth: "calc(100vw - 32px)" }}
-      styles={{ wrapper: { padding: "16px" } }}
-      destroyOnClose
-      centered
-      footer={[
-        <Button key="later" icon={<ClockCircleOutlined />} onClick={close}>
-          I&apos;ll read later
-        </Button>,
-        <Button
-          key="never"
-          type="primary"
-          icon={<CheckOutlined />}
-          onClick={dismissForever}
-        >
-          Never show again
-        </Button>,
-      ]}
-    >
-      <Typography.Paragraph type="secondary" style={{ marginBottom: 20 }}>
-        Glad to have you here. A short tour of what to do first — click any
-        item to jump straight to it:
-      </Typography.Paragraph>
-
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
-          gap: 12,
-        }}
-      >
-        {STEPS.map((step) => {
-          return (
-            <Link
-              key={step.number}
-              to={step.href}
-              onClick={close}
-              style={{
-                display: "block",
-                padding: "14px 16px",
-                overflow: "hidden",
-                borderRadius: 12,
-                border: `1px solid ${borderBase}`,
-                background: bgSubtle,
-                color: "inherit",
-                textDecoration: "none",
-                transition: "background 0.15s, border-color 0.15s",
-              }}
-              onMouseEnter={(e) => {
-                (e.currentTarget as HTMLAnchorElement).style.background =
-                  bgSubtleHover;
-                (e.currentTarget as HTMLAnchorElement).style.borderColor =
-                  borderHover;
-              }}
-              onMouseLeave={(e) => {
-                (e.currentTarget as HTMLAnchorElement).style.background =
-                  bgSubtle;
-                (e.currentTarget as HTMLAnchorElement).style.borderColor =
-                  borderBase;
-              }}
-            >
-              <div
-                style={{
-                  width: 36,
-                  height: 36,
-                  borderRadius: "50%",
-                  background: step.color,
-                  color: "white",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontSize: 15,
-                  fontWeight: 700,
-                  float: "left",
-                  marginRight: 14,
-                  marginBottom: 4,
-                }}
-              >
-                {step.number}
-              </div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <Typography.Text strong style={{ fontSize: 16, display: "block" }}>
-                  {step.title}
-                </Typography.Text>
-                <Typography.Text type="secondary" style={{ fontSize: 13 }}>
-                  {step.desc}
-                </Typography.Text>
-              </div>
-              
-            </Link>
-          );
-        })}
-      </div>
-
-      <div
-        style={{
-          marginTop: 20,
-          padding: "16px 18px",
-          borderRadius: 12,
-          background: hexAlpha("#3b82f6", 0.08),
-          border: "1px solid " + hexAlpha("#3b82f6", 0.25),
-          display: "flex",
-          alignItems: "center",
-          gap: 14,
-        }}
-      >
-        <QuestionCircleOutlined
-          style={{ fontSize: 24, color: "#3b82f6", flexShrink: 0 }}
-        />
-        <Typography.Text style={{ flex: 1 }}>
-          Stuck? Use{" "}
-          <Link to="/jabali-admin/support" onClick={close}>
-            Support
-          </Link>{" "}
-          or read the docs at{" "}
-          <a
-            href="https://jabali-panel.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            jabali-panel.com
-          </a>
-          .
-        </Typography.Text>
-        <span
-          role="img"
-          aria-label="docs"
-          style={{ fontSize: 28, flexShrink: 0 }}
-        >
-          📖
-        </span>
-      </div>
-    </Modal>
-  );
+  return <QuickStartGuide audience={AUDIENCE} />;
 }

--- a/panel-ui/src/shells/user/QuickStartModal.tsx
+++ b/panel-ui/src/shells/user/QuickStartModal.tsx
@@ -1,42 +1,24 @@
-// QuickStartModal — first-login welcome + quick-start guide for the
-// tenant (user) shell. Per-user localStorage dismiss; "I'll read later"
-// only closes for the session, "Never show again" persists.
-import { useEffect, useState, type ComponentType, type CSSProperties } from "react";
-import { Button, Modal, theme, Typography } from "antd";
-import {
-  ApiOutlined,
-  AppstoreAddOutlined,
-  CheckOutlined,
-  ClockCircleOutlined,
-  DatabaseOutlined,
-  GlobalOutlined,
-  MailOutlined,
-  QuestionCircleOutlined,
-  SaveOutlined,
-} from "@icons";
-import { Link } from "react-router";
+// QuickStartModal — tenant-shell adapter for the shared QuickStartGuide.
+// Supplies the tenant audience: preference key, the six tenant destinations,
+// and the tenant support callout (docs-only — no Support link, no emoji). All
+// loading, dismissal, and layout live in the Module.
+import { Typography } from "antd";
+import { QuestionCircleOutlined } from "@icons";
 
-import { useAuth } from "../../auth/AuthContext";
-import { apiClient } from "../../apiClient";
+import {
+  QuickStartGuide,
+  type QuickStartAudience,
+  type QuickStartStep,
+} from "../../components/quickstart/QuickStartGuide";
 
 const PREF_KEY = "quickstart_user";
 
-interface Step {
-  number: number;
-  title: string;
-  desc: string;
-  href: string;
-  icon: ComponentType<{ style?: CSSProperties }>;
-  color: string; // accent for icon tile + number badge
-}
-
-const STEPS: Step[] = [
+const STEPS: QuickStartStep[] = [
   {
     number: 1,
     title: "Domains",
     desc: "Add your first domain — Jabali provisions the vhost, DNS zone, and SSL automatically.",
     href: "/jabali-panel/domains",
-    icon: GlobalOutlined,
     color: "#f59e0b", // amber
   },
   {
@@ -44,7 +26,6 @@ const STEPS: Step[] = [
     title: "Mail",
     desc: "Create mailboxes + forwarders on your mail-enabled domains.",
     href: "/jabali-panel/mail/mailboxes",
-    icon: MailOutlined,
     color: "#10b981", // green
   },
   {
@@ -52,7 +33,6 @@ const STEPS: Step[] = [
     title: "Applications",
     desc: "1-click install WordPress, Joomla, Drupal, and more onto any domain.",
     href: "/jabali-panel/applications",
-    icon: AppstoreAddOutlined,
     color: "#3b82f6", // bright blue
   },
   {
@@ -60,7 +40,6 @@ const STEPS: Step[] = [
     title: "Databases",
     desc: "Create MariaDB / Postgres databases + per-tenant users.",
     href: "/jabali-panel/databases",
-    icon: DatabaseOutlined,
     color: "#2563eb", // blue
   },
   {
@@ -68,7 +47,6 @@ const STEPS: Step[] = [
     title: "Backups",
     desc: "Schedule snapshots or trigger an on-demand backup; restore in one click.",
     href: "/jabali-panel/backups",
-    icon: SaveOutlined,
     color: "#a855f7", // purple
   },
   {
@@ -76,205 +54,33 @@ const STEPS: Step[] = [
     title: "Personal API Tokens",
     desc: "Mint a token for scripting / DDNS — same key works in routers, ddclient, CI.",
     href: "/jabali-panel/api-tokens",
-    icon: ApiOutlined,
     color: "#22c55e", // emerald
   },
 ];
 
-const hexAlpha = (hex: string, alpha: number) => {
-  const n = parseInt(hex.slice(1), 16);
-  const r = (n >> 16) & 0xff;
-  const g = (n >> 8) & 0xff;
-  const b = n & 0xff;
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+const AUDIENCE: QuickStartAudience = {
+  prefKey: PREF_KEY,
+  steps: STEPS,
+  renderSupport: () => (
+    <>
+      <QuestionCircleOutlined
+        style={{ fontSize: 22, color: "#3b82f6", flexShrink: 0 }}
+      />
+      <Typography.Text style={{ flex: 1, minWidth: 0 }}>
+        Stuck? Read the docs at{" "}
+        <a
+          href="https://jabali-panel.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          jabali-panel.com
+        </a>
+        .
+      </Typography.Text>
+    </>
+  ),
 };
 
 export function QuickStartModal() {
-  const { token } = theme.useToken();
-  const borderBase = token.colorBorderSecondary;
-  const borderHover = token.colorBorder;
-  const bgSubtle = token.colorFillTertiary;
-  const bgSubtleHover = token.colorFillSecondary;
-  const { user } = useAuth();
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    if (!user?.id) return;
-    let cancelled = false;
-    // Server-side dismissal (GH #218) so it survives browsers that clear
-    // storage on close. On error, leave the modal closed — don't pester.
-    apiClient
-      .get<{ prefs: Record<string, string> }>("/me/ui-prefs")
-      .then(({ data }) => {
-        if (!cancelled && data.prefs?.[PREF_KEY] !== "1") setOpen(true);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [user?.id]);
-
-  const close = () => setOpen(false);
-
-  const dismissForever = () => {
-    setOpen(false);
-    // Fire-and-forget persist; failure just means it may reappear later.
-    apiClient.put(`/me/ui-prefs/${PREF_KEY}`, { value: "1" }).catch(() => {});
-  };
-
-  return (
-    <Modal
-      title={
-        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "nowrap", minWidth: 0 }}>
-          <div
-            style={{
-              width: 40,
-              height: 40,
-              borderRadius: 10,
-              background: hexAlpha("#3b82f6", 0.18),
-              color: "#3b82f6",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 20,
-              flexShrink: 0,
-            }}
-          >
-            <span role="img" aria-label="jabali">
-              🐃
-            </span>
-          </div>
-          <Typography.Title level={4} style={{ margin: 0, minWidth: 0, fontSize: "clamp(16px, 4.5vw, 22px)" }}>
-            Welcome to Jabali Panel!{" "}
-            <span role="img" aria-label="wave">
-              👋
-            </span>
-          </Typography.Title>
-        </div>
-      }
-      open={open}
-      onCancel={close}
-      width={960}
-      style={{ maxWidth: "calc(100vw - 32px)" }}
-      styles={{ wrapper: { padding: "16px" } }}
-      destroyOnClose
-      centered
-      footer={[
-        <Button key="later" icon={<ClockCircleOutlined />} onClick={close}>
-          I&apos;ll read later
-        </Button>,
-        <Button
-          key="never"
-          type="primary"
-          icon={<CheckOutlined />}
-          onClick={dismissForever}
-        >
-          Never show again
-        </Button>,
-      ]}
-    >
-      <Typography.Paragraph type="secondary" style={{ marginBottom: 20 }}>
-        Glad to have you here. A short tour of what to do first — click any
-        item to jump straight to it:
-      </Typography.Paragraph>
-
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
-          gap: 12,
-        }}
-      >
-        {STEPS.map((step) => {
-          return (
-            <Link
-              key={step.number}
-              to={step.href}
-              onClick={close}
-              style={{
-                display: "block",
-                padding: "14px 16px",
-                overflow: "hidden",
-                borderRadius: 12,
-                border: `1px solid ${borderBase}`,
-                background: bgSubtle,
-                color: "inherit",
-                textDecoration: "none",
-                transition: "background 0.15s, border-color 0.15s",
-              }}
-              onMouseEnter={(e) => {
-                (e.currentTarget as HTMLAnchorElement).style.background =
-                  bgSubtleHover;
-                (e.currentTarget as HTMLAnchorElement).style.borderColor =
-                  borderHover;
-              }}
-              onMouseLeave={(e) => {
-                (e.currentTarget as HTMLAnchorElement).style.background =
-                  bgSubtle;
-                (e.currentTarget as HTMLAnchorElement).style.borderColor =
-                  borderBase;
-              }}
-            >
-              <div
-                style={{
-                  width: 36,
-                  height: 36,
-                  borderRadius: "50%",
-                  background: step.color,
-                  color: "white",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontSize: 15,
-                  fontWeight: 700,
-                  float: "left",
-                  marginRight: 14,
-                  marginBottom: 4,
-                }}
-              >
-                {step.number}
-              </div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <Typography.Text strong style={{ fontSize: 16, display: "block" }}>
-                  {step.title}
-                </Typography.Text>
-                <Typography.Text type="secondary" style={{ fontSize: 13 }}>
-                  {step.desc}
-                </Typography.Text>
-              </div>
-              
-            </Link>
-          );
-        })}
-      </div>
-
-      <div
-        style={{
-          marginTop: 20,
-          padding: "16px 18px",
-          borderRadius: 12,
-          background: hexAlpha("#3b82f6", 0.08),
-          border: "1px solid " + hexAlpha("#3b82f6", 0.25),
-          display: "flex",
-          alignItems: "center",
-          gap: 14,
-        }}
-      >
-        <QuestionCircleOutlined
-          style={{ fontSize: 22, color: "#3b82f6", flexShrink: 0 }}
-        />
-        <Typography.Text style={{ flex: 1, minWidth: 0 }}>
-          Stuck? Read the docs at{" "}
-          <a
-            href="https://jabali-panel.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            jabali-panel.com
-          </a>
-          .
-        </Typography.Text>
-      </div>
-    </Modal>
-  );
+  return <QuickStartGuide audience={AUDIENCE} />;
 }


### PR DESCRIPTION
## What

The admin and tenant shells each carried a near-identical `QuickStartModal` —
the first-login welcome dialog, the `/me/ui-prefs` load with its cancelled-flag
guard, the "read later" / "never show again" dismissal, and the whole layout.
They differed in only three things: the preference key, the six landing steps,
and the support callout. The classic drift trap — a fix to the load policy or
the footer lands on one shell and not the other.

This extracts the guide into `components/quickstart/QuickStartGuide`. The two
shells become thin **Adapters** that supply a `QuickStartAudience`:

- `prefKey` — the server-side dismissal key (`quickstart_admin` / `quickstart_user`),
- `steps` — the six destinations for that shell,
- `renderSupport(close)` — the support callout's inner content, so each shell
  keeps its **exact** copy and variant (admin links to Support and shows a 📖;
  the tenant is docs-only).

The Module owns everything that was byte-identical across the two files: the
`GET /me/ui-prefs` load and its display policy, the late-response cancel guard,
the fire-and-forget `PUT` on "Never show again", navigation, and the dialog
layout. This is the third UI slice on the audience-policy shape from **JAB-299**
(shared DNS Zone Inventory, #1525).

## Acceptance criteria (JAB-297)

- **Missing preference opens; dismissed stays closed; failed lookup stays
  closed** — MET; the display policy lives once in the Module and is asserted
  in all three branches (AC1 tests).
- **Late responses after unmount are ignored** — MET; the `cancelled` flag is
  carried verbatim. Two tests: an unmount case (a post-unmount resolve is a
  no-op that doesn't throw) and — the load-bearing one — a *supersede* case
  (change the audience so the effect's cleanup cancels the in-flight request,
  then resolve it with an "open" answer; the guard keeps the mounted guide
  shut). The supersede case is what actually distinguishes the guard: React 18
  dropped the unmounted-setState warning, so the unmount case alone can't.
- **"Read later" writes nothing; "Never show again" writes the correct audience
  key** — MET; asserted (`putMock` not called vs. `PUT /me/ui-prefs/<prefKey>`
  with the audience's own key).
- **Admin and tenant definitions preserve their copy, destinations, and support
  variants** — MET; two tests render the *real* admin/user adapters and assert
  admin steps + `/jabali-admin/*` routes + Support link + 📖 vs. tenant steps +
  `/jabali-panel/*` routes + docs-only (no Support link, no emoji).
- **The unused step-icon field is either rendered intentionally or removed** —
  **removed.** The `icon` field was assigned on every step but never rendered
  (the number badge uses `color`, which is kept). It was the only reason each
  file imported half a dozen antd icons; dropping it deletes those dead imports.
- **Both shell layouts mount thin audience Adapters** — MET; each
  `QuickStartModal.tsx` is now an audience object plus
  `<QuickStartGuide audience={…} />`. The export name and path are unchanged, so
  `AdminLayout` / `UserLayout` mount them without edits.

## Notes for reviewers

- **Zero pixels moved.** The support callout is byte-preserved per shell,
  including the 24px (admin) vs. 22px (tenant) `QuestionCircleOutlined` size and
  the tenant's extra `minWidth: 0`. That was the reason `renderSupport` owns the
  whole inner callout region rather than just a copy string — the deltas include
  style, so a render prop preserves them exactly with no per-property seam.
- **Effect deps** went from `[user?.id]` to `[user?.id, audience.prefKey]`.
  `prefKey` is a per-shell module constant, so the effect fires identically in
  production; the added dep is correct for hook exhaustive-deps and is what makes
  the supersede test possible.
- **`destroyOnClose` deprecation** — antd now prefers `destroyOnHidden`; the
  warning is pre-existing (carried forward unchanged from both originals), not
  introduced here.
- UI-only, no live/agent/reconciler/migration surface — no box verification;
  `tsc -b` + vitest + `vite build` + eslint is proportionate.
- `App.tsx`, `AdminLayout.tsx`, `UserLayout.tsx` untouched.

## Test plan

- [x] `npx vitest run src/components/quickstart/QuickStartGuide.test.tsx` — 9/9
      (AC1 ×3, AC2 ×2, AC3 ×2, AC4 ×2)
- [x] `npx tsc -b` clean
- [x] `npx vite build` clean
- [x] `npx eslint` on the four files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
