### PR TITLE
refactor(notifications): shared Notification Channels Module behind explicit adapters (JAB-336)

### DIFF
--- a/panel-ui/src/components/notifications/ChannelDrawer.test.tsx
+++ b/panel-ui/src/components/notifications/ChannelDrawer.test.tsx
@@ -1,0 +1,72 @@
+// ChannelDrawer.test — the shared drawer's audience-neutral behaviour (JAB-336).
+// Focus is the write-only masked-secret affordance (AC3) — on edit a secret field
+// advertises "leave blank to keep" (the GET redacted it; the server preserves an
+// empty secret) but on create shows its real placeholder — and the policy-driven
+// notes (admin webpush / tenant forced-email) that stand in for config fields.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChannelDrawer } from "./ChannelDrawer";
+import {
+  ADMIN_CHANNEL_POLICY,
+  tenantChannelPolicy,
+  type NotificationChannel,
+} from "./channelPolicy";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+function renderDrawer(props: Partial<Parameters<typeof ChannelDrawer>[0]>) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <ChannelDrawer open onClose={() => {}} policy={ADMIN_CHANNEL_POLICY} {...props} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+// A webhook row — hmac_secret is a password field. A GET redacts the secret, so
+// the seeded config carries only the public url.
+const webhookRow: NotificationChannel = {
+  id: "c1",
+  name: "hook",
+  kind: "webhook",
+  enabled: true,
+  config: { url: "https://x.test/h" },
+};
+
+describe("ChannelDrawer masked-secret affordance (AC3)", () => {
+  it("advertises 'leave blank to keep' for a secret field when editing", () => {
+    renderDrawer({ existing: webhookRow });
+    expect(screen.getByText(/Edit hook/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/leave blank to keep/i)).toBeInTheDocument();
+  });
+
+  it("shows no masked hint for a secret field when creating", () => {
+    renderDrawer({ policy: { ...ADMIN_CHANNEL_POLICY, defaultKind: "webhook" } });
+    // The HMAC secret field still renders (it's a create form for a webhook)…
+    expect(screen.getByText("HMAC secret")).toBeInTheDocument();
+    // …but without the write-only "leave blank to keep" placeholder.
+    expect(screen.queryByPlaceholderText(/leave blank to keep/i)).toBeNull();
+  });
+});
+
+describe("ChannelDrawer policy-driven notes", () => {
+  it("shows the admin webpush note in place of config fields", () => {
+    renderDrawer({ policy: { ...ADMIN_CHANNEL_POLICY, defaultKind: "webpush" } });
+    expect(screen.getByText(ADMIN_CHANNEL_POLICY.webpushNote.message)).toBeInTheDocument();
+  });
+
+  it("shows the tenant forced-email note and hides the destination fields (AC5)", () => {
+    const p = tenantChannelPolicy(["email"]);
+    renderDrawer({ policy: p });
+    expect(screen.getByText(p.emailNote!.message)).toBeInTheDocument();
+    // Forced email → the Recipient / SMTP fields are not rendered.
+    expect(screen.queryByText("Recipient")).toBeNull();
+  });
+});

--- a/panel-ui/src/components/notifications/ChannelDrawer.tsx
+++ b/panel-ui/src/components/notifications/ChannelDrawer.tsx
@@ -1,0 +1,219 @@
+// ChannelDrawer — the neutral create/edit drawer for a notification channel
+// (JAB-336, ADR-0083). The admin (server-wide) and tenant (self-service) shells
+// render this exact Module and differ only through the ChannelPolicy their
+// adapter supplies: resource path, creatable kinds, default kind, form id, the
+// name placeholder, the forced-email note and the SMTP port range. Field
+// rendering, validation and the write-only masked-secret affordance are
+// identical and live here — previously they were duplicated across the two
+// drawers with only cosmetic drift.
+//
+// Secrets are write-only. A GET redacts every secret field (notifsecret.Redact),
+// so an edit seeds a blank secret and shows a "leave blank to keep" placeholder;
+// submitting blank preserves the stored value server-side
+// (notifsecret.PreserveEmptySecrets, wired on BOTH update paths). AC3.
+import { useEffect, useMemo } from "react";
+import { Alert, Button, Drawer, Form, Grid, Input, InputNumber, Select, Switch } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+
+import { StandardDrawerFooter } from "../StandardActionFooter";
+import { useCreateMutation, useUpdateMutation } from "../../hooks/useQueries";
+import { sendChannelTest } from "./useChannelActions";
+import {
+  kindFields,
+  kindLabels,
+  type ChannelFormConfig,
+  type ChannelKind,
+} from "../../utils/channelKindConfig";
+import type { ChannelPolicy, NotificationChannel } from "./channelPolicy";
+
+type FormValues = {
+  name: string;
+  kind: ChannelKind;
+  enabled: boolean;
+  config: ChannelFormConfig;
+};
+
+export interface ChannelDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  /** Existing row for edit mode; undefined for create. */
+  existing?: NotificationChannel;
+  policy: ChannelPolicy;
+}
+
+// Placeholder shown for a secret field on edit — the write-only affordance: the
+// stored secret was redacted by the GET, so a blank field keeps it. AC3.
+const MASKED_SECRET_PLACEHOLDER = "•••••• (leave blank to keep)";
+
+export function ChannelDrawer({ open, onClose, existing, policy }: ChannelDrawerProps) {
+  const [form] = Form.useForm<FormValues>();
+  const screens = Grid.useBreakpoint();
+  const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
+  const create = useCreateMutation<NotificationChannel, Partial<FormValues>>({
+    resource: policy.resourcePath,
+  });
+  const update = useUpdateMutation<NotificationChannel, Partial<FormValues>>({
+    resource: policy.resourcePath,
+  });
+  const isEdit = Boolean(existing);
+  // Edit keeps the row's kind (the Select is disabled); create uses the policy's
+  // default. Never pre-select a kind the server would reject.
+  const defaultKind: ChannelKind = existing?.kind ?? policy.defaultKind;
+
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    form.setFieldsValue({
+      name: existing?.name ?? "",
+      kind: defaultKind,
+      enabled: existing?.enabled ?? true,
+      config: existing?.config ?? {},
+    });
+  }, [open, existing, form, defaultKind]);
+
+  const watchedKind = Form.useWatch<ChannelKind | undefined>("kind", form) ?? defaultKind;
+  const watchedConfig = Form.useWatch<ChannelFormConfig | undefined>("config", form);
+  const fields = useMemo(() => {
+    // Tenant email is forced server-side to the caller's own account address, so
+    // rendering the admin email form's destination + SMTP fields would only
+    // mislead: the server silently overrides them. Show a note instead and
+    // submit no email config. (AC5)
+    if (policy.forceOwnEmail && watchedKind === "email") return [];
+    const all = kindFields[watchedKind] ?? [];
+    return all.filter((f) => {
+      if (!f.dependsOn) return true;
+      // Treat empty/undefined as the first option so dependent rows stay hidden
+      // until the parent has been picked.
+      return watchedConfig?.[f.dependsOn.name] === f.dependsOn.value;
+    });
+  }, [policy.forceOwnEmail, watchedKind, watchedConfig]);
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      if (isEdit && existing) {
+        await update.mutateAsync({ id: existing.id, input: values });
+        feedback.message.success(`Channel "${values.name}" updated`);
+      } else {
+        await create.mutateAsync(values);
+        feedback.message.success(`Channel "${values.name}" created`);
+      }
+      onClose();
+    } catch (err) {
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
+    }
+  };
+
+  const handleSendTest = async () => {
+    if (!existing) return;
+    await sendChannelTest(policy, existing);
+  };
+
+  return (
+    <Drawer
+      title={isEdit ? `Edit ${existing?.name ?? "channel"}` : "Add channel"}
+      open={open}
+      onClose={onClose}
+      width={isDesktop ? 520 : undefined}
+      placement="right"
+      destroyOnClose
+      footer={
+        <StandardDrawerFooter
+          formId={policy.formId}
+          primaryText={isEdit ? "Save" : "Create"}
+          primaryLoading={create.isPending || update.isPending}
+          onCancel={onClose}
+          extra={isEdit ? <Button onClick={handleSendTest}>Send test</Button> : null}
+        />
+      }
+    >
+      <Form<FormValues>
+        id={policy.formId}
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        initialValues={{ kind: defaultKind, enabled: true, config: {} }}
+      >
+        <Form.Item
+          name="name"
+          label="Name"
+          rules={[
+            { required: true, message: "Name required" },
+            { max: 120, message: "Max 120 chars" },
+          ]}
+        >
+          <Input placeholder={policy.namePlaceholder} />
+        </Form.Item>
+
+        <Form.Item name="kind" label="Kind" rules={[{ required: true }]}>
+          <Select
+            disabled={isEdit}
+            options={policy.allowedKinds.map((k) => ({ value: k, label: kindLabels[k] }))}
+          />
+        </Form.Item>
+
+        <Form.Item name="enabled" label="Enabled" valuePropName="checked">
+          <Switch />
+        </Form.Item>
+
+        {watchedKind === "webpush" ? (
+          <Alert
+            type="info"
+            showIcon
+            message={policy.webpushNote.message}
+            description={policy.webpushNote.description}
+          />
+        ) : null}
+
+        {policy.forceOwnEmail && watchedKind === "email" && policy.emailNote ? (
+          <Alert
+            type="info"
+            showIcon
+            message={policy.emailNote.message}
+            description={policy.emailNote.description}
+          />
+        ) : null}
+
+        {fields.map((f) => {
+          const rules: { required?: boolean; message: string }[] = [];
+          if (f.required) rules.push({ required: true, message: `${f.label} required` });
+          const input = (() => {
+            if (f.type === "number") {
+              // The ntfy priority field is the historical 1–5 caller; the SMTP
+              // port input wants the full TCP range. Split on the policy flag +
+              // field name rather than overload FieldSpec so bounds stay legible.
+              if (policy.smtpPortFullRange && f.name === "smtp_port") {
+                return (
+                  <InputNumber min={1} max={65535} style={{ width: "100%" }} placeholder={f.placeholder} />
+                );
+              }
+              return <InputNumber min={1} max={5} style={{ width: "100%" }} />;
+            }
+            if (f.type === "password") {
+              return (
+                <Input.Password placeholder={isEdit ? MASKED_SECRET_PLACEHOLDER : f.placeholder} />
+              );
+            }
+            if (f.type === "tags") {
+              return <Select mode="tags" tokenSeparators={[",", " "]} placeholder="tag1,tag2" />;
+            }
+            if (f.type === "select") {
+              return <Select options={f.options ?? []} placeholder={f.placeholder} />;
+            }
+            return <Input placeholder={f.placeholder} />;
+          })();
+          return (
+            <Form.Item
+              key={String(f.name)}
+              name={["config", f.name]}
+              label={f.label}
+              rules={rules}
+              extra={f.help}
+            >
+              {input}
+            </Form.Item>
+          );
+        })}
+      </Form>
+    </Drawer>
+  );
+}

