### PR TITLE
fix(updates): reap update runs stuck "running" in the Tasks indicator (GH #1486)

### DIFF
--- a/panel-api/internal/reconciler/update_run_reconciler.go
+++ b/panel-api/internal/reconciler/update_run_reconciler.go
@@ -29,6 +29,16 @@ import (
 // shorter window risks false-failing a legitimately slow run.
 const staleOrphanRunTimeout = 30 * time.Minute
 
+// maxRunningRunAge is a HARD backstop (GH #1486): any running row older than this
+// is reaped as failed regardless of unit or poll outcome. Without it a run could
+// spin "running" in the Tasks indicator forever — the per-unit poll path had no
+// timeout, so a pollable unit whose agent status call errors (unreachable/old
+// agent) or whose transient unit hangs "activating" never sealed, and the CLI
+// self-update path stamps a unit the poller doesn't recognise (jabali-autoupdate)
+// whose finish() closure is skipped if the update restarts the process. No real
+// update runs anywhere near this long.
+const maxRunningRunAge = 2 * time.Hour
+
 // statusCmdForUnit maps a run unit to its agent status command. Only the two
 // known transient units are pollable; anything else is left alone.
 func statusCmdForUnit(unit string) (string, bool) {
@@ -59,6 +69,17 @@ func (r *Reconciler) reconcileUpdateRuns(ctx context.Context) {
 	}
 	for i := range rows {
 		row := rows[i]
+		// GH #1486 hard backstop: reap any run that has spun far past the longest
+		// plausible update, no matter its unit or why the normal path didn't seal
+		// it (agent status call erroring, unit hung "activating", or an
+		// unrecognised/legacy unit). The fast paths below still seal a healthy run
+		// in one tick; this only catches the ones that would otherwise never clear.
+		if time.Since(row.StartedAt) > maxRunningRunAge {
+			if err := r.updateRunHistory.MarkFinished(ctx, row.ID, models.UpdateStatusFailed, "timed out — no completion signal within 2h", ""); err != nil {
+				r.log.Warn("update-run reconcile: reap stale run failed", "id", row.ID, "error", err)
+			}
+			continue
+		}
 		cmd, ok := statusCmdForUnit(row.Unit)
 		if !ok {
 			// No pollable unit (empty/unknown) — can't reconcile via systemd.
@@ -78,6 +99,14 @@ func (r *Reconciler) reconcileUpdateRuns(ctx context.Context) {
 		})
 		if cerr != nil {
 			r.log.Debug("update-run reconcile: status call failed", "unit", row.Unit, "error", cerr)
+			// GH #1486: a pollable unit whose status can't be read (agent down /
+			// too old to answer this verb) must not spin forever. Reap it once
+			// clearly stale, like an orphan — retry next tick below that window.
+			if time.Since(row.StartedAt) > staleOrphanRunTimeout {
+				if err := r.updateRunHistory.MarkFinished(ctx, row.ID, models.UpdateStatusFailed, "no completion signal — update status unavailable from the agent", ""); err != nil {
+					r.log.Warn("update-run reconcile: reap unpollable run failed", "id", row.ID, "error", err)
+				}
+			}
 			continue
 		}
 		var v unitStatusView

--- a/panel-api/internal/reconciler/update_run_reconciler_test.go
+++ b/panel-api/internal/reconciler/update_run_reconciler_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"testing"
@@ -32,9 +33,13 @@ func (f *fakeUpdRunRepo) MarkFinished(_ context.Context, id, status, _, _ string
 }
 
 func newUpdRunReconciler(repo *fakeUpdRunRepo) *Reconciler {
+	return newUpdRunReconcilerWithAgent(repo, &fakeAgent{})
+}
+
+func newUpdRunReconcilerWithAgent(repo *fakeUpdRunRepo, ag *fakeAgent) *Reconciler {
 	return &Reconciler{
 		updateRunHistory: repo,
-		agent:            &fakeAgent{},
+		agent:            ag,
 		log:              slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 }
@@ -62,5 +67,51 @@ func TestReconcileUpdateRuns_KeepsFreshUnitlessRow(t *testing.T) {
 	newUpdRunReconciler(repo).reconcileUpdateRuns(context.Background())
 	if _, ok := repo.marked["fresh"]; ok {
 		t.Fatalf("fresh unit-less row must NOT be reaped yet")
+	}
+}
+
+// GH #1486: a pollable-unit row that has spun past the hard cap is reaped even
+// when its unit still reports "active" — a hung transient unit must not spin the
+// Tasks indicator forever.
+func TestReconcileUpdateRuns_HardBackstopReapsRunawayActiveRow(t *testing.T) {
+	repo := &fakeUpdRunRepo{running: []models.UpdateHistory{{
+		ID: "runaway", Kind: models.UpdateKindJabali, Unit: "jabali-update-oneshot.service",
+		Status: models.UpdateStatusRunning, StartedAt: time.Now().Add(-3 * time.Hour),
+	}}}
+	ag := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"system.update_status": json.RawMessage(`{"status":"active"}`),
+	}}
+	newUpdRunReconcilerWithAgent(repo, ag).reconcileUpdateRuns(context.Background())
+	if repo.marked["runaway"] != models.UpdateStatusFailed {
+		t.Fatalf("a >2h running row must be reaped even if the unit still reports active; got %v", repo.marked)
+	}
+}
+
+// GH #1486: a pollable-unit row whose agent status call ERRORS (agent down / too
+// old to answer) is reaped once clearly stale — this was the hole that let update
+// tasks spin "running" forever (only unit-less orphans were reaped before).
+func TestReconcileUpdateRuns_ReapsStalePollableWhenAgentErrors(t *testing.T) {
+	repo := &fakeUpdRunRepo{running: []models.UpdateHistory{{
+		ID: "noagent", Kind: models.UpdateKindJabali, Unit: "jabali-update-oneshot.service",
+		Status: models.UpdateStatusRunning, StartedAt: time.Now().Add(-40 * time.Minute),
+	}}}
+	ag := &fakeAgent{failMethod: "system.update_status"}
+	newUpdRunReconcilerWithAgent(repo, ag).reconcileUpdateRuns(context.Background())
+	if repo.marked["noagent"] != models.UpdateStatusFailed {
+		t.Fatalf("a stale pollable row must be reaped when the agent can't report status; got %v", repo.marked)
+	}
+}
+
+// A fresh pollable row whose status call errored ONCE is left alone — a transient
+// agent blip must not false-fail a run that may still be going.
+func TestReconcileUpdateRuns_KeepsFreshPollableWhenAgentErrors(t *testing.T) {
+	repo := &fakeUpdRunRepo{running: []models.UpdateHistory{{
+		ID: "young", Kind: models.UpdateKindJabali, Unit: "jabali-update-oneshot.service",
+		Status: models.UpdateStatusRunning, StartedAt: time.Now().Add(-2 * time.Minute),
+	}}}
+	ag := &fakeAgent{failMethod: "system.update_status"}
+	newUpdRunReconcilerWithAgent(repo, ag).reconcileUpdateRuns(context.Background())
+	if _, ok := repo.marked["young"]; ok {
+		t.Fatalf("a fresh pollable row must NOT be reaped after a single agent error")
 	}
 }


### PR DESCRIPTION
Fixes #1486: 6 "Panel update" tasks spinning forever in the Tasks indicator — panel already up to date, reboot didn't clear them. They're `update_history` rows stuck `status=running` (DB rows, hence reboot-proof).

## Root cause
The run reconciler (`reconcileUpdateRuns`) polls each run's systemd unit and seals it success/failed — but its only stale-timeout reap covered rows with an **unrecognized/empty** unit. The hole:
- A row whose unit **is** pollable (`jabali-update-oneshot.service`) but whose **agent status call errors** (agent down, or too old to answer the verb) hit `continue` every tick — never sealed, never reaped.
- Same for a transient unit that **hangs "activating"** and never terminates.
- The CLI self-update path (`jabali update` / the 04:30 timer) stamps a unit the poller doesn't recognize (`jabali-autoupdate`) and relies on a `finish()` closure that's **skipped if the update restarts the process** mid-run.

`.60` (current main) seals/reaps normal rows fine — I confirmed with a live experiment (flipped rows back to running → sealed in one tick). The stuck case only happens down the un-backstopped pollable path, which matches johnnyq's box (a stale agent erroring on `system.update_status` is the most likely trigger — the fleet-agent redeploy is still owed).

## Fix — two backstops, so no running row can spin forever
- **Hard cap**: any running row older than **2h** is reaped `failed` regardless of unit or poll outcome (covers a hung "activating" unit).
- **Agent-error reap**: a pollable-unit row whose status call errors is reaped once clearly stale (>30m, same window as unit-less orphans) instead of being skipped indefinitely.

Healthy runs still seal in one tick via the fast path; a single transient agent blip on a fresh run does **not** false-fail it. This also **clears johnnyq's already-stuck rows** — once his panel carries the fix, they're all >2h old and reap on the next reconcile tick.

## Test plan
- [x] `go build` / `go vet` / `gofmt`; `go test -race ./internal/reconciler`
- [x] New unit tests: a >2h row reaped even when the unit still reports `active`; a stale pollable row reaped when the agent status call errors; a fresh pollable row NOT reaped after a single agent error
- [x] **Box drill on .60** (deployed the fixed panel-api): seeded a >2.5h running row → reaped as `failed` / "timed out — no completion signal within 2h" (old code would have sealed it `success`); restored the original binary after