### PR TITLE
refactor(applications): shared Application Inventory Module for admin and tenant lists (JAB-334)

### DIFF
--- a/panel-ui/src/components/applications/ApplicationDomainCell.test.tsx
+++ b/panel-ui/src/components/applications/ApplicationDomainCell.test.tsx
@@ -1,0 +1,62 @@
+// ApplicationDomainCell.test.tsx — the domain/CMS cell both lists render. A
+// ready install links to its live site (honoring the subdirectory); anything
+// else is plain text; a missing domain name falls back to the domain id. The
+// optional status slot stacks under the link for the tenant list and is absent
+// for the admin list (which keeps status in its own column). CmsIcon reads the
+// theme, so renders are wrapped in ThemeModeProvider.
+import { describe, it, expect } from "vitest";
+import { type ReactElement } from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeModeProvider } from "../../theme/ThemeModeContext";
+import { ApplicationDomainCell } from "./ApplicationDomainCell";
+import { ApplicationStatusTag } from "./ApplicationStatusTag";
+import type { ApplicationInstall } from "./applicationInventory";
+
+const renderCell = (ui: ReactElement) =>
+  render(<ThemeModeProvider>{ui}</ThemeModeProvider>);
+
+const row = (over: Partial<ApplicationInstall> = {}): ApplicationInstall =>
+  ({
+    id: "i1",
+    domain_name: "site.test",
+    domain_id: "d1",
+    subdirectory: "",
+    status: "ready",
+    app_type: "wordpress",
+    ...over,
+  }) as ApplicationInstall;
+
+describe("ApplicationDomainCell", () => {
+  it("links a ready install to its live site, honoring the subdirectory", () => {
+    renderCell(<ApplicationDomainCell record={row({ subdirectory: "blog" })} />);
+    const link = screen.getByRole("link", { name: "site.test/blog/" });
+    expect(link).toHaveAttribute("href", "https://site.test/blog/");
+  });
+
+  it("renders plain text (no link) for a non-ready install", () => {
+    renderCell(<ApplicationDomainCell record={row({ status: "installing" })} />);
+    expect(screen.getByText("site.test/")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the domain id when there is no domain name", () => {
+    renderCell(<ApplicationDomainCell record={row({ domain_name: "" })} />);
+    expect(screen.getByText("d1/")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders the status slot when supplied (tenant list)", () => {
+    renderCell(
+      <ApplicationDomainCell
+        record={row({ status: "failed" })}
+        status={<ApplicationStatusTag status="failed" />}
+      />,
+    );
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("omits the status slot when none is supplied (admin list)", () => {
+    renderCell(<ApplicationDomainCell record={row({ status: "failed" })} />);
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/components/applications/ApplicationDomainCell.tsx
+++ b/panel-ui/src/components/applications/ApplicationDomainCell.tsx
@@ -1,0 +1,55 @@
+// ApplicationDomainCell — the CMS icon + domain/path link both application
+// lists render. A ready row with a domain links to the live site; anything
+// else is plain text. When `status` is supplied (the tenant list) it stacks
+// under the link; when omitted (the admin list, which keeps status in its own
+// column) the cell is a single inline row. One domain renderer for both lists
+// (JAB-334).
+import type { ReactNode } from "react";
+import { CmsIcon } from "../../shells/user/applications/CmsIcon";
+import type { ApplicationInstall } from "./applicationInventory";
+
+type DomainCellRow = Pick<
+  ApplicationInstall,
+  "domain_name" | "domain_id" | "subdirectory" | "status" | "app_type"
+>;
+
+export function ApplicationDomainCell({
+  record,
+  status,
+}: {
+  record: DomainCellRow;
+  status?: ReactNode;
+}) {
+  const base = record.domain_name || record.domain_id;
+  const path = record.subdirectory ? `/${record.subdirectory}/` : "/";
+  const label = `${base}${path}`;
+  const isLink = record.status === "ready" && !!record.domain_name;
+  const appKey = record.app_type || "wordpress";
+
+  const link = isLink ? (
+    <a href={`https://${record.domain_name}${path}`} target="_blank" rel="noopener noreferrer">
+      {label}
+    </a>
+  ) : (
+    <span>{label}</span>
+  );
+
+  if (status === undefined) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <CmsIcon appType={appKey} />
+        {link}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
+      <CmsIcon appType={appKey} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "flex-start" }}>
+        {link}
+        {status}
+      </div>
+    </div>
+  );
+}

--- a/panel-ui/src/components/applications/ApplicationStatusTag.test.tsx
+++ b/panel-ui/src/components/applications/ApplicationStatusTag.test.tsx
@@ -1,0 +1,26 @@
+// ApplicationStatusTag.test.tsx — AC2 failure presentation. A failed row with
+// a last_error surfaces that error (in a tooltip); a failed row without one is
+// a plain tag; every other status is a plain tag. One failure presentation for
+// both lists.
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ApplicationStatusTag } from "./ApplicationStatusTag";
+
+describe("ApplicationStatusTag", () => {
+  it("renders the status label", () => {
+    render(<ApplicationStatusTag status="ready" />);
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+  });
+
+  it("surfaces the failure reason on hover for a failed row", async () => {
+    render(<ApplicationStatusTag status="failed" lastError="disk full" />);
+    fireEvent.mouseEnter(screen.getByText("Failed"));
+    expect(await screen.findByText("disk full")).toBeInTheDocument();
+  });
+
+  it("renders a plain failed tag when there is no error detail", () => {
+    render(<ApplicationStatusTag status="failed" />);
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.queryByText("disk full")).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/components/applications/ApplicationStatusTag.tsx
+++ b/panel-ui/src/components/applications/ApplicationStatusTag.tsx
@@ -1,0 +1,25 @@
+// ApplicationStatusTag — the shared install-status badge for both application
+// lists. Renders the status meta (color/icon/label); a failed row with a
+// last_error wraps the tag in a Tooltip exposing the error. One failure
+// presentation for both lists (JAB-334 AC2).
+import { Tag, Tooltip } from "antd";
+import { applicationStatusMeta, type ApplicationStatus } from "../../utils/applicationStatus";
+
+export function ApplicationStatusTag({
+  status,
+  lastError,
+}: {
+  status: ApplicationStatus;
+  lastError?: string;
+}) {
+  const meta = applicationStatusMeta(status);
+  const tag = (
+    <Tag color={meta.color} icon={meta.icon}>
+      {meta.label}
+    </Tag>
+  );
+  if (status === "failed" && lastError) {
+    return <Tooltip title={lastError}>{tag}</Tooltip>;
+  }
+  return tag;
+}

--- a/panel-ui/src/components/applications/applicationInventory.test.ts
+++ b/panel-ui/src/components/applications/applicationInventory.test.ts
@@ -1,0 +1,68 @@
+// applicationInventory.test.ts — pins the shared Application Inventory login
+// capability, invalidation keys, and error extraction (JAB-334 AC2/AC3) so the
+// admin and tenant lists can't drift from each other or from the backend.
+import { describe, it, expect } from "vitest";
+import {
+  canApplicationLogin,
+  APPLICATION_LOGIN_APP_TYPES,
+  APPLICATION_INVALIDATION_KEYS,
+  extractApiError,
+} from "./applicationInventory";
+
+describe("canApplicationLogin", () => {
+  it("allows the CMS types the SSO flow drives, when ready", () => {
+    expect(canApplicationLogin({ status: "ready", app_type: "wordpress" })).toBe(true);
+    expect(canApplicationLogin({ status: "ready", app_type: "drupal" })).toBe(true);
+    expect(canApplicationLogin({ status: "ready", app_type: "joomla" })).toBe(true);
+  });
+
+  it("defaults a missing app_type to wordpress", () => {
+    expect(canApplicationLogin({ status: "ready", app_type: undefined })).toBe(true);
+    expect(canApplicationLogin({ status: "ready" })).toBe(true);
+  });
+
+  it("denies a CMS with no SSO handler", () => {
+    expect(canApplicationLogin({ status: "ready", app_type: "magento" })).toBe(false);
+  });
+
+  it("denies any non-ready row", () => {
+    expect(canApplicationLogin({ status: "installing", app_type: "wordpress" })).toBe(false);
+    expect(canApplicationLogin({ status: "failed", app_type: "wordpress" })).toBe(false);
+    expect(canApplicationLogin({ status: "deleting", app_type: "wordpress" })).toBe(false);
+    expect(canApplicationLogin({ status: "pending", app_type: "wordpress" })).toBe(false);
+  });
+});
+
+describe("APPLICATION_LOGIN_APP_TYPES", () => {
+  it("mirrors panel-api ssoAgentCommandFor (wordpress/drupal/joomla)", () => {
+    // If the backend gains an SSO-file handler for another CMS, widen the set
+    // here too — this assertion is the guard against the button drifting from
+    // the backend capability.
+    expect([...APPLICATION_LOGIN_APP_TYPES].sort()).toEqual([
+      "drupal",
+      "joomla",
+      "wordpress",
+    ]);
+  });
+});
+
+describe("APPLICATION_INVALIDATION_KEYS", () => {
+  it("invalidates both the applications and databases lists", () => {
+    expect(APPLICATION_INVALIDATION_KEYS.map((k) => [...k])).toEqual([
+      ["list", "applications"],
+      ["list", "databases"],
+    ]);
+  });
+});
+
+describe("extractApiError", () => {
+  it("prefers detail, then error, then transport message, then fallback", () => {
+    expect(
+      extractApiError({ response: { data: { detail: "d", error: "e" } }, message: "m" }, "fb"),
+    ).toBe("d");
+    expect(extractApiError({ response: { data: { error: "e" } }, message: "m" }, "fb")).toBe("e");
+    expect(extractApiError({ message: "m" }, "fb")).toBe("m");
+    expect(extractApiError({}, "fb")).toBe("fb");
+    expect(extractApiError(null, "fb")).toBe("fb");
+  });
+});

--- a/panel-ui/src/components/applications/applicationInventory.ts
+++ b/panel-ui/src/components/applications/applicationInventory.ts
@@ -1,0 +1,89 @@
+// applicationInventory.ts — the canonical Application Inventory row plus the
+// login capability, invalidation keys, and error extraction the admin and
+// tenant application lists both used to define for themselves (JAB-334).
+//
+// The status vocabulary (status union, badge meta, transitional rule) lives in
+// utils/applicationStatus — this module owns the rest of the shared behavior.
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import type { ApplicationStatus } from "../../utils/applicationStatus";
+
+// Canonical Application Inventory row. The admin (cross-user) list carries the
+// owner columns; the tenant list carries the #406 cache flag. Both audience
+// fields are optional so one type serves both lists.
+export interface ApplicationInstall {
+  id: string;
+  app_type?: string;
+  domain_id: string;
+  domain_name: string;
+  db_id: string;
+  admin_username: string;
+  admin_email: string;
+  locale: string;
+  subdirectory: string;
+  status: ApplicationStatus;
+  version: string | null;
+  last_error: string;
+  created_at: string;
+  updated_at: string;
+  // Admin-only (cross-user list).
+  owner_email?: string;
+  owner_username?: string;
+  // Tenant-only (#406 single-switch cache).
+  cache_enabled?: boolean;
+}
+
+// The CMS types the admin-login (magic-link SSO) flow can drive. This MUST
+// match panel-api ssoAgentCommandFor (magic_link.go) — when a new CMS gains an
+// SSO-file handler there, widen this set here so the button can't drift from
+// the backend capability.
+export const APPLICATION_LOGIN_APP_TYPES: ReadonlySet<string> = new Set<string>([
+  "wordpress",
+  "drupal",
+  "joomla",
+]);
+
+// canApplicationLogin — is the admin-login action available for this row? Ready
+// plus a CMS the SSO flow knows. app_type defaults to wordpress (the historical
+// single-CMS value) when the backend omits it. One login rule for both lists
+// (JAB-334 AC3).
+export const canApplicationLogin = (
+  record: Pick<ApplicationInstall, "status" | "app_type">,
+): boolean =>
+  record.status === "ready" &&
+  APPLICATION_LOGIN_APP_TYPES.has(record.app_type ?? "wordpress");
+
+// openApplicationLogin — mint a magic link, open the admin dashboard in a new
+// tab, and toast. Both lists ran this identical flow behind their login button;
+// centralizing it keeps the SSO affordance in one place (JAB-334 AC3). `mint`
+// is useMagicLink().mint; `fallbackError` is its captured error string.
+export async function openApplicationLogin(
+  mint: () => Promise<{ url: string }>,
+  fallbackError?: string | null,
+): Promise<void> {
+  try {
+    const { url } = await mint();
+    window.open(url, "_blank", "noopener,noreferrer");
+    feedback.message.success("Admin login link opened");
+  } catch {
+    feedback.message.error(fallbackError || "Failed to generate admin login link");
+  }
+}
+
+// Deleting an install also frees its database, so both lists invalidate the
+// applications AND databases lists after a delete. One canonical key set
+// (JAB-334 AC2).
+export const APPLICATION_INVALIDATION_KEYS: ReadonlyArray<readonly [string, string]> = [
+  ["list", "applications"],
+  ["list", "databases"],
+];
+
+// extractApiError — the `detail ?? error ?? message ?? fallback` ladder the
+// tenant list used for its richer delete/scan errors. Prefers the server's
+// `detail`, then `error`, then the transport message.
+export function extractApiError(err: unknown, fallback: string): string {
+  const e = err as {
+    response?: { data?: { detail?: string; error?: string } };
+    message?: string;
+  };
+  return e?.response?.data?.detail ?? e?.response?.data?.error ?? e?.message ?? fallback;
+}

--- a/panel-ui/src/components/applications/buildApplicationActions.test.ts
+++ b/panel-ui/src/components/applications/buildApplicationActions.test.ts
@@ -1,0 +1,77 @@
+// buildApplicationActions.test.ts — AC4: role-specific actions stay explicit.
+// The admin context (no clone) yields only login + delete; the tenant context
+// adds the privileged cache + clone actions. Absence, not a flag, is what keeps
+// the admin list from ever rendering a purge/warmup/clone.
+import { describe, it, expect } from "vitest";
+import {
+  buildApplicationActions,
+  type SharedActionCtx,
+  type TenantActionCtx,
+} from "./buildApplicationActions";
+
+const noop = () => {};
+
+const adminCtx: SharedActionCtx = {
+  canLogin: true,
+  onLogin: noop,
+  loginLoading: false,
+  onDelete: noop,
+  deleting: false,
+  deleteDescription: "admin desc",
+};
+
+const tenantCtx: TenantActionCtx = {
+  ...adminCtx,
+  deleteDescription: "tenant desc",
+  cacheEnabled: true,
+  onPurge: noop,
+  purging: false,
+  onWarmup: noop,
+  warming: false,
+  canClone: true,
+  onClone: noop,
+};
+
+const keys = (ctx: SharedActionCtx | TenantActionCtx) =>
+  buildApplicationActions(ctx).map((a) => a.key);
+
+describe("buildApplicationActions", () => {
+  it("admin (no clone context) gets only login + delete", () => {
+    expect(keys(adminCtx)).toEqual(["login", "delete"]);
+  });
+
+  it("tenant gets login + cache + clone + delete", () => {
+    expect(keys(tenantCtx)).toEqual(["login", "purge", "warmup", "clone", "delete"]);
+  });
+
+  it("hides login when the row cannot log in", () => {
+    const actions = buildApplicationActions({ ...adminCtx, canLogin: false });
+    expect(actions.find((a) => a.key === "login")?.hidden).toBe(true);
+  });
+
+  it("hides purge + warmup when caching is off", () => {
+    const actions = buildApplicationActions({ ...tenantCtx, cacheEnabled: false });
+    expect(actions.find((a) => a.key === "purge")?.hidden).toBe(true);
+    expect(actions.find((a) => a.key === "warmup")?.hidden).toBe(true);
+  });
+
+  it("shows purge + warmup when caching is on", () => {
+    const actions = buildApplicationActions(tenantCtx);
+    expect(actions.find((a) => a.key === "purge")?.hidden).toBe(false);
+    expect(actions.find((a) => a.key === "warmup")?.hidden).toBe(false);
+  });
+
+  it("disables clone when the install cannot be cloned", () => {
+    const actions = buildApplicationActions({ ...tenantCtx, canClone: false });
+    const clone = actions.find((a) => a.key === "clone");
+    expect(clone?.disabled).toBe(true);
+    expect(clone?.tooltip).toMatch(/only available for healthy WordPress/i);
+  });
+
+  it("passes the audience-specific delete copy through", () => {
+    const admin = buildApplicationActions(adminCtx).find((a) => a.key === "delete");
+    const tenant = buildApplicationActions(tenantCtx).find((a) => a.key === "delete");
+    expect(admin?.confirm?.description).toBe("admin desc");
+    expect(tenant?.confirm?.description).toBe("tenant desc");
+  });
+});

--- a/panel-ui/src/components/applications/buildApplicationActions.ts
+++ b/panel-ui/src/components/applications/buildApplicationActions.ts
@@ -1,0 +1,107 @@
+// buildApplicationActions — the per-row action set for the Application
+// Inventory lists. The shared login + delete actions live here once; the
+// tenant list adds its privileged cache/clone actions by passing a tenant
+// context. Admin literally cannot supply purge/warmup/clone (its context has
+// no `onClone`), so those actions are absent, not merely hidden — the JAB-335
+// absence-over-flag shape. AC4: role-specific actions stay explicit and are
+// unit-tested against these key sets.
+import { createElement, type ReactNode } from "react";
+import {
+  LoginOutlined,
+  DeleteOutlined,
+  ThunderboltOutlined,
+  CopyOutlined,
+} from "@icons";
+import type { RowAction } from "../RowActions";
+
+// The login + delete actions every list has.
+export interface SharedActionCtx {
+  canLogin: boolean;
+  onLogin: () => void;
+  loginLoading: boolean;
+  onDelete: () => void;
+  deleting: boolean;
+  // The confirm copy differs per audience (admin: "…and its data"; tenant:
+  // "…database, files, and any associated cron jobs"), so it is a context
+  // field, not a constant baked into the builder.
+  deleteDescription: ReactNode;
+}
+
+// The tenant list additionally exposes cache + clone actions.
+export interface TenantActionCtx extends SharedActionCtx {
+  cacheEnabled: boolean;
+  onPurge: () => void;
+  purging: boolean;
+  onWarmup: () => void;
+  warming: boolean;
+  canClone: boolean;
+  onClone: () => void;
+}
+
+const isTenantCtx = (
+  ctx: SharedActionCtx | TenantActionCtx,
+): ctx is TenantActionCtx => "onClone" in ctx;
+
+export function buildApplicationActions(
+  ctx: SharedActionCtx | TenantActionCtx,
+): RowAction[] {
+  const login: RowAction = {
+    key: "login",
+    label: "Log in to admin",
+    icon: createElement(LoginOutlined),
+    onClick: ctx.onLogin,
+    loading: ctx.loginLoading,
+    tooltip: "Log in to the admin dashboard",
+    hidden: !ctx.canLogin,
+  };
+
+  const del: RowAction = {
+    key: "delete",
+    label: "Delete",
+    icon: createElement(DeleteOutlined),
+    danger: true,
+    loading: ctx.deleting,
+    onClick: ctx.onDelete,
+    confirm: {
+      title: "Delete this application?",
+      description: ctx.deleteDescription,
+      okText: "Delete",
+    },
+  };
+
+  if (!isTenantCtx(ctx)) {
+    // Admin: read-only cross-user list — login + delete only.
+    return [login, del];
+  }
+
+  return [
+    login,
+    {
+      key: "purge",
+      label: "Purge cache",
+      icon: createElement(ThunderboltOutlined),
+      onClick: ctx.onPurge,
+      loading: ctx.purging,
+      hidden: !ctx.cacheEnabled,
+    },
+    {
+      key: "warmup",
+      label: "Warm cache",
+      icon: createElement(ThunderboltOutlined),
+      onClick: ctx.onWarmup,
+      loading: ctx.warming,
+      hidden: !ctx.cacheEnabled,
+    },
+    {
+      key: "clone",
+      label: "Clone",
+      icon: createElement(CopyOutlined),
+      onClick: ctx.onClone,
+      disabled: !ctx.canClone,
+      tooltip: ctx.canClone
+        ? undefined
+        : "Clone is only available for healthy WordPress installs",
+    },
+    del,
+  ];
+}

--- a/panel-ui/src/components/applications/useDeleteApplication.ts
+++ b/panel-ui/src/components/applications/useDeleteApplication.ts
@@ -1,0 +1,38 @@
+// useDeleteApplication — delete an install and invalidate the shared query
+// keys, one path for both application lists (JAB-334 AC2). Tracks the in-flight
+// id so a row can show a spinner. Uses the richer server-detail error
+// extraction both lists want (the admin list previously surfaced only the
+// transport message).
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import {
+  APPLICATION_INVALIDATION_KEYS,
+  extractApiError,
+  type ApplicationInstall,
+} from "./applicationInventory";
+
+type DeletableRow = Pick<ApplicationInstall, "id" | "domain_name" | "domain_id">;
+
+export function useDeleteApplication() {
+  const qc = useQueryClient();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const deleteApplication = async (row: DeletableRow): Promise<void> => {
+    setDeletingId(row.id);
+    try {
+      await apiClient.delete(`/applications/${row.id}`);
+      feedback.message.success(`Deleting ${row.domain_name || row.domain_id}…`);
+      for (const key of APPLICATION_INVALIDATION_KEYS) {
+        qc.invalidateQueries({ queryKey: [...key] });
+      }
+    } catch (err) {
+      feedback.message.error(extractApiError(err, "Delete failed"));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return { deletingId, deleteApplication };
+}

--- a/panel-ui/src/components/applications/useTransitionalPoll.test.tsx
+++ b/panel-ui/src/components/applications/useTransitionalPoll.test.tsx
@@ -1,0 +1,48 @@
+// useTransitionalPoll.test.tsx — AC1: one polling rule. The predicate lives in
+// utils/applicationStatus (tested there); this proves the *loop* — that a
+// transitional row keeps the list refetching on the shared cadence and a fully
+// settled list does not, and that landing the last transitional row tears the
+// timer down.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ApplicationStatus } from "../../utils/applicationStatus";
+import { useTransitionalPoll, APPLICATION_POLL_MS } from "./useTransitionalPoll";
+
+type Rows = { status: ApplicationStatus }[];
+
+describe("useTransitionalPoll", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("refetches on the poll cadence while a row is transitional", () => {
+    const refetch = vi.fn();
+    renderHook(() => useTransitionalPoll([{ status: "installing" }], refetch));
+    expect(refetch).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(APPLICATION_POLL_MS);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(APPLICATION_POLL_MS);
+    expect(refetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poll when every row has settled", () => {
+    const refetch = vi.fn();
+    renderHook(() =>
+      useTransitionalPoll([{ status: "ready" }, { status: "failed" }], refetch),
+    );
+    vi.advanceTimersByTime(APPLICATION_POLL_MS * 3);
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("stops polling once the last transitional row lands", () => {
+    const refetch = vi.fn();
+    const { rerender } = renderHook(
+      ({ rows }: { rows: Rows }) => useTransitionalPoll(rows, refetch),
+      { initialProps: { rows: [{ status: "installing" }] as Rows } },
+    );
+    vi.advanceTimersByTime(APPLICATION_POLL_MS);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    rerender({ rows: [{ status: "ready" }] as Rows });
+    vi.advanceTimersByTime(APPLICATION_POLL_MS * 3);
+    expect(refetch).toHaveBeenCalledTimes(1); // interval was cleared
+  });
+});

--- a/panel-ui/src/components/applications/useTransitionalPoll.ts
+++ b/panel-ui/src/components/applications/useTransitionalPoll.ts
@@ -1,0 +1,25 @@
+// useTransitionalPoll — the "poll while a row is still settling" rule both
+// application lists carried inline (JAB-334 AC1). While any row is transitional
+// (pending/installing/cloning/deleting) the list refetches on a fixed cadence;
+// once every row lands on ready/failed the timer is torn down.
+import { useEffect } from "react";
+import { anyTransitional, type ApplicationStatus } from "../../utils/applicationStatus";
+
+// Five-second cadence — what Refine's old refetchInterval returned, kept when
+// both lists moved off it.
+export const APPLICATION_POLL_MS = 5000;
+
+export function useTransitionalPoll(
+  rows: ReadonlyArray<{ status: ApplicationStatus }>,
+  refetch: () => void,
+): void {
+  const hasTransitional = anyTransitional(rows);
+  useEffect(() => {
+    if (!hasTransitional) return;
+    const h = setInterval(() => refetch(), APPLICATION_POLL_MS);
+    return () => clearInterval(h);
+    // refetch identity is stable (useTableURL's is), so only the
+    // transitional/settled edge re-installs the timer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasTransitional]);
+}

--- a/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
+++ b/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
@@ -3,113 +3,51 @@
 // Admins modify installs by opening the relevant user's panel directly
 // in their own browser tab — no in-panel impersonation after M20.
 //
-// Status badge metadata + the transitional-poll rule are shared with the
-// tenant list via utils/applicationStatus (JAB-334) — a neutral module, so
-// neither shell depends on the other.
+// The install row, status badge, domain cell, transitional-poll rule, login
+// capability, and delete + invalidation are shared with the tenant list via
+// components/applications (JAB-334) — a neutral module, so neither shell
+// depends on the other. This adapter keeps the admin deltas: the owner column,
+// the created_at-desc default sort, and a read-only action set (login + delete).
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
-import { useQueryClient } from "@tanstack/react-query";
-import { Card, Input, Space, Table, Tag, Tooltip, Typography } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import {
-  AppstoreOutlined,
-  DeleteOutlined,
-  LoginOutlined,
-  SearchOutlined,
-} from "@icons";
+import { Card, Input, Space, Table, Typography } from "antd";
+import { AppstoreOutlined, SearchOutlined } from "@icons";
 import { RowActions } from "../../../components/RowActions";
 import { sorterToParams } from "../../../utils/tableSorter";
 
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { useMagicLink } from "../../../hooks/useMagicLink";
-import { apiClient } from "../../../apiClient";
-import { CmsIcon } from "../../user/applications/CmsIcon";
+import { ApplicationDomainCell } from "../../../components/applications/ApplicationDomainCell";
+import { ApplicationStatusTag } from "../../../components/applications/ApplicationStatusTag";
+import { buildApplicationActions } from "../../../components/applications/buildApplicationActions";
+import { useTransitionalPoll } from "../../../components/applications/useTransitionalPoll";
+import { useDeleteApplication } from "../../../components/applications/useDeleteApplication";
 import {
-  applicationStatusMeta,
-  anyTransitional,
-  type ApplicationStatus,
-} from "../../../utils/applicationStatus";
-
-type ApplicationInstall = {
-  id: string;
-  app_type?: string;
-  domain_id: string;
-  domain_name: string;
-  db_id: string;
-  admin_username: string;
-  admin_email: string;
-  owner_email: string;
-  owner_username?: string;
-  locale: string;
-  subdirectory: string;
-  status: ApplicationStatus;
-  version: string | null;
-  last_error: string;
-  created_at: string;
-  updated_at: string;
-};
+  canApplicationLogin,
+  openApplicationLogin,
+  type ApplicationInstall,
+} from "../../../components/applications/applicationInventory";
 
 interface AdminActionsCellProps {
   record: ApplicationInstall;
   canLogin: boolean;
 }
 
-const AdminActionsCell = ({
-  record,
-  canLogin,
-}: AdminActionsCellProps) => {
-  const qc = useQueryClient();
-  const [deleting, setDeleting] = useState(false);
-  const { mint: mintMagicLink, loading: magicLinkLoading, error: magicLinkError } = useMagicLink(record.id);
-
-  const handleDelete = async () => {
-    setDeleting(true);
-    try {
-      await apiClient.delete(`/applications/${record.id}`);
-      feedback.message.success(
-        `Deleting ${record.domain_name || record.domain_id}\u2026`,
-      );
-      qc.invalidateQueries({ queryKey: ["list", "applications"] });
-      qc.invalidateQueries({ queryKey: ["list", "databases"] });
-    } catch (err) {
-      feedback.message.error(
-        (err as Error)?.message ?? "Failed to delete application",
-      );
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleMagicLink = async () => {
-    try {
-      const response = await mintMagicLink();
-      window.open(
-        response.url,
-        "_blank",
-        "noopener,noreferrer"
-      );
-      feedback.message.success("Admin login link opened");
-    } catch {
-      feedback.message.error(magicLinkError || "Failed to generate admin login link");
-    }
-  };
+const AdminActionsCell = ({ record, canLogin }: AdminActionsCellProps) => {
+  const { mint, loading: loginLoading, error: loginError } = useMagicLink(record.id);
+  const { deletingId, deleteApplication } = useDeleteApplication();
 
   return (
     <RowActions
-      actions={[
-        { key: "login", label: "Log in to admin", icon: <LoginOutlined />, loading: magicLinkLoading, onClick: handleMagicLink, tooltip: "Log in to the admin dashboard", hidden: !canLogin },
-        {
-          key: "delete",
-          label: "Delete",
-          icon: <DeleteOutlined />,
-          danger: true,
-          loading: deleting,
-          onClick: handleDelete,
-          confirm: { title: "Delete this application?", description: `Permanently removes ${record.domain_name || record.domain_id} and its data. This cannot be undone.`, okText: "Delete" },
-        },
-      ]}
+      actions={buildApplicationActions({
+        canLogin,
+        onLogin: () => openApplicationLogin(mint, loginError),
+        loginLoading,
+        onDelete: () => deleteApplication(record),
+        deleting: deletingId === record.id,
+        deleteDescription: `Permanently removes ${record.domain_name || record.domain_id} and its data. This cannot be undone.`,
+      })}
     />
   );
 };
@@ -122,16 +60,8 @@ export const AdminApplicationList = () => {
     defaultOrder: "desc",
   });
 
-  // Poll while any row is transitional — same cadence as the
-  // user-shell list. Cheaper than running a second useQuery with
-  // its own subscription.
-  const hasTransitional = anyTransitional(query.items);
-  useEffect(() => {
-    if (!hasTransitional) return;
-    const h = setInterval(() => query.refetch(), 5000);
-    return () => clearInterval(h);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasTransitional]);
+  // Poll while any row is transitional — same rule as the tenant list.
+  useTransitionalPoll(query.items, query.refetch);
 
   const handleTableChange: React.ComponentProps<
     typeof Table<ApplicationInstall>
@@ -201,33 +131,9 @@ export const AdminApplicationList = () => {
                 />
               </div>
             )}
-            render={(domainName: string, record) => {
-              const base = domainName || record.domain_id;
-              const path = record.subdirectory
-                ? `/${record.subdirectory}/`
-                : "/";
-              const label = `${base}${path}`;
-              const isLink = record.status === "ready" && !!domainName;
-              const appKey = record.app_type || "wordpress";
-              return (
-                <div
-                  style={{ display: "flex", alignItems: "center", gap: 8 }}
-                >
-                  <CmsIcon appType={appKey} />
-                  {isLink ? (
-                    <a
-                      href={`https://${domainName}${path}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {label}
-                    </a>
-                  ) : (
-                    <span>{label}</span>
-                  )}
-                </div>
-              );
-            }}
+            render={(_domainName: string, record) => (
+              <ApplicationDomainCell record={record} />
+            )}
           />
           <Table.Column<ApplicationInstall>
             dataIndex="owner_email"
@@ -262,18 +168,9 @@ export const AdminApplicationList = () => {
           <Table.Column<ApplicationInstall>
             dataIndex="status"
             title={t("adminapplicationlist.status")}
-            render={(status: ApplicationInstall["status"], record) => {
-              const meta = applicationStatusMeta(status);
-              const tag = (
-                <Tag color={meta.color} icon={meta.icon}>
-                  {meta.label}
-                </Tag>
-              );
-              if (status === "failed" && record.last_error) {
-                return <Tooltip title={record.last_error}>{tag}</Tooltip>;
-              }
-              return tag;
-            }}
+            render={(status: ApplicationInstall["status"], record) => (
+              <ApplicationStatusTag status={status} lastError={record.last_error} />
+            )}
           />
           <Table.Column<ApplicationInstall>
             dataIndex="created_at"
@@ -286,21 +183,9 @@ export const AdminApplicationList = () => {
           <Table.Column<ApplicationInstall>
             title={t("adminapplicationlist.actions")}
             dataIndex="actions"
-            render={(_, r) => {
-              const appType = r.app_type ?? "wordpress";
-              // Admin login is implemented for WordPress, Drupal, and
-              // Joomla — matches panel-api ssoAgentCommandFor.
-              const canLogin =
-                r.status === "ready" &&
-                (appType === "wordpress" || appType === "drupal" || appType === "joomla");
-
-              return (
-                <AdminActionsCell
-                  record={r}
-                  canLogin={canLogin}
-                />
-              );
-            }}
+            render={(_, r) => (
+              <AdminActionsCell record={r} canLogin={canApplicationLogin(r)} />
+            )}
           />
         </SearchableTableStringQ>
       </Card>

--- a/panel-ui/src/shells/user/applications/UserApplicationList.tsx
+++ b/panel-ui/src/shells/user/applications/UserApplicationList.tsx
@@ -1,10 +1,11 @@
 // User-shell Applications page — lists every install (WordPress
-// today, DokuWiki/MediaWiki/etc. as M19 lands them). Post-M21:
-// useTableURL with a custom useQuery `refetchInterval` so
-// transitional statuses (pending/installing/cloning/deleting) poll
-// until ready.
+// today, DokuWiki/MediaWiki/etc. as M19 lands them). The install row,
+// status badge, domain cell, transitional-poll rule, login capability,
+// and delete + invalidation are shared with the admin list via
+// components/applications (JAB-334); this shell keeps the tenant deltas:
+// the install/scan/migrate/clone/cache actions, the StatCards, and the Tabs.
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { Button, Tabs, Col, Empty, Row, Space, Switch, Table, Tag, Typography, Tooltip } from "antd";
@@ -16,25 +17,26 @@ import {
   CheckCircleOutlined,
   ExclamationCircleOutlined,
   SyncOutlined,
-  DeleteOutlined,
-  CopyOutlined,
-  LoginOutlined,
   SearchOutlined,
-  ThunderboltOutlined,
   SettingOutlined,
 } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  applicationStatusMeta,
-  anyTransitional,
-  isTransitionalStatus,
-  type ApplicationStatus,
-} from "../../../utils/applicationStatus";
+import { isTransitionalStatus } from "../../../utils/applicationStatus";
 import { sorterToParams } from "../../../utils/tableSorter";
 
 import { columnSearchProps } from "../../../components/columnSearch";
 import { RowActions } from "../../../components/RowActions";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
+import { ApplicationDomainCell } from "../../../components/applications/ApplicationDomainCell";
+import { ApplicationStatusTag } from "../../../components/applications/ApplicationStatusTag";
+import { buildApplicationActions } from "../../../components/applications/buildApplicationActions";
+import { useTransitionalPoll } from "../../../components/applications/useTransitionalPoll";
+import { useDeleteApplication } from "../../../components/applications/useDeleteApplication";
+import {
+  canApplicationLogin,
+  openApplicationLogin,
+  type ApplicationInstall,
+} from "../../../components/applications/applicationInventory";
 import { apiClient } from "../../../apiClient";
 import { useAuth } from "../../../auth/AuthContext";
 import { useTableURL } from "../../../hooks/useTableURL";
@@ -44,27 +46,9 @@ import { MigrateRemoteDrawer } from "./MigrateRemoteDrawer";
 import { CloneApplicationModal } from "./CloneApplicationModal";
 import { CacheSettingsDrawer } from "./CacheSettingsDrawer";
 import { CatalogTab } from "./CatalogTab";
-import { CmsIcon, appDisplayName } from "./CmsIcon";
+import { appDisplayName } from "./CmsIcon";
 import { useAppRegistry } from "./appRegistry";
 import { StatCard } from "../../../components/StatCard";
-
-type ApplicationInstall = {
-  id: string;
-  app_type?: string;
-  domain_id: string;
-  domain_name: string;
-  db_id: string;
-  admin_username: string;
-  admin_email: string;
-  locale: string;
-  subdirectory: string;
-  status: ApplicationStatus;
-  version: string | null;
-  last_error: string;
-  cache_enabled?: boolean;
-  created_at: string;
-  updated_at: string;
-};
 
 interface ActionsCellProps {
   record: ApplicationInstall;
@@ -83,21 +67,7 @@ const ActionsCell = ({
   onClone,
   onDelete,
 }: ActionsCellProps) => {
-  const { mint: mintMagicLink, loading: magicLinkLoading, error: magicLinkError } = useMagicLink(record.id);
-
-  const handleMagicLink = async () => {
-    try {
-      const response = await mintMagicLink();
-      window.open(
-        response.url,
-        "_blank",
-        "noopener,noreferrer"
-      );
-      feedback.message.success("Admin login link opened");
-    } catch {
-      feedback.message.error(magicLinkError || "Failed to generate admin login link");
-    }
-  };
+  const { mint, loading: loginLoading, error: loginError } = useMagicLink(record.id);
 
   const [purging, setPurging] = useState(false);
   const [warming, setWarming] = useState(false);
@@ -138,54 +108,22 @@ const ActionsCell = ({
 
   return (
     <RowActions
-      actions={[
-        {
-          key: "login",
-          label: "Log in to admin",
-          icon: <LoginOutlined />,
-          onClick: handleMagicLink,
-          loading: magicLinkLoading,
-          tooltip: "Log in to the admin dashboard",
-          hidden: !canLogin,
-        },
-        {
-          key: "purge",
-          label: "Purge cache",
-          icon: <ThunderboltOutlined />,
-          onClick: handlePurge,
-          loading: purging,
-          hidden: !record.cache_enabled,
-        },
-        {
-          key: "warmup",
-          label: "Warm cache",
-          icon: <ThunderboltOutlined />,
-          onClick: handleWarmup,
-          loading: warming,
-          hidden: !record.cache_enabled,
-        },
-        {
-          key: "clone",
-          label: "Clone",
-          icon: <CopyOutlined />,
-          onClick: onClone,
-          disabled: !canClone,
-          tooltip: canClone ? undefined : "Clone is only available for healthy WordPress installs",
-        },
-        {
-          key: "delete",
-          label: "Delete",
-          icon: <DeleteOutlined />,
-          onClick: onDelete,
-          danger: true,
-          loading: isDeleting,
-          confirm: {
-            title: "Delete this application?",
-            description: "The database, files, and any associated cron jobs will be removed. This cannot be undone.",
-            okText: "Delete",
-          },
-        },
-      ]}
+      actions={buildApplicationActions({
+        canLogin,
+        onLogin: () => openApplicationLogin(mint, loginError),
+        loginLoading,
+        onDelete,
+        deleting: isDeleting,
+        deleteDescription:
+          "The database, files, and any associated cron jobs will be removed. This cannot be undone.",
+        cacheEnabled: !!record.cache_enabled,
+        onPurge: handlePurge,
+        purging,
+        onWarmup: handleWarmup,
+        warming,
+        canClone,
+        onClone,
+      })}
     />
   );
 };
@@ -208,7 +146,7 @@ export const UserApplicationList = () => {
   const [activeTab, setActiveTab] = useTabParam<string>("installed");
   const [cloneOpen, setCloneOpen] = useState(false);
   const [cloningId, setCloningId] = useState<string | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const { deletingId, deleteApplication } = useDeleteApplication();
   const [cachingId, setCachingId] = useState<string | null>(null);
   const [cacheSettingsFor, setCacheSettingsFor] =
     useState<ApplicationInstall | null>(null);
@@ -255,41 +193,8 @@ export const UserApplicationList = () => {
   };
 
   // Poll the list while any row is transitional (pending/installing/
-  // cloning/deleting). Five-second cadence matches what Refine's old
-  // refetchInterval returned. refetch identity is stable, so only
-  // `active` triggers re-installing the timer.
-  const hasTransitional = anyTransitional(tableQuery.items);
-  useEffect(() => {
-    if (!hasTransitional) return;
-    const h = setInterval(() => {
-      tableQuery.refetch();
-    }, 5000);
-    return () => clearInterval(h);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasTransitional]);
-
-  const handleDelete = async (row: ApplicationInstall) => {
-    setDeletingId(row.id);
-    try {
-      await apiClient.delete(`/applications/${row.id}`);
-      feedback.message.success(`Deleting ${row.domain_name || row.domain_id}…`);
-      qc.invalidateQueries({ queryKey: ["list", "applications"] });
-      qc.invalidateQueries({ queryKey: ["list", "databases"] });
-    } catch (err) {
-      const msg =
-        (err as {
-          response?: { data?: { error?: string; detail?: string } };
-          message?: string;
-        })?.response?.data?.detail ??
-        (err as { response?: { data?: { error?: string } } })?.response?.data
-          ?.error ??
-        (err as { message?: string })?.message ??
-        "Delete failed";
-      feedback.message.error(msg);
-    } finally {
-      setDeletingId(null);
-    }
-  };
+  // cloning/deleting) — shared rule with the admin list (JAB-334 AC1).
+  useTransitionalPoll(tableQuery.items, tableQuery.refetch);
 
   // #406: single switch -> Redis object cache (jabali-wp-cache plugin) + nginx
   // page cache for the app's domain. WordPress + ready only.
@@ -500,53 +405,17 @@ export const UserApplicationList = () => {
               currentQ: tableQuery.params.q,
               onSearch: (v) => tableQuery.setParams({ q: v, page: 1 }),
             })}
-            render={(domainName: string, record) => {
-              const base = domainName || record.domain_id;
-              const path = record.subdirectory
-                ? `/${record.subdirectory}/`
-                : "/";
-              const label = `${base}${path}`;
-              const isLink = record.status === "ready" && !!domainName;
-              const appKey = record.app_type || "wordpress";
-              const meta = applicationStatusMeta(record.status);
-              const statusTag = (
-                <Tag color={meta.color} icon={meta.icon}>
-                  {meta.label}
-                </Tag>
-              );
-              const statusEl =
-                record.status === "failed" && record.last_error ? (
-                  <Tooltip title={record.last_error}>{statusTag}</Tooltip>
-                ) : (
-                  statusTag
-                );
-              return (
-                <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
-                  <CmsIcon appType={appKey} />
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 4,
-                      alignItems: "flex-start",
-                    }}
-                  >
-                    {isLink ? (
-                      <a
-                        href={`https://${domainName}${path}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {label}
-                      </a>
-                    ) : (
-                      <span>{label}</span>
-                    )}
-                    {statusEl}
-                  </div>
-                </div>
-              );
-            }}
+            render={(_domainName: string, record) => (
+              <ApplicationDomainCell
+                record={record}
+                status={
+                  <ApplicationStatusTag
+                    status={record.status}
+                    lastError={record.last_error}
+                  />
+                }
+              />
+            )}
           />
           <Table.Column<ApplicationInstall>
             dataIndex="version"
@@ -614,27 +483,19 @@ export const UserApplicationList = () => {
             render={(_, r) => {
               const isDeleting =
                 deletingId === r.id || r.status === "deleting";
-              const appType = r.app_type ?? "wordpress";
               const canClone =
-                r.status === "ready" && appType === "wordpress";
-              // Admin login is implemented for WordPress, Drupal, and
-              // Joomla — matches panel-api ssoAgentCommandFor. When
-              // adding a new CMS to the SSO-file flow, widen this list.
-              const canLogin =
-                r.status === "ready" &&
-                (appType === "wordpress" || appType === "drupal" || appType === "joomla");
-
+                r.status === "ready" && (r.app_type ?? "wordpress") === "wordpress";
               return (
                 <ActionsCell
                   record={r}
                   isDeleting={isDeleting}
                   canClone={canClone}
-                  canLogin={canLogin}
+                  canLogin={canApplicationLogin(r)}
                   onClone={() => {
                     setCloningId(r.id);
                     setCloneOpen(true);
                   }}
-                  onDelete={() => handleDelete(r)}
+                  onDelete={() => deleteApplication(r)}
                 />
               );
             }}


### PR DESCRIPTION
## What

Consolidates the admin and tenant Application Inventory lists behind a shared,
neutral `components/applications` module (ADR-0083 audience-policy pattern).
Both lists previously carried their own copy of the transitional-poll loop, the
status badge, the domain/CMS cell, the magic-link login capability, and the
delete + query invalidation.

Foundation `utils/applicationStatus` (the status vocabulary) shipped in #1497
under JAB-334; this PR completes the remaining ACs, so JAB-334 is done on merge.

## Module

Building blocks, not one table component — the two lists are structurally
different (admin is a flat table with an owner column; tenant has StatCards +
Tabs + a cache column), so they compose shared pieces instead:

- `applicationInventory.ts` — canonical `ApplicationInstall` row;
  `canApplicationLogin` (pinned to panel-api `ssoAgentCommandFor`:
  wordpress/drupal/joomla); `openApplicationLogin`;
  `APPLICATION_INVALIDATION_KEYS`; `extractApiError`.
- `useTransitionalPoll` — the "poll while a row is still settling" rule (AC1).
- `ApplicationStatusTag` — the status badge + the failed→tooltip failure
  presentation (AC2).
- `useDeleteApplication` — delete + applications/databases invalidation (AC2).
- `ApplicationDomainCell` — the CMS icon + domain link (inline for admin,
  stacked with the status tag for tenant).
- `buildApplicationActions` — the per-row action set. Admin gets
  `login + delete`; the tenant context adds the privileged
  `purge/warmup/clone` (AC4). The admin context cannot express clone —
  absence, not a flag.

## AC coverage

- **AC1** Transitional states use one polling rule → `useTransitionalPoll`,
  with a fake-timer test on the loop (the predicate is already tested in
  `applicationStatus.test.tsx`).
- **AC2** Failure presentation and invalidation are shared →
  `ApplicationStatusTag` (failure-tooltip test) + `useDeleteApplication` with
  the pinned invalidation keys.
- **AC3** Login capability is centralized → `canApplicationLogin` (truth table
  + backend-parity pin) + `openApplicationLogin`.
- **AC4** Role-specific actions remain explicit and tested →
  `buildApplicationActions` key sets: admin `[login, delete]`, tenant
  `[login, purge, warmup, clone, delete]`.

## Preserved deltas

Admin: owner column, `created_at` desc default sort, read-only action set,
"…and its data" delete copy. Tenant: install/scan/migrate/clone/cache actions,
StatCards, Tabs, `domain_name` asc default sort, "…database, files, and any
associated cron jobs" delete copy.

## Normalization

The admin delete now surfaces the server's error `detail` (it previously showed
only the transport message), matching the tenant list — via the shared
`extractApiError`.

## Follow-up (not this slice)

`CmsIcon`/`appDisplayName` still live under `shells/user/applications/`; the
neutral module now imports across into the tenant shell. Same smell #1498 fixed
for `channelKindConfig`. Left in place because `CatalogTab` and the
install/migrate/clone modals also import it.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx vitest run src/components/applications` — 25 tests pass
      (canApplicationLogin truth table + backend-parity pin, action key sets +
      hidden/disabled gating, poll loop with fake timers, failure tooltip,
      domain cell link/fallback/status-slot)
- [x] `applicationStatus.test.tsx` + `CacheSettingsDrawer.test.tsx` still pass
- [x] `npx eslint` clean on the module + both adapters
- [x] `npx vite build` clean
- [x] Falsified all three guards (drop joomla from the login set; invert the
      `"onClone" in ctx` discriminant; invert the poll gate) — each reddens its
      intended tests, then reverted
- [x] E2E `magic-link.spec.ts` `button:has-text("Log in to admin")` preserved
      (login is the first visible action in RowActions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