--- a/panel-ui/src/components/notifications/channelColumns.test.ts
+++ b/panel-ui/src/components/notifications/channelColumns.test.ts
@@ -1,0 +1,31 @@
+// channelColumns.test — the owner column is admin-only (AC4). The builder must
+// include the user_id column only when showOwnerColumn is set, so a tenant (who
+// only ever sees its own rows) never renders it.
+import { describe, expect, it } from "vitest";
+
+import { buildChannelColumns } from "./channelColumns";
+
+const labels = { name: "Name", kind: "Kind", owner: "Owner", enabled: "Enabled", actions: "Actions" };
+
+function dataIndexes(cols: ReturnType<typeof buildChannelColumns>): (string | undefined)[] {
+  return cols.map((c) => (c as { dataIndex?: string }).dataIndex);
+}
+
+describe("buildChannelColumns owner column (AC4)", () => {
+  const base = {
+    labels,
+    onOpenEdit: () => {},
+    onToggleEnabled: () => {},
+    renderActions: () => null,
+  };
+
+  it("includes the owner column when showOwnerColumn is true (admin)", () => {
+    const cols = buildChannelColumns({ ...base, showOwnerColumn: true });
+    expect(dataIndexes(cols)).toContain("user_id");
+  });
+
+  it("omits the owner column when showOwnerColumn is false (tenant)", () => {
+    const cols = buildChannelColumns({ ...base, showOwnerColumn: false });
+    expect(dataIndexes(cols)).not.toContain("user_id");
+  });
+});

--- a/panel-ui/src/components/notifications/channelColumns.tsx
+++ b/panel-ui/src/components/notifications/channelColumns.tsx
@@ -1,0 +1,89 @@
+// channelColumns — the shared column set for a notification-channel inventory
+// (JAB-336, ADR-0083). Both the admin tab and the tenant page render their own
+// table shell (server-paginated SearchableTable vs a plain client Table inside a
+// Card with event routing) but the name / kind / owner / enabled columns are
+// identical, so they live here. The owner column is admin-only, gated by a single
+// policy flag — that's AC4 in one place.
+//
+// The actions cell differs structurally between the two surfaces (an overflow
+// RowActions menu vs inline buttons + Popconfirm), so each host supplies it via
+// renderActions rather than the builder guessing.
+import type { ReactNode } from "react";
+import { Switch, Tag } from "antd";
+import type { TableProps } from "antd";
+import { kindColors, kindLabels } from "../../utils/channelKindConfig";
+import type { NotificationChannel } from "./channelPolicy";
+
+type ChannelColumns = NonNullable<TableProps<NotificationChannel>["columns"]>;
+
+export type ChannelColumnLabels = {
+  name: string;
+  kind: string;
+  owner: string;
+  enabled: string;
+  actions: string;
+};
+
+export function buildChannelColumns(opts: {
+  labels: ChannelColumnLabels;
+  showOwnerColumn: boolean;
+  onOpenEdit: (row: NotificationChannel) => void;
+  onToggleEnabled: (row: NotificationChannel, next: boolean) => void;
+  renderActions: (row: NotificationChannel) => ReactNode;
+}): ChannelColumns {
+  const { labels, showOwnerColumn, onOpenEdit, onToggleEnabled, renderActions } = opts;
+
+  const columns: ChannelColumns = [
+    {
+      dataIndex: "name",
+      title: labels.name,
+      render: (name: string, row: NotificationChannel) => (
+        <a onClick={() => onOpenEdit(row)}>{name}</a>
+      ),
+    },
+    {
+      dataIndex: "kind",
+      title: labels.kind,
+      render: (k: string) => (
+        <Tag color={kindColors[k as keyof typeof kindColors]}>
+          {kindLabels[k as keyof typeof kindLabels] ?? k}
+        </Tag>
+      ),
+    },
+  ];
+
+  // Owner column is admin-only: it distinguishes server-wide channels from
+  // tenant-owned ones. A tenant only ever sees its own rows, so the column would
+  // be noise. (AC4)
+  if (showOwnerColumn) {
+    columns.push({
+      dataIndex: "user_id",
+      title: labels.owner,
+      render: (userID: string | null | undefined) =>
+        userID ? (
+          <Tag color="blue" title={userID}>
+            Tenant
+          </Tag>
+        ) : (
+          <Tag>Server-wide</Tag>
+        ),
+    });
+  }
+
+  columns.push(
+    {
+      dataIndex: "enabled",
+      title: labels.enabled,
+      render: (enabled: boolean, row: NotificationChannel) => (
+        <Switch checked={enabled} onChange={(next) => onToggleEnabled(row, next)} />
+      ),
+    },
+    {
+      key: "actions",
+      title: labels.actions,
+      render: (_: unknown, row: NotificationChannel) => renderActions(row),
+    },
+  );
+
+  return columns;
+}

