### PR TITLE
fix(nginx): don't send HSTS while the panel serves a self-signed cert (GH #1507)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7510,6 +7510,37 @@ _nginx_http2_form() {
   return 0
 }
 
+# GH #1507: the panel :8443 vhost serves its HSTS header via an include snippet
+# whose content depends on the cert kind. Strict-Transport-Security over a
+# SELF-SIGNED cert hard-blocks the browser with no exception path (and a compliant
+# browser discards STS received over an unauthenticated connection per RFC 6797,
+# so it protects nothing there) — so the header is OMITTED until a CA cert is
+# deployed. jabali-panel-cert.sh writes it ON at LE deploy; the ssl.panel.selfsign
+# agent verb writes it OFF on a self-signed regen. Fail-safe: any inspection error
+# resolves to OFF — a missing header is harmless, a wrong ON is the lockout this
+# fixes. The ON body is kept byte-identical to jabali-panel-cert.sh (drift test).
+_write_panel_hsts_snippet() {
+  local cert_file="${1:-/etc/jabali/tls/panel.crt}"
+  local snippet="/etc/nginx/snippets/jabali-panel-hsts.conf"
+  install -d -m 0755 /etc/nginx/snippets
+  local issuer_o=""
+  if [[ -f "$cert_file" ]]; then
+    issuer_o="$(openssl x509 -in "$cert_file" -noout -issuer 2>/dev/null \
+      | sed -n 's/.*O *= *\([^,/]*\).*/\1/p' | sed 's/[[:space:]]*$//')"
+  fi
+  if [[ -n "$issuer_o" && "$issuer_o" != "Jabali Panel" ]]; then
+    cat > "$snippet" <<'HSTS_ON'
+# GH #1507: panel serves a CA-issued cert — HSTS enabled.
+add_header Strict-Transport-Security "max-age=31536000" always;
+HSTS_ON
+  else
+    cat > "$snippet" <<'HSTS_OFF'
+# GH #1507: HSTS omitted — the panel is serving a self-signed cert. It hard-blocks
+# the browser over an untrusted cert; enabled automatically once a CA cert deploys.
+HSTS_OFF
+  fi
+}
+
 install_nginx_panel_vhost() {
   _log "installing nginx panel vhost (M25 Step 4 — TLS terminator on :8443)"
 
@@ -7586,6 +7617,10 @@ d}" "$panel_vhost_file"
   mkdir -p /etc/nginx/sites-available/includes /etc/nginx/snippets
   [[ -f /etc/nginx/sites-available/includes/phpmyadmin.conf ]] || : > /etc/nginx/sites-available/includes/phpmyadmin.conf
   [[ -f /etc/nginx/snippets/jabali-adminer.conf ]] || : > /etc/nginx/snippets/jabali-adminer.conf
+  # GH #1507: the vhost `include`s the HSTS snippet — it MUST exist before the
+  # nginx -t below or the whole panel vhost fails validation. Content is keyed on
+  # the live cert kind (self-signed → empty header; CA → HSTS on).
+  _write_panel_hsts_snippet "$tls_cert"
 
   # GH #1146: the panel vhost's /dav/ location references limit_req zone
   # `jabali_webdav`, which is declared at http{} scope — install it into conf.d

--- a/install/letsencrypt/jabali-panel-cert.sh
+++ b/install/letsencrypt/jabali-panel-cert.sh
@@ -129,6 +129,14 @@ case "$kind" in
   *)
     install -m 0640 -o root -g jabali "$src/fullchain.pem" "$dst_dir/panel.crt"
     install -m 0640 -o root -g jabali "$src/privkey.pem"   "$dst_dir/panel.key"
+    # GH #1507: a CA (Let's Encrypt) cert is now on :8443 — enable HSTS. The vhost
+    # includes this snippet; install.sh writes it OFF while self-signed. The ON
+    # body is byte-identical to install.sh's _write_panel_hsts_snippet (drift test).
+    install -d -m 0755 /etc/nginx/snippets
+    cat > /etc/nginx/snippets/jabali-panel-hsts.conf <<'HSTS_ON'
+# GH #1507: panel serves a CA-issued cert — HSTS enabled.
+add_header Strict-Transport-Security "max-age=31536000" always;
+HSTS_ON
     systemctl reload nginx           || echo "jabali-panel-cert.sh: nginx reload failed (continuing)" >&2
     # --no-block on jabali-panel: this hook is invoked synchronously by
     # the panel-agent ssl.panel.issue command, whose CALLER is

