### PR TITLE
refactor(docker): shared Docker App Inventory module with capability adapters (JAB-335)

### DIFF
--- a/panel-ui/src/components/docker/DockerAppInventory.test.tsx
+++ b/panel-ui/src/components/docker/DockerAppInventory.test.tsx
@@ -1,0 +1,383 @@
+// DockerAppInventory.test.tsx — JAB-335. One common-action matrix invoked for
+// BOTH real shells (AdminDockerAppsPage, UserDockerAppsPage), so the two Docker
+// inventories cannot drift on the shared behavior, plus the load-bearing
+// security assertions: the tenant UI must not render or dispatch
+// exec / edit / update / backups, and its ports stay loopback-only regardless
+// of the row's bind_interface.
+//
+// The admin privileged drawers are mocked to probes; the tenant's inline
+// Logs/Credentials modals are real. Both api modules are mocked so no network
+// happens. feedback.modal.confirm (the RowActions delete confirm) is
+// short-circuited to its onOk so Delete reaches the delete fn.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { App as AntApp } from "antd";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeModeProvider } from "../../theme/ThemeModeContext";
+import type { InstalledApp } from "../../shells/admin/docker-apps/types";
+
+const adminApi = vi.hoisted(() => ({
+  listCatalog: vi.fn(),
+  listInstalled: vi.fn(),
+  lifecycleAction: vi.fn(),
+  deleteApp: vi.fn(),
+  updateApp: vi.fn(),
+  // Privileged wire calls that the tenant must never reach.
+  execCmd: vi.fn(),
+  patchApp: vi.fn(),
+  getEnv: vi.fn(),
+  putEnv: vi.fn(),
+  regenerateEnv: vi.fn(),
+  fetchLogs: vi.fn(),
+  listBackups: vi.fn(),
+  createBackup: vi.fn(),
+  restoreBackup: vi.fn(),
+  installApp: vi.fn(),
+}));
+const userApi = vi.hoisted(() => ({
+  listCatalog: vi.fn(),
+  listInstalled: vi.fn(),
+  lifecycleAction: vi.fn(),
+  deleteApp: vi.fn(),
+  fetchLogs: vi.fn(),
+  fetchEnv: vi.fn(),
+  fetchUsage: vi.fn(),
+  installApp: vi.fn(),
+  catalogIconUrl: vi.fn((slug: string) => `/api/v1/docker-apps/catalog/${slug}/icon`),
+}));
+
+vi.mock("../../shells/admin/docker-apps/api", () => adminApi);
+vi.mock("../../shells/user/docker-apps/api", () => userApi);
+
+// The tenant InstallModal mounts an ungated /domains query on the real
+// apiClient; stub it so no test opens a socket.
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+}));
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+// RowActions' delete confirm goes through feedback.modal.confirm — short-circuit
+// to onOk so the delete action reaches the delete fn.
+vi.mock("../../lib/feedback", () => ({
+  feedback: {
+    modal: { confirm: (o: { onOk?: () => void }) => o.onOk?.() },
+    message: { success: vi.fn(), error: vi.fn() },
+  },
+}));
+
+// Admin privileged drawers -> probes exposing open + the app id.
+vi.mock("../../shells/admin/docker-apps/LogsDrawer", () => ({
+  LogsDrawer: ({ open, appId }: { open: boolean; appId: string | null }) =>
+    open ? <div data-testid="logs-drawer" data-appid={appId ?? ""} /> : null,
+}));
+vi.mock("../../shells/admin/docker-apps/ExecDrawer", () => ({
+  ExecDrawer: ({ open, appId }: { open: boolean; appId: string | null }) =>
+    open ? <div data-testid="exec-drawer" data-appid={appId ?? ""} /> : null,
+}));
+vi.mock("../../shells/admin/docker-apps/EditDrawer", () => ({
+  EditDrawer: ({ open, app }: { open: boolean; app: InstalledApp | null }) =>
+    open ? <div data-testid="edit-drawer" data-appid={app?.id ?? ""} /> : null,
+}));
+vi.mock("../../shells/admin/docker-apps/BackupsDrawer", () => ({
+  BackupsDrawer: ({ open, appId }: { open: boolean; appId: string | null }) =>
+    open ? <div data-testid="backups-drawer" data-appid={appId ?? ""} /> : null,
+}));
+vi.mock("../../shells/admin/docker-apps/InstallDrawer", () => ({
+  InstallDrawer: () => null,
+}));
+vi.mock("../../shells/admin/docker-apps/EnvSection", () => ({
+  EnvSection: ({ appId }: { appId: string }) => <div data-testid="env-section" data-appid={appId} />,
+}));
+vi.mock("../../shells/admin/docker-apps/MaintenanceTab", () => ({
+  MaintenanceTab: () => <div data-testid="maintenance" />,
+}));
+
+import { AdminDockerAppsPage } from "../../shells/admin/docker-apps/AdminDockerAppsPage";
+import { UserDockerAppsPage } from "../../shells/user/docker-apps/UserDockerAppsPage";
+
+const makeApp = (over: Partial<InstalledApp>): InstalledApp => ({
+  id: "j1",
+  user_id: "u1",
+  slug: "notes",
+  name: "alpha",
+  catalog_version: "1.0",
+  image_sha: "sha-1",
+  available_digest: null,
+  last_check_at: null,
+  backup_destination_id: null,
+  status: "running",
+  update_mode: "manual",
+  cpu_limit: "1",
+  memory_limit: "512m",
+  pids_limit: 128,
+  data_bytes: 0,
+  size_checked_at: null,
+  last_error: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  domain: "app.example.com",
+  ports: [],
+  ...over,
+});
+
+const renderAdapter = (Adapter: () => JSX.Element) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ThemeModeProvider>
+          <AntApp>
+            <Adapter />
+          </AntApp>
+        </ThemeModeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { ...utils, qc, invalidateSpy };
+};
+
+// Open the row's overflow ("More actions") menu and return its scoped queries.
+const openRowMenu = async () => {
+  fireEvent.click(screen.getByLabelText("More actions"));
+  // menu items render into a portal; wait for a known shared item
+  await screen.findByText("Restart");
+};
+
+interface MatrixOpts {
+  Adapter: () => JSX.Element;
+  api: { listInstalled: ReturnType<typeof vi.fn>; lifecycleAction: ReturnType<typeof vi.fn>; deleteApp: ReturnType<typeof vi.fn> };
+  installedKey: unknown[];
+  otherKey: unknown[];
+  deleteLabel: string;
+  privileged: boolean;
+  loopbackOnly: boolean;
+}
+
+const commonMatrix = (label: string, opts: MatrixOpts) => {
+  describe(`${label} docker inventory (common matrix)`, () => {
+    beforeEach(() => {
+      [...Object.values(adminApi), ...Object.values(userApi)].forEach((m) => m.mockReset());
+      adminApi.listCatalog.mockResolvedValue([]);
+      userApi.listCatalog.mockResolvedValue([]);
+      userApi.fetchUsage.mockResolvedValue({ used_bytes: 0, quota_bytes: 0, over_quota: false });
+      userApi.fetchLogs.mockResolvedValue({ slug: "notes", logs: "hello" });
+      userApi.fetchEnv.mockResolvedValue([]);
+      userApi.catalogIconUrl.mockImplementation((slug: string) => `/api/v1/docker-apps/catalog/${slug}/icon`);
+      adminApi.updateApp.mockResolvedValue({ status: "updating", id: "j1" });
+      opts.api.lifecycleAction.mockResolvedValue(undefined);
+      opts.api.deleteApp.mockResolvedValue(undefined);
+    });
+
+    it("renders installed rows", async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1", name: "alpha" })]);
+      renderAdapter(opts.Adapter);
+      expect(await screen.findByText("alpha")).toBeInTheDocument();
+    });
+
+    it("filters by name / slug / domain", async () => {
+      opts.api.listInstalled.mockResolvedValue([
+        makeApp({ id: "j1", name: "alpha", slug: "notes", domain: "a.example.com" }),
+        makeApp({ id: "j2", name: "beta", slug: "wiki", domain: "b.example.com" }),
+      ]);
+      renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      fireEvent.change(screen.getByRole("searchbox"), { target: { value: "wiki" } });
+      expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+      expect(screen.getByText("beta")).toBeInTheDocument();
+    });
+
+    it("stops a running app through the shared lifecycle and invalidates only its own key", async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1", status: "running" })]);
+      const { invalidateSpy } = renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      fireEvent.click(screen.getByText("Stop"));
+      await waitFor(() => expect(opts.api.lifecycleAction).toHaveBeenCalledWith("j1", "stop"));
+      await waitFor(() =>
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: opts.installedKey }),
+      );
+      expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: opts.otherKey });
+    });
+
+    it("starts a stopped app through the shared lifecycle", async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1", status: "stopped" })]);
+      renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      fireEvent.click(screen.getByText("Start"));
+      await waitFor(() => expect(opts.api.lifecycleAction).toHaveBeenCalledWith("j1", "start"));
+    });
+
+    it("restarts through the overflow menu", async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1" })]);
+      renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      await openRowMenu();
+      fireEvent.click(screen.getByText("Restart"));
+      await waitFor(() => expect(opts.api.lifecycleAction).toHaveBeenCalledWith("j1", "restart"));
+    });
+
+    it("deletes through the overflow menu (confirm short-circuited)", async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1" })]);
+      renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      await openRowMenu();
+      fireEvent.click(screen.getByText(opts.deleteLabel));
+      await waitFor(() => expect(opts.api.deleteApp).toHaveBeenCalled());
+      expect(opts.api.deleteApp.mock.calls[0][0]).toBe("j1");
+    });
+
+    it("surfaces the backend detail when a lifecycle action fails", async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1", status: "running" })]);
+      opts.api.lifecycleAction.mockRejectedValue({ response: { data: { detail: "engine offline" } } });
+      renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      fireEvent.click(screen.getByText("Stop"));
+      expect(await screen.findByText("engine offline")).toBeInTheDocument();
+    });
+
+    it("renders ports with the audience's presentation regardless of bind_interface", async () => {
+      opts.api.listInstalled.mockResolvedValue([
+        makeApp({
+          id: "j1",
+          ports: [
+            {
+              id: "p1",
+              app_id: "j1",
+              port_name: "http",
+              container_port: 80,
+              bind_interface: "0.0.0.0", // public on the wire...
+              host_port: 8080,
+              protocol: "tcp",
+              reverse_proxy: false,
+              enabled: true,
+              created_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+        }),
+      ]);
+      const { container } = renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      if (opts.loopbackOnly) {
+        // ...but the tenant forces loopback regardless of bind_interface.
+        expect(screen.getByText("loopback:8080/tcp")).toBeInTheDocument();
+        expect(container.querySelector('a[href^="http://127.0.0.1:8080"]')).not.toBeNull();
+        expect(screen.queryByText("public:8080/tcp")).not.toBeInTheDocument();
+      } else {
+        expect(screen.getByText("public:8080/tcp")).toBeInTheDocument();
+        expect(container.querySelector('a[href^="http://localhost:8080"]')).not.toBeNull();
+      }
+    });
+
+    it(`${opts.privileged ? "offers" : "hides"} the privileged verbs (exec / edit / update / backups)`, async () => {
+      opts.api.listInstalled.mockResolvedValue([makeApp({ id: "j1", status: "stopped" })]);
+      renderAdapter(opts.Adapter);
+      await screen.findByText("alpha");
+      await openRowMenu();
+      for (const verb of ["Exec", "Edit", "Update", "Backups"]) {
+        if (opts.privileged) {
+          expect(screen.getByText(verb)).toBeInTheDocument();
+        } else {
+          expect(screen.queryByText(verb)).not.toBeInTheDocument();
+        }
+      }
+    });
+  });
+};
+
+commonMatrix("admin", {
+  Adapter: AdminDockerAppsPage,
+  api: adminApi,
+  installedKey: ["docker-apps-installed"],
+  otherKey: ["user-docker-installed"],
+  deleteLabel: "Uninstall",
+  privileged: true,
+  loopbackOnly: false,
+});
+
+commonMatrix("tenant", {
+  Adapter: UserDockerAppsPage,
+  api: userApi,
+  installedKey: ["user-docker-installed"],
+  otherKey: ["docker-apps-installed"],
+  deleteLabel: "Delete",
+  privileged: false,
+  loopbackOnly: true,
+});
+
+// ---- audience-specific: overlays + privileged dispatch --------------------
+
+describe("admin docker inventory (privileged wiring)", () => {
+  beforeEach(() => {
+    [...Object.values(adminApi), ...Object.values(userApi)].forEach((m) => m.mockReset());
+    adminApi.listCatalog.mockResolvedValue([]);
+    adminApi.updateApp.mockResolvedValue({ status: "updating", id: "j1" });
+    adminApi.lifecycleAction.mockResolvedValue(undefined);
+  });
+
+  it("dispatches Update through the admin api and invalidates the admin key", async () => {
+    adminApi.listInstalled.mockResolvedValue([makeApp({ id: "j1", status: "stopped", available_digest: "sha-2", image_sha: "sha-1" })]);
+    const { invalidateSpy } = renderAdapter(AdminDockerAppsPage);
+    await screen.findByText("alpha");
+    await openRowMenu();
+    fireEvent.click(screen.getByText("Update"));
+    await waitFor(() => expect(adminApi.updateApp).toHaveBeenCalledWith("j1"));
+    // The admin shell's updateImage.onSuccess hardcodes the installed key — pin it.
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["docker-apps-installed"] }),
+    );
+  });
+
+  it("opens the exec drawer for a row", async () => {
+    adminApi.listInstalled.mockResolvedValue([makeApp({ id: "j1", status: "stopped" })]);
+    renderAdapter(AdminDockerAppsPage);
+    await screen.findByText("alpha");
+    await openRowMenu();
+    fireEvent.click(screen.getByText("Exec"));
+    const drawer = await screen.findByTestId("exec-drawer");
+    expect(drawer.getAttribute("data-appid")).toBe("j1");
+  });
+
+  it("opens the log drawer for a row", async () => {
+    adminApi.listInstalled.mockResolvedValue([makeApp({ id: "j1" })]);
+    renderAdapter(AdminDockerAppsPage);
+    await screen.findByText("alpha");
+    await openRowMenu();
+    fireEvent.click(screen.getByText("Logs"));
+    const drawer = await screen.findByTestId("logs-drawer");
+    expect(drawer.getAttribute("data-appid")).toBe("j1");
+  });
+});
+
+describe("tenant docker inventory (overlays)", () => {
+  beforeEach(() => {
+    [...Object.values(adminApi), ...Object.values(userApi)].forEach((m) => m.mockReset());
+    userApi.listCatalog.mockResolvedValue([]);
+    userApi.fetchUsage.mockResolvedValue({ used_bytes: 0, quota_bytes: 0, over_quota: false });
+    userApi.fetchLogs.mockResolvedValue({ slug: "notes", logs: "hello" });
+    userApi.fetchEnv.mockResolvedValue([]);
+    userApi.catalogIconUrl.mockImplementation((slug: string) => `/api/v1/docker-apps/catalog/${slug}/icon`);
+    userApi.lifecycleAction.mockResolvedValue(undefined);
+  });
+
+  it("opens the inline Logs modal for a row", async () => {
+    userApi.listInstalled.mockResolvedValue([makeApp({ id: "j1", name: "alpha" })]);
+    renderAdapter(UserDockerAppsPage);
+    await screen.findByText("alpha");
+    await openRowMenu();
+    fireEvent.click(screen.getByText("Logs"));
+    expect(await screen.findByText("Logs — alpha")).toBeInTheDocument();
+  });
+
+  it("shows the not-enabled notice on a 403 and renders no table", async () => {
+    userApi.listInstalled.mockRejectedValue({ response: { status: 403 } });
+    userApi.listCatalog.mockRejectedValue({ response: { status: 403 } });
+    renderAdapter(UserDockerAppsPage);
+    expect(
+      await screen.findByText("userdockerappspage.docker_apps_are_not_enabled_on_this_server"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/components/docker/DockerAppInventory.tsx
+++ b/panel-ui/src/components/docker/DockerAppInventory.tsx
@@ -1,0 +1,210 @@
+// DockerAppInventory — the shared Installed-app inventory body for the admin and
+// tenant Docker Apps pages (JAB-335). The two pages duplicated the installed
+// stats, search, table, polling, and the toggle/delete/logs/credentials
+// orchestration; the tenant's restrictions (loopback-only ports, no
+// exec/edit/update/rebuild/backups) were expressed by role inference rather than
+// an explicit contract. This Module owns the shared behavior with ONE
+// implementation; a capability audience supplies the list operation, cache key,
+// port presentation, the shared verbs, and — only for the admin — the privileged
+// verbs. The privileged verbs are absent from the tenant audience, so the tenant
+// UI cannot render or dispatch them by construction.
+//
+// Scope is the Installed tab body only. The two shells keep their tabs, the
+// catalog grid + install flow, owner filter / breadcrumbs (admin), the
+// not-enabled and over-quota notices and maintenance tab, and the log /
+// credentials overlays (which differ in capability: admin edits env, tenant
+// reads it) — the Module dispatches those through onLogs / onCredentials.
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { App, Button, Col, Empty, Input, Row, Table, Typography } from "antd";
+import {
+  AppstoreOutlined,
+  PauseCircleOutlined,
+  PlayCircleOutlined,
+  SyncOutlined,
+} from "@icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { StatCard } from "../StatCard";
+import type { RowAction } from "../RowActions";
+import type { InstalledApp } from "../../shells/admin/docker-apps/types";
+import {
+  dockerInstalledColumns,
+  type DockerRemovePolicy,
+  type PortPresentation,
+} from "./dockerColumns";
+import { TRANSITIONAL_STATUSES } from "./dockerStatus";
+
+export interface DockerInventoryLabels {
+  installedApps: string; // i18n key
+  updatesAvailable: string;
+  running: string;
+  stopped: string;
+  searchPlaceholder: string;
+  noAppsYet: string;
+}
+
+export interface DockerInventoryAudience {
+  // list operation + the SINGLE cache key used for the query and every
+  // invalidation (AC5) — admin ["docker-apps-installed"], tenant ["user-docker-installed"].
+  installedKey: unknown[];
+  listInstalled: () => Promise<InstalledApp[]>;
+  catalogCount: number; // from the shell's own catalog query (no second fetch here)
+  catalogIconUrl: (slug: string) => string;
+  portPresentation: PortPresentation;
+  // Tenant-safe lifecycle union. Admin's wider fn (which also accepts "rebuild")
+  // is assignable here; the Module can only ever dispatch start/stop/restart.
+  lifecycle: (id: string, action: "start" | "stop" | "restart") => Promise<void>;
+  remove: DockerRemovePolicy & { successMessage: string; fn: (id: string) => Promise<void> };
+  onLogs: (app: InstalledApp) => void;
+  onCredentials: (app: InstalledApp) => void;
+  // Admin-only privileged verbs; tenant omits the field entirely.
+  privilegedActions?: (app: InstalledApp) => RowAction[];
+  // Admin scopes the list to a selected owner; tenant sees only its own.
+  rowFilter?: (app: InstalledApp) => boolean;
+  labels: DockerInventoryLabels;
+  onBrowseCatalog: () => void;
+}
+
+export function DockerAppInventory({ audience }: { audience: DockerInventoryAudience }) {
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const qc = useQueryClient();
+  const [search, setSearch] = useState("");
+
+  const installed = useQuery({
+    queryKey: audience.installedKey,
+    queryFn: audience.listInstalled,
+    // One polling policy: refetch every 8s only while a row is mid-transition,
+    // then stop. (Admin previously polled unconditionally; the tenant missed
+    // pending/rolling_back.)
+    refetchInterval: (q) =>
+      (q.state.data ?? []).some((a) => TRANSITIONAL_STATUSES.has(a.status)) ? 8000 : false,
+  });
+
+  const surfaceErr = (err: unknown, fallback: string) => {
+    const msg =
+      (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
+      (err as { message?: string })?.message ??
+      fallback;
+    message.error(msg);
+  };
+
+  const life = useMutation({
+    mutationFn: ({ id, action }: { id: string; action: "start" | "stop" | "restart" }) =>
+      audience.lifecycle(id, action),
+    onSuccess: () => qc.invalidateQueries({ queryKey: audience.installedKey }),
+    onError: (e: unknown) => surfaceErr(e, "Action failed"),
+  });
+
+  const del = useMutation({
+    mutationFn: (id: string) => audience.remove.fn(id),
+    onSuccess: () => {
+      message.success(audience.remove.successMessage);
+      qc.invalidateQueries({ queryKey: audience.installedKey });
+    },
+    onError: (e: unknown) => surfaceErr(e, "Delete failed"),
+  });
+
+  const allRows = useMemo(() => installed.data ?? [], [installed.data]);
+  const scopedRows = useMemo(
+    () => (audience.rowFilter ? allRows.filter(audience.rowFilter) : allRows),
+    [allRows, audience],
+  );
+  const filteredRows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return scopedRows;
+    return scopedRows.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) ||
+        r.slug.toLowerCase().includes(q) ||
+        (r.domain ?? "").toLowerCase().includes(q),
+    );
+  }, [scopedRows, search]);
+
+  const installedCount = scopedRows.length;
+  const runningCount = scopedRows.filter((r) => r.status === "running").length;
+  const stoppedCount = scopedRows.filter((r) => r.status === "stopped").length;
+  const updateCount = scopedRows.filter(
+    (r) => r.available_digest && r.available_digest !== (r.image_sha ?? ""),
+  ).length;
+  const pct = (n: number) => (installedCount > 0 ? Math.round((n / installedCount) * 100) : 0);
+
+  const columns = dockerInstalledColumns({
+    catalogIconUrl: audience.catalogIconUrl,
+    portPresentation: audience.portPresentation,
+    onLifecycle: (app, action) => life.mutate({ id: app.id, action }),
+    onLogs: audience.onLogs,
+    onCredentials: audience.onCredentials,
+    onDelete: (app) => del.mutate(app.id),
+    remove: audience.remove,
+    privilegedActions: audience.privilegedActions,
+  });
+
+  return (
+    <div>
+      <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
+        <Col xs={24} sm={12} lg={6}>
+          <StatCard
+            iconBg="rgba(207, 19, 34, 0.12)" iconColor="#cf1322" Icon={AppstoreOutlined}
+            label={t(audience.labels.installedApps)} value={installedCount}
+            subtitle={<Typography.Text type="secondary">{audience.catalogCount} in catalog</Typography.Text>}
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <StatCard
+            iconBg="rgba(114, 46, 209, 0.12)" iconColor="#722ed1" Icon={SyncOutlined}
+            label={t(audience.labels.updatesAvailable)} value={updateCount}
+            subtitle={updateCount > 0
+              ? <Typography.Text type="warning">Needs attention</Typography.Text>
+              : <Typography.Text type="secondary">Up to date</Typography.Text>}
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <StatCard
+            iconBg="rgba(63, 134, 0, 0.12)" iconColor="#3f8600" Icon={PlayCircleOutlined}
+            label={t(audience.labels.running)} value={runningCount}
+            subtitle={<Typography.Text type="secondary">{pct(runningCount)}% of installed</Typography.Text>}
+          />
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <StatCard
+            iconBg="rgba(212, 107, 8, 0.12)" iconColor="#d46b08" Icon={PauseCircleOutlined}
+            label={t(audience.labels.stopped)} value={stoppedCount}
+            subtitle={<Typography.Text type="secondary">{pct(stoppedCount)}% of installed</Typography.Text>}
+          />
+        </Col>
+      </Row>
+
+      <Input.Search
+        allowClear
+        placeholder={t(audience.labels.searchPlaceholder)}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        style={{ marginBottom: 16, maxWidth: 360 }}
+      />
+
+      <Table<InstalledApp>
+        rowKey="id"
+        size="small"
+        loading={installed.isLoading}
+        dataSource={filteredRows}
+        scroll={{ x: 1100 }}
+        pagination={{
+          defaultPageSize: 25,
+          showTotal: (total, range) => `Showing ${range[0]} to ${range[1]} of ${total} results`,
+        }}
+        locale={{
+          emptyText: (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t(audience.labels.noAppsYet)}>
+              <Button type="primary" onClick={audience.onBrowseCatalog}>
+                Browse Catalog
+              </Button>
+            </Empty>
+          ),
+        }}
+        columns={columns}
+      />
+    </div>
+  );
+}

--- a/panel-ui/src/components/docker/dockerColumns.tsx
+++ b/panel-ui/src/components/docker/dockerColumns.tsx
@@ -1,0 +1,239 @@
+// dockerColumns — the shared Installed-app table columns for the admin and
+// tenant Docker inventories (JAB-335). Column set and order are identical for
+// both screens; the only audience-driven differences are folded in through the
+// column context:
+//   - portPresentation: "loopback-only" (tenant) forces every port to render as
+//     127.0.0.1/loopback REGARDLESS of the row's bind_interface — that is the
+//     load-bearing isolation invariant (ADR-0117), not a cosmetic default;
+//     "bind-aware" (admin) honours the row's bind_interface.
+//   - privilegedActions: an OPTIONAL builder the admin supplies (edit / update /
+//     exec / backups) and the tenant OMITS. The privileged verbs are ABSENT
+//     from the tenant action list by construction — there is no per-verb boolean
+//     to get wrong, so the tenant UI cannot render or dispatch them.
+import type { ReactNode } from "react";
+import { Alert, Avatar, Space, Tag, Tooltip, Typography, type TableColumnsType } from "antd";
+import {
+  DeleteOutlined,
+  ExportOutlined,
+  FileTextOutlined,
+  KeyOutlined,
+  PauseCircleOutlined,
+  PlayCircleOutlined,
+  ReloadOutlined,
+  SyncOutlined,
+} from "@icons";
+
+import { humanBytes } from "../../utils/bytes";
+import { RowActions, type RowAction } from "../RowActions";
+import type { InstalledApp } from "../../shells/admin/docker-apps/types";
+import { TRANSITIONAL_STATUSES } from "./dockerStatus";
+
+// Admin's superset palette — the tenant screen previously lacked stopped=orange
+// and rolling_back=purple; consolidating takes the richer set for both.
+const STATUS_COLOR: Record<string, string> = {
+  pending: "default",
+  installing: "blue",
+  running: "green",
+  stopped: "orange",
+  failed: "red",
+  updating: "blue",
+  rolling_back: "purple",
+  deleted: "default",
+};
+
+export type PortPresentation = "loopback-only" | "bind-aware";
+
+export interface DockerRemovePolicy {
+  label: string; // "Uninstall" (admin) / "Delete" (tenant)
+  confirm: (app: InstalledApp) => { title: string; description: string; okText: string };
+}
+
+export interface DockerColumnContext {
+  catalogIconUrl: (slug: string) => string;
+  portPresentation: PortPresentation;
+  onLifecycle: (app: InstalledApp, action: "start" | "stop" | "restart") => void;
+  onLogs: (app: InstalledApp) => void;
+  onCredentials: (app: InstalledApp) => void;
+  onDelete: (app: InstalledApp) => void;
+  remove: DockerRemovePolicy;
+  // Admin supplies privileged verbs; tenant omits the field entirely.
+  privilegedActions?: (app: InstalledApp) => RowAction[];
+}
+
+const nameColumn = (ctx: DockerColumnContext) => ({
+  title: "Name",
+  dataIndex: "name" as const,
+  width: 260,
+  sorter: (a: InstalledApp, b: InstalledApp) => a.name.localeCompare(b.name),
+  defaultSortOrder: "ascend" as const,
+  render: (n: string, r: InstalledApp): ReactNode => (
+    <Space size={12} align="start">
+      <Avatar shape="square" size={40} src={ctx.catalogIconUrl(r.slug)} style={{ background: "rgba(255,255,255,0.04)" }}>
+        {r.slug.slice(0, 2).toUpperCase()}
+      </Avatar>
+      <Space direction="vertical" size={0}>
+        <Typography.Text strong>{n}</Typography.Text>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          {r.slug} @ {r.catalog_version}
+        </Typography.Text>
+        {r.domain && (
+          <Typography.Link href={`https://${r.domain}/`} target="_blank" rel="noopener noreferrer" style={{ fontSize: 12 }}>
+            {r.domain}
+          </Typography.Link>
+        )}
+        {r.post_install_note && (
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginTop: 6, padding: "4px 8px", maxWidth: 320 }}
+            message={
+              <Typography.Text style={{ fontSize: 11, whiteSpace: "normal" }}>{r.post_install_note}</Typography.Text>
+            }
+          />
+        )}
+      </Space>
+    </Space>
+  ),
+});
+
+const statusColumn = () => ({
+  title: "Status",
+  dataIndex: "status" as const,
+  width: 180,
+  sorter: (a: InstalledApp, b: InstalledApp) => a.status.localeCompare(b.status),
+  render: (s: string, r: InstalledApp): ReactNode => (
+    <Space direction="vertical" size={4}>
+      <Space size={4}>
+        <Tag color={STATUS_COLOR[s] || "default"}>{s}</Tag>
+        {TRANSITIONAL_STATUSES.has(s) && <SyncOutlined spin />}
+        {r.last_error && (
+          <Tooltip title={r.last_error}>
+            <Tag color="red">err</Tag>
+          </Tooltip>
+        )}
+      </Space>
+      {r.available_digest && r.available_digest !== (r.image_sha ?? "") && (
+        <Tooltip title={`Upstream digest moved to ${r.available_digest.slice(0, 19)}...`}>
+          <Tag color="purple">update available</Tag>
+        </Tooltip>
+      )}
+    </Space>
+  ),
+});
+
+const portsColumn = (ctx: DockerColumnContext) => ({
+  title: "Ports",
+  dataIndex: "ports" as const,
+  width: 320,
+  render: (_: unknown, r: InstalledApp): ReactNode => (
+    <Space direction="vertical" size={4} style={{ width: "100%" }}>
+      {(r.ports ?? []).map((p) => {
+        // loopback-only forces isolation regardless of the row's bind_interface.
+        const loopback =
+          ctx.portPresentation === "loopback-only" ||
+          p.bind_interface === "loopback" ||
+          p.bind_interface === "127.0.0.1";
+        const bindLabel = loopback ? "loopback" : "public";
+        const linkHost = loopback ? "127.0.0.1" : window.location.hostname;
+        const proto = p.protocol === "tcp" ? "http" : p.protocol;
+        const href = `${proto === "http" ? "http" : "https"}://${linkHost}:${p.host_port}`;
+        return (
+          <Space key={p.id} size={6} style={{ width: "100%" }}>
+            <Tag style={{ margin: 0, minWidth: 48, textAlign: "center" }}>{p.port_name}</Tag>
+            <Tag style={{ margin: 0 }}>
+              <Space size={4}>
+                <span>
+                  {bindLabel}:{p.host_port}/{p.protocol}
+                </span>
+                <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", display: "inline-flex" }}>
+                  <ExportOutlined style={{ fontSize: 12 }} />
+                </a>
+              </Space>
+            </Tag>
+          </Space>
+        );
+      })}
+    </Space>
+  ),
+});
+
+const limitsColumn = () => ({
+  title: "Limits",
+  width: 280,
+  render: (_: unknown, r: InstalledApp): ReactNode => (
+    <Space size={16} wrap>
+      <span>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>CPU: </Typography.Text>
+        <Typography.Text strong style={{ fontSize: 12 }}>{r.cpu_limit ?? "—"}</Typography.Text>
+      </span>
+      <span>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>Memory: </Typography.Text>
+        <Typography.Text strong style={{ fontSize: 12 }}>{r.memory_limit ?? "—"}</Typography.Text>
+      </span>
+      <span>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>PIDs: </Typography.Text>
+        <Typography.Text strong style={{ fontSize: 12 }}>{r.pids_limit ?? "—"}</Typography.Text>
+      </span>
+    </Space>
+  ),
+});
+
+const diskColumn = () => ({
+  title: "Disk",
+  dataIndex: "data_bytes" as const,
+  width: 110,
+  sorter: (a: InstalledApp, b: InstalledApp) => (a.data_bytes ?? 0) - (b.data_bytes ?? 0),
+  render: (_: unknown, r: InstalledApp): ReactNode => (
+    <Tooltip
+      title={
+        r.size_checked_at
+          ? `Persistent data on disk · checked ${new Date(r.size_checked_at).toLocaleString()}`
+          : "Persistent data size — not measured yet"
+      }
+    >
+      <Typography.Text strong style={{ fontSize: 12 }}>
+        {r.data_bytes > 0 ? humanBytes(r.data_bytes) : "—"}
+      </Typography.Text>
+    </Tooltip>
+  ),
+});
+
+const actionsColumn = (ctx: DockerColumnContext) => ({
+  title: "Actions",
+  key: "actions",
+  width: 180,
+  align: "right" as const,
+  render: (_: unknown, r: InstalledApp): ReactNode => {
+    const running = r.status === "running";
+    const actions: RowAction[] = [
+      running
+        ? { key: "stop", label: "Stop", icon: <PauseCircleOutlined />, onClick: () => ctx.onLifecycle(r, "stop") }
+        : { key: "start", label: "Start", icon: <PlayCircleOutlined />, onClick: () => ctx.onLifecycle(r, "start") },
+      { key: "restart", label: "Restart", icon: <ReloadOutlined />, onClick: () => ctx.onLifecycle(r, "restart") },
+      // Privileged verbs (edit / update / exec / backups) exist only when the
+      // admin audience supplies them; the tenant audience omits the field, so
+      // they are absent from the row — not rendered, not dispatchable.
+      ...(ctx.privilegedActions ? ctx.privilegedActions(r) : []),
+      { key: "logs", label: "Logs", icon: <FileTextOutlined />, onClick: () => ctx.onLogs(r) },
+      { key: "creds", label: "Credentials", icon: <KeyOutlined />, onClick: () => ctx.onCredentials(r) },
+      {
+        key: "delete",
+        label: ctx.remove.label,
+        icon: <DeleteOutlined />,
+        danger: true,
+        onClick: () => ctx.onDelete(r),
+        confirm: ctx.remove.confirm(r),
+      },
+    ];
+    return <RowActions actions={actions} />;
+  },
+});
+
+export const dockerInstalledColumns = (ctx: DockerColumnContext): TableColumnsType<InstalledApp> => [
+  nameColumn(ctx),
+  statusColumn(),
+  portsColumn(ctx),
+  limitsColumn(),
+  diskColumn(),
+  actionsColumn(ctx),
+];