--- a/panel-ui/src/components/notifications/channelPolicy.test.ts
+++ b/panel-ui/src/components/notifications/channelPolicy.test.ts
@@ -1,0 +1,61 @@
+// channelPolicy.test — pins the explicit audience policy (JAB-336). With a single
+// shared Module, "both surfaces render the same fields" is tautological; the teeth
+// are in the policy deltas each adapter supplies. These assert the resource paths
+// (AC2), the admin-only owner column (AC4), and the tenant allowed-kind policy
+// (AC5), including the JAB-326 widening + the deliberate webpush asymmetry.
+import { describe, expect, it } from "vitest";
+
+import { CHANNEL_KINDS } from "../../utils/channelKindConfig";
+import { ADMIN_CHANNEL_POLICY, TENANT_KINDS, tenantChannelPolicy } from "./channelPolicy";
+
+describe("channel policy (JAB-336)", () => {
+  it("admin targets the admin resource, shows the owner column, full SMTP range (AC2, AC4)", () => {
+    expect(ADMIN_CHANNEL_POLICY.resourcePath).toBe("admin/notifications/channels");
+    expect(ADMIN_CHANNEL_POLICY.showOwnerColumn).toBe(true);
+    expect(ADMIN_CHANNEL_POLICY.smtpPortFullRange).toBe(true);
+    expect(ADMIN_CHANNEL_POLICY.forceOwnEmail).toBe(false);
+    expect(ADMIN_CHANNEL_POLICY.formId).toBe("channel-form");
+  });
+
+  it("tenant targets the me resource, hides the owner column, forces own email (AC2, AC4, AC5)", () => {
+    const p = tenantChannelPolicy(TENANT_KINDS);
+    expect(p.resourcePath).toBe("me/notifications/channels");
+    expect(p.showOwnerColumn).toBe(false);
+    expect(p.smtpPortFullRange).toBe(false);
+    expect(p.forceOwnEmail).toBe(true);
+    expect(p.emailNote).toBeDefined();
+    expect(p.formId).toBe("my-channel-form");
+  });
+
+  it("admin creatable kinds are the full admin set and exclude webpush (AC5 asymmetry pinned)", () => {
+    expect(ADMIN_CHANNEL_POLICY.allowedKinds).toEqual(CHANNEL_KINDS);
+    expect(ADMIN_CHANNEL_POLICY.allowedKinds).not.toContain("webpush");
+  });
+
+  it("tenant defaults to the safe kinds and never the risky ones (AC5)", () => {
+    const p = tenantChannelPolicy();
+    expect(p.allowedKinds).toEqual(TENANT_KINDS);
+    expect(p.allowedKinds).toContain("webpush");
+    for (const risky of ["email", "slack", "sms", "webhook"] as const) {
+      expect(p.allowedKinds).not.toContain(risky);
+    }
+  });
+
+  it("tenant honours an admin-widened allowlist and defaults to its first kind (JAB-326, AC5)", () => {
+    const p = tenantChannelPolicy(["ntfy", "webhook", "email"]);
+    expect(p.allowedKinds).toEqual(["ntfy", "webhook", "email"]);
+    expect(p.defaultKind).toBe("ntfy");
+  });
+
+  it("tenant falls back to the safe kinds when the allowlist is empty (AC5)", () => {
+    const p = tenantChannelPolicy([]);
+    expect(p.allowedKinds).toEqual(TENANT_KINDS);
+    expect(p.defaultKind).toBe("ntfy");
+  });
+
+  it("test-result copy: admin distinguishes delivered vs queued; tenant is fixed", () => {
+    expect(ADMIN_CHANNEL_POLICY.testResult("Ops", true)).toMatch(/delivered/i);
+    expect(ADMIN_CHANNEL_POLICY.testResult("Ops", false)).toMatch(/queued/i);
+    expect(tenantChannelPolicy().testResult("Phone", undefined)).toMatch(/sent/i);
+  });
+});

--- a/panel-ui/src/components/notifications/channelPolicy.ts
+++ b/panel-ui/src/components/notifications/channelPolicy.ts
@@ -1,0 +1,115 @@
+// channelPolicy — the explicit audience policy for the notification-channel
+// Module (JAB-336, ADR-0083). One neutral <ChannelDrawer> plus one channel
+// inventory (buildChannelColumns + useChannelActions) render both the admin
+// (server-wide) and the tenant (self-service) surfaces. Everything that differs
+// between the two audiences is captured here as data and supplied by each
+// shell's thin adapter — nothing about "admin vs tenant" lives in the Module.
+//
+// This is the explicit-adapter shape: the adapter states resource path, the
+// effective creatable kinds, the owner-column policy, the default kind and the
+// tenant email/routing rules. The Module never infers audience.
+import {
+  CHANNEL_KINDS,
+  type ChannelFormConfig,
+  type ChannelKind,
+} from "../../utils/channelKindConfig";
+
+// NotificationChannel — the canonical channel row. Admin rows may be server-wide
+// (user_id null/undefined) or tenant-owned (user_id set); a tenant only ever sees
+// its own rows. Both shells' previous local types collapse into this one.
+export type NotificationChannel = {
+  id: string;
+  name: string;
+  kind: ChannelKind;
+  config: ChannelFormConfig;
+  enabled: boolean;
+  user_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+};
+
+// TENANT_KINDS — the safe default server allowlist for self-service channels,
+// used only as a fallback (first paint / an older API without allowed_kinds).
+// The real creatable set comes from the server's effective policy (JAB-326),
+// passed to tenantChannelPolicy(). The server create-gate stays authoritative.
+export const TENANT_KINDS: ChannelKind[] = ["ntfy", "telegram", "discord", "webpush"];
+
+// ChannelNote — copy for the info alert a kind shows instead of config fields.
+export type ChannelNote = { message: string; description: string };
+
+export type ChannelPolicy = {
+  /** REST resource, e.g. "admin/notifications/channels" or "me/…". AC2. */
+  resourcePath: string;
+  /** Kinds offered in the create picker. AC5 (tenant allowed-kind is explicit). */
+  allowedKinds: readonly ChannelKind[];
+  /** Pre-selected kind for a brand-new channel. */
+  defaultKind: ChannelKind;
+  /** <Form id> — stable per surface so the drawer footer's submit button binds. */
+  formId: string;
+  namePlaceholder: string;
+  /** Owner column is admin-only (server-wide vs tenant-owned). AC4. */
+  showOwnerColumn: boolean;
+  /** SMTP port wants the full TCP range; the ntfy priority number wants 1–5. */
+  smtpPortFullRange: boolean;
+  /**
+   * Tenant email is forced server-side to the caller's own account address, so
+   * its destination/SMTP fields are hidden and a note is shown instead. AC5.
+   */
+  forceOwnEmail: boolean;
+  webpushNote: ChannelNote;
+  /** Only rendered when forceOwnEmail is true. */
+  emailNote?: ChannelNote;
+  /**
+   * Toast copy after POST /:id/test. `delivered` is read from the response body
+   * (a synchronous send reports true/false; an async one omits it).
+   */
+  testResult: (name: string, delivered: boolean | undefined) => string;
+};
+
+export const ADMIN_CHANNEL_POLICY: ChannelPolicy = {
+  resourcePath: "admin/notifications/channels",
+  allowedKinds: CHANNEL_KINDS,
+  defaultKind: "slack",
+  formId: "channel-form",
+  namePlaceholder: "Ops Slack",
+  showOwnerColumn: true,
+  smtpPortFullRange: true,
+  forceOwnEmail: false,
+  webpushNote: {
+    message: "Web Push has no admin-configured fields",
+    description:
+      "Subscriptions are created per-browser from the user bell. VAPID keys live in server settings.",
+  },
+  testResult: (name, delivered) =>
+    delivered
+      ? `Test delivered to ${name}`
+      : `Test queued for ${name} — see the History tab for the result`,
+};
+
+// tenantChannelPolicy — the self-service policy for a given effective allowlist.
+// The default kind is the first allowed kind so we never pre-select something the
+// server would reject; an empty/absent allowlist falls back to TENANT_KINDS.
+export function tenantChannelPolicy(allowedKinds?: readonly ChannelKind[]): ChannelPolicy {
+  const kinds = allowedKinds && allowedKinds.length > 0 ? allowedKinds : TENANT_KINDS;
+  return {
+    resourcePath: "me/notifications/channels",
+    allowedKinds: kinds,
+    defaultKind: kinds[0] ?? "ntfy",
+    formId: "my-channel-form",
+    namePlaceholder: "My phone",
+    showOwnerColumn: false,
+    smtpPortFullRange: false,
+    forceOwnEmail: true,
+    webpushNote: {
+      message: "Web Push has no fields to configure",
+      description:
+        "It delivers to this browser's push subscription, created from the notification bell.",
+    },
+    emailNote: {
+      message: "Email delivers to your account address",
+      description:
+        "For security, tenant email notifications are always sent to your own account email over the local mail server — the destination and SMTP settings are fixed.",
+    },
+    testResult: (name) => `Test sent to ${name}`,
+  };
+}