--- a/install/nginx/jabali-panel-vhost.conf.tmpl
+++ b/install/nginx/jabali-panel-vhost.conf.tmpl
@@ -68,8 +68,12 @@ server {
   access_log /var/log/nginx/jabali-panel.access.log;
   error_log  /var/log/nginx/jabali-panel.error.log;
 
-  # Security headers
-  add_header Strict-Transport-Security "max-age=31536000" always;
+  # Security headers.
+  # HSTS is toggled by cert kind (GH #1507): the snippet is empty while the panel
+  # serves a self-signed cert (Strict-Transport over an untrusted cert hard-blocks
+  # the browser with no exception path), and carries the header once a CA cert is
+  # deployed. install_nginx_panel_vhost writes it; jabali-panel-cert.sh flips it on.
+  include /etc/nginx/snippets/jabali-panel-hsts.conf;
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-XSS-Protection "1; mode=block" always;
@@ -141,7 +145,7 @@ server {
     proxy_send_timeout 3600s;
     # Re-declared security headers (parent's not inherited because of
     # the per-location CSP override below).
-    add_header Strict-Transport-Security "max-age=31536000" always;
+    include /etc/nginx/snippets/jabali-panel-hsts.conf;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -167,7 +171,7 @@ server {
     root ${PANEL_DIST_DIR};
     try_files $uri @panel_assets_embed;
     add_header Cache-Control "public, max-age=31536000, immutable" always;
-    add_header Strict-Transport-Security "max-age=31536000" always;
+    include /etc/nginx/snippets/jabali-panel-hsts.conf;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -186,7 +190,7 @@ server {
     proxy_http_version 1.1;
     proxy_hide_header Cache-Control;
     add_header Cache-Control "public, max-age=31536000, immutable" always;
-    add_header Strict-Transport-Security "max-age=31536000" always;
+    include /etc/nginx/snippets/jabali-panel-hsts.conf;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/install/tests/test_panel_hsts_selfsigned.sh
+++ b/install/tests/test_panel_hsts_selfsigned.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# install/tests/test_panel_hsts_selfsigned.sh — regression coverage for GH #1507
+# (fresh install: panel :8443 serves a self-signed cert WITH an HSTS header, which
+# hard-blocks the browser with no exception path).
+#
+# HSTS over a self-signed cert is a lockout: the browser pins strict-transport but
+# can't validate the cert, so there's no "add exception" path to the panel. The
+# fix serves the HSTS header via an include snippet whose content is toggled by
+# cert kind — empty while self-signed, the header once a CA cert is deployed.
+#
+# Asserts, source-level (no host mutation):
+#   1. The panel vhost template includes the snippet, and hardcodes NO raw HSTS.
+#   2. install.sh's writer gates HSTS-ON on a NON-"Jabali Panel" issuer (i.e.
+#      self-signed → OFF), fail-safe.
+#   3. The snippet is written BEFORE `nginx -t` (a missing include fails the test,
+#      taking :8443 down on upgrade).
+#   4. jabali-panel-cert.sh writes HSTS ON in the hostname (LE) branch.
+#   5. Drift: the ON `add_header` line is byte-identical in install.sh and cert.sh.
+#
+# Run from repo root:  bash install/tests/test_panel_hsts_selfsigned.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+tmpl="install/nginx/jabali-panel-vhost.conf.tmpl"
+installer="install.sh"
+hook="install/letsencrypt/jabali-panel-cert.sh"
+snippet_inc="/etc/nginx/snippets/jabali-panel-hsts.conf"
+hsts_line='add_header Strict-Transport-Security "max-age=31536000" always;'
+fail=0
+
+for f in "$tmpl" "$installer" "$hook"; do
+  [[ -f "$f" ]] || { echo "FAIL: $f not found"; exit 1; }
+done
+
+# --- 1. template includes the snippet, no raw HSTS left ---
+if grep -q 'Strict-Transport-Security' "$tmpl"; then
+  echo "FAIL: $tmpl still hardcodes a Strict-Transport-Security header — HSTS must come from the toggled snippet"
+  fail=1
+fi
+inc_count=$(grep -c "include ${snippet_inc};" "$tmpl" || true)
+if [[ "$inc_count" -lt 1 ]]; then
+  echo "FAIL: $tmpl does not include ${snippet_inc}"
+  fail=1
+fi
+
+# --- 2. install.sh writer: HSTS ON only for a non-self-signed issuer ---
+if ! grep -q '!= "Jabali Panel"' "$installer"; then
+  echo "FAIL: install.sh HSTS writer must gate ON on issuer != 'Jabali Panel' (self-signed stays OFF)"
+  fail=1
+fi
+
+# --- 3. the snippet is written BEFORE nginx -t inside install_nginx_panel_vhost ---
+write_ln=$(grep -nE '_write_panel_hsts_snippet "\$tls_cert"' "$installer" | head -1 | cut -d: -f1)
+test_ln=$(grep -nE 'testing nginx configuration' "$installer" | head -1 | cut -d: -f1)
+if [[ -z "$write_ln" ]]; then
+  echo "FAIL: install_nginx_panel_vhost never calls _write_panel_hsts_snippet — the include would be missing"
+  fail=1
+elif [[ -n "$test_ln" && "$write_ln" -ge "$test_ln" ]]; then
+  echo "FAIL: the HSTS snippet write (line $write_ln) must precede 'nginx -t' (line $test_ln) or the vhost fails validation"
+  fail=1
+fi
+
+# --- 4. cert.sh hostname (LE) branch enables HSTS ---
+if ! grep -qF "$hsts_line" "$hook"; then
+  echo "FAIL: jabali-panel-cert.sh must write the HSTS header ON when a CA cert is deployed"
+  fail=1
+fi
+
+# --- 5. drift: the ON line is byte-identical in both writers ---
+if ! grep -qF "$hsts_line" "$installer"; then
+  echo "FAIL: install.sh HSTS-ON body drifted from the canonical header line"
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "OK: panel HSTS is snippet-toggled — off on self-signed, on for a CA cert (GH #1507)"
+else
+  exit 1
+fi

--- a/panel-agent/internal/commands/ssl_panel_selfsign.go
+++ b/panel-agent/internal/commands/ssl_panel_selfsign.go
@@ -68,7 +68,24 @@ var (
 	// panelSelfSignReloadFn applies the freshly written cert to the running
 	// services. Seam so unit tests don't spawn systemctl.
 	panelSelfSignReloadFn = defaultPanelSelfSignReload
+	// panelHSTSSnippetPath is the include the panel vhost pulls the HSTS header
+	// from (GH #1507). Overridable in tests.
+	panelHSTSSnippetPath = "/etc/nginx/snippets/jabali-panel-hsts.conf"
 )
+
+// writePanelHSTSSnippetOff clears the HSTS header the panel :8443 vhost includes.
+// GH #1507: Strict-Transport-Security over a self-signed cert hard-blocks the
+// browser with no exception path, so once this verb (re)writes a self-signed cert
+// HSTS must be off. jabali-panel-cert.sh writes it back ON when a CA cert deploys.
+// Best-effort: a stale ON snippet only re-pins browsers that were already pinned
+// during a prior CA-cert period.
+func writePanelHSTSSnippetOff() {
+	_ = os.MkdirAll(filepath.Dir(panelHSTSSnippetPath), 0o755)
+	_ = os.WriteFile(panelHSTSSnippetPath,
+		[]byte("# GH #1507: HSTS omitted — the panel is serving a self-signed cert. It hard-blocks\n"+
+			"# the browser over an untrusted cert; enabled automatically once a CA cert deploys.\n"),
+		0o644)
+}
 
 // panelSelfSignOrg is the Subject/Issuer Organization stamped onto our
 // self-signed panel cert (matches install.sh's -subj "…/O=Jabali Panel").
@@ -162,6 +179,11 @@ func sslPanelSelfSignHandler(ctx context.Context, params json.RawMessage) (any, 
 	// container/CI, where the temp path used by tests needs no chown.
 	_ = os.Chmod(panelSelfSignCertPath, 0o644)
 	applyPanelKeyOwnership(panelSelfSignKeyPath)
+
+	// GH #1507: :8443 now presents a self-signed cert — HSTS must be OFF before the
+	// reload, or a browser that reaches the freshly-served cert gets a strict-
+	// transport pin over an untrusted cert (hard block, no exception).
+	writePanelHSTSSnippetOff()
 
 	panelSelfSignReloadFn(ctx)
 

--- a/panel-agent/internal/commands/ssl_panel_selfsign_test.go
+++ b/panel-agent/internal/commands/ssl_panel_selfsign_test.go
@@ -12,9 +12,65 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+// seamHSTSSnippet points panelHSTSSnippetPath at a temp file pre-seeded with the
+// HSTS-ON header, and restores it. Returns the temp path.
+func seamHSTSSnippet(t *testing.T) string {
+	t.Helper()
+	snip := filepath.Join(t.TempDir(), "jabali-panel-hsts.conf")
+	if err := os.WriteFile(snip, []byte("add_header Strict-Transport-Security \"max-age=31536000\" always;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := panelHSTSSnippetPath
+	panelHSTSSnippetPath = snip
+	t.Cleanup(func() { panelHSTSSnippetPath = old })
+	return snip
+}
+
+// GH #1507: regenerating a self-signed cert must clear the HSTS snippet — HSTS
+// over an untrusted cert hard-blocks the browser with no exception path.
+func TestPanelSelfSign_WritesHSTSOffOnRegen(t *testing.T) {
+	certPath, _, _ := setupPanelSelfSign(t)
+	snip := seamHSTSSnippet(t)
+	_ = os.Remove(certPath) // no cert on disk → force a self-signed regen
+
+	resp, err := callPanelSelfSign(t, "box.example.com", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !resp.Regenerated {
+		t.Fatalf("expected a self-signed regen, got %+v", resp)
+	}
+	got, _ := os.ReadFile(snip)
+	if strings.Contains(string(got), "Strict-Transport-Security") {
+		t.Errorf("HSTS snippet must be OFF after a self-signed regen, got:\n%s", got)
+	}
+}
+
+// Preserving a real CA cert must NOT touch the HSTS snippet (it stays ON).
+func TestPanelSelfSign_LeavesHSTSWhenPreservingCACert(t *testing.T) {
+	certPath, keyPath, _ := setupPanelSelfSign(t)
+	writeTestCert(t, certPath, keyPath, "Let's Encrypt", "box.example.com",
+		[]string{"box.example.com", "mail.box.example.com"}, time.Now().AddDate(0, 3, 0))
+	snip := seamHSTSSnippet(t)
+	before, _ := os.ReadFile(snip)
+
+	resp, err := callPanelSelfSign(t, "box.example.com", "")
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if resp.Regenerated {
+		t.Fatalf("CA cert must be preserved, not regenerated")
+	}
+	after, _ := os.ReadFile(snip)
+	if string(before) != string(after) {
+		t.Errorf("HSTS snippet must be untouched when a CA cert is preserved")
+	}
+}
 
 // writeTestCert writes a self-signed cert+key with the given issuer/subject
 // Organization, CN, and DNS SANs — a test double for "a cert already on


### PR DESCRIPTION
Fixes the lockout in #1507: a fresh install serves the panel on :8443 with the **self-signed bootstrap cert AND an unconditional HSTS header**. HSTS over an untrusted cert hard-blocks the browser — it pins strict-transport but can't validate the self-signed cert, so there's **no "add exception" path**. The admin can't reach the panel at all until they shell in and issue Let's Encrypt (exactly the reporter's experience: `MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT`, "You can't add an exception").

Per RFC 6797 §8.1 a compliant browser **discards** STS received over an unauthenticated connection, so HSTS on a self-signed cert protects nothing — it's pure lockout risk. This removes it there and keeps it, unchanged, on valid certs.

## Fix
Serve the HSTS header via an **include snippet** toggled by cert kind — empty while self-signed, the header once a CA cert is deployed. Three convergence points write it:

- **Template** — the 4 `add_header Strict-Transport-Security` lines become `include /etc/nginx/snippets/jabali-panel-hsts.conf;`.
- **install.sh** `_write_panel_hsts_snippet` — content from the live cert's issuer `O`: anything other than the self-signed `"Jabali Panel"` gets HSTS on (empty/unparseable/missing → **fail-safe OFF**). Written **inside `install_nginx_panel_vhost` before `nginx -t`**, so the include always resolves (a missing include would fail validation and take :8443 down on upgrade).
- **jabali-panel-cert.sh** (LE deploy hook) — writes the snippet **ON** when the LE cert lands (ON body byte-identical to install.sh; a drift test guards it).
- **`ssl.panel.selfsign`** agent verb — writes the snippet **OFF** on a self-signed regen (hostname drift), before the nginx reload.

Unchanged for valid-cert boxes: same header, same `max-age`.

## Scope
Panel :8443 vhost only. **Follow-up flagged, not fixed here:** tenant domain vhosts (`domain_create.go`) emit HSTS during their own self-signed bootstrap phase too — same class. The demo vhost is left untouched (deliberate — real cert).

## Recovery note for the reporter (important)
This **prevents the class going forward**; it can't un-pin a browser already HSTS-pinned to that FQDN from a prior valid-cert period. Those browsers recover by issuing LE (the header then legitimately returns) or clearing the site's HSTS/site data.

## Test plan
- [x] `go build` / `go vet` / `gofmt`; `go test -race` panel-agent/internal/commands
- [x] `ssl_panel_selfsign_test.go`: snippet written OFF on a self-signed regen; untouched when a CA cert is preserved
- [x] `install/tests/test_panel_hsts_selfsigned.sh` (auto-run by the install-tests CI glob): template uses the include (no raw HSTS); install.sh gates ON on a non-"Jabali Panel" issuer; snippet write precedes `nginx -t`; cert.sh enables HSTS; ON line byte-identical across install.sh + cert.sh (drift guard)
- [x] `bash -n` install.sh + cert.sh
- [x] **Box drill on .60** (real nginx; panel vhost temporarily rewritten to the include, then restored; cert never touched): OFF snippet → HSTS **absent** on `/` and `/assets/`; ON snippet → HSTS **present**. Passed.

## Fleet note
The `ssl.panel.selfsign` OFF-write ships in the agent binary → needs the fleet agent redeploy (already owed from #1408). Skew (new install.sh, old agent) at worst leaves a stale ON snippet after a self-signed regen — not a new harm class.