--- a/panel-ui/src/components/docker/dockerStatus.ts
+++ b/panel-ui/src/components/docker/dockerStatus.ts
@@ -1,0 +1,12 @@
+// Shared Docker-app status vocabulary for the inventory Module and its columns
+// (JAB-335). Kept in a plain .ts (no JSX exports) so the column builders file
+// can stay component-only for fast refresh.
+
+// Statuses that are mid-transition — the row shows a spinner and the installed
+// list keeps polling while any row is in one of these.
+export const TRANSITIONAL_STATUSES: ReadonlySet<string> = new Set([
+  "pending",
+  "installing",
+  "updating",
+  "rolling_back",
+]);

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -1,32 +1,27 @@
 // AdminDockerAppsPage — landing page for the M48 marketplace.
-// Two tabs: Catalog (browse + install) and Installed (lifecycle).
+// Two tabs: Catalog (browse + install) and Installed (lifecycle), plus
+// Maintenance. The Installed table body is the shared DockerAppInventory Module
+// (JAB-335); this shell supplies the admin capability audience (bind-aware
+// ports, the privileged edit / update / exec / backups verbs, owner scoping)
+// and keeps the privileged drawers, the owner filter, and the catalog +
+// maintenance tabs.
 import { useTranslation } from "react-i18next";
-import { Alert, App, Avatar, Button, Col, Drawer, Empty, Input, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { App, Drawer, Space, Tabs, Tag, Typography } from "antd";
 import { useTabParam } from "../../../hooks/useTabParam";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { humanBytes } from "../../../utils/bytes";
 import { useMemo, useState } from "react";
 import {
-  AppstoreOutlined,
   ContainerOutlined,
-  ExportOutlined,
-  PlayCircleOutlined,
-  PauseCircleOutlined,
-  ReloadOutlined,
-  DeleteOutlined,
   SyncOutlined,
-  FileTextOutlined,
   CodeOutlined,
   SaveOutlined,
   EditOutlined,
-  KeyOutlined,
 } from "@icons";
-import { RowActions, type RowAction } from "../../../components/RowActions";
+import type { RowAction } from "../../../components/RowActions";
 
 import { deleteApp, lifecycleAction, listCatalog, listInstalled, updateApp } from "./api";
 import type { CatalogEntry, InstalledApp } from "./types";
 import { useSearchParams } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useOneQuery } from "../../../hooks/useQueries";
 import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, ownerLabel } from "../../../components/admin/entityLinks";
@@ -38,19 +33,8 @@ import { BackupsDrawer } from "./BackupsDrawer";
 import { EditDrawer } from "./EditDrawer";
 import { EnvSection } from "./EnvSection";
 import { MaintenanceTab } from "./MaintenanceTab";