--- a/panel-ui/src/components/notifications/useChannelActions.ts
+++ b/panel-ui/src/components/notifications/useChannelActions.ts
@@ -1,0 +1,56 @@
+// useChannelActions — the shared toggle / delete / test handlers for a
+// notification-channel inventory (JAB-336, ADR-0083). The admin tab and the
+// tenant page render different table shells but drive the same three actions
+// against their own resource path (policy.resourcePath, AC2). The delete path
+// takes an optional onDeleted hook so the tenant page can invalidate its event
+// routes (a deleted channel unpicks itself from the routing matrix).
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import { useDeleteMutation, useUpdateMutation } from "../../hooks/useQueries";
+import type { ChannelPolicy, NotificationChannel } from "./channelPolicy";
+
+// sendChannelTest — POST /:id/test and toast the outcome. Shared by the inventory
+// "Test" action and the drawer's "Send test" button so there is one test path.
+export async function sendChannelTest(
+  policy: ChannelPolicy,
+  row: { id: string; name: string },
+): Promise<void> {
+  try {
+    const res = await apiClient.post<{ delivered?: boolean }>(
+      `/${policy.resourcePath}/${row.id}/test`,
+    );
+    feedback.message.success(policy.testResult(row.name, res.data?.delivered));
+  } catch (err) {
+    // A synchronous send surfaces the real delivery error (e.g. SMTP auth).
+    feedback.message.error(err instanceof Error ? err.message : "Test failed");
+  }
+}
+
+export function useChannelActions(policy: ChannelPolicy, opts?: { onDeleted?: () => void }) {
+  const update = useUpdateMutation<NotificationChannel, { enabled: boolean }>({
+    resource: policy.resourcePath,
+  });
+  const remove = useDeleteMutation({ resource: policy.resourcePath });
+
+  const toggleEnabled = async (row: NotificationChannel, next: boolean) => {
+    try {
+      await update.mutateAsync({ id: row.id, input: { enabled: next } });
+    } catch (err) {
+      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
+    }
+  };
+
+  const deleteChannel = async (row: NotificationChannel) => {
+    try {
+      await remove.mutateAsync({ id: row.id });
+      feedback.message.success(`Deleted ${row.name}`);
+      opts?.onDeleted?.();
+    } catch (err) {
+      feedback.message.error(err instanceof Error ? err.message : "Delete failed");
+    }
+  };
+
+  const testChannel = (row: NotificationChannel) => sendChannelTest(policy, row);
+
+  return { toggleEnabled, deleteChannel, testChannel };
+}

--- a/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
+++ b/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
@@ -1,205 +1,25 @@
-// AdminChannelDrawer — create + edit drawer for notification channels.
-// Kind-specific fields are sourced from channelKindConfig so adding a
-// new channel type is a single-file diff.
-import { useEffect, useMemo } from "react";
-import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
-import { Alert, Button, Drawer, Form, Grid, Input, InputNumber, Select, Switch } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-
-import { apiClient } from "../../../apiClient";
-import { useCreateMutation, useUpdateMutation } from "../../../hooks/useQueries";
-
+// AdminChannelDrawer — the server-wide notification-channel drawer. A thin
+// adapter over the neutral ChannelDrawer Module (JAB-336, ADR-0083): it supplies
+// the admin policy and re-exports the canonical row type its callers already
+// import. All field rendering, validation and the write-only masked-secret
+// affordance live in the Module.
+import { ChannelDrawer } from "../../../components/notifications/ChannelDrawer";
 import {
-  CHANNEL_KINDS,
-  kindFields,
-  kindLabels,
-  type ChannelFormConfig,
-  type ChannelKind,
-} from "../../../utils/channelKindConfig";
+  ADMIN_CHANNEL_POLICY,
+  type NotificationChannel,
+} from "../../../components/notifications/channelPolicy";
 
-export type NotificationChannel = {
-  id: string;
-  name: string;
-  kind: ChannelKind;
-  config: ChannelFormConfig;
-  enabled: boolean;
-  // user_id is set for tenant-owned channels (JAB-171); null/undefined = a
-  // server-wide admin channel.
-  user_id?: string | null;
-  created_at?: string;
-  updated_at?: string;
-};
-
-type FormValues = {
-  name: string;
-  kind: ChannelKind;
-  enabled: boolean;
-  config: ChannelFormConfig;
-};
+export type { NotificationChannel };
 
 export interface AdminChannelDrawerProps {
   open: boolean;
   onClose: () => void;
-  // existing row for edit mode, undefined for create
+  /** Existing row for edit mode; undefined for create. */
   existing?: NotificationChannel;
 }
 
