### PR TITLE
feat(backup): restore the system leg from an uploaded container via `jabali system restore --from-tar` (GH #1408)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -5284,6 +5284,7 @@ jabali system restore [flags]
 - `--apply-stage` — restrict apply to named stages (repeatable). Empty = panel_db + panel_config + tls (the safe defaults) (default `[]`)
 - `--credentials-ref` — absolute path to env file with backend creds (root:root 0600)
 - `--force` — required — restore overwrites the running panel
+- `--from-tar` — restore the SYSTEM leg from a downloaded Full Server container (.tar) instead of a restic repo (GH #1408). Applies panel_db + panel_config + tls by default
 - `--include-accounts` — also restore each linked account
 - `--interactive` — force interactive prompts even when --remote-url is set
 - `--password` — restic password (literal; overrides --password-file). Avoid in shell history; prefer --interactive

--- a/panel-agent/internal/commands/system_fullbackup_apply_system.go
+++ b/panel-agent/internal/commands/system_fullbackup_apply_system.go
@@ -1,0 +1,289 @@
+package commands
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+const (
+	sysApplyStagePrefix = "sysapply-"
+	sysApplyStageTTL    = 24 * time.Hour
+)
+
+// system_fullbackup_apply_system.go — GH #1408 slice 3 (Option C).
+//
+// Restore the SYSTEM leg (panel_db / panel_config / tls) from an uploaded
+// Full Server container, WITHOUT a restic repo. The existing `system.restore`
+// verb only restores from restic; this one re-sources the very same apply
+// phase (applySystemRestore) from the container's local `system.tar.zst`.
+//
+// It is CLI-triggered on purpose (`jabali system restore --from-tar`): a
+// system apply loads the backup's Kratos identity DB, so driving it from the
+// panel would log out the very admin who clicked it on the real cross-server
+// DR path. The CLI stops jabali-panel before dispatch and restarts it after;
+// jabali-agent (this process) stays up and owns the whole apply.
+//
+// The container's system.tar.zst is `<job_id>/<stage>/…` (exactly what the
+// packer wrote — see packOneJob), so after a two-step extract the job dir is a
+// materialized stage tree identical to the one systemRestoreHandler feeds
+// applySystemRestore. The manifest is reconstructed FROM that tree (one
+// panel_db stage per <db>.sql), so old containers work unchanged.
+
+type systemFullbackupApplySystemParams struct {
+	// ContainerPath is the uploaded Full Server container (the plain outer tar).
+	ContainerPath string `json:"container_path"`
+	// Apply=false is a RECON: extract + reconstruct the stage list and report
+	// what WOULD be applied, touching nothing live. Apply=true runs the real
+	// panel_db/panel_config/tls load.
+	Apply bool `json:"apply"`
+	// ApplyStages restricts the apply to named stages (empty = the auto set:
+	// panel_db, panel_config, tls). Mirrors system.restore's apply_stages.
+	ApplyStages []string `json:"apply_stages,omitempty"`
+}
+
+type systemFullbackupApplySystemResult struct {
+	JobID          string   `json:"job_id"`
+	StagesDetected []string `json:"stages_detected"`
+	Applied        []string `json:"applied,omitempty"`
+	ApplyWarnings  []string `json:"apply_warnings,omitempty"`
+	Recon          bool     `json:"recon"`
+}
+
+// systemFullbackupApplySystemHandler applies (or recons) the system leg of an
+// uploaded container. The container is confined under the uploads root exactly
+// like restore_from_tar / extract_uploaded.
+func systemFullbackupApplySystemHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p systemFullbackupApplySystemParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, bkInvalidArg(fmt.Sprintf("invalid params: %v", err))
+	}
+	clean, aerr := fullContainerPathClean(p.ContainerPath)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if err := hostreserve.CheckReserve("/var/lib/jabali-backups", 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "system-restore staging is under the host disk reserve: " + err.Error()}
+	}
+	// A defer only reaps a live agent; the fleet agent auto-restarts nightly and a
+	// dropped CLI leaks its staged copy — sweep older stages/copies at entry.
+	evictStaleSysApplyStages()
+
+	stage := filepath.Join(restoreUploadsRoot, sysApplyStagePrefix+randomULID())
+	_ = os.RemoveAll(stage)
+	if err := os.MkdirAll(stage, 0o750); err != nil {
+		return nil, bkInternal("mkdir stage", err)
+	}
+	// Synchronous handler, agent-lifetime — safe to clean up on return.
+	defer os.RemoveAll(stage)
+
+	// 1. pull ONLY the system leg out of the container. The container also holds
+	// every users/*.tar.zst inner; a full extract would write (then delete)
+	// potentially hundreds of GB to reach a ~50MB system tree — the last thing a
+	// disk-stressed DR box can afford.
+	systemInner := filepath.Join(stage, "system.tar.zst")
+	if err := extractSystemInnerFromContainer(clean, systemInner); err != nil {
+		return nil, bkInvalidArg(err.Error())
+	}
+
+	// 2. inner system.tar.zst (zstd tar) → stage/system, yielding <job_id>/<stage>/…
+	extractRoot := filepath.Join(stage, "system")
+	if err := os.MkdirAll(extractRoot, 0o750); err != nil {
+		return nil, bkInternal("mkdir extract root", err)
+	}
+	if _, err := safeExtractZstdTar(ctx, systemInner, extractRoot); err != nil {
+		return nil, bkInvalidArg("system leg rejected: " + err.Error())
+	}
+
+	jobDir, jobID, jerr := soleJobDir(extractRoot)
+	if jerr != nil {
+		return nil, bkInvalidArg(jerr.Error())
+	}
+
+	stages, err := reconstructSystemStages(jobDir)
+	if err != nil {
+		return nil, bkInvalidArg(err.Error())
+	}
+	if len(stages) == 0 {
+		return nil, bkInvalidArg("no recognizable system stages in the container")
+	}
+
+	out := systemFullbackupApplySystemResult{JobID: jobID, Recon: !p.Apply}
+	for _, st := range stages {
+		if len(st.Items) > 0 {
+			out.StagesDetected = append(out.StagesDetected, st.Name+":"+strings.Join(st.Items, ","))
+		} else {
+			out.StagesDetected = append(out.StagesDetected, st.Name)
+		}
+	}
+
+	if !p.Apply {
+		return out, nil
+	}
+
+	applied, warnings := applySystemRestore(ctx, jobDir, stages, p.ApplyStages)
+	out.Applied = applied
+	out.ApplyWarnings = warnings
+
+	// Post-apply MariaDB account password sync — the cross-host panel_db load
+	// leaves service accounts on the destination's old passwords while
+	// /etc/jabali-panel/<svc>-db-password now holds the source's. Same fix the
+	// restic path applies (see systemRestoreHandler).
+	dbResyncs, dbWarnings := resyncDBAccountPasswords(ctx)
+	out.Applied = append(out.Applied, dbResyncs...)
+	out.ApplyWarnings = append(out.ApplyWarnings, dbWarnings...)
+	return out, nil
+}
+
+// soleJobDir returns the single <job_id>/ directory the packer wrote under the
+// extract root. The container's system leg always tars exactly one job dir.
+func soleJobDir(extractRoot string) (dir, jobID string, err error) {
+	ents, rerr := os.ReadDir(extractRoot)
+	if rerr != nil {
+		return "", "", fmt.Errorf("read extracted system leg: %v", rerr)
+	}
+	var dirs []string
+	for _, e := range ents {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	if len(dirs) != 1 {
+		return "", "", fmt.Errorf("expected exactly one job dir in the system leg, found %d", len(dirs))
+	}
+	return filepath.Join(extractRoot, dirs[0]), dirs[0], nil
+}
+
+// knownSystemStages is the set of stage dir names the packer can write. Only
+// panel_db/panel_config/tls are auto-applied by applySystemRestore; the rest
+// are reconstructed so an explicit --apply-stage can reach them and so
+// panel_config's ownership-normalization can read os_users.
+func knownSystemStages() map[string]bool {
+	return map[string]bool{
+		backup.StagePanelDB:       true,
+		backup.StagePanelConfig:   true,
+		backup.StageServiceConfig: true,
+		backup.StageMailState:     true,
+		backup.StageTLS:           true,
+		backup.StageSecurity:      true,
+		backup.StageOSUsers:       true,
+		backup.StageDataState:     true,
+	}
+}
+
+// reconstructSystemStages rebuilds the manifest stage list from the extracted
+// job tree. panel_db yields one stage per <db>.sql (applyPanelDBStage loads
+// st.Items[0]); every other recognized stage dir yields a single stage.
+func reconstructSystemStages(jobDir string) ([]backup.ManifestStage, error) {
+	ents, err := os.ReadDir(jobDir)
+	if err != nil {
+		return nil, fmt.Errorf("read job dir: %v", err)
+	}
+	known := knownSystemStages()
+	var stages []backup.ManifestStage
+	for _, e := range ents {
+		if !e.IsDir() || !known[e.Name()] {
+			continue
+		}
+		if e.Name() == backup.StagePanelDB {
+			dbs, derr := panelDBNames(filepath.Join(jobDir, e.Name()))
+			if derr != nil {
+				return nil, derr
+			}
+			for _, db := range dbs {
+				stages = append(stages, backup.ManifestStage{Name: backup.StagePanelDB, Items: []string{db}})
+			}
+			continue
+		}
+		stages = append(stages, backup.ManifestStage{Name: e.Name()})
+	}
+	return stages, nil
+}
+
+// panelDBNames lists the database names in a panel_db stage dir — one per
+// <db>.sql file the dump produced.
+func panelDBNames(panelDBDir string) ([]string, error) {
+	ents, err := os.ReadDir(panelDBDir)
+	if err != nil {
+		return nil, fmt.Errorf("read panel_db dir: %v", err)
+	}
+	var dbs []string
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		if n := strings.TrimSuffix(e.Name(), ".sql"); n != e.Name() && n != "" {
+			dbs = append(dbs, n)
+		}
+	}
+	sort.Strings(dbs)
+	if len(dbs) == 0 {
+		return nil, fmt.Errorf("panel_db stage has no <db>.sql files")
+	}
+	return dbs, nil
+}
+
+// extractSystemInnerFromContainer streams ONLY the top-level `system.tar.zst`
+// member out of the plain outer container to destPath — never the users/*
+// inners. Bounded to the member's own tar-header size (the outer is an
+// uncompressed tar, so no decompression bomb).
+func extractSystemInnerFromContainer(containerPath, destPath string) error {
+	f, err := os.Open(containerPath)
+	if err != nil {
+		return fmt.Errorf("open container: %v", err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read container: %v", err)
+		}
+		if hdr.Typeflag != tar.TypeReg || filepath.Clean(hdr.Name) != "system.tar.zst" {
+			continue
+		}
+		out, oerr := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if oerr != nil {
+			return bkInternal("open system inner dest", oerr)
+		}
+		if _, cerr := io.CopyN(out, tr, hdr.Size); cerr != nil {
+			out.Close()
+			return fmt.Errorf("extract system.tar.zst: %v", cerr)
+		}
+		return out.Close()
+	}
+	return fmt.Errorf("container has no system.tar.zst member — it holds no system backup leg")
+}
+
+// evictStaleSysApplyStages removes leftover sysapply-* stages and the CLI's
+// sysrestore-*.tar staged copies older than the TTL. Mirrors the fullrestore-*
+// eviction; runs at handler entry.
+func evictStaleSysApplyStages() {
+	cutoff := time.Now().Add(-sysApplyStageTTL)
+	for _, pat := range []string{sysApplyStagePrefix + "*", "sysrestore-*.tar"} {
+		matches, _ := filepath.Glob(filepath.Join(restoreUploadsRoot, pat))
+		for _, m := range matches {
+			if fi, err := os.Stat(m); err == nil && fi.ModTime().Before(cutoff) {
+				_ = os.RemoveAll(m)
+			}
+		}
+	}
+}
+
+func init() {
+	Default.Register("system.fullbackup.apply_system_from_tar", systemFullbackupApplySystemHandler)
+}

