### PR TITLE
feat(mail): Create Mail Domain button on the Mail Domains page (GH #1479)

### DIFF
--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -5,6 +5,7 @@ import { Button, Checkbox, Drawer, Form, Grid, Input, InputNumber, Select, Space
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
+import { apiClient } from "../../../apiClient";
 import { useCreateMutation } from "../../../hooks/useQueries";
 import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 
@@ -32,6 +33,11 @@ type UserDomainCreateInput = {
   // DNS-only zone or mail-only domain; manage_dns=false → external DNS.
   web_enabled?: boolean;
   manage_dns?: boolean;
+  // GH #1479: mail-domain webmail toggle. NOT a create-request field (the model
+  // defaults webmail_enabled ON); the drawer only acts on the OFF case, via a
+  // follow-up PATCH — setting the tinyint false at create hits GORM's
+  // zero-value-omit trap, but the update path persists it explicitly.
+  enable_webmail?: boolean;
 };
 type DomainCreated = { id: string; reverse_proxy_port?: number };
 
@@ -77,12 +83,15 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
 
   const handleFinish = async (values: UserDomainCreateInput) => {
     try {
+      // GH #1479: enable_webmail is a drawer-only field, never a create-request
+      // field — carve it out so it never reaches POST /domains.
+      const { enable_webmail: wantWebmail, ...rest } = values;
       // A reverse-proxy domain has no document root; drop any value the field
       // may have kept (antd preserves unmounted field values by default) so we
       // never send a docroot the server would validate but never use.
-      let payload: UserDomainCreateInput = values.reverse_proxy
-        ? { ...values, doc_root: undefined }
-        : values;
+      let payload: UserDomainCreateInput = rest.reverse_proxy
+        ? { ...rest, doc_root: undefined }
+        : rest;
       // GH #1449: a web-off entry (DNS-only zone / mail-only domain) must not
       // carry web-only fields antd may have kept for hidden inputs.
       if (!isWeb) {
@@ -97,6 +106,18 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
         };
       }
       const created = await createMutation.mutateAsync(payload);
+      // GH #1479: webmail defaults ON at the model, so only the OFF case needs a
+      // write — done as a PATCH (not at create) to sidestep GORM's tinyint
+      // zero-value-omit trap. Best-effort: the domain is already created.
+      if (isMail && wantWebmail === false && created?.id) {
+        try {
+          await apiClient.patch(`/domains/${created.id}`, { webmail_enabled: false });
+        } catch {
+          feedback.message.warning(
+            "Mail domain added, but disabling webmail failed — turn it off from the domain's settings.",
+          );
+        }
+      }
       feedback.message.success(
         isDNS ? "DNS zone added" : isMail ? "Mail domain added" : "Domain added",
       );
@@ -213,10 +234,27 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
             options={[
               { value: "le", label: "Let's Encrypt (recommended)" },
               { value: "self", label: "Self-signed" },
+              // GH #1479: 'None' is offered for WEB only. A mail domain needs a
+              // real cert on mail.<domain> for IMAPS/SMTPS/autoconfig + webmail,
+              // and the server rejects ssl_mode=none while mail is on
+              // (ssl_none_with_email), so mail mode shows LE / Self-signed only.
               ...(isWeb ? [{ value: "none", label: "None (HTTP only)" }] : []),
             ]}
           />
         </Form.Item>
+        )}
+
+        {/* GH #1479: webmail toggle for mail domains. Default ON (matches the
+            model default); unchecking issues a follow-up PATCH after create. */}
+        {isMail && (
+          <Form.Item
+            name="enable_webmail"
+            valuePropName="checked"
+            initialValue={true}
+            tooltip="Serve the Jabali webmail app at this domain (webmail.<domain>). Uncheck if your users only use their own mail clients."
+          >
+            <Checkbox>Enable webmail</Checkbox>
+          </Form.Item>
         )}
 
         {/* GH #1449: opt out of Jabali DNS (run DNS elsewhere). Not shown for
@@ -226,9 +264,13 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
             name="manage_dns"
             valuePropName="checked"
             initialValue={true}
-            tooltip="Host this domain's DNS zone on this server. Uncheck if your DNS is managed elsewhere (e.g. your registrar or Cloudflare)."
+            tooltip={
+              isMail
+                ? "Create this domain's mail DNS records (MX, SPF, DKIM, autodiscover) on this server's DNS. Uncheck if you manage DNS elsewhere — then point MX/SPF/DKIM at this server yourself."
+                : "Host this domain's DNS zone on this server. Uncheck if your DNS is managed elsewhere (e.g. your registrar or Cloudflare)."
+            }
           >
-            <Checkbox>Manage DNS here</Checkbox>
+            <Checkbox>{isMail ? "Create DNS mail records" : "Manage DNS here"}</Checkbox>
           </Form.Item>
         )}
 

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -12,7 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MailDomainsPage } from "./MailDomainsPage";
 
 vi.mock("../../../apiClient", () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
 
 import { apiClient } from "../../../apiClient";
@@ -20,6 +20,7 @@ import { apiClient } from "../../../apiClient";
 const mocked = apiClient as unknown as {
   get: ReturnType<typeof vi.fn>;
   post: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
 };
 
@@ -148,5 +149,62 @@ describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
       }),
     );
     expect(mocked.delete).not.toHaveBeenCalled();
+  });
+
+  // GH #1479 (johnnyq): a Create Mail Domain button opens the Add-domain drawer
+  // in mail mode, exposing the requested knobs — TLS (incl. None), Enable
+  // webmail, Create DNS mail records.
+  it("Create Mail Domain button opens the mail drawer with TLS/webmail/DNS fields", async () => {
+    renderPage();
+    await screen.findByText("on.test");
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Mail Domain/i }));
+
+    // The shared Add-domain drawer opens in mail mode.
+    expect(await screen.findByText("Add Mail Domain")).toBeInTheDocument();
+    // #1479 knobs are present.
+    expect(screen.getByRole("checkbox", { name: /Enable webmail/i })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /Create DNS mail records/i })).toBeChecked();
+    // Domain-name field is there to type into.
+    expect(screen.getByPlaceholderText(/example\.com/i)).toBeInTheDocument();
+  });
+
+  // GH #1479: the mail-mode create posts the right domain shape (web off, mail on
+  // Jabali, ssl le, DNS on), and webmail-OFF fires a follow-up PATCH.
+  it("submits a mail domain: POST /domains (web off, jabali mail) + webmail-off PATCH", async () => {
+    mocked.post.mockReset().mockResolvedValue({ data: { id: "d-new" } });
+    mocked.patch.mockReset().mockResolvedValue({ data: {} });
+    renderPage();
+    await screen.findByText("on.test");
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Mail Domain/i }));
+    await screen.findByText("Add Mail Domain");
+
+    fireEvent.change(screen.getByPlaceholderText(/example\.com/i), {
+      target: { value: "new.test" },
+    });
+    // Turn webmail OFF so the follow-up PATCH fires.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Enable webmail/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Add$/ }));
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith(
+        "/domains",
+        expect.objectContaining({
+          name: "new.test",
+          web_enabled: false,
+          mail_provider: "jabali",
+          ssl_mode: "le",
+          manage_dns: true,
+        }),
+      ),
+    );
+    // enable_webmail is a drawer-only field — it must NOT be in the create body.
+    expect(mocked.post.mock.calls[0][1]).not.toHaveProperty("enable_webmail");
+    await waitFor(() =>
+      expect(mocked.patch).toHaveBeenCalledWith("/domains/d-new", {
+        webmail_enabled: false,
+      }),
+    );
   });
 });

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -23,7 +23,7 @@ import {
   Typography,
   type TableColumnsType,
 } from "antd";
-import { DeleteOutlined, MoreOutlined, PoweroffOutlined } from "@icons";
+import { DeleteOutlined, MoreOutlined, PlusOutlined, PoweroffOutlined } from "@icons";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useListQuery } from "../../../hooks/useQueries";
@@ -31,6 +31,7 @@ import { humanBytes } from "../../../utils/bytes";
 import { getSSLTagColor, getSSLTagLabel } from "../../../utils/sslState";
 import { apiClient } from "../../../apiClient";
 import { feedback } from "../../../lib/feedback";
+import { UserDomainDrawer } from "../domains/UserDomainDrawer";
 
 interface MailDomainRow {
   id: string;
@@ -59,6 +60,9 @@ export function MailDomainsPage() {
   // domain name that must match before the destructive button enables.
   const [deleteRow, setDeleteRow] = useState<MailDomainRow | null>(null);
   const [confirmText, setConfirmText] = useState("");
+  // GH #1479: Create Mail Domain drawer (reuses the tenant Add-domain drawer in
+  // its mail mode — web-off, mail on, TLS/webmail/DNS-records options).
+  const [createOpen, setCreateOpen] = useState(false);
   const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
   const rows = query.items;
 
@@ -220,7 +224,18 @@ export function MailDomainsPage() {
   ];
 
   return (
-    <Card title="Mail Domains">
+    <Card
+      title="Mail Domains"
+      extra={
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={() => setCreateOpen(true)}
+        >
+          Create Mail Domain
+        </Button>
+      }
+    >
       <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
         Domains with mail active, at a glance. Select a domain to manage its
         accounts and add mailboxes.
@@ -230,8 +245,12 @@ export function MailDomainsPage() {
       ) : rows.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="No domains have mail active yet. Enable mail on a domain from the Domains page."
-        />
+          description="No domains have mail active yet. Create a mail domain here, or enable mail on an existing domain from the Domains page."
+        >
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>
+            Create Mail Domain
+          </Button>
+        </Empty>
       ) : (
         <Table<MailDomainRow>
           rowKey="id"
@@ -282,6 +301,17 @@ export function MailDomainsPage() {
           }}
         />
       </Modal>
+
+      <UserDomainDrawer
+        open={createOpen}
+        mode="mail"
+        onClose={() => {
+          setCreateOpen(false);
+          // The drawer creates via the "domains" resource; this page lists
+          // "me/mail-domains", so refetch to show the new mail domain.
+          void query.refetch?.();
+        }}
+      />
     </Card>
   );
 }


### PR DESCRIPTION
johnnyq asked for a "Create Mail Domain" button on the tenant Mail Domains page (#1479), with fields for the domain, TLS certificate, webmail, and DNS mail records.

The tenant Add-domain drawer already has a **mail mode** (GH #1449: web-off, mail on). This wires it up from the Mail Domains page and adds the requested knobs — no backend change, no migration, no new permission surface (`POST /domains` is already tenant-accessible and scoped to the caller).

## What's added
- **MailDomainsPage**: a primary **Create Mail Domain** button (in the card header, and inside the empty state) opens the shared `UserDomainDrawer` in `mode="mail"`; the list refetches on close so the new mail domain appears (the drawer invalidates the `domains` query key, but this page lists `me/mail-domains`).
- **UserDomainDrawer (mail mode)**:
  - **Enable webmail** toggle (default ON, matches the model default). Only the OFF case writes — a `PATCH webmail_enabled=false` **after** create, because setting the tinyint `false` at create hits GORM's zero-value-omit trap; the update path persists it explicitly (and `Schedule()`s a reconcile). Minor create-then-off churn (webmail vhost written then removed next tick) is the accepted trade vs. the GORM trap.
  - The DNS checkbox is relabelled **Create DNS mail records** with mail copy. It maps to `manage_dns` (GH #1449 `dns_disabled`): ON writes the mail records (MX/SPF/DKIM/autodiscover); OFF = the tenant manages DNS elsewhere and points MX/SPF/DKIM at this server.

## Two deliberate deviations from the issue's field list
- **TLS "None" is NOT offered for mail domains.** A mail domain needs a real cert on `mail.<domain>` for IMAPS/SMTPS/autoconfig + webmail, and the server rejects `ssl_mode=none` while mail is on (`ssl_none_with_email`). Mail mode shows **Let's Encrypt / Self-signed**; "None" stays a web-only option.
- **"Create DNS mail records = off" maps to `dns_disabled`**, not `mail_provider='external'`. `DeriveMailFlags` sets `EmailEnabled=false` for any provider other than `jabali`, so mapping the toggle to `mail_provider` would have silently turned mail *off* — defeating "create a mail domain". Same tenant intent (mail here, DNS elsewhere), correct mechanism.

## Test plan
- [x] `tsc -b` clean
- [x] `MailDomainsPage.test.tsx`: the button opens the mail drawer with the Enable-webmail + Create-DNS-mail-records toggles; **and a contract test** asserting the submit posts `POST /domains { web_enabled:false, mail_provider:"jabali", ssl_mode:"le", manage_dns:true }` (no `enable_webmail` leak) and webmail-off fires `PATCH /domains/:id { webmail_enabled:false }`
- [x] existing domains/mail vitest green (shared drawer web/dns modes unaffected)
- [ ] Authed box drill skipped by design: UI-only, both endpoints (`POST /domains` mail mode, `PATCH` webmail) are shipped and live-proven; the payload mapping is asserted at the unit level instead.