-const RESOURCE = "admin/notifications/channels";
-
 export function AdminChannelDrawer({ open, onClose, existing }: AdminChannelDrawerProps) {
-  const [form] = Form.useForm<FormValues>();
-  const screens = Grid.useBreakpoint();
-  const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
-  const create = useCreateMutation<NotificationChannel, Partial<FormValues>>({ resource: RESOURCE });
-  const update = useUpdateMutation<NotificationChannel, Partial<FormValues>>({ resource: RESOURCE });
-  const isEdit = Boolean(existing);
-
-  useEffect(() => {
-    if (!open) return;
-    form.resetFields();
-    form.setFieldsValue({
-      name: existing?.name ?? "",
-      kind: existing?.kind ?? "slack",
-      enabled: existing?.enabled ?? true,
-      config: existing?.config ?? {},
-    });
-  }, [open, existing, form]);
-
-  const watchedKind = Form.useWatch<ChannelKind | undefined>("kind", form) ?? existing?.kind ?? "slack";
-  const watchedConfig = Form.useWatch<ChannelFormConfig | undefined>("config", form);
-  const fields = useMemo(() => {
-    const all = kindFields[watchedKind] ?? [];
-    return all.filter((f) => {
-      if (!f.dependsOn) return true;
-      const current = watchedConfig?.[f.dependsOn.name];
-      // Treat empty/undefined as the first option for select fields so
-      // dependent rows stay hidden until the parent has been picked.
-      return current === f.dependsOn.value;
-    });
-  }, [watchedKind, watchedConfig]);
-
-  const handleSubmit = async (values: FormValues) => {
-    try {
-      if (isEdit && existing) {
-        await update.mutateAsync({ id: existing.id, input: values });
-        feedback.message.success(`Channel "${values.name}" updated`);
-      } else {
-        await create.mutateAsync(values);
-        feedback.message.success(`Channel "${values.name}" created`);
-      }
-      onClose();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Save failed";
-      feedback.message.error(msg);
-    }
-  };
-
-  const handleSendTest = async () => {
-    if (!existing) return;
-    try {
-      await apiClient.post(`/${RESOURCE}/${existing.id}/test`);
-      feedback.message.success(`Test envelope fired for "${existing.name}"`);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Test failed";
-      feedback.message.error(msg);
-    }
-  };
-
   return (
-    <Drawer
-      title={isEdit ? `Edit ${existing?.name ?? "channel"}` : "Add channel"}
-      open={open}
-      onClose={onClose}
-      width={isDesktop ? 520 : undefined}
-      placement="right"
-      destroyOnClose
-      footer={
-        <StandardDrawerFooter
-          formId="channel-form"
-          primaryText={isEdit ? "Save" : "Create"}
-          primaryLoading={create.isPending || update.isPending}
-          onCancel={onClose}
-          extra={isEdit ? <Button onClick={handleSendTest}>Send test</Button> : null}
-        />
-      }
-    >
-      <Form<FormValues>
-        id="channel-form"
-        form={form}
-        layout="vertical"
-        onFinish={handleSubmit}
-        initialValues={{ kind: "slack", enabled: true, config: {} }}
-      >
-        <Form.Item
-          name="name"
-          label="Name"
-          rules={[
-            { required: true, message: "Name required" },
-            { max: 120, message: "Max 120 chars" },
-          ]}
-        >
-          <Input placeholder="Ops Slack" />
-        </Form.Item>
-
-        <Form.Item name="kind" label="Kind" rules={[{ required: true }]}>
-          <Select
-            disabled={isEdit}
-            options={CHANNEL_KINDS.map((k) => ({ value: k, label: kindLabels[k] }))}
-          />
-        </Form.Item>
-
-        <Form.Item name="enabled" label="Enabled" valuePropName="checked">
-          <Switch />
-        </Form.Item>
-
-        {watchedKind === "webpush" ? (
-          <Alert
-            type="info"
-            showIcon
-            message="Web Push has no admin-configured fields"
-            description="Subscriptions are created per-browser from the user bell. VAPID keys live in server settings."
-          />
-        ) : null}
-
-        {fields.map((f) => {
-          const rules: { required?: boolean; message: string }[] = [];
-          if (f.required) rules.push({ required: true, message: `${f.label} required` });
-          const input = (() => {
-            if (f.type === "number") {
-              // The ntfy priority field is the historical 1–5 caller; the
-              // SMTP port input wants the full TCP range. We split on the
-              // field name rather than overload FieldSpec so each kind's
-              // bounds stay legible.
-              if (f.name === "smtp_port") {
-                return <InputNumber min={1} max={65535} style={{ width: "100%" }} placeholder={f.placeholder} />;
-              }
-              return <InputNumber min={1} max={5} style={{ width: "100%" }} />;
-            }
-            if (f.type === "password") return <Input.Password placeholder={f.placeholder} />;
-            if (f.type === "tags") {
-              return (
-                <Select mode="tags" tokenSeparators={[",", " "]} placeholder="tag1,tag2" />
-              );
-            }
-            if (f.type === "select") {
-              return <Select options={f.options ?? []} placeholder={f.placeholder} />;
-            }
-            return <Input placeholder={f.placeholder} />;
-          })();
-          return (
-            <Form.Item
-              key={String(f.name)}
-              name={["config", f.name]}
-              label={f.label}
-              rules={rules}
-              extra={f.help}
-            >
-              {input}
-            </Form.Item>
-          );
-        })}
-
-      </Form>
-    </Drawer>
+    <ChannelDrawer open={open} onClose={onClose} existing={existing} policy={ADMIN_CHANNEL_POLICY} />
   );
 }

--- a/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
@@ -3,25 +3,27 @@
 // Rendered inside NotificationsTabsPage Card.tabList. Strips its own
 // page-level header; the "Add channel" button stays here because it's
 // tab-specific (the History tab has a different action).
+//
+// The channel rows, columns and the toggle/test/delete handlers are the shared
+// notification-channel inventory (JAB-336, ADR-0083); this tab keeps its own
+// server-paginated table shell and supplies the admin policy + an overflow
+// RowActions menu.
 import { useTranslation } from "react-i18next";
-import { Button, Space, Switch, Table, Tag } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { Button, Space } from "antd";
 import { useState } from "react";
 
 import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
 
 import { RowActions } from "../../../components/RowActions";
-import { apiClient } from "../../../apiClient";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
-import {
-  useDeleteMutation,
-  useUpdateMutation,
-} from "../../../hooks/useQueries";
 import { useTableURL } from "../../../hooks/useTableURL";