-import { StatCard } from "../../../components/StatCard";
+import { DockerAppInventory, type DockerInventoryAudience } from "../../../components/docker/DockerAppInventory";
 import { useThemeMode } from "../../../theme/ThemeModeContext";
-
-const STATUS_COLOR: Record<string, string> = {
-  pending: "default",
-  installing: "blue",
-  running: "green",
-  stopped: "orange",
-  failed: "red",
-  updating: "blue",
-  rolling_back: "purple",
-  deleted: "default",
-};
 
 export const AdminDockerAppsPage = () => {
   const { t } = useTranslation();
@@ -65,7 +49,6 @@ export const AdminDockerAppsPage = () => {
   const [editApp, setEditApp] = useState<InstalledApp | null>(null);
   const [activeTab, setActiveTab] = useTabParam<string>("installed");
   const [backupsAppId, setBackupsAppId] = useState<string | null>(null);
-  const [installedSearch, setInstalledSearch] = useState("");
   const [searchParams, setSearchParams] = useSearchParams();
   const ownerId = searchParams.get("user_id") ?? undefined;
   const ownerQ = useOneQuery<{ id: string; username?: string | null }>({
@@ -94,47 +77,85 @@ export const AdminDockerAppsPage = () => {
     if (catalogTags.length === 0) return items;
     return items.filter((e) => (e.tags ?? []).some((t) => catalogTags.includes(t)));
   }, [catalog.data, catalogTags]);
-  const installed = useQuery({
-    queryKey: ["docker-apps-installed"],
-    queryFn: listInstalled,
-    refetchInterval: 8000, // poll while installs are in flight
-  });
 
-  const lifecycle = useMutation({
-    mutationFn: async ({ id, action }: { id: string; action: "start" | "stop" | "restart" | "rebuild" }) =>
-      lifecycleAction(id, action),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["docker-apps-installed"] }),
-    onError: (e: unknown) => message.error(e instanceof Error ? e.message : "Action failed"),
-  });
+  // Shared with the Module by cache key: the Module owns the installed query;
+  // this observer (same key, deduped) resolves an app id -> name/last_error for
+  // the log drawer.
+  const installed = useQuery({ queryKey: ["docker-apps-installed"], queryFn: listInstalled });
 
   const updateImage = useMutation({
     mutationFn: async (id: string) => updateApp(id),
     onSuccess: () => {
       // Async: the server returned 202 (update started). The row shows the
-      // "updating" spinner and the 8s poll flips it to running/failed when
-      // the background pull + recreate finishes. The click handler already
-      // toasted the right message (update vs already-current, GH #794).
+      // "updating" spinner and the poll flips it to running/failed when the
+      // background pull + recreate finishes. The click handler already toasted.
       qc.invalidateQueries({ queryKey: ["docker-apps-installed"] });
     },
     onError: (e: unknown) => message.error(e instanceof Error ? e.message : "Update failed"),
   });
 
-  const remove = useMutation({
-    mutationFn: async (id: string) => deleteApp(id, false),
-    onSuccess: () => {
-      message.success("Uninstalled");
-      qc.invalidateQueries({ queryKey: ["docker-apps-installed"] });
-    },
-    onError: (e: unknown) => message.error(e instanceof Error ? e.message : "Delete failed"),
-  });
-
-  const ownerRef = ownerId
-    ? { id: ownerId, username: ownerQ.data?.username }
-    : undefined;
+  const ownerRef = ownerId ? { id: ownerId, username: ownerQ.data?.username } : undefined;
 
   useSetBreadcrumbs(
     ownerRef ? ownerResourceCrumbs(ownerRef, { key: "docker-apps", label: "Docker Apps" }) : null,
   );
+
+  // Privileged verbs — supplied only by the admin audience. Their absence from
+  // the tenant audience is what makes them unrenderable/undispatchable there.
+  const privilegedActions = (r: InstalledApp): RowAction[] => [
+    { key: "edit", label: "Edit", icon: <EditOutlined />, disabled: r.status === "running", onClick: () => setEditApp(r) },
+    {
+      key: "update",
+      label: "Update",
+      icon: <SyncOutlined />,
+      // GH #794: catalog images are pinned to a reviewed digest, so a newer
+      // version only appears when the catalog is bumped. Tell the operator
+      // up-front why "Update" won't change the version when already current.
+      onClick: () => {
+        const hasUpdate = !!r.available_digest && r.available_digest !== (r.image_sha ?? "");
+        message.info(
+          hasUpdate
+            ? "Update started — this can take a few minutes"
+            : "Already on the latest catalog version — re-applying catalog config, but there's no newer version to pull yet. New app versions arrive when the catalog is bumped.",
+        );
+        updateImage.mutate(r.id);
+      },
+    },
+    { key: "exec", label: "Exec", icon: <CodeOutlined />, onClick: () => setExecAppId(r.id) },
+    { key: "backups", label: "Backups", icon: <SaveOutlined />, onClick: () => setBackupsAppId(r.id) },
+  ];
+
+  const audience: DockerInventoryAudience = {
+    installedKey: ["docker-apps-installed"],
+    listInstalled,
+    catalogCount: (catalog.data ?? []).length,
+    catalogIconUrl: (slug) => `/api/v1/admin/docker-apps/catalog/${slug}/icon?theme=${mode}`,
+    portPresentation: "bind-aware",
+    lifecycle: lifecycleAction,
+    remove: {
+      label: "Uninstall",
+      successMessage: "Uninstalled",
+      confirm: (r) => ({
+        title: `Uninstall ${r.name}?`,
+        description: "Volumes will be purged. This cannot be undone.",
+        okText: "Uninstall",
+      }),
+      fn: (id) => deleteApp(id, false),
+    },
+    onLogs: (r) => setLogsAppId(r.id),
+    onCredentials: (r) => setCredsAppId(r.id),
+    privilegedActions,
+    rowFilter: (r) => !ownerId || r.user_id === ownerId,
+    labels: {
+      installedApps: "admindockerappspage.installed_apps",
+      updatesAvailable: "admindockerappspage.updates_available",
+      running: "admindockerappspage.running",
+      stopped: "admindockerappspage.stopped",
+      searchPlaceholder: "admindockerappspage.search_by_name",
+      noAppsYet: "admindockerappspage.no_installed_apps_yet",
+    },
+    onBrowseCatalog: () => setActiveTab("catalog"),
+  };
 
   return (
     <div>
@@ -156,303 +177,26 @@ export const AdminDockerAppsPage = () => {
           {
             key: "installed",
             label: "Installed",
-            children: (
-              <div>
-                {(() => {
-                  const rows = (installed.data ?? []).filter((r) => !ownerId || r.user_id === ownerId);
-                  const installedCount = rows.length;
-                  const runningCount = rows.filter(r => r.status === "running").length;
-                  const stoppedCount = rows.filter(r => r.status === "stopped").length;
-                  const updateCount = rows.filter(r => r.available_digest && r.available_digest !== r.image_sha).length;
-                  const catalogCount = (catalog.data ?? []).length;
-                  const pct = (n: number) => installedCount > 0 ? Math.round((n / installedCount) * 100) : 0;
-                  return (
-                    <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
-                      <Col xs={24} sm={12} lg={6}>
-                        <StatCard
-                          iconBg="rgba(207, 19, 34, 0.12)" iconColor="#cf1322" Icon={AppstoreOutlined}
-                          label={t("admindockerappspage.installed_apps")} value={installedCount}
-                          subtitle={<Typography.Text type="secondary">{catalogCount} in catalog</Typography.Text>}
-                        />
-                      </Col>
-                      <Col xs={24} sm={12} lg={6}>
-                        <StatCard
-                          iconBg="rgba(114, 46, 209, 0.12)" iconColor="#722ed1" Icon={SyncOutlined}
-                          label={t("admindockerappspage.updates_available")} value={updateCount}
-                          subtitle={updateCount > 0
-                            ? <Typography.Text type="warning">Needs attention</Typography.Text>
-                            : <Typography.Text type="secondary">Up to date</Typography.Text>}
-                        />
-                      </Col>
-                      <Col xs={24} sm={12} lg={6}>
-                        <StatCard
-                          iconBg="rgba(63, 134, 0, 0.12)" iconColor="#3f8600" Icon={PlayCircleOutlined}
-                          label={t("admindockerappspage.running")} value={runningCount}
-                          subtitle={<Typography.Text type="secondary">{pct(runningCount)}% of installed</Typography.Text>}
-                        />
-                      </Col>
-                      <Col xs={24} sm={12} lg={6}>
-                        <StatCard
-                          iconBg="rgba(212, 107, 8, 0.12)" iconColor="#d46b08" Icon={PauseCircleOutlined}
-                          label={t("admindockerappspage.stopped")} value={stoppedCount}
-                          subtitle={<Typography.Text type="secondary">{pct(stoppedCount)}% of installed</Typography.Text>}
-                        />
-                      </Col>
-                    </Row>
-                  );
-                })()}
-              <Input.Search
-                allowClear
-                placeholder={t("admindockerappspage.search_by_name")}
-                value={installedSearch}
-                onChange={(e) => setInstalledSearch(e.target.value)}
-                style={{ marginBottom: 16, maxWidth: 360 }}
-              />
-              <Table<InstalledApp>
-                rowKey="id"
-                size="small"
-                loading={installed.isLoading}
-                dataSource={(installed.data ?? []).filter((r) => {
-                  if (ownerId && r.user_id !== ownerId) return false;
-                  const q = installedSearch.trim().toLowerCase();
-                  if (!q) return true;
-                  return (
-                    r.name.toLowerCase().includes(q) ||
-                    r.slug.toLowerCase().includes(q) ||
-                    (r.domain ?? "").toLowerCase().includes(q)
-                  );
-                })}
-                scroll={{ x: 1100 }}
-                pagination={{
-                  defaultPageSize: 25,
-                  showTotal: (total, range) => `Showing ${range[0]} to ${range[1]} of ${total} results`,
-                }}
-                locale={{
-                  emptyText: (
-                    <Empty
-                      image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={t("admindockerappspage.no_installed_apps_yet")}
-                    >
-                      <Button type="primary" onClick={() => setActiveTab("catalog")}>
-                        Browse Catalog
-                      </Button>
-                    </Empty>
-                  ),
-                }}
-                columns={[
-                  {
-                    title: "Name",
-                    dataIndex: "name",
-                    width: 260,
-                    sorter: (a, b) => a.name.localeCompare(b.name),
-                    defaultSortOrder: "ascend",
-                    render: (n, r) => (
-                      <Space size={12} align="start">
-                        <Avatar
-                          shape="square"
-                          size={40}
-                          src={`/api/v1/admin/docker-apps/catalog/${r.slug}/icon?theme=${mode}`}
-                          style={{ background: "rgba(255,255,255,0.04)" }}
-                        >
-                          {r.slug.slice(0, 2).toUpperCase()}
-                        </Avatar>
-                        <Space direction="vertical" size={0}>
-                          <Typography.Text strong>{n}</Typography.Text>
-                          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                            {r.slug} @ {r.catalog_version}
-                          </Typography.Text>
-                          {r.domain && (
-                            <Typography.Link
-                              href={`https://${r.domain}/`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              style={{ fontSize: 12 }}
-                            >
-                              {r.domain}
-                            </Typography.Link>
-                          )}
-                          {r.post_install_note && (
-                            <Alert
-                              type="info"
-                              showIcon
-                              style={{ marginTop: 6, padding: "4px 8px", maxWidth: 320 }}
-                              message={
-                                <Typography.Text style={{ fontSize: 11, whiteSpace: "normal" }}>
-                                  {r.post_install_note}
-                                </Typography.Text>
-                              }
-                            />
-                          )}
-                        </Space>
-                      </Space>
-                    ),
-                  },
-                  {
-                    title: "Status",
-                    dataIndex: "status",
-                    width: 180,
-                    sorter: (a, b) => a.status.localeCompare(b.status),
-                    render: (s, r) => (
-                      <Space direction="vertical" size={4}>
-                        <Space size={4}>
-                          <Tag color={STATUS_COLOR[s] || "default"}>{s}</Tag>
-                          {(s === "installing" || s === "updating" || s === "rolling_back") && <SyncOutlined spin />}
-                          {r.last_error && (
-                            <Tooltip title={r.last_error}>
-                              <Tag color="red">err</Tag>
-                            </Tooltip>
-                          )}
-                        </Space>
-                        {r.available_digest && r.available_digest !== (r.image_sha ?? "") && (
-                          <Tooltip title={`Upstream digest moved to ${r.available_digest.slice(0, 19)}...`}>
-                            <Tag color="purple">update available</Tag>
-                          </Tooltip>
-                        )}
-                      </Space>
-                    ),
-                  },
-                  {
-                    title: "Ports",
-                    dataIndex: "ports",
-                    width: 320,
-                    render: (_, r) => (
-                      <Space direction="vertical" size={4} style={{ width: "100%" }}>
-                        {(r.ports ?? []).map((p) => {
-                          const bindLabel = p.bind_interface === "loopback" || p.bind_interface === "127.0.0.1" ? "loopback" : "public";
-                          const linkHost = p.bind_interface === "loopback" || p.bind_interface === "127.0.0.1" ? "127.0.0.1" : window.location.hostname;
-                          const proto = p.protocol === "tcp" ? "http" : p.protocol;
-                          const href = `${proto === "http" ? "http" : "https"}://${linkHost}:${p.host_port}`;
-                          return (
-                            <Space key={p.id} size={6} style={{ width: "100%" }}>
-                              <Tag style={{ margin: 0, minWidth: 48, textAlign: "center" }}>{p.port_name}</Tag>
-                              <Tag style={{ margin: 0 }}>
-                                <Space size={4}>
-                                  <span>{bindLabel}:{p.host_port}/{p.protocol}</span>
-                                  <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", display: "inline-flex" }}>
-                                    <ExportOutlined style={{ fontSize: 12 }} />
-                                  </a>
-                                </Space>
-                              </Tag>
-                            </Space>
-                          );
-                        })}
-                      </Space>
-                    ),
-                  },
-                  {
-                    title: "Limits",
-                    width: 280,
-                    render: (_, r) => (
-                      <Space size={16} wrap>
-                        <span>
-                          <Typography.Text type="secondary" style={{ fontSize: 12 }}>CPU: </Typography.Text>
-                          <Typography.Text strong style={{ fontSize: 12 }}>{r.cpu_limit ?? "—"}</Typography.Text>
-                        </span>
-                        <span>
-                          <Typography.Text type="secondary" style={{ fontSize: 12 }}>Memory: </Typography.Text>
-                          <Typography.Text strong style={{ fontSize: 12 }}>{r.memory_limit ?? "—"}</Typography.Text>
-                        </span>
-                        <span>
-                          <Typography.Text type="secondary" style={{ fontSize: 12 }}>PIDs: </Typography.Text>
-                          <Typography.Text strong style={{ fontSize: 12 }}>{r.pids_limit ?? "—"}</Typography.Text>
-                        </span>
-                      </Space>
-                    ),
-                  },
-                  {
-                    title: "Disk",
-                    dataIndex: "data_bytes",
-                    width: 110,
-                    sorter: (a, b) => (a.data_bytes ?? 0) - (b.data_bytes ?? 0),
-                    render: (_, r) => (
-                      <Tooltip
-                        title={
-                          r.size_checked_at
-                            ? `Persistent data on disk · checked ${new Date(r.size_checked_at).toLocaleString()}`
-                            : "Persistent data size — not measured yet"
-                        }
-                      >
-                        <Typography.Text strong style={{ fontSize: 12 }}>
-                          {r.data_bytes > 0 ? humanBytes(r.data_bytes) : "—"}
-                        </Typography.Text>
-                      </Tooltip>
-                    ),
-                  },
-                  {
-                    title: "Actions",
-                    width: 180,
-                    align: "right" as const,
-                    render: (_, r) => {
-                      const running = r.status === "running";
-                      const confirmDelete = () =>
-                        feedback.modal.confirm({
-                          title: `Uninstall ${r.name}?`,
-                          content: "Volumes will be purged. This cannot be undone.",
-                          okText: "Uninstall",
-                          okButtonProps: { danger: true },
-                          onOk: () => remove.mutate(r.id),
-                        });
-                      const actions: RowAction[] = [
-                        running
-                          ? { key: "stop", label: "Stop", icon: <PauseCircleOutlined />, onClick: () => lifecycle.mutate({ id: r.id, action: "stop" }) }
-                          : { key: "start", label: "Start", icon: <PlayCircleOutlined />, onClick: () => lifecycle.mutate({ id: r.id, action: "start" }) },
-                        { key: "restart", label: "Restart", icon: <ReloadOutlined />, onClick: () => lifecycle.mutate({ id: r.id, action: "restart" }) },
-                        { key: "edit", label: "Edit", icon: <EditOutlined />, disabled: running, onClick: () => setEditApp(r) },
-                        {
-                          key: "update",
-                          label: "Update",
-                          icon: <SyncOutlined />,
-                          // GH #794: catalog images are pinned to a reviewed
-                          // digest, so a newer version only appears when the
-                          // catalog is bumped. Tell the operator up-front why
-                          // "Update" won't change the version when they're
-                          // already current (it still re-applies catalog config).
-                          onClick: () => {
-                            const hasUpdate = !!r.available_digest && r.available_digest !== (r.image_sha ?? "");
-                            message.info(
-                              hasUpdate
-                                ? "Update started — this can take a few minutes"
-                                : "Already on the latest catalog version — re-applying catalog config, but there's no newer version to pull yet. New app versions arrive when the catalog is bumped.",
-                            );
-                            updateImage.mutate(r.id);
-                          },
-                        },
-                        { key: "logs", label: "Logs", icon: <FileTextOutlined />, onClick: () => setLogsAppId(r.id) },
-                        { key: "creds", label: "Credentials", icon: <KeyOutlined />, onClick: () => setCredsAppId(r.id) },
-                        { key: "exec", label: "Exec", icon: <CodeOutlined />, onClick: () => setExecAppId(r.id) },
-                        { key: "backups", label: "Backups", icon: <SaveOutlined />, onClick: () => setBackupsAppId(r.id) },
-                        { key: "delete", label: "Uninstall", icon: <DeleteOutlined />, danger: true, onClick: confirmDelete },
-                      ];
-                      return <RowActions actions={actions} />;
-                    },
-                  },
-                ]}
-              />
-              </div>
-            ),
+            children: <DockerAppInventory audience={audience} />,
           },
           {
             key: "catalog",
             label: "Catalog",
             children: (
               <>
-              <CategoryFilter
-                tags={allCatalogTags}
-                selected={catalogTags}
-                onChange={setCatalogTags}
-              />
-              <CatalogGrid>
-                {visibleCatalog.map((e) => (
-                  <CatalogCard
-                    key={e.slug}
-                    name={e.name}
-                    iconUrl={`/api/v1/admin/docker-apps/catalog/${e.slug}/icon?theme=${mode}`}
-                    meta={<Tag style={{ marginInlineEnd: 0 }}>v{e.version}</Tag>}
-                    description={e.description}
-                    onInstall={() => setInstallEntry(e)}
-                  />
-                ))}
-              </CatalogGrid>
+                <CategoryFilter tags={allCatalogTags} selected={catalogTags} onChange={setCatalogTags} />
+                <CatalogGrid>
+                  {visibleCatalog.map((e) => (
+                    <CatalogCard
+                      key={e.slug}
+                      name={e.name}
+                      iconUrl={`/api/v1/admin/docker-apps/catalog/${e.slug}/icon?theme=${mode}`}
+                      meta={<Tag style={{ marginInlineEnd: 0 }}>v{e.version}</Tag>}
+                      description={e.description}
+                      onInstall={() => setInstallEntry(e)}
+                    />
+                  ))}
+                </CatalogGrid>
               </>
             ),
           },
@@ -460,8 +204,7 @@ export const AdminDockerAppsPage = () => {
             key: "maintenance",
             label: "Maintenance",
             children: <MaintenanceTab />,
-          }
-
+          },
         ]}
       />
 
@@ -478,21 +221,9 @@ export const AdminDockerAppsPage = () => {
         lastError={(installed.data ?? []).find((a) => a.id === logsAppId)?.last_error}
         onClose={() => setLogsAppId(null)}
       />
-      <ExecDrawer
-        open={execAppId !== null}
-        appId={execAppId}
-        onClose={() => setExecAppId(null)}
-      />
-      <EditDrawer
-        open={editApp !== null}
-        app={editApp}
-        onClose={() => setEditApp(null)}
-      />
-      <BackupsDrawer
-        open={backupsAppId !== null}
-        appId={backupsAppId}
-        onClose={() => setBackupsAppId(null)}
-      />
+      <ExecDrawer open={execAppId !== null} appId={execAppId} onClose={() => setExecAppId(null)} />
+      <EditDrawer open={editApp !== null} app={editApp} onClose={() => setEditApp(null)} />
+      <BackupsDrawer open={backupsAppId !== null} appId={backupsAppId} onClose={() => setBackupsAppId(null)} />
       <Drawer
         title={t("admindockerappspage.credentials")}
         open={credsAppId !== null}

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -1,30 +1,20 @@
 // Tenant Docker Apps page (M49, GH #170). Catalog grid of tenant-installable
-// apps + an install modal (loopback-only, attached to a domain you own) + a
-// table of your installs with start/stop/restart/delete. Degrades to a clear
-// "not enabled on this server" notice when the host has no userns-remap (the
-// backend 403s docker_tenant_not_enabled).
+// apps + an install modal (loopback-only, attached to a domain you own) + the
+// shared DockerAppInventory Module for the installed list. This shell supplies
+// the tenant capability audience: loopback-only ports and NO
+// exec / edit-compose / update / rebuild / backups — those verbs are absent
+// from the audience, so the Module cannot render or dispatch them (ADR-0117 D8,
+// JAB-335). Degrades to a clear "not enabled on this server" notice when the
+// host has no userns-remap (the backend 403s docker_tenant_not_enabled).
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import { RowActions } from "../../../components/RowActions";
 import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
-import { Alert, Avatar, Button, AutoComplete, Col, Descriptions, Empty, Form, Input, Modal, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { Alert, AutoComplete, Descriptions, Form, Input, Modal, Tabs, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import {
-  AppstoreOutlined,
-  DeleteOutlined,
-  ExportOutlined,
-  FileTextOutlined,
-  KeyOutlined,
-  PauseCircleOutlined,
-  PlayCircleOutlined,
-  ReloadOutlined,
-  SyncOutlined,
-} from "@icons";
+import { AppstoreOutlined } from "@icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 import { apiClient } from "../../../apiClient";
-import { StatCard } from "../../../components/StatCard";
-import { humanBytes } from "../../../utils/bytes";
 import { useTabParam } from "../../../hooks/useTabParam";
 
 import type { CatalogEntry, InstalledApp } from "../../admin/docker-apps/types";
@@ -40,15 +30,7 @@ import {
   listInstalled,
 } from "./api";
 import type { EnvVarView } from "./api";
-
-const statusColor = (s: InstalledApp["status"]) =>
-  s === "running"
-    ? "green"
-    : s === "failed"
-      ? "red"
-      : s === "installing" || s === "updating"
-        ? "blue"
-        : "default";
+import { DockerAppInventory, type DockerInventoryAudience } from "../../../components/docker/DockerAppInventory";
 
 export const UserDockerAppsPage = () => {
   const { t } = useTranslation();
@@ -69,47 +51,50 @@ export const UserDockerAppsPage = () => {
     if (catalogTags.length === 0) return items;
     return items.filter((e) => (e.tags ?? []).some((t) => catalogTags.includes(t)));
   }, [catalog.data, catalogTags]);
-  const installed = useQuery({
-    queryKey: ["user-docker-installed"],
-    queryFn: listInstalled,
-    // Poll while anything is mid-install so the status tag flips live.
-    refetchInterval: (q) =>
-      (q.state.data ?? []).some((a) => a.status === "installing" || a.status === "updating")
-        ? 8000
-        : false,
-  });
 
+  // Observed for the host-flag 403 (deduped with the Module's query by key).
+  const installed = useQuery({ queryKey: ["user-docker-installed"], queryFn: listInstalled });
   const usage = useQuery({ queryKey: ["user-docker-usage"], queryFn: fetchUsage, retry: false });
 
-  // The host-flag 403 surfaces on the installed-list query; treat it as the
-  // "tenant docker disabled on this server" state.
+  // The host-flag 403 surfaces on the installed-list / catalog query; treat it
+  // as the "tenant docker disabled on this server" state.
   const disabled =
     (installed.error as AxiosError | undefined)?.response?.status === 403 ||
     (catalog.error as AxiosError | undefined)?.response?.status === 403;
 
-  const lifecycle = useMutation({
-    mutationFn: ({ id, action }: { id: string; action: "start" | "stop" | "restart" }) =>
-      lifecycleAction(id, action),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["user-docker-installed"] }),
-    onError: (e: AxiosError<{ detail?: string }>) =>
-      feedback.message.error(`Action failed: ${e.response?.data?.detail}`),
-  });
-  const remove = useMutation({
-    mutationFn: (id: string) => deleteApp(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["user-docker-installed"] }),
-  });
-
-  const rows = useMemo(() => installed.data ?? [], [installed.data]);
-  const [installedSearch, setInstalledSearch] = useState("");
   const [tab, setTab] = useTabParam<string>("installed");
-  const installedCount = rows.length;
-  const runningCount = rows.filter((r) => r.status === "running").length;
-  const stoppedCount = rows.filter((r) => r.status === "stopped").length;
-  const updateCount = rows.filter(
-    (r) => r.available_digest && r.available_digest !== (r.image_sha ?? ""),
-  ).length;
-  const catalogCount = (catalog.data ?? []).length;
-  const pct = (n: number) => (installedCount > 0 ? Math.round((n / installedCount) * 100) : 0);
+
+  const audience: DockerInventoryAudience = {
+    installedKey: ["user-docker-installed"],
+    listInstalled,
+    catalogCount: (catalog.data ?? []).length,
+    catalogIconUrl,
+    portPresentation: "loopback-only",
+    lifecycle: lifecycleAction,
+    remove: {
+      label: "Delete",
+      successMessage: "Deleted",
+      confirm: (r) => ({
+        title: `Delete "${r.name}"?`,
+        description: "This removes the container and its data.",
+        okText: "Delete",
+      }),
+      fn: deleteApp,
+    },
+    onLogs: (r) => setLogsFor(r),
+    onCredentials: (r) => setCredsFor(r),
+    // No privilegedActions / rowFilter: tenants get the constrained verb set and
+    // see only their own installs.
+    labels: {
+      installedApps: "userdockerappspage.installed_apps",
+      updatesAvailable: "userdockerappspage.updates_available",
+      running: "userdockerappspage.running",
+      stopped: "userdockerappspage.stopped",
+      searchPlaceholder: "userdockerappspage.search_by_name",
+      noAppsYet: "userdockerappspage.no_installed_apps_yet",
+    },
+    onBrowseCatalog: () => setTab("catalog"),
+  };
 
   if (disabled) {
     return (
@@ -149,228 +134,14 @@ export const UserDockerAppsPage = () => {
           {
             key: "installed",
             label: "Installed",
-            children: (
-              <>
-                <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
-                  <Col xs={24} sm={12} lg={6}>
-                    <StatCard
-                      iconBg="rgba(207, 19, 34, 0.12)" iconColor="#cf1322" Icon={AppstoreOutlined}
-                      label={t("userdockerappspage.installed_apps")} value={installedCount}
-                      subtitle={<Typography.Text type="secondary">{catalogCount} in catalog</Typography.Text>}
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <StatCard
-                      iconBg="rgba(114, 46, 209, 0.12)" iconColor="#722ed1" Icon={SyncOutlined}
-                      label={t("userdockerappspage.updates_available")} value={updateCount}
-                      subtitle={updateCount > 0
-                        ? <Typography.Text type="warning">Needs attention</Typography.Text>
-                        : <Typography.Text type="secondary">Up to date</Typography.Text>}
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <StatCard
-                      iconBg="rgba(63, 134, 0, 0.12)" iconColor="#3f8600" Icon={PlayCircleOutlined}
-                      label={t("userdockerappspage.running")} value={runningCount}
-                      subtitle={<Typography.Text type="secondary">{pct(runningCount)}% of installed</Typography.Text>}
-                    />
-                  </Col>
-                  <Col xs={24} sm={12} lg={6}>
-                    <StatCard
-                      iconBg="rgba(212, 107, 8, 0.12)" iconColor="#d46b08" Icon={PauseCircleOutlined}
-                      label={t("userdockerappspage.stopped")} value={stoppedCount}
-                      subtitle={<Typography.Text type="secondary">{pct(stoppedCount)}% of installed</Typography.Text>}
-                    />
-                  </Col>
-                </Row>
-                <Input.Search
-                  allowClear
-                  placeholder={t("userdockerappspage.search_by_name")}
-                  value={installedSearch}
-                  onChange={(e) => setInstalledSearch(e.target.value)}
-                  style={{ marginBottom: 16, maxWidth: 360 }}
-                />
-                <Table<InstalledApp>
-                  rowKey="id"
-                  size="small"
-                  loading={installed.isLoading}
-                  dataSource={rows.filter((r) => {
-                    const q = installedSearch.trim().toLowerCase();
-                    if (!q) return true;
-                    return (
-                      r.name.toLowerCase().includes(q) ||
-                      r.slug.toLowerCase().includes(q) ||
-                      (r.domain ?? "").toLowerCase().includes(q)
-                    );
-                  })}
-                  scroll={{ x: 1000 }}
-                  pagination={{
-                    defaultPageSize: 25,
-                    showTotal: (total, range) => `Showing ${range[0]} to ${range[1]} of ${total} results`,
-                  }}
-                  locale={{
-                    emptyText: (
-                      <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userdockerappspage.no_installed_apps_yet")}>
-                        <Button type="primary" onClick={() => setTab("catalog")}>
-                          Browse Catalog
-                        </Button>
-                      </Empty>
-                    ),
-                  }}
-                  columns={[
-                    {
-                      title: "Name",
-                      dataIndex: "name",
-                      width: 240,
-                      sorter: (a, b) => a.name.localeCompare(b.name),
-                      defaultSortOrder: "ascend",
-                      render: (n, r) => (
-                        <Space size={12} align="start">
-                          <Avatar shape="square" size={40} src={catalogIconUrl(r.slug)} style={{ background: "rgba(255,255,255,0.04)" }}>
-                            {r.slug.slice(0, 2).toUpperCase()}
-                          </Avatar>
-                          <Space direction="vertical" size={0}>
-                            <Typography.Text strong>{n}</Typography.Text>
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                              {r.slug} @ {r.catalog_version}
-                            </Typography.Text>
-                            {r.domain && (
-                              <Typography.Link href={`https://${r.domain}/`} target="_blank" rel="noopener noreferrer" style={{ fontSize: 12 }}>
-                                {r.domain}
-                              </Typography.Link>
-                            )}
-                            {r.post_install_note && (
-                              <Alert
-                                type="info"
-                                showIcon
-                                style={{ marginTop: 6, padding: "4px 8px", maxWidth: 320 }}
-                                message={
-                                  <Typography.Text style={{ fontSize: 11, whiteSpace: "normal" }}>
-                                    {r.post_install_note}
-                                  </Typography.Text>
-                                }
-                              />
-                            )}
-                          </Space>
-                        </Space>
-                      ),
-                    },
-                    {
-                      title: "Status",
-                      dataIndex: "status",
-                      width: 160,
-                      sorter: (a, b) => a.status.localeCompare(b.status),
-                      render: (st: InstalledApp["status"], r) => (
-                        <Space direction="vertical" size={4}>
-                          <Space size={4}>
-                            <Tag color={statusColor(st)}>{st}</Tag>
-                            {(st === "installing" || st === "updating") && <SyncOutlined spin />}
-                            {r.last_error && (
-                              <Tooltip title={r.last_error}><Tag color="red">err</Tag></Tooltip>
-                            )}
-                          </Space>
-                          {r.available_digest && r.available_digest !== (r.image_sha ?? "") && (
-                            <Tag color="purple">update available</Tag>
-                          )}
-                        </Space>
-                      ),
-                    },
-                    {
-                      title: "Ports",
-                      width: 300,
-                      render: (_, r) => (
-                        <Space direction="vertical" size={4} style={{ width: "100%" }}>
-                          {(r.ports ?? []).map((p) => {
-                            const proto = p.protocol === "tcp" ? "http" : p.protocol;
-                            const href = `${proto === "http" ? "http" : "https"}://127.0.0.1:${p.host_port}`;
-                            return (
-                              <Space key={p.id} size={6}>
-                                <Tag style={{ margin: 0, minWidth: 48, textAlign: "center" }}>{p.port_name}</Tag>
-                                <Tag style={{ margin: 0 }}>
-                                  <Space size={4}>
-                                    <span>loopback:{p.host_port}/{p.protocol}</span>
-                                    <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", display: "inline-flex" }}>
-                                      <ExportOutlined style={{ fontSize: 12 }} />
-                                    </a>
-                                  </Space>
-                                </Tag>
-                              </Space>
-                            );
-                          })}
-                        </Space>
-                      ),
-                    },
-                    {
-                      title: "Limits",
-                      width: 250,
-                      render: (_, r) => (
-                        <Space size={16} wrap>
-                          <span>
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>CPU: </Typography.Text>
-                            <Typography.Text strong style={{ fontSize: 12 }}>{r.cpu_limit ?? "—"}</Typography.Text>
-                          </span>
-                          <span>
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>Memory: </Typography.Text>
-                            <Typography.Text strong style={{ fontSize: 12 }}>{r.memory_limit ?? "—"}</Typography.Text>
-                          </span>
-                          <span>
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>PIDs: </Typography.Text>
-                            <Typography.Text strong style={{ fontSize: 12 }}>{r.pids_limit ?? "—"}</Typography.Text>
-                          </span>
-                        </Space>
-                      ),
-                    },
-                    {
-                      title: "Disk",
-                      dataIndex: "data_bytes",
-                      width: 100,
-                      sorter: (a, b) => (a.data_bytes ?? 0) - (b.data_bytes ?? 0),
-                      render: (_, r) => (
-                        <Typography.Text strong style={{ fontSize: 12 }}>
-                          {r.data_bytes > 0 ? humanBytes(r.data_bytes) : "—"}
-                        </Typography.Text>
-                      ),
-                    },
-                    {
-                      title: "Actions",
-                      key: "actions",
-                      width: 160,
-                      align: "right" as const,
-                      render: (_, r) => (
-                        <RowActions
-                          actions={[
-                            { key: "start", label: "Start", icon: <PlayCircleOutlined />, hidden: r.status !== "stopped", onClick: () => lifecycle.mutate({ id: r.id, action: "start" }) },
-                            { key: "stop", label: "Stop", icon: <PauseCircleOutlined />, hidden: r.status === "stopped", onClick: () => lifecycle.mutate({ id: r.id, action: "stop" }) },
-                            { key: "restart", label: "Restart", icon: <ReloadOutlined />, onClick: () => lifecycle.mutate({ id: r.id, action: "restart" }) },
-                            { key: "logs", label: "Logs", icon: <FileTextOutlined />, onClick: () => setLogsFor(r) },
-                            { key: "creds", label: "Credentials", icon: <KeyOutlined />, onClick: () => setCredsFor(r) },
-                            {
-                              key: "delete",
-                              label: "Delete",
-                              icon: <DeleteOutlined />,
-                              danger: true,
-                              onClick: () => { void remove.mutateAsync(r.id); },
-                              confirm: { title: `Delete "${r.name}"?`, description: "This removes the container and its data.", okText: "Delete" },
-                            },
-                          ]}
-                        />
-                      ),
-                    },
-                  ]}
-                />
-              </>
-            ),
+            children: <DockerAppInventory audience={audience} />,
           },
           {
             key: "catalog",
             label: "Catalog",
             children: (
               <>
-                <CategoryFilter
-                  tags={allCatalogTags}
-                  selected={catalogTags}
-                  onChange={setCatalogTags}
-                />
+                <CategoryFilter tags={allCatalogTags} selected={catalogTags} onChange={setCatalogTags} />
                 <CatalogGrid>
                   {visibleCatalog.map((e) => (
                     <CatalogCard
@@ -423,10 +194,9 @@ const InstallModal = ({
   const domainsQuery = useQuery({
     queryKey: ["user-domains-min"],
     queryFn: async () => {
-      const { data } = await apiClient.get<{ data: { id: string; name: string }[] }>(
-        "/domains",
-        { params: { page: 1, page_size: 100 } },
-      );
+      const { data } = await apiClient.get<{ data: { id: string; name: string }[] }>("/domains", {
+        params: { page: 1, page_size: 100 },
+      });
       return data.data ?? [];
     },
   });
@@ -471,9 +241,7 @@ const InstallModal = ({
           <AutoComplete
             placeholder="Select a domain you own, or type a new hostname"
             options={(domainsQuery.data ?? []).map((d) => ({ value: d.name }))}
-            filterOption={(input, opt) =>
-              (opt?.value ?? "").toLowerCase().includes(input.toLowerCase())
-            }
+            filterOption={(input, opt) => (opt?.value ?? "").toLowerCase().includes(input.toLowerCase())}
           />
         </Form.Item>
       </Form>
@@ -488,14 +256,7 @@ const LogsModal = ({ app, onClose }: { app: InstalledApp | null; onClose: () => 
     enabled: !!app,
   });
   return (
-    <Modal
-      open={!!app}
-      title={app ? `Logs — ${app.name}` : ""}
-      onCancel={onClose}
-      onOk={onClose}
-      width={760}
-      footer={null}
-    >
+    <Modal open={!!app} title={app ? `Logs — ${app.name}` : ""} onCancel={onClose} onOk={onClose} width={760} footer={null}>
       {q.isLoading ? (
         "Loading…"
       ) : (
@@ -523,14 +284,7 @@ const CredentialsModal = ({ app, onClose }: { app: InstalledApp | null; onClose:
     enabled: !!app,
   });
   return (
-    <Modal
-      open={!!app}
-      title={app ? `Credentials — ${app.name}` : ""}
-      onCancel={onClose}
-      onOk={onClose}
-      width={640}
-      footer={null}
-    >
+    <Modal open={!!app} title={app ? `Credentials — ${app.name}` : ""} onCancel={onClose} onOk={onClose} width={640} footer={null}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Generated secrets for this install (admin password, DB password, keys).
       </Typography.Paragraph>


### PR DESCRIPTION
## JAB-335 — [Security] Consolidate Docker App Inventory through capability adapters

The admin (`AdminDockerAppsPage`) and tenant (`UserDockerAppsPage`) Docker
inventories duplicated the installed stats, search, table, polling, and the
toggle/delete/logs/credentials orchestration. The tenant's isolation —
loopback-only ports and no exec/edit-compose/update/rebuild/backups — was
expressed by role inference in the JSX rather than an explicit contract, so the
security boundary was one careless edit from leaking a privileged verb into the
tenant UI.

This extracts the **Installed-tab body** into `components/docker/DockerAppInventory`.
The two pages become shells that supply a capability **audience** — the same
audience-policy shape as the recent ADR-0083 UI slices (JAB-299 #1525, JAB-297
#1527, JAB-298 #1529).

### Security structure (the point of the ticket)
- **Privileged verbs are an optional audience field** (`privilegedActions?`) the
  admin supplies and the tenant **omits**. No per-verb boolean to get wrong —
  the tenant has no privileged actions to render or dispatch.
- The Module's shared lifecycle type is the **tenant-safe union**
  (`start|stop|restart`). Admin's wider fn (also accepts `"rebuild"`) is
  assignable by contravariance; the Module can never dispatch rebuild.
- The Module imports **neither `api.ts`** — the audience supplies every wire
  call, so a gating bug cannot surface a tenant action that would 403 server-side.
- Ports render through an explicit `portPresentation` mode: **`loopback-only`
  (tenant) forces `127.0.0.1`/loopback regardless of the row's `bind_interface`**
  — the isolation invariant, not a cosmetic default; `bind-aware` (admin) honours
  it.
- A single `installedKey` drives the list query **and every invalidation** (AC5).

### Acceptance criteria
- **AC1 — tenant cannot render or dispatch exec / edit-compose / rebuild:** ✅ the
  tenant audience omits `privilegedActions`; the shared lifecycle union has no
  rebuild; the tenant `api.ts` has no exec/patch/update fns. Test asserts none of
  Exec/Edit/Update/Backups appear in the tenant menu. **Falsified:** injecting an
  Exec verb into the tenant audience made that test fail (then reverted).
- **AC2 — admin retains privileged actions:** ✅ admin supplies edit/update/exec/
  backups; tests assert Update dispatches and the exec/log drawers open.
- **AC3 — tenant ports loopback-only:** ✅ `portPresentation: "loopback-only"`;
  test feeds a port with `bind_interface: "0.0.0.0"` and asserts the tenant still
  renders `loopback:…` with a `127.0.0.1` href, while admin renders `public:…`.
- **AC4 — common status/polling/disk/update presentation identical:** ✅ one
  columns builder + one polling predicate (see "Behavior normalized").
- **AC5 — each adapter invalidates the correct cache keys:** ✅ the Module uses
  `audience.installedKey` for the query and every `invalidateQueries`; tests spy
  the QueryClient and assert admin → `["docker-apps-installed"]`, tenant →
  `["user-docker-installed"]`, and never the other (including the admin shell's
  hardcoded update-invalidation).

### Behavior normalized to one implementation (previously drifted)
1. **Polling** — 8s only while a row is transitional (`pending`/`installing`/
   `updating`/`rolling_back`), then stop. Admin was unconditional 8s → a new
   install by *another* owner now surfaces on window-focus refetch, not within
   8s; tenant gains `pending`/`rolling_back`.
2. **Status presentation** — tenant gains admin's superset: `stopped=orange`,
   `rolling_back=purple`, spinner on `pending`/`rolling_back`, the digest tooltip
   on "update available", and the `size_checked_at` tooltip on Disk.
3. **Error surfacing** — one `surfaceErr` (`detail → message → fallback`) via
   `App.useApp().message`. **Bug fix:** the tenant delete had no `onError`, so a
   failed tenant delete was silently swallowed; it is now surfaced.
4. **Delete success toast** on both (admin `Uninstalled`, tenant `Deleted` — the
   tenant was previously silent). Both delete paths now go through `RowActions`'
   `confirm`; the confirm copy stays distinct (admin warns volumes are purged).
5. **Overflow-menu order** (admin): privileged verbs now sit between Restart and
   Logs/Credentials — menu-only, no inline-button change.

### Left as-is
`types.ts` stays under `shells/admin/docker-apps` (`import type` only from the
Module); the catalog grid + install flow, owner filter/breadcrumbs, not-enabled
and over-quota notices, and the maintenance tab stay in the shells; the admin
shell keeps an installed observer on the same cache key (deduped) purely to
resolve an app id → name/`last_error` for the log drawer.

### Tests
`components/docker/DockerAppInventory.test.tsx` runs one common-action matrix for
**both real shells** plus admin privileged wiring and tenant overlays/403 —
23/23. Verified: `tsc -b` clean, `vitest` 23/23, `vite build` clean, `eslint` 0
warnings.

Fixes the JAB-335 acceptance criteria (Plane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