--- a/panel-agent/internal/commands/system_fullbackup_apply_system_test.go
+++ b/panel-agent/internal/commands/system_fullbackup_apply_system_test.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+// The container also holds every users/*.tar.zst; the extractor must pull ONLY
+// the top-level system.tar.zst (a full extract would write hundreds of GB to
+// reach it on a real DR box).
+func TestExtractSystemInnerFromContainer(t *testing.T) {
+	dir := t.TempDir()
+	container := filepath.Join(dir, "container.tar")
+	f, err := os.Create(container)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(f)
+	write := func(name, body string) {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("manifest.json", `{"run_id":"x"}`)
+	write("users/alice.tar.zst", strings.Repeat("A", 4096)) // must be skipped
+	write("system.tar.zst", "SYSTEM-LEG")
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	dest := filepath.Join(dir, "out", "system.tar.zst")
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractSystemInnerFromContainer(container, dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != "SYSTEM-LEG" {
+		t.Errorf("extracted content = %q, want the system leg", got)
+	}
+	// Only the one dest file exists in the out dir — no users/ leaked through.
+	ents, _ := os.ReadDir(filepath.Dir(dest))
+	if len(ents) != 1 || ents[0].Name() != "system.tar.zst" {
+		t.Errorf("out dir should hold only system.tar.zst, got %v", ents)
+	}
+}
+
+func TestExtractSystemInnerFromContainer_MissingLeg(t *testing.T) {
+	dir := t.TempDir()
+	container := filepath.Join(dir, "c.tar")
+	f, _ := os.Create(container)
+	tw := tar.NewWriter(f)
+	_ = tw.WriteHeader(&tar.Header{Name: "manifest.json", Mode: 0o600, Size: 2, Typeflag: tar.TypeReg})
+	_, _ = tw.Write([]byte("{}"))
+	_ = tw.Close()
+	f.Close()
+	if err := extractSystemInnerFromContainer(container, filepath.Join(dir, "out.zst")); err == nil {
+		t.Error("a container with no system.tar.zst must be rejected")
+	}
+}
+
+// GH #1408 slice 3: the manifest is reconstructed from the extracted job tree.
+// panel_db yields one stage PER <db>.sql (applyPanelDBStage loads Items[0]);
+// every other recognized stage dir yields one stage; unknown dirs are ignored.
+func TestReconstructSystemStages(t *testing.T) {
+	job := t.TempDir()
+	mk := func(parts ...string) {
+		if err := os.MkdirAll(filepath.Join(append([]string{job}, parts...)...), 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	touch := func(dir, name string) {
+		if err := os.WriteFile(filepath.Join(job, dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk(backup.StagePanelDB)
+	touch(backup.StagePanelDB, "jabali_panel.sql")
+	touch(backup.StagePanelDB, "jabali_kratos.sql")
+	touch(backup.StagePanelDB, "jabali_pdns.sql")
+	touch(backup.StagePanelDB, "notes.txt") // non-.sql ignored
+	mk(backup.StagePanelConfig)
+	mk(backup.StageTLS)
+	mk(backup.StageOSUsers)
+	mk("junk") // unknown dir ignored
+
+	stages, err := reconstructSystemStages(job)
+	if err != nil {
+		t.Fatalf("reconstruct: %v", err)
+	}
+
+	var panelDBs []string
+	others := map[string]int{}
+	for _, s := range stages {
+		if s.Name == backup.StagePanelDB {
+			if len(s.Items) != 1 {
+				t.Fatalf("panel_db stage must carry exactly one db, got %v", s.Items)
+			}
+			panelDBs = append(panelDBs, s.Items[0])
+		} else {
+			others[s.Name]++
+		}
+	}
+	if got := strings.Join(panelDBs, ","); got != "jabali_kratos,jabali_panel,jabali_pdns" {
+		t.Errorf("panel_db stages (sorted) = %q, want the three system DBs", got)
+	}
+	for _, want := range []string{backup.StagePanelConfig, backup.StageTLS, backup.StageOSUsers} {
+		if others[want] != 1 {
+			t.Errorf("stage %s: got %d, want 1", want, others[want])
+		}
+	}
+	if others["junk"] != 0 {
+		t.Error("unknown 'junk' dir must not become a stage")
+	}
+}
+
+// A panel_db dir with no <db>.sql is a corrupt container — fail, don't return an
+// empty (silently no-op) db load.
+func TestReconstructSystemStages_EmptyPanelDBFails(t *testing.T) {
+	job := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(job, backup.StagePanelDB), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconstructSystemStages(job); err == nil {
+		t.Error("empty panel_db stage must be rejected")
+	}
+}
+
+func TestSoleJobDir(t *testing.T) {
+	// exactly one job dir → returned
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "01JOBULID"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	dir, id, err := soleJobDir(root)
+	if err != nil || id != "01JOBULID" || dir != filepath.Join(root, "01JOBULID") {
+		t.Fatalf("soleJobDir single: dir=%q id=%q err=%v", dir, id, err)
+	}
+
+	// two job dirs → refuse (ambiguous; never guess which system to apply)
+	two := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(two, "a"), 0o750)
+	_ = os.MkdirAll(filepath.Join(two, "b"), 0o750)
+	if _, _, err := soleJobDir(two); err == nil {
+		t.Error("two job dirs must be rejected")
+	}
+}

--- a/panel-api/cmd/server/system_restore_cmd.go
+++ b/panel-api/cmd/server/system_restore_cmd.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +49,7 @@ func newSystemRestoreCmd() *cobra.Command {
 		apply        bool
 		force        bool
 		interactive  bool
+		fromTar      string
 	)
 	cmd := &cobra.Command{
 		Use:   "restore",
@@ -69,6 +71,19 @@ the running panel.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 6*time.Hour)
 			defer cancel()
+
+			// GH #1408 slice 3: restore the system leg from a downloaded Full
+			// Server container instead of a restic repo. Short-circuits the
+			// restic flow entirely (no repo URL / password / snapshot).
+			if fromTar != "" {
+				if !force {
+					return errors.New("system restore requires --force; refusing on a running panel")
+				}
+				if remoteURL != "" || snapshot != "" || includeAccts {
+					return errors.New("--from-tar restores from a local container; --remote-url/--snapshot/--include-accounts don't apply (accounts restore via the panel or restore-upload)")
+				}
+				return runSystemRestoreFromTar(ctx, cmd, fromTar, apply, applyStages)
+			}
 
 			useInteractive := interactive || (remoteURL == "" && term.IsTerminal(int(os.Stdin.Fd())))
 			if useInteractive {
@@ -183,7 +198,97 @@ the running panel.`,
 	cmd.Flags().BoolVar(&apply, "apply", true, "after staging, apply selected stages onto live host (default true)")
 	cmd.Flags().BoolVar(&force, "force", false, "required — restore overwrites the running panel")
 	cmd.Flags().BoolVar(&interactive, "interactive", false, "force interactive prompts even when --remote-url is set")
+	cmd.Flags().StringVar(&fromTar, "from-tar", "", "restore the SYSTEM leg from a downloaded Full Server container (.tar) instead of a restic repo (GH #1408). Applies panel_db + panel_config + tls by default")
 	return cmd
+}
+
+// runSystemRestoreFromTar restores the system leg (panel_db/panel_config/tls)
+// from a downloaded Full Server container, via the agent's local-tar apply
+// verb. The container is copied into the agent-readable uploads dir (the verb
+// confines its input there), the panel is stopped for the DB load, and the
+// agent — which stays up — owns the apply. See system_fullbackup_apply_system.go.
+func runSystemRestoreFromTar(ctx context.Context, cmd *cobra.Command, container string, apply bool, applyStages []string) error {
+	fi, err := os.Stat(container)
+	if err != nil || !fi.Mode().IsRegular() {
+		return fmt.Errorf("--from-tar: %q is not a readable file", container)
+	}
+
+	// The apply verb only accepts a path under /var/lib/jabali-uploads (its
+	// socket-peer confinement). Copy the operator's container there; the copy is
+	// removed on return.
+	if err := os.MkdirAll("/var/lib/jabali-uploads", 0o750); err != nil {
+		return fmt.Errorf("prepare uploads dir: %w", err)
+	}
+	staged := filepath.Join("/var/lib/jabali-uploads", "sysrestore-"+ids.NewULID()+".tar")
+	if err := copyFileTo(container, staged); err != nil {
+		return fmt.Errorf("stage container: %w", err)
+	}
+	defer os.Remove(staged)
+
+	ag := agent.NewClient(agent.Config{Timeout: 4 * time.Hour})
+	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 4*time.Hour)
+	defer deadlineCancel()
+
+	if apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "stopping jabali-panel.service…")
+		_ = exec.CommandContext(ctx, "systemctl", "stop", "jabali-panel.service").Run()
+		defer restartPanelUntilActive(cmd.OutOrStdout())
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"→ agent system.fullbackup.apply_system_from_tar apply=%v stages=%v\n", apply, applyStages)
+	raw, err := ag.Call(deadlineCtx, "system.fullbackup.apply_system_from_tar", map[string]any{
+		"container_path": staged,
+		"apply":          apply,
+		"apply_stages":   applyStages,
+	})
+	if err != nil {
+		return fmt.Errorf("agent apply_system_from_tar: %w", err)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "✓ agent returned:")
+	pretty, _ := json.MarshalIndent(json.RawMessage(raw), "  ", "  ")
+	fmt.Fprintln(cmd.OutOrStdout(), "  "+string(pretty))
+	if !apply {
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"(recon only — re-run with --apply to load panel_db/panel_config/tls)")
+	}
+	return nil
+}
+
+// copyFileTo copies src to dst (0600), overwriting. Small helper for staging a
+// container into the agent-readable dir.
+func copyFileTo(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// restartPanelUntilActive restarts jabali-panel and waits for it to report
+// active (a single `systemctl start` can return 0 while still activating). Same
+// loop the restic restore path uses.
+func restartPanelUntilActive(w io.Writer) {
+	fmt.Fprintln(w, "starting jabali-panel.service…")
+	for i := 0; i < 6; i++ {
+		_ = exec.CommandContext(context.Background(), "systemctl", "start", "jabali-panel.service").Run()
+		out, _ := exec.CommandContext(context.Background(), "systemctl", "is-active", "jabali-panel.service").Output()
+		if strings.TrimSpace(string(out)) == "active" {
+			fmt.Fprintln(w, "✓ jabali-panel.service active")
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	fmt.Fprintln(w, "⚠ jabali-panel.service did not reach active after 6 attempts — investigate via `journalctl -u jabali-panel.service`")
 }
 
 // writeTempPassword stashes the password under a 0600 root-owned tmp


### PR DESCRIPTION
Slice 3 (Option C) of "restore from an uploaded backup archive" (GH #1408). **Independent of #1523/#1526** — no shared files, base `main`.

## The gap
Slices 1+2 restore the *accounts* in an uploaded Full Server container. The **system leg** (panel_db / panel_config / tls) couldn't be restored from an upload at all: the existing `system.restore` verb is restic-remote only (`repo_url`/`password_file`/`snapshot`) and can't consume the container's local `system.tar.zst`.

## Why CLI-triggered (not a panel button)
The system backup **includes the Kratos identity DB**. Applying it replaces the live Kratos DB — so on the real cross-server DR/migration path, a *panel-driven* apply would log out the very admin who clicked it, recoverable only over SSH. So this is `jabali system restore --from-tar <container.tar>`: it runs where there's no session to lose, stops jabali-panel for the DB load and restarts it after, while jabali-agent (which stays up) owns the apply. (Decision confirmed with the operator.)

## Agent — `system.fullbackup.apply_system_from_tar`
- **Selectively** pulls only the top-level `system.tar.zst` out of the container (never the `users/*` inners — a full extract would write hundreds of GB to reach a ~50MB leg on a disk-stressed DR box), then extracts it to the `<job_id>/<stage>/…` tree.
- **Re-sources the existing apply phase unchanged**: `applySystemRestore` (panel_db load / panel_config + tls rsync, same whitelist) + `resyncDBAccountPasswords`. No reimplementation of the sensitive logic.
- The manifest is **reconstructed from the extracted tree** (one panel_db stage per `<db>.sql`, one stage per other recognized dir), so containers packed by **any prior agent** work — no packer change.
- `apply:false` is a **RECON** that reports detected stages while touching nothing live. Input confined under `/var/lib/jabali-uploads`; host-disk-reserve checked at entry; ambiguous (multi-job-dir) or empty-`panel_db` containers rejected, not silently no-op'd.
- Leftover `sysapply-*` stages + the CLI's `sysrestore-*.tar` copies are swept at entry (24h TTL) — the `defer` cleanup alone wouldn't survive the nightly fleet-agent restart or a dropped SSH.

## CLI — `--from-tar`
- Copies the operator's container into the agent-readable dir (removed after), dispatches the verb, drives the same stop-panel/restart-until-active dance as the restic path. Rejects `--remote-url`/`--snapshot`/`--include-accounts` (they don't apply to a local container) instead of ignoring them silently. Recon is `--apply=false` (apply defaults true, matching the restic sibling).

## Test plan
- [x] go build / vet / gofmt clean (panel-agent + panel-api)
- [x] `go test -race` panel-agent/internal/commands — new unit tests: selective extractor (pulls only `system.tar.zst`, skips a `users/` member, errors when the leg is absent), stage reconstruction (per-db panel_db, unknown dirs ignored, empty-panel_db rejected), single-job-dir guard
- [x] CLI-reference golden regenerated for `--from-tar`
- [x] **Box drill on .60** (real agent binary, throwaway instance): RECON end-to-end on a container **including a 10MB `users/` member** — container → `system.tar.zst` → job tree → detected `panel_db:{panel,kratos,pdns}` + panel_config + tls + os_users, recon applied nothing, users inner skipped. ALL PASS.
- [ ] **DESTRUCTIVE apply (`apply:true`) intentionally NOT drilled on the shared test box** — it would overwrite that box's own panel/Kratos DB + /etc/jabali-panel. It reuses the already-tested `applySystemRestore`; the new code (selective extract + reconstruct) is unit-tested and recon-drilled.

## Follow-ups (not in this PR)
- After #1526 merges, update the full-server drawer's "restored via the CLI, not here" copy to name `jabali system restore --from-tar` (kept off this branch to avoid a conflict).
- Fleet agent redeploy owed for the new verb before this reaches boxes.