### PR TITLE
docs(backup): name the `jabali system restore --from-tar` command in the full-server restore drawer (GH #1408)

### DIFF
--- a/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
@@ -160,7 +160,19 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
               type="success"
               showIcon
               message={`Full server backup — ${info.users.length} user(s)`}
-              description={info.has_system ? "Includes a system backup (restored via the CLI, not here)." : undefined}
+              description={
+                info.has_system ? (
+                  <>
+                    Includes a system backup (panel DB / config / TLS). Restore it
+                    over SSH with{" "}
+                    <Typography.Text code>
+                      jabali system restore --from-tar &lt;container.tar&gt;
+                    </Typography.Text>{" "}
+                    — not from here, because a system restore replaces the login
+                    (Kratos) database and would sign you out mid-restore.
+                  </>
+                ) : undefined
+              }
             />
             <div>
               <Typography.Text strong>Restore these users</Typography.Text>


### PR DESCRIPTION
Follow-up to #1528 (flagged in that PR). Copy-only change.

When an uploaded Full Server container includes a system backup, the restore drawer previously said only *"Includes a system backup (restored via the CLI, not here)."* — without saying which command. Now it names the exact command and says why it's CLI-only:

> Includes a system backup (panel DB / config / TLS). Restore it over SSH with `jabali system restore --from-tar <container.tar>` — not from here, because a system restore replaces the login (Kratos) database and would sign you out mid-restore.

No behavior change; one Alert description.

## Test plan
- [x] `tsc -b` clean
- [x] No test referenced the old string (grep); no dedicated drawer vitest exists