-import { AdminChannelDrawer, type NotificationChannel } from "./AdminChannelDrawer";
-import { kindColors, kindLabels } from "../../../utils/channelKindConfig";
-
-const RESOURCE = "admin/notifications/channels";
+import { AdminChannelDrawer } from "./AdminChannelDrawer";
+import {
+  ADMIN_CHANNEL_POLICY,
+  type NotificationChannel,
+} from "../../../components/notifications/channelPolicy";
+import { buildChannelColumns } from "../../../components/notifications/channelColumns";
+import { useChannelActions } from "../../../components/notifications/useChannelActions";
 
 export const ChannelsTab = () => {
   const { t } = useTranslation();
@@ -29,43 +31,11 @@ export const ChannelsTab = () => {
   const [editing, setEditing] = useState<NotificationChannel | undefined>();
 
   const query = useTableURL<NotificationChannel>({
-    resource: RESOURCE,
+    resource: ADMIN_CHANNEL_POLICY.resourcePath,
     defaultSort: "created_at",
     defaultOrder: "desc",
   });
-  const updateMutation = useUpdateMutation<NotificationChannel, { enabled: boolean }>({ resource: RESOURCE });
-  const deleteMutation = useDeleteMutation({ resource: RESOURCE });
-
-  const handleToggleEnabled = async (row: NotificationChannel, next: boolean) => {
-    try {
-      await updateMutation.mutateAsync({ id: row.id, input: { enabled: next } });
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
-    }
-  };
-
-  const handleDelete = async (row: NotificationChannel) => {
-    try {
-      await deleteMutation.mutateAsync({ id: row.id });
-      feedback.message.success(`Deleted ${row.name}`);
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Delete failed");
-    }
-  };
-
-  const handleTest = async (row: NotificationChannel) => {
-    try {
-      const res = await apiClient.post<{ delivered?: boolean }>(`/${RESOURCE}/${row.id}/test`);
-      if (res.data?.delivered) {
-        feedback.message.success(`Test delivered to ${row.name}`);
-      } else {
-        feedback.message.success(`Test queued for ${row.name} — see the History tab for the result`);
-      }
-    } catch (err) {
-      // Synchronous send surfaces the real delivery error (e.g. SMTP auth).
-      feedback.message.error(err instanceof Error ? err.message : "Test failed");
-    }
-  };
+  const { toggleEnabled, deleteChannel, testChannel } = useChannelActions(ADMIN_CHANNEL_POLICY);
 
   const openCreate = () => {
     setEditing(undefined);
@@ -76,6 +46,35 @@ export const ChannelsTab = () => {
     setEditing(row);
     setDrawerOpen(true);
   };
+
+  const columns = buildChannelColumns({
+    labels: {
+      name: t("channelstab.name"),
+      kind: t("channelstab.kind"),
+      owner: "Owner",
+      enabled: t("channelstab.enabled"),
+      actions: t("channelstab.actions"),
+    },
+    showOwnerColumn: ADMIN_CHANNEL_POLICY.showOwnerColumn,
+    onOpenEdit: openEdit,
+    onToggleEnabled: toggleEnabled,
+    renderActions: (row) => (
+      <RowActions
+        actions={[
+          { key: "test", label: "Test", icon: <SendOutlined />, onClick: () => testChannel(row) },
+          { key: "edit", label: "Edit", icon: <EditOutlined />, onClick: () => openEdit(row) },
+          {
+            key: "delete",
+            label: "Delete",
+            icon: <DeleteOutlined />,
+            danger: true,
+            onClick: () => deleteChannel(row),
+            confirm: { title: `Delete ${row.name}?` },
+          },
+        ]}
+      />
+    ),
+  });
 
   return (
     <div>
@@ -89,6 +88,7 @@ export const ChannelsTab = () => {
         rowKey="id"
         loading={query.isLoading}
         dataSource={query.items}
+        columns={columns}
         initialSearch={query.params.q}
         searchPlaceholder="Search by name"
         onSearchChange={(q) => query.setParams({ q, page: 1 })}
@@ -102,57 +102,7 @@ export const ChannelsTab = () => {
           onChange: (page, pageSize) => query.setParams({ page, pageSize }),
         }}
         scroll={{ x: "max-content" }}
-      >
-        <Table.Column
-          dataIndex="name"
-          title={t("channelstab.name")}
-          render={(name: string, row: NotificationChannel) => (
-            <a onClick={() => openEdit(row)}>{name}</a>
-          )}
-        />
-        <Table.Column
-          dataIndex="kind"
-          title={t("channelstab.kind")}
-          render={(k: string) => (
-            <Tag color={kindColors[k as keyof typeof kindColors]}>
-              {kindLabels[k as keyof typeof kindLabels] ?? k}
-            </Tag>
-          )}
-        />
-        <Table.Column
-          dataIndex="user_id"
-          title="Owner"
-          render={(userID: string | null | undefined) =>
-            userID ? (
-              <Tag color="blue" title={userID}>
-                Tenant
-              </Tag>
-            ) : (
-              <Tag>Server-wide</Tag>
-            )
-          }
-        />
-        <Table.Column
-          dataIndex="enabled"
-          title={t("channelstab.enabled")}
-          render={(enabled: boolean, row: NotificationChannel) => (
-            <Switch checked={enabled} onChange={(next) => handleToggleEnabled(row, next)} />
-          )}
-        />
-        <Table.Column
-          title={t("channelstab.actions")}
-          key="actions"
-          render={(_: unknown, row: NotificationChannel) => (
-            <RowActions
-              actions={[
-                { key: "test", label: "Test", icon: <SendOutlined />, onClick: () => handleTest(row) },
-                { key: "edit", label: "Edit", icon: <EditOutlined />, onClick: () => openEdit(row) },
-                { key: "delete", label: "Delete", icon: <DeleteOutlined />, danger: true, onClick: () => handleDelete(row), confirm: { title: `Delete ${row.name}?` } },
-              ]}
-            />
-          )}
-        />
-      </SearchableTableStringQ>
+      />
 
       <AdminChannelDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} existing={editing} />
     </div>

--- a/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
+++ b/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
@@ -1,47 +1,21 @@
-// MyChannelDrawer — tenant create/edit drawer for a user's OWN notification
-// channels (JAB-171 phase 5). Mirrors AdminChannelDrawer but points at the
-// ownership-scoped /me/notifications/channels surface and offers only the
-// tenant-creatable kinds. Secrets are write-only: an edit leaves a secret
-// field blank to keep the stored (sealed) value — the placeholder says so.
-import { useEffect, useMemo } from "react";
-import { Alert, Button, Drawer, Form, Grid, Input, InputNumber, Select, Switch } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-
-import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
-import { apiClient } from "../../../apiClient";
-import { useCreateMutation, useUpdateMutation } from "../../../hooks/useQueries";
+// MyChannelDrawer — the tenant self-service notification-channel drawer. A thin
+// adapter over the neutral ChannelDrawer Module (JAB-336, ADR-0083): it supplies
+// the tenant policy (ownership-scoped resource + the effective creatable kinds,
+// JAB-326) and re-exports the names its page and tests already import. All field
+// rendering, validation and the write-only masked-secret affordance live in the
+// Module.
+import { ChannelDrawer } from "../../../components/notifications/ChannelDrawer";
 import {
-  kindFields,
-  kindLabels,
-  type ChannelFormConfig,
-  type ChannelKind,
-} from "../../../utils/channelKindConfig";
+  TENANT_KINDS,
+  tenantChannelPolicy,
+  type NotificationChannel,
+} from "../../../components/notifications/channelPolicy";
+import type { ChannelKind } from "../../../utils/channelKindConfig";
 
-// TENANT_KINDS — the safe default server allowlist, used as a fallback only
-// (first paint / older API). JAB-326: the real list of creatable kinds comes
-// from the server's effective policy (GET /me/notifications/channels →
-// allowed_kinds), passed in as the allowedKinds prop, so an admin who widens the
-// policy (webhook/slack/sms/email) makes those kinds appear in the picker. The
-// server create-gate stays authoritative regardless.
-export const TENANT_KINDS: ChannelKind[] = ["ntfy", "telegram", "discord", "webpush"];
-
-export type MyChannel = {
-  id: string;
-  name: string;
-  kind: ChannelKind;
-  config: ChannelFormConfig;
-  enabled: boolean;
-  user_id?: string;
-  created_at?: string;
-  updated_at?: string;
-};
-
-type FormValues = {
-  name: string;
-  kind: ChannelKind;
-  enabled: boolean;
-  config: ChannelFormConfig;
-};
+export { TENANT_KINDS };
+// MyChannel is the canonical channel row — kept as a named re-export so the
+// tenant page keeps importing it from here.
+export type MyChannel = NotificationChannel;
 
 export interface MyChannelDrawerProps {
   open: boolean;
@@ -51,165 +25,13 @@ export interface MyChannelDrawerProps {
   allowedKinds?: ChannelKind[];
 }
 
-const RESOURCE = "me/notifications/channels";
-
 export function MyChannelDrawer({ open, onClose, existing, allowedKinds }: MyChannelDrawerProps) {
-  // Effective creatable kinds: server policy when present, else the safe
-  // defaults. The default selected kind is the first allowed one so we never
-  // pre-select a kind the server would reject.
-  const kinds = allowedKinds && allowedKinds.length > 0 ? allowedKinds : TENANT_KINDS;
-  const defaultKind: ChannelKind = existing?.kind ?? kinds[0] ?? "ntfy";
-  const [form] = Form.useForm<FormValues>();
-  const screens = Grid.useBreakpoint();
-  const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
-  const create = useCreateMutation<MyChannel, Partial<FormValues>>({ resource: RESOURCE });
-  const update = useUpdateMutation<MyChannel, Partial<FormValues>>({ resource: RESOURCE });
-  const isEdit = Boolean(existing);
-
-  useEffect(() => {
-    if (!open) return;
-    form.resetFields();
-    form.setFieldsValue({
-      name: existing?.name ?? "",
-      kind: defaultKind,
-      enabled: existing?.enabled ?? true,
-      config: existing?.config ?? {},
-    });
-  }, [open, existing, form, defaultKind]);
-
-  const watchedKind = Form.useWatch<ChannelKind | undefined>("kind", form) ?? defaultKind;
-  const watchedConfig = Form.useWatch<ChannelFormConfig | undefined>("config", form);
-  const fields = useMemo(() => {
-    // Tenant email is forced server-side to the caller's own account address
-    // over the local mail server (no arbitrary destination / custom SMTP — see
-    // forceOwnEmailConfig). Rendering the admin email form's destination + SMTP
-    // fields would only mislead: the server silently overrides them. Show a note
-    // instead and submit no email config.
-    if (watchedKind === "email") return [];
-    const all = kindFields[watchedKind] ?? [];
-    return all.filter((f) => {
-      if (!f.dependsOn) return true;
-      return watchedConfig?.[f.dependsOn.name] === f.dependsOn.value;
-    });
-  }, [watchedKind, watchedConfig]);
-
-  const handleSubmit = async (values: FormValues) => {
-    try {
-      if (isEdit && existing) {
-        await update.mutateAsync({ id: existing.id, input: values });
-        feedback.message.success(`Channel "${values.name}" updated`);
-      } else {
-        await create.mutateAsync(values);
-        feedback.message.success(`Channel "${values.name}" created`);
-      }
-      onClose();
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Save failed");
-    }
-  };
-
-  const handleSendTest = async () => {
-    if (!existing) return;
-    try {
-      await apiClient.post(`/${RESOURCE}/${existing.id}/test`);
-      feedback.message.success(`Test sent to "${existing.name}"`);
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Test failed");
-    }
-  };
-
   return (
-    <Drawer
-      title={isEdit ? `Edit ${existing?.name ?? "channel"}` : "Add channel"}
+    <ChannelDrawer
       open={open}
       onClose={onClose}
-      width={isDesktop ? 520 : undefined}
-      placement="right"
-      destroyOnClose
-      footer={
-        <StandardDrawerFooter
-          formId="my-channel-form"
-          primaryText={isEdit ? "Save" : "Create"}
-          primaryLoading={create.isPending || update.isPending}
-          onCancel={onClose}
-          extra={isEdit ? <Button onClick={handleSendTest}>Send test</Button> : null}
-        />
-      }
-    >
-      <Form<FormValues>
-        id="my-channel-form"
-        form={form}
-        layout="vertical"
-        onFinish={handleSubmit}
-        initialValues={{ kind: defaultKind, enabled: true, config: {} }}
-      >
-        <Form.Item
-          name="name"
-          label="Name"
-          rules={[
-            { required: true, message: "Name required" },
-            { max: 120, message: "Max 120 chars" },
-          ]}
-        >
-          <Input placeholder="My phone" />
-        </Form.Item>
-
-        <Form.Item name="kind" label="Kind" rules={[{ required: true }]}>
-          <Select
-            disabled={isEdit}
-            options={kinds.map((k) => ({ value: k, label: kindLabels[k] }))}
-          />
-        </Form.Item>
-
-        <Form.Item name="enabled" label="Enabled" valuePropName="checked">
-          <Switch />
-        </Form.Item>
-
-        {watchedKind === "webpush" ? (
-          <Alert
-            type="info"
-            showIcon
-            message="Web Push has no fields to configure"
-            description="It delivers to this browser's push subscription, created from the notification bell."
-          />
-        ) : null}
-
-        {watchedKind === "email" ? (
-          <Alert
-            type="info"
-            showIcon
-            message="Email delivers to your account address"
-            description="For security, tenant email notifications are always sent to your own account email over the local mail server — the destination and SMTP settings are fixed."
-          />
-        ) : null}
-
-        {fields.map((f) => {
-          const rules: { required?: boolean; message: string }[] = [];
-          if (f.required) rules.push({ required: true, message: `${f.label} required` });
-          const input = (() => {
-            if (f.type === "number") {
-              return <InputNumber min={1} max={5} style={{ width: "100%" }} />;
-            }
-            if (f.type === "password") {
-              return (
-                <Input.Password placeholder={isEdit ? "•••••• (leave blank to keep)" : f.placeholder} />
-              );
-            }
-            if (f.type === "tags") {
-              return <Select mode="tags" tokenSeparators={[",", " "]} placeholder="tag1,tag2" />;
-            }
-            if (f.type === "select") {
-              return <Select options={f.options ?? []} placeholder={f.placeholder} />;
-            }
-            return <Input placeholder={f.placeholder} />;
-          })();
-          return (
-            <Form.Item key={String(f.name)} name={["config", f.name]} label={f.label} rules={rules} extra={f.help}>
-              {input}
-            </Form.Item>
-          );
-        })}
-      </Form>
-    </Drawer>
+      existing={existing}
+      policy={tenantChannelPolicy(allowedKinds)}
+    />
   );
 }

--- a/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
+++ b/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
@@ -4,21 +4,28 @@
 // admin switch; when it's off every call returns 403 and we render a calm
 // "not enabled" state rather than an error.
 //
+// The channel list, its columns and the toggle/test/delete handlers are the
+// shared notification-channel inventory (JAB-336, ADR-0083). This page keeps its
+// own client-side table shell, supplies the tenant policy + inline row actions,
+// and owns the event-routing matrix below (tenant-only, no admin equivalent).
+//
 // Routing is a matrix: the server hands back a labelled catalog of the events
 // that fire for this user (GET .../event-catalog), and for each the tenant picks
 // which of their channels should receive it — no raw event-kind typing.
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Alert, Button, Card, Empty, Popconfirm, Select, Space, Switch, Table, Tag, Typography } from "antd";
+import { Alert, Button, Card, Empty, Popconfirm, Select, Space, Table, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { AxiosError } from "axios";
 
 import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
 import { apiClient } from "../../../apiClient";
-import { useDeleteMutation, useUpdateMutation } from "../../../hooks/useQueries";
-import { kindColors, kindLabels, type ChannelKind } from "../../../utils/channelKindConfig";
+import { type ChannelKind } from "../../../utils/channelKindConfig";
 import { MyChannelDrawer, TENANT_KINDS, type MyChannel } from "./MyChannelDrawer";
+import { tenantChannelPolicy } from "../../../components/notifications/channelPolicy";
+import { buildChannelColumns } from "../../../components/notifications/channelColumns";
+import { useChannelActions } from "../../../components/notifications/useChannelActions";
 
 const CH_RESOURCE = "me/notifications/channels";
 const RT_RESOURCE = "me/notifications/routes";
@@ -90,11 +97,20 @@ export function MyNotificationsPage(): JSX.Element {
     enabled: !disabled,
   });
 
-  const updateMutation = useUpdateMutation<MyChannel, { enabled: boolean }>({ resource: CH_RESOURCE });
-  const deleteMutation = useDeleteMutation({ resource: CH_RESOURCE });
-
   const channels = channelsQ.data?.items ?? [];
   const allowedKinds = channelsQ.data?.allowedKinds ?? TENANT_KINDS;
+
+  // Shared inventory actions. A deleted channel unpicks itself from the routing
+  // matrix, so invalidate the routes list after a delete.
+  const { toggleEnabled, deleteChannel, testChannel } = useChannelActions(
+    tenantChannelPolicy(allowedKinds),
+    { onDeleted: () => qc.invalidateQueries({ queryKey: ["list", RT_RESOURCE] }) },
+  );
+
+  const openEdit = (row: MyChannel) => {
+    setEditing(row);
+    setDrawerOpen(true);
+  };
 
   // event_kind -> [{channelId, routeId}] so the matrix can show current
   // selections and delete the right route row when a channel is unpicked.
@@ -107,33 +123,6 @@ export function MyNotificationsPage(): JSX.Element {
     }
     return m;
   }, [routesQ.data]);
-
-  const toggleEnabled = async (row: MyChannel, next: boolean) => {
-    try {
-      await updateMutation.mutateAsync({ id: row.id, input: { enabled: next } });
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
-    }
-  };
-
-  const removeChannel = async (row: MyChannel) => {
-    try {
-      await deleteMutation.mutateAsync({ id: row.id });
-      feedback.message.success(`Deleted ${row.name}`);
-      qc.invalidateQueries({ queryKey: ["list", RT_RESOURCE] });
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Delete failed");
-    }
-  };
-
-  const testChannel = async (row: MyChannel) => {
-    try {
-      await apiClient.post(`/${CH_RESOURCE}/${row.id}/test`);
-      feedback.message.success(`Test sent to ${row.name}`);
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Test failed");
-    }
-  };
 
   // Reconcile a row's channel multi-select against the stored routes: POST the
   // added channels, DELETE the removed ones, then refetch.
@@ -171,6 +160,26 @@ export function MyNotificationsPage(): JSX.Element {
 
   const channelOptions = channels.map((c) => ({ value: c.id, label: c.name }));
 
+  // Tenant inventory: no owner column (a tenant only sees its own rows), inline
+  // row actions with a Popconfirm delete.
+  const channelColumns = buildChannelColumns({
+    labels: { name: "Name", kind: "Kind", owner: "Owner", enabled: "Enabled", actions: "Actions" },
+    showOwnerColumn: false,
+    onOpenEdit: openEdit,
+    onToggleEnabled: toggleEnabled,
+    renderActions: (row) => (
+      <Space>
+        <Button size="small" icon={<SendOutlined />} onClick={() => testChannel(row)}>
+          Test
+        </Button>
+        <Button size="small" icon={<EditOutlined />} onClick={() => openEdit(row)} />
+        <Popconfirm title={`Delete ${row.name}?`} onConfirm={() => deleteChannel(row)}>
+          <Button size="small" danger icon={<DeleteOutlined />} />
+        </Popconfirm>
+      </Space>
+    ),
+  });
+
   return (
     <Space direction="vertical" size="large" style={{ width: "100%" }}>
       <Card
@@ -192,63 +201,11 @@ export function MyNotificationsPage(): JSX.Element {
           rowKey="id"
           loading={channelsQ.isLoading}
           dataSource={channels}
+          columns={channelColumns}
           pagination={false}
           locale={{ emptyText: <Empty description="No channels yet — add one to get notified." /> }}
           scroll={{ x: "max-content" }}
-        >
-          <Table.Column
-            dataIndex="name"
-            title="Name"
-            render={(name: string, row: MyChannel) => (
-              <a
-                onClick={() => {
-                  setEditing(row);
-                  setDrawerOpen(true);
-                }}
-              >
-                {name}
-              </a>
-            )}
-          />
-          <Table.Column
-            dataIndex="kind"
-            title="Kind"
-            render={(k: string) => (
-              <Tag color={kindColors[k as keyof typeof kindColors]}>
-                {kindLabels[k as keyof typeof kindLabels] ?? k}
-              </Tag>
-            )}
-          />
-          <Table.Column
-            dataIndex="enabled"
-            title="Enabled"
-            render={(enabled: boolean, row: MyChannel) => (
-              <Switch checked={enabled} onChange={(next) => toggleEnabled(row, next)} />
-            )}
-          />
-          <Table.Column
-            title="Actions"
-            key="actions"
-            render={(_: unknown, row: MyChannel) => (
-              <Space>
-                <Button size="small" icon={<SendOutlined />} onClick={() => testChannel(row)}>
-                  Test
-                </Button>
-                <Button
-                  size="small"
-                  icon={<EditOutlined />}
-                  onClick={() => {
-                    setEditing(row);
-                    setDrawerOpen(true);
-                  }}
-                />
-                <Popconfirm title={`Delete ${row.name}?`} onConfirm={() => removeChannel(row)}>
-                  <Button size="small" danger icon={<DeleteOutlined />} />
-                </Popconfirm>
-              </Space>
-            )}
-          />
-        </Table>
+        />
       </Card>
 
       <Card title="Event routing">


### PR DESCRIPTION
## JAB-336 — Consolidate notification-channel UI behind policy adapters

ADR-0083 audience-policy slice. The admin (server-wide) and tenant (self-service)
notification-channel drawers were ~90% identical, and the channel inventory (list +
toggle/test/delete) was duplicated between the admin `ChannelsTab` and the tenant
`MyNotificationsPage`. This extracts one neutral **Notification Channels Module**
driven by an **explicit audience policy** — each shell's thin adapter states the
resource path, the creatable kinds, the owner-column policy, the default kind and the
tenant email rule; nothing about "admin vs tenant" lives in the Module.

`#1498` already extracted the neutral `channelKindConfig` *data*; this slice extracts
the *rendering*, *validation* and *inventory behaviour*.

### What moved
- **`components/notifications/channelPolicy.ts`** — canonical `NotificationChannel`
  row + `ChannelPolicy`; `ADMIN_CHANNEL_POLICY` and `tenantChannelPolicy(allowedKinds)`.
- **`components/notifications/ChannelDrawer.tsx`** — the neutral create/edit drawer
  (field rendering, validation, the write-only masked-secret affordance).
- **`components/notifications/channelColumns.tsx`** + **`useChannelActions.ts`** — the
  shared inventory: name/kind/owner/enabled columns and the toggle/test/delete handlers
  (plus a shared `sendChannelTest` used by both the inventory action and the drawer's
  "Send test").
- `AdminChannelDrawer` / `MyChannelDrawer` are now thin adapters that re-export the
  names their callers import. `ChannelsTab` and `MyNotificationsPage` keep their own
  table shells (admin server-paginated `SearchableTable` vs the tenant client-side
  `Table`) and drive the shared columns + actions. The tenant **event-routing matrix**
  and the **403 "not enabled"** gating stay in `MyNotificationsPage` — tenant-only, not
  duplicated.

### Acceptance criteria
- **AC1 — field definitions + validation shared.** ✅ One `ChannelDrawer` renders the
  `kindFields` form + `dependsOn` visibility + `required` rules for both audiences.
- **AC2 — each adapter uses the correct resource path.** ✅ `policy.resourcePath`
  (`admin/notifications/channels` vs `me/notifications/channels`) drives the drawer
  mutations, `useTableURL`, and `useChannelActions`.
- **AC3 — masked secrets preserved on edit.** ✅ On edit a secret field shows
  "•••••• (leave blank to keep)"; a blank submit preserves the stored value.
  **Backend finding:** this is server-authoritative and symmetric —
  `notifsecret.PreserveEmptySecrets` is wired on **both** update paths
  (`notifications_channels.go:197`, `me_notifications.go:318`) and `Redact` on every
  GET. So no frontend stripping is needed; the Module's job is the write-only
  affordance, which the **admin drawer previously lacked** and now gains.
- **AC4 — owner column admin-only.** ✅ `buildChannelColumns` includes the `user_id`
  ("Server-wide"/"Tenant") column only when `policy.showOwnerColumn` — admin true,
  tenant false. Unit-tested at the builder.
- **AC5 — tenant allowed-kind + routing policy explicit and tested.** ✅
  `tenantChannelPolicy.allowedKinds` (JAB-326 widening + `TENANT_KINDS` fallback +
  webpush asymmetry) and `forceOwnEmail` (email → own-address note, destination/SMTP
  fields hidden) are explicit and unit-tested. **Interpretation:** "routing policy"
  here is the forced-own-email rule; the **event-routing matrix** is tenant-only,
  not part of the duplication, and is left in place in `MyNotificationsPage`.

### Normalizations (deliberate, folded in)
- The **admin drawer now shows the masked-secret hint** on edit (backed by the same
  server-side preservation the tenant drawer already relied on).
- The **drawer "Send test"** now reports delivered/queued like the inventory action
  (previously "Test envelope fired"), via the shared `sendChannelTest`.

### Falsification (each guard broken, seen red, reverted)
- AC3: drop the edit-mode placeholder → `Unable to find an element with the
  placeholder text of: /leave blank to keep/i`.
- AC4: invert `showOwnerColumn` → both `buildChannelColumns owner column` tests red.
- AC5: add `slack` to `TENANT_KINDS` → `tenant defaults to the safe kinds and never
  the risky ones` red.

### Test plan
- [x] `tsc -b` clean; `vite build` clean.
- [x] `vitest run src/components/notifications src/shells/**/notifications` — 33 passed
  (policy pinning, owner-column builder, masked-secret affordance + notes; existing
  `MyChannelDrawer` / `EventsTab` suites still green).
- [x] eslint clean (incl. react-refresh) on all changed files.
- [x] E2E selectors preserved (`admin-notifications.spec.ts`): `Add channel`,
  `^Name$`, `^Kind$`/`Generic webhook`, `Target URL`/`HMAC secret`, `^Create$`,
  `button[role=switch]`, RowActions delete — admin actions DOM unchanged.
- [x] Rebased onto `origin/main` (`9f566e22c`); re-ran `tsc -b` + vitest post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
