### PR TITLE
docs: feature backfill — README + docs/site guides, factual corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ See [`docs/adr/`](docs/adr/) for the full architectural-decision record
   tick; operator hand-edits to nginx vhosts are lost-by-design
 - CSP, HSTS, SameSite cookies, X-Forwarded-Proto handled by nginx
 - Migrations are schema-only (no app-populated tables seeded by SQL)
-- Audit log on every admin write + impersonation start/stop
+- Audit log on every privileged mutation; actions performed while impersonating are attributed to the target user
 - Pre-commit + CI gates: `go vet`, `go test -race ./...`, `npx tsc -b`,
   `bash -n install.sh`, Playwright E2E, AppSec geoblock golden tests
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ operators can recover via `jabali` CLI without losing in-flight state.
 - Database admin ops (curated tuner, root password, processlist,
   pmaAdmin SSO)
 - Email queue, throttles, MTA-STS, outbound reports
-- Audit logs, notifications dispatcher, jabali-isolator events
+- Audit logs, notifications dispatcher, malware / quarantine events
 - Notification channel admin (test-send, scopes, throttles)
 
 ### User Panel
@@ -269,8 +269,9 @@ operators can recover via `jabali` CLI without losing in-flight state.
   runtime on the host
 - **Webmail**: Bulwark (Next.js JMAP) at `/opt/jabali-webmail`, served on
   `mail.<tenant>` per-domain via nginx → Unix socket
-- **SSH shell**: nspawn containers (debian-13-v1 image) for SSH access
-  isolation; jabali-isolator handles container lifecycle
+- **SSH shell**: mandatory sandbox per login — default `bubblewrap`
+  (namespace + bind-mount jail via setuid `bwrap`); an `nspawn` mode is
+  selectable but not yet wired. Fail-closed to `nologin`, never a bare shell
 - **Security**: CrowdSec parsers + AppSec (nginx-bouncer Lua, WAF) +
   per-user egress firewall (nftables + cgroupv2-vmap, ADR-0084) + LMD +
   ClamAV-on-demand + YARA + Tetragon
@@ -294,7 +295,6 @@ Service stack (single-node default):
 - **Kratos** (Unix socket admin + public, sole auth source — M20)
 - **CrowdSec** (LAPI socket + AppSec :7422 + nginx-bouncer Lua)
 - **Restic** (encrypted, dedup, backup destinations)
-- **jabali-isolator** (nspawn container lifecycle)
 - **systemd-user** (cron jobs as user-scope timers)
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ operators can recover via `jabali` CLI without losing in-flight state.
 ## Highlights
 
 - Per-user Linux accounts with per-user PHP-FPM master + cgroup v2 + POSIX quota
-- SSH shell access via nspawn containers with auto-start and idle timeout
+- SSH shell access always inside a mandatory sandbox — default `bubblewrap`
+  (namespace + bind-mount jail; hides other tenants, sockets, and PIDs);
+  fail-closed to `nologin`, never a bare host shell
+- FTP/SFTP subaccounts (opt-in) with same-uid or true separate-uid isolation,
+  per-subaccount WebDAV, and an opt-in PAM-gated vsftpd FTP(S) module
 - Root agent for SSL, mail, DNS, backups, migrations — fronted by a typed
   NDJSON RPC contract over `/run/jabali-agent/agent.sock` (no shelling out
   from the panel)
@@ -146,7 +150,12 @@ operators can recover via `jabali` CLI without losing in-flight state.
 - Per-domain opt-in nginx FastCGI micro-cache with safe-bypass for cart /
   admin / authenticated cookies
 - Restic backups (account_full + system_backup) with encryption, dedup,
-  SFTP / S3 destinations, scheduled + on-demand
+  SFTP / S3 / B2 / Azure / GCS / REST destinations, scheduled + on-demand,
+  per-destination slot cap + circuit breaker, opt-in auto daily backups
+- Portable Full Server container backup + restore-from-upload, tenant
+  self-service restore (files / DB / mail), single-domain docroot restore,
+  and per-database Download + Restore-from-file for MariaDB **and**
+  PostgreSQL (chunked async upload; pgAdmin custom/tar formats accepted)
 - WordPress 1-click install / delete / clone (M10) — 15-app catalogue (M19)
   incl. Moodle / Joomla / NextCloud / OpenCart / Mautic / Drupal
 - Per-user resource limits: cgroups v2 slice drop-in, nginx limit_req,
@@ -155,6 +164,10 @@ operators can recover via `jabali` CLI without losing in-flight state.
   egress firewall (nftables + cgroupv2-vmap) + ModSecurity replaced by
   CrowdSec AppSec (ADR-0060) + LMD + ClamAV-on-demand + YARA + Tetragon
   for malware detection + jabali quarantine + M14 notifications dispatch
+- CrowdSec 1.8 AppSec bot-detection challenge (default OFF; per-domain
+  opt-in / opt-out; tenant self-service on own domains), step-up (MFA)
+  auth for the admin File Manager + Root Terminal, and secret-rotation
+  tooling (DB app-user / JWT / foundation)
 - 6-channel notifications: Discord, ntfy, Web Push (VAPID), SMS,
   Email, Webhook, Slack, in-app bell — 4 event sources incl. cert renew,
   disk full, service down, CrowdSec spike
@@ -169,7 +182,8 @@ operators can recover via `jabali` CLI without losing in-flight state.
 ### Admin Panel
 
 - Dashboard with stats, health, recent activity, notifications bell
-- User management with suspension, packages, quotas, impersonation
+- User management with suspension, packages, quotas, impersonation,
+  in-place username rename, at-a-glance resource + bandwidth counts
 - Server settings (hostname, nameservers, public IPs, panel cert)
 - Service manager for systemd services + start/stop/restart
 - PHP version and per-user pool management (server-wide extensions tab)
@@ -180,7 +194,8 @@ operators can recover via `jabali` CLI without losing in-flight state.
   schedules, encrypted destinations
 - Migrations (cPanel restore, WHM downloads, IMAP sync)
 - Security: CrowdSec allowlists / alerts / console / captcha + UFW + AppSec
-  geoblock + per-user egress firewall + malware quarantine
+  geoblock + AppSec bot-detection (default OFF, per-domain scoped) + per-user
+  egress firewall + malware quarantine + secret-rotation tooling
 - Updates + Support tabs: live `jabali update` with transient systemd units,
   enclosed-encrypted diagnostic sharing to webmaster
 - Server status (CPU / mem / disk / queues / 5s polling)
@@ -192,21 +207,29 @@ operators can recover via `jabali` CLI without losing in-flight state.
 
 ### User Panel
 
-- Domains, redirects, custom nginx rules, listen-IP, FastCGI micro-cache
+- Domains with independent Web / Mail / DNS service flags, redirects,
+  custom nginx rules, listen-IP, FastCGI micro-cache, reverse-proxy mode,
+  per-domain environment variables, custom document root
 - DNS records editor with conflict detection (CNAME exclusivity per
   RFC 1034 §3.6.2) and dedup
-- Mail: domains, mailboxes, forwarders, autoresponders, catch-all,
-  disclaimers (HTML), shared folders, mail logs
+- Mail Domains drill-down: mailboxes, forwarders, autoresponders,
+  catch-all, disclaimers (HTML), shared folders, CalDAV/CardDAV (with
+  per-domain server override), per-domain logs + statistics, mail-only delete
 - IMAP sync (single + bulk)
 - Webmail SSO (Bulwark, Next.js JMAP)
 - WordPress (install, update, scan, SSO) + 14 other 1-click apps
-- File manager (AntD-native) + SFTP + SSH keys
-- SSH shell access via nspawn containers (idle timeout)
-- Databases (MariaDB + Postgres in tabbed view) with phpMyAdmin SSO
-- PHP settings per account
-- SSL management
-- Cron jobs (systemd-user timers + allowlist)
-- Backups + restore (account_full)
+- File manager (AntD-native, chunked upload with cancel + live speed,
+  async copy/move/extract progress) + SFTP + SSH keys
+- SSH shell access inside a mandatory bubblewrap sandbox
+- FTP/SFTP subaccounts (opt-in) + WebDAV
+- Databases (MariaDB + Postgres, tabbed) with phpMyAdmin (MariaDB) /
+  Adminer (Postgres) SSO + per-database Download + Restore-from-file
+- PHP settings per account + per-domain (OPcache/JIT, Xdebug, Composer,
+  extra extensions, env vars)
+- SSL management (Let's Encrypt + custom certificates)
+- Cron jobs (systemd-user timers + allowlist: php / wp / python / node)
+- Backups + restore (account_full) + restore-from-upload
+- Tenant-owned notification channels (when enabled by the admin)
 - Logs, statistics, bandwidth usage (daily nginx-log sync)
 - Support access link generator (one-time IP-bound tokens)
 - Notification preferences (Discord, ntfy, Web Push, SMS, Email)
@@ -222,6 +245,10 @@ operators can recover via `jabali` CLI without losing in-flight state.
 - Redis (Unix socket, ACL-scoped) for cache, sessions, notifications
   dispatcher streams
 - Per-domain opt-in FastCGI micro-cache + manual purge
+- Opt-in read-only Automation API on :443 for firewalled billing hosts
+- Disaster-recovery standby sync + promote (status card, stall alerts)
+- Zabbix 7 monitoring template; OS security auto-updates on by default
+- Side-nav badge counts (tenant + admin); admin header Health badge
 - Multi-language UI (en default; i18n harness ready)
 
 ## Architecture
@@ -366,8 +393,16 @@ jabali repair      --diagnose|--auto|--all
 jabali panel-primary set|show                 # ADR-0048 primary mail domain
 jabali nspawn      list|build|update|delete
 jabali malware-purge                          # M33 retention sweep
+jabali ftp         list|create|delete|reset   # FTP/SFTP subaccounts (GH #1053)
+jabali notification channels|routing|test     # server-wide + tenant-owned
 jabali update      [--force]
 ```
+
+`jabali domain create` takes `--web-enabled` / `--manage-dns` / `--mail`
+(independent per-domain services), and `jabali system restore --from-tar`
+restores a whole server from a Full Server container archive. The complete,
+generated flag reference lives in
+[`docs/site/platform/cli-reference.md`](docs/site/platform/cli-reference.md).
 
 See [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) for the full repo-wide
 patterns (route families, SearchableTable, Drawer-for-CRUD, list envelope,
@@ -506,9 +541,11 @@ See the [`docs/`](docs/) directory for detailed guides:
   limits) + anti-patterns learnt the hard way
 - [Blueprint](docs/BLUEPRINT.md) — full feature map + milestone roadmap
 - [ADRs](docs/adr/) — every load-bearing architectural decision (110+)
+- [User & admin guides](docs/site/) — per-feature docs (domains, mail,
+  databases, backups, security, PHP, cron, files, SFTP/FTP, and more)
 - [Plans](plans/) — per-milestone implementation blueprints
-- [Runbooks](plans/) — operational guides for SSL, mail, M16 rollback,
-  M22 SSO rework, M27 CrowdSec extensions, M30/M30.1 backups
+- [Runbooks](docs/runbooks/) — operational guides (SSL, mail, backups,
+  secondary nameserver, DNS, applications)
 - [Known Issues](docs/KNOWN_ISSUES.md) — caveats + workarounds
 - [Contributing](docs/CONTRIBUTING.md) — feature development workflow
 - [Translations](https://translate.jabali-panel.com/) — Weblate instance; English

--- a/docs/site/INTEGRATION.md
+++ b/docs/site/INTEGRATION.md
@@ -261,7 +261,7 @@ The new pages land in EN first. For other languages:
 Glossary terms that **must not be translated** (keep English exact):
 
 - `Agent`, `Reconciler`, `Privileged DB Admin Action`, `Cron Job`, `Cron Job Intake`, `SSO Token`, `Shadow Account`, `SSO Token Resolution` (CONTEXT.md domain language).
-- Product names: `CrowdSec`, `AppSec`, `Stalwart`, `Bulwark`, `Kratos`, `Roundcube`, `PowerDNS`, `pdns-recursor`, `MariaDB`, `PostgreSQL`, `Snuffleupagus`, `AppArmor`, `AIDE`, `Tetragon`, `ClamAV`, `LMD`, `YARA`, `restic`.
+- Product names: `CrowdSec`, `AppSec`, `Stalwart`, `Bulwark`, `Kratos`, `Adminer`, `phpMyAdmin`, `PowerDNS`, `pdns-recursor`, `MariaDB`, `PostgreSQL`, `Snuffleupagus`, `AppArmor`, `AIDE`, `Tetragon`, `ClamAV`, `LMD`, `YARA`, `restic`.
 - CLI verbs (everything starting with `jabali …`).
 - File paths (`/etc/...`, `/var/...`, `/run/...`).
 - Service / unit names (`jabali-panel.service`, `nginx`, etc.).

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -37,7 +37,8 @@ Comprehensive English docs for the current (Go) generation of Jabali Panel. Desi
 | [removed-features.md](./removed-features.md) | What's intentionally not here (OIDC, ModSec, filebrowser, impersonation, Refine). |
 | [platform/stack.md](./platform/stack.md) | Process / data / reconciler model. |
 | [platform/agent.md](./platform/agent.md) | Privileged-agent contract. |
-| [platform/cli.md](./platform/cli.md) | Full `jabali` CLI reference. |
+| [platform/cli.md](./platform/cli.md) | `jabali` CLI cheat-sheet — common commands, hand-written. |
+| [platform/cli-reference.md](./platform/cli-reference.md) | Full generated `jabali` command reference (every subcommand + flag). |
 | [platform/dnssec.md](./platform/dnssec.md) | DNSSEC architecture. |
 | [platform/mail-autoconfig.md](./platform/mail-autoconfig.md) | Thunderbird / Outlook / Apple autoconfig. |
 | [platform/health-monitor.md](./platform/health-monitor.md) | `/api/v1/health` + `/metrics`. |

--- a/docs/site/admin.md
+++ b/docs/site/admin.md
@@ -5,7 +5,7 @@ Lives at `/jabali-admin`. Top-level pages:
 | Page | Path | Purpose |
 |---|---|---|
 | Dashboard | `/jabali-admin/dashboard` | Counts (users, domains, mailboxes), recent activity, health summary, version. |
-| Users | `/jabali-admin/users` | Create / edit / delete panel users; reset password; reset 2FA; suspend; assign package. |
+| Users | `/jabali-admin/users` | Create / edit / delete panel users; reset password; reset 2FA; suspend; assign package; rename username in place; impersonate (scoped, time-bounded, audited); at-a-glance resource counts + monthly bandwidth. |
 | Packages | `/jabali-admin/packages` | Bundles of quotas (disk, bandwidth, mailboxes, domains, DBs, PHP-INI overrides). |
 | Domains | `/jabali-admin/domains` | All hosted domains across all users; per-domain settings (PHP, SSL, DNSSEC, listen IP, redirects, aliases, cache). |
 | DNS | `/jabali-admin/dns` | All DNS zones; per-domain DNSSEC enable + DS record display. |
@@ -21,12 +21,12 @@ Lives at `/jabali-admin`. Top-level pages:
 | Logs | `/jabali-admin/logs` | Tail panel / agent / nginx / Stalwart / Kratos / Bulwark / PowerDNS / CrowdSec. |
 | Audit | `/jabali-admin/audit` | Append-only audit log (every privileged mutation; ADR-0106). |
 | Server Settings | `/jabali-admin/settings` | Panel hostname; primary mail domain; default IP pool; DB admin sections; notifications channels; AppSec policy; CrowdSec console enrol; updates source. |
-| Notifications | `/jabali-admin/notifications/{channels,events,routing,test}` | Configure 6 channels (in-app, email, Slack, Telegram, ntfy, Web Push); per-event routing; test send. |
-| Updates | `/jabali-admin/updates` | Run `jabali update` from the UI as a transient systemd unit (survives panel restart mid-update). |
+| Notifications | `/jabali-admin/notifications/{channels,events,routing,test}` | Configure channels (in-app, email, Slack, Telegram, Discord, ntfy, Web Push, SMS, webhook); per-event routing (category rail); test send; owns an **Owner** column for tenant-owned channels. |
+| Updates | `/jabali-admin/updates` | Run `jabali update` from the UI as a transient systemd unit (survives panel restart mid-update); Update Center reports OS security-update state. |
 | Support | `/jabali-admin/support` | Generate an encrypted diag bundle (enclosed.cc), `mailto:` ticket. |
 | Migrations | `/jabali-admin/migrations` | Ingest cPanel / DirectAdmin / Hestia / WHM archives, track restore progress. |
-| Backups | `/jabali-admin/backups` | Destinations (local / sftp / s3 / b2 / azure / gcs / rest), schedules, retention, restore. |
-| Automation | `/jabali-admin/automation` | Scoped API tokens for the future Automation API. |
+| Backups | `/jabali-admin/backups` | Destinations (local / sftp / s3 / b2 / azure / gcs / rest), schedules, retention, restore; Full Server container backup + restore-from-upload. |
+| Automation | `/jabali-admin/automation` | Scoped API tokens for the opt-in Automation API (read-only endpoints on :443 for firewalled billing hosts, GH #1161). |
 | Terminal | `/jabali-admin/terminal` | Web terminal (root). |
 
 ## Sidebar groups
@@ -41,7 +41,6 @@ The sidebar groups pages by activity:
 
 ## What is intentionally *not* here
 
-- **In-panel impersonation** — removed with the M20 Kratos migration. The audit emitter is wired and an ADR-0106 toggle reserves the audit-visibility setting, but no admin → user session-handoff is currently shipped.
 - **OIDC / Hydra** — rolled back in M16. The panel does not act as an OIDC provider.
 - **ModSecurity** — replaced by CrowdSec AppSec (M27).
 - **filebrowser** — replaced by the in-panel AntD File Manager (M11).

--- a/docs/site/admin/appsec.md
+++ b/docs/site/admin/appsec.md
@@ -24,6 +24,21 @@ The install path is **flat** (`/etc/crowdsec/appsec-rules/`). An earlier bug use
 - **Per-rule exception** — exclude a specific rule for a specific URL path or for a specific user (drop the rule from the inspector configuration).
 - **Per-domain exception** — exclude all AppSec checks for a domain (rarely useful; documented for completeness).
 
+## Bot detection (CrowdSec 1.8)
+
+A separate **bot-detection challenge** is available, **off by default**
+(per-server). Enable it under Security → AppSec. It is layered and scoped so it
+never silently challenges traffic on a domain the operator didn't choose:
+
+- **Per-server** master switch (default OFF).
+- **Per-domain opt-in** (`scope=selected`) — challenge only chosen domains.
+- **Per-domain opt-out** — exclude a specific domain.
+- **Tenant self-service** — a tenant can toggle it on their **own** domains.
+
+Oversized request bodies are inspected up to the AppSec limit and then passed
+(the `partial` body-size action) rather than dropped, so large uploads on
+`/api/v1/*` are not blocked before the panel's own allowlist runs.
+
 ## Inspecting blocks
 
 The AppSec inspector logs every blocking decision with the matched rule and the request body excerpt. Surface them in [Email Logs](./email-logs.md) under the AppSec filter, or tail directly:

--- a/docs/site/admin/automation-api.md
+++ b/docs/site/admin/automation-api.md
@@ -1,10 +1,17 @@
 # Automation API
 
-`/jabali-admin/automation`. Scoped API tokens for the future Automation API.
+`/jabali-admin/automation`. Scoped API tokens for the Automation API.
 
 ## Current status
 
-The UI for minting and revoking scoped tokens is shipped. The public Automation API surface itself is rolling out incrementally — read endpoints first, then write endpoints, then bulk operations. Until the surface is GA, prefer the CLI for unattended automation.
+The whole Automation API is **opt-in** and **off by default** (GH #1161) — an
+admin enables it under Server Settings, and it can additionally listen on `:443`
+for **firewalled billing hosts** that can't reach the Unix socket. The UI for
+minting and revoking scoped tokens is shipped, and the **read-only** endpoints
+(domains, mailboxes, databases, mail forwarders / domain-forwarders / groups /
+autoresponders, and the fleet-monitor `server-status`) are live (JAB-74, JAB-76).
+Write and bulk endpoints are still rolling out — until they're GA, prefer the CLI
+for unattended mutation.
 
 ## Token shape
 

--- a/docs/site/admin/backup-restore.md
+++ b/docs/site/admin/backup-restore.md
@@ -13,8 +13,11 @@ Filter by kind, by subject (for `account_full`), by date range.
 Pick a snapshot, then choose:
 
 - **Target user** — restore to the same user (overwrite), to a new user (preserve original), or to an existing different user (uncommon; usually for forensic investigation).
-- **Components** — restore everything, or pick subsets (files only, databases only, mailboxes only, DNS only).
+- **Components** — restore everything (a **Select all** toggle) or pick subsets (files, databases, mailboxes, DNS, FTP subaccounts). FTP/SFTP subaccounts are rebuilt with their original login password (GH #1361); MariaDB **and** PostgreSQL databases are covered.
 - **Dry run** — see what would be touched without writing.
+
+A single domain's document root can be restored on its own (GH #1359) without
+touching the rest of the account.
 
 The agent restores in the same per-stage order the backup ran: files first, databases second, mailboxes third, DNS records last. Each stage is idempotent at the file or row level.
 
@@ -35,6 +38,19 @@ System restores are typically performed on a freshly-bootstrapped panel host. Se
 5. After completion, run `jabali repair --diagnose` to surface any drift between restored state and the fresh host (typically only IP-related mismatches if the new host has a different IP).
 
 Round-trip restore was live-verified on 192.168.100.150.
+
+## Restore from an uploaded archive
+
+Besides restic destinations, both account and full-server restores accept a
+backup **archive you upload** directly (GH #1408) — the portable path for moving
+to a host that shares no restic destination with the source:
+
+- **Account** — upload an account backup and restore selected legs. Tenants can
+  do this for their own account (self-service restore-from-upload).
+- **Full server** — `jabali system restore --from-tar <file>` rebuilds the system
+  leg and every account from a Full Server container, **creating missing OS
+  users** and even restoring an account into a user that doesn't yet exist
+  (create-from-manifest).
 
 ## Operator-only safety rails
 

--- a/docs/site/admin/hestiacp-migration.md
+++ b/docs/site/admin/hestiacp-migration.md
@@ -28,7 +28,7 @@ The resulting archive lands under `/backup/<user>.<timestamp>.tar`.
 ## What requires manual work
 
 - **Exim ACL rules** — HestiaCP often carries non-trivial Exim acl_smtp_data / acl_check_recipient rules. These do not translate directly to Stalwart's expression filter syntax; rewrite under [Server Settings](./server-settings.md) → Mail → Stalwart expressions.
-- **Per-domain Roundcube identities** — Roundcube installations on the source are not migrated; the destination ships its own Roundcube.
+- **Per-domain webmail identities** — Roundcube identities on the HestiaCP source are not migrated; the destination serves its own **Bulwark** webmail instead.
 - **Spamassassin / rspamd thresholds** — Stalwart spam scoring is independent; recalibrate if your Hestia setup had custom thresholds.
 
 ## Operator workflow

--- a/docs/site/admin/notifications-events.md
+++ b/docs/site/admin/notifications-events.md
@@ -19,6 +19,7 @@
 | `malware_file_hit` | A M33 detector (ClamAV, LMD, YARA, Tetragon) hits on a file. |
 | `db_root_rotated` | The administrator rotates the MariaDB root password. |
 | `mail_throttle_suspended` | A sender is suspended after repeated throttle hits. |
+| `ssh_login` | A shell / SFTP login to an account. Each account owner can keep a per-account **ignore list** so logins from known hosts / users don't notify (GH #1436). |
 
 ## Stub sources
 

--- a/docs/site/applications.md
+++ b/docs/site/applications.md
@@ -52,6 +52,19 @@ Every app uses the same 6-step pipeline:
 - "Clone" → currently WP-only, others on the roadmap.
 - "Delete" → destructive teardown.
 
+## Python apps — media directory
+
+A Python app can serve a per-app **media directory straight from nginx** (GH
+#878), parallel to the static-files mapping: `media_url` → `media_root` gets its
+own nginx `alias` rule (1-hour cache, vs 30-day for static assets), so
+user-uploaded media is served without going through the WSGI/ASGI worker.
+
+## Database admin tooling
+
+MariaDB databases open in **phpMyAdmin**; PostgreSQL databases open in
+**Adminer** (upgraded to 6.0.1 with a ported single-sign-on plugin, GH #1405).
+See [Databases](./databases.md).
+
 ## CLI
 
 ```bash

--- a/docs/site/backups.md
+++ b/docs/site/backups.md
@@ -7,6 +7,13 @@ Two backup kinds:
 
 Both are restic-backed (deduplicated, encrypted at rest, multi-destination).
 
+Beyond the scheduled restic snapshots, Jabali also supports **portable container
+backups** (a single downloadable archive) and **restore-from-upload**, so an
+account — or a whole server — can be rebuilt on a host that has no restic
+destination in common with the source (GH #1408). See
+[Full Server backup / restore](#full-server-backup--restore) and
+[Restore from an uploaded archive](#restore-from-an-uploaded-archive).
+
 ## Destinations
 
 `/jabali-admin/backups` → Destinations:
@@ -32,6 +39,19 @@ Multiple destinations per backup are supported — restic writes to each.
 
 Retention policies use restic's `--keep-daily`, `--keep-weekly`, `--keep-monthly`, `--keep-yearly` flags.
 
+The dispatcher runs jobs with a **per-destination slot cap and a circuit
+breaker** (JAB-362): one dead or unreachable destination can no longer starve
+the whole queue — its jobs are skipped-if-pending and retried on their own
+per-destination slots while other destinations keep draining, and a failing
+destination raises an alert instead of silently backing up.
+
+### Automatic daily local backups
+
+Admins can enable **opt-in automatic daily local backups for all users**
+(default **off**, GH #1240) under `/jabali-admin/backups`. When on, every account
+is backed up daily to the local destination on a staggered window, giving a
+baseline safety net without configuring a per-user schedule.
+
 ## system_backup contents
 
 7 stages:
@@ -46,13 +66,76 @@ Retention policies use restic's `--keep-daily`, `--keep-weekly`, `--keep-monthly
 
 ## Restore
 
-Restores are admin-only (`/jabali-admin/backups` → Restore tab):
+### From a restic snapshot (admin)
+
+`/jabali-admin/backups` → Restore tab:
 
 - Pick a destination, browse snapshots, pick one.
-- For `account_full`: choose target user (overwrite or new).
-- For `system_backup`: typically restored on a fresh host — the panel is bootstrapped, then `jabali system restore` is run from the CLI.
+- For `account_full`: choose target user (overwrite or new). The restore drawer
+  has a **Select all** toggle (GH #1363) plus per-leg checkboxes, so you can
+  restore only the home dir, only the databases, only mail, and so on.
+- For `system_backup`: typically restored on a fresh host — the panel is
+  bootstrapped, then `jabali system restore` is run from the CLI.
 
-Round-trip is live-verified on 192.168.100.150 as of M30.1.
+An `account_full` restore rebuilds the account's databases (MariaDB **and**
+PostgreSQL), mail, DNS, cron, apps, and **FTP/SFTP subaccounts** — the last with
+their original login password preserved through a root-only one-shot staging
+file (GH #1361).
+
+### Tenant self-service restore-from-upload
+
+Tenants no longer need an admin for a restore. From the user Backups page a
+tenant can **upload a backup archive and restore selected legs** — files,
+databases, and mail — of their own account (GH #1408). A per-account download is
+prepared in the background with a live **"Preparing…"** indicator so a large
+account doesn't block the request.
+
+### Restore a single domain's document root
+
+From a backup you can restore just **one domain's document root** without
+touching the rest of the account (GH #1359) — useful for reverting a single site
+after a bad deploy.
+
+### Database restore from a file
+
+Both engines support **Restore from file** on the per-database row (see
+[Databases](./databases.md)):
+
+- The upload is **chunked and async** so it beats Cloudflare's ~100 MB / 524
+  origin limits (GH #1323), with an upload-progress modal.
+- **MariaDB** and **PostgreSQL** are both covered. PostgreSQL accepts plain-SQL
+  **and** pgAdmin's default custom / tar archive formats, and surfaces the real
+  loader error instead of a generic failure (GH #1045). The uploaded dump is
+  never loaded as a superuser — it runs through a per-database, non-superuser
+  scoped role, built in a throwaway staging database and swapped onto the real
+  name only on success, so a bad upload never wipes the live database.
+
+Round-trip is live-verified on the test fleet.
+
+## Full Server backup / restore
+
+A **Full Server backup** packages one backup run into a single downloadable
+**container archive** (GH #1408, #502) — everything needed to reconstruct the
+host, in one file you can move anywhere.
+
+Restoring from an uploaded container (`jabali system restore --from-tar`, GH
+#1408):
+
+- Rebuilds the **system leg** and every hosted account.
+- **Creates missing OS users** and rebuilds per-user metadata, so the target
+  host does not have to already know the accounts.
+- Can **create-from-manifest** — restore an account into a user that does not yet
+  exist on the target.
+
+This is the path for moving a whole server to new hardware when the source and
+target share no restic destination.
+
+## Restore from an uploaded archive
+
+Both the account and full-server flows accept a backup **archive you upload**
+directly, rather than one reached through a configured restic destination — the
+portable counterpart to snapshot restore for cross-host moves and disaster
+recovery.
 
 ## CLI
 
@@ -63,9 +146,19 @@ jabali destination test daily-offsite
 
 jabali backup schedule list
 jabali backup schedule create --kind account_full --user <id> --destination daily-offsite --cron "0 3 * * *" --keep-daily 7 --keep-weekly 4
+jabali backup schedule run-now <id>
 
+# Restore one account from a snapshot (add --apply to write to the live system)
+jabali backup account-restore --user <name> --destination daily-offsite --snapshot <id> --force --apply
+
+# System restore
 jabali system restore --snapshot <id> --destination daily-offsite
+# …or from a Full Server container archive (no shared restic destination needed):
+jabali system restore --from-tar /path/to/full-server-backup.tar
 ```
+
+See [`platform/cli-reference.md`](./platform/cli-reference.md) for the complete,
+generated flag reference.
 
 ## What you don't get
 

--- a/docs/site/cron.md
+++ b/docs/site/cron.md
@@ -8,7 +8,7 @@ A **Cron Job** is:
 
 - 5-field cron schedule (`min hour day month dow`).
 - An owner user (must have a Linux account).
-- A command from the **allowlist** (`php`, `wp`, plus a curated set per-app).
+- A command from the **allowlist** (`php`, `wp`, `python`, `node`, plus a curated set per-app), or an **ordered sequence** of `wp` / `php` commands run one after another in a single job (GH #1435, #1437).
 - An optional name (display label).
 
 Internally each cron row becomes:
@@ -29,7 +29,7 @@ systemd-user timers give:
 
 ## Command allowlist
 
-Only commands the admin has marked allowed can be scheduled. The default allowlist (`/internal/cronvalidate/`) is the shared validator used by both the REST API and the CLI (`Cron Job Intake` — the single ingest path, per CONTEXT.md). Custom shell scripts are not allowed by default — admins can extend the allowlist.
+Only commands the admin has marked allowed can be scheduled. The default allowlist (`/internal/cronvalidate/`) is the shared validator used by both the REST API and the CLI (`Cron Job Intake` — the single ingest path, per CONTEXT.md). Alongside `php` and `wp`, the validator accepts **`python` and `node`** scripts located under the owner's home (GH #1435), and an **ordered sequence** of `wp`/`php` steps in one job (GH #1437). Custom shell scripts are not allowed by default — admins can extend the allowlist.
 
 ## CLI
 

--- a/docs/site/databases.md
+++ b/docs/site/databases.md
@@ -1,6 +1,6 @@
 # Databases
 
-MariaDB and PostgreSQL, per-user databases and DB-users, with SSO into phpMyAdmin / pgAdmin.
+MariaDB and PostgreSQL, per-user databases and DB-users, with SSO into phpMyAdmin (MariaDB) / Adminer (PostgreSQL).
 
 ## Engines
 

--- a/docs/site/databases.md
+++ b/docs/site/databases.md
@@ -13,10 +13,30 @@ MariaDB and PostgreSQL, per-user databases and DB-users, with SSO into phpMyAdmi
 
 `/jabali-panel/databases`:
 
+Databases are shown in a **tabbed view** (MariaDB and PostgreSQL side by side).
+
 - **Create database** — pick the engine, name (`<user>_<suffix>` prefix enforced by `db_admin` policies), default DB user.
-- **Create DB user** — username + password (shown once). The agent provisions the user with `GRANT ALL ON <user>_*.* TO …`.
-- **phpMyAdmin SSO** — single-use, short-TTL **SSO Token** (CONTEXT.md). Click "Open phpMyAdmin" → land authenticated as the DB user.
-- **pgAdmin SSO** — same flow for PostgreSQL.
+- **Create DB user** — username + password (shown once). The agent provisions the user with `GRANT ALL ON <user>_*.* TO …`. For PostgreSQL, a DB-user granted to a database gets usable schema access, not just a bare `CONNECT` (GH #1406).
+- **phpMyAdmin SSO** (MariaDB) — single-use, short-TTL **SSO Token** (CONTEXT.md). Click "Open phpMyAdmin" → land authenticated as the DB user.
+- **Adminer SSO** (PostgreSQL) — same single-use SSO flow into **Adminer** (upgraded to 6.0.1 with a ported SSO plugin, GH #1405).
+
+### Per-database Backup / Restore (GH #1045)
+
+Each database row has **Download backup** and **Restore from file** actions, for
+**both** MariaDB and PostgreSQL:
+
+- **Download** streams a dump (`--no-owner --no-privileges` for Postgres).
+- **Restore from file** uploads a dump and replaces the whole database. The
+  upload is **chunked and async** to beat Cloudflare's ~100 MB / 524 origin
+  limits (GH #1323), with an upload-progress modal.
+- PostgreSQL restore accepts plain-SQL **and** pgAdmin's default custom / tar
+  archive formats and surfaces the real loader error, not a generic failure (GH
+  #1045). Uploaded dumps are never loaded as a superuser — they run through a
+  per-database non-superuser scoped role and are built in a throwaway staging
+  database, swapped onto the real name only on success (a bad upload never wipes
+  the live database).
+
+See [Backups](./backups.md) for account- and server-level restore.
 
 ## Admin DB Ops (M46)
 

--- a/docs/site/domains.md
+++ b/docs/site/domains.md
@@ -16,8 +16,11 @@ Edit a domain via `/jabali-admin/domains/edit/:id` (admin) or `/jabali-panel/dom
 | **Listen IP** | Pick from the admin's managed IP pool. Default: server's primary IP. Apex DNS records auto-update. |
 | **Redirects** | HTTP → HTTPS (always emitted when SSL is on); per-path redirects (planned). |
 | **Aliases** | Additional `server_name` values that resolve to the same vhost + same docroot. |
-| **Cache** | Per-domain FastCGI micro-cache (planned, ADR-0108). |
-| **Email** | Toggle whether this domain runs mail (adds DKIM keys + MX hint to DNS + Stalwart Domain entry). |
+| **Cache** | Per-domain opt-in FastCGI micro-cache (ADR-0108), with a safe-bypass for cart / admin / authenticated cookies and a manual purge. Default off. |
+| **Document root** | Set the docroot when adding the domain, confined to the owner's home tree (GH #1413). |
+| **Environment variables** | Per-domain env vars passed to the FPM pool (GH #1332). |
+| **Web / Mail / DNS** | Each service is an **independent per-domain flag** (GH #1449) — a domain can run any combination. Turning **Mail** on adds DKIM keys + MX hint + Stalwart Domain entry; **DNS** on manages the zone in PowerDNS; **Web** on builds the nginx vhost. |
+| **Reverse proxy** | Instead of serving files, proxy the domain to a local app on a chosen loopback port. Tenants pick the port through an SSRF-safe validator with an agent-side bind check (GH #1175, #1401); ports come from a shared loopback-port allocator so two tenants can't collide. |
 
 ## Domain lifecycle
 
@@ -29,6 +32,13 @@ delete  → DB row removed    → reconciler tears down vhost, revokes cert, dro
 
 The reconciler is the only thing that re-applies vhosts; never edit nginx site files by hand — they'll be overwritten on the next tick.
 
+**Delete also removes files (opt-in).** Domain delete keeps the document root by
+default; tick **also delete files** (default off, GH #1382) to remove the docroot
+tree at the same time.
+
+**Change owner.** An admin can reassign a domain to a different user (GH #1238);
+the vhost, DNS, and mail follow the new owner on the next reconcile.
+
 ## What lives outside the vhost
 
 - **DNS records** are managed under DNS (PowerDNS auth backend, MariaDB-backed).
@@ -39,10 +49,14 @@ The reconciler is the only thing that re-applies vhosts; never edit nginx site f
 
 ```bash
 jabali domain list                 # all domains
-jabali domain create <name> --user <id>
+jabali domain create <name> --user <id> --web-enabled --manage-dns --mail
 jabali domain enable <name|id>
 jabali domain disable <name|id>
 jabali domain delete <name|id>
 ```
 
-See [platform/cli.md](./platform/cli.md) for full flag reference.
+`jabali domain create` takes `--web-enabled`, `--manage-dns`, and `--mail` to set
+the independent Web / Mail / DNS service flags at create time (GH #1449).
+
+See [platform/cli-reference.md](./platform/cli-reference.md) for the full,
+generated flag reference.

--- a/docs/site/files.md
+++ b/docs/site/files.md
@@ -5,13 +5,14 @@
 ## What you can do
 
 - Browse: navigate inside your own home directory (`/home/<you>`). Symlinks resolved, no escaping above your root.
-- Upload: drag-and-drop multiple files; chunked uploads for large files.
+- Upload: drag-and-drop multiple files; **chunked uploads with a cancel button and a live speed readout** (GH #1410). Direct upload works even over a bare IP (no domain configured yet).
 - Download: single file or selected files (zipped server-side).
 - Create / rename / delete: files and directories.
 - Edit text files in-browser (Monaco editor; syntax highlighting for common languages).
 - View images, archives (list contents), PDFs.
 - Set permissions: octal (`755`, `644`, etc.) or per-bit checkboxes.
-- Compress / extract: tar.gz, zip, 7z.
+- Compress / extract: tar.gz, zip, 7z — with **live progress for extract, copy, and move** (GH #1392).
+- Copy / move (Paste): runs **async with a real byte-progress bar** on large trees (GH #1392) instead of blocking the request.
 
 ## What you can't do
 
@@ -20,9 +21,19 @@
 - Run arbitrary shell commands from the file manager (use SSH / SFTP for that).
 - Execute uploaded scripts directly (they execute only when served by nginx → PHP-FPM; the file manager doesn't shell out).
 
+## Admin File Manager (GH #1184)
+
+Admins get the **same** File Manager UI (layout, functions, design) as tenants,
+but scoped to the **whole filesystem** rather than one home tree. It is:
+
+- **Opt-in** and **deny-listed** — sensitive paths are blocked, and the write
+  allow-list is enforced **on the API**, not just in the UI (JAB-367).
+- Gated behind **step-up (recent-auth / MFA) re-authentication** before it opens
+  (JAB-380), so a stolen session alone can't reach the whole filesystem.
+
 ## Implementation note
 
-Filesystem ops run through the agent over Unix socket. The panel-api translates UI requests into agent calls; the agent enforces "this UID can only touch its own home". No bind-mounts, no chroot helpers, no separate file-browser process.
+Filesystem ops run through the agent over Unix socket. The panel-api translates UI requests into agent calls; the agent enforces "this UID can only touch its own home" for tenants (and the deny-list + write allow-list for the admin manager). No bind-mounts, no chroot helpers, no separate file-browser process.
 
 ## Why the rewrite
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -37,7 +37,7 @@ Jabali is an open-source Linux web-hosting control panel. Go agent + React UI, M
 - Notifications: in-app bell, email, Slack, Telegram, Discord, ntfy.sh, Web Push (VAPID), SMS, webhook — server-wide and opt-in tenant-owned channels.
 - Server Status dashboard with service controls.
 - One-click `jabali update` from the panel, encrypted diag bundle for support.
-- Migration ingest from cPanel (`.tar.gz`/`cpmove`), DirectAdmin, Hestia, WHM.
+- Migration ingest from cPanel (`.tar.gz`/`cpmove`), DirectAdmin, Hestia, WHM (archive or live SSH), plus live-SSH import from Plesk, CloudPanel, CyberPanel, and Jabali → Jabali.
 
 ## How it's built
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -19,10 +19,10 @@ Jabali is an open-source Linux web-hosting control panel. Go agent + React UI, M
 - Per-domain DNSSEC (KSK + ZSK auto-generated, DS record displayed for parent registrar publication).
 
 **Storage & databases**
-- MariaDB and PostgreSQL databases per user, with phpMyAdmin / pgAdmin SSO.
+- MariaDB and PostgreSQL databases per user, with phpMyAdmin (MariaDB) / Adminer (PostgreSQL) SSO, and per-database Download + Restore-from-file.
 - Admin DB Ops: root-password rotation, curated config tune, maintenance, processlist + kill.
-- File Manager (AntD-native — no filebrowser process).
-- SFTP via OpenSSH `Match Group` + per-user SSH key vault.
+- File Manager (AntD-native — no filebrowser process); admin whole-filesystem File Manager, opt-in + deny-listed.
+- SFTP via OpenSSH `Match Group` + per-user SSH key vault; FTP/SFTP subaccounts (opt-in) with optional true separate-uid isolation and WebDAV.
 
 **Security**
 - CrowdSec is the single IP-trust source (UFW handles port baseline only).
@@ -33,8 +33,8 @@ Jabali is an open-source Linux web-hosting control panel. Go agent + React UI, M
 
 **Operations**
 - Per-user resource limits: POSIX quota + cgroup v2 slice drop-ins + nginx `limit_req`.
-- Backups: per-account `account_full` + whole-server `system_backup` (panel DB × 3 + OS users + sites), restic-backed, multi-destination (local / sftp / s3 / b2 / azure / gcs / rest), scheduled with retention.
-- Notifications: in-app bell, email, Slack, Telegram, ntfy.sh, Web Push (VAPID).
+- Backups: per-account `account_full` + whole-server `system_backup` (panel DB × 3 + OS users + sites), restic-backed, multi-destination (local / sftp / s3 / b2 / azure / gcs / rest), scheduled with retention — plus portable Full Server container backups and tenant self-service restore-from-upload.
+- Notifications: in-app bell, email, Slack, Telegram, Discord, ntfy.sh, Web Push (VAPID), SMS, webhook — server-wide and opt-in tenant-owned channels.
 - Server Status dashboard with service controls.
 - One-click `jabali update` from the panel, encrypted diag bundle for support.
 - Migration ingest from cPanel (`.tar.gz`/`cpmove`), DirectAdmin, Hestia, WHM.
@@ -58,4 +58,4 @@ See [platform/stack.md](./platform/stack.md) for the full architecture.
 
 - New install → [installation.md](./installation.md)
 - Already installed → [quickstart.md](./quickstart.md)
-- Looking for something old → [removed-features.md](./removed-features.md) (OIDC/Hydra, ModSecurity, filebrowser, in-panel impersonation are gone).
+- Looking for something old → [removed-features.md](./removed-features.md) (OIDC/Hydra, ModSecurity, filebrowser are gone).

--- a/docs/site/mail.md
+++ b/docs/site/mail.md
@@ -1,26 +1,41 @@
 # Mail
 
-Jabali's mail stack is [**Stalwart**](https://stalw.art) (SMTP submission + MTA + JMAP + IMAP, single process) + **Bulwark** (rate-limit / spam policy bridge) + **Roundcube** webmail.
+Jabali's mail stack is [**Stalwart**](https://stalw.art) (SMTP submission + MTA + JMAP + IMAP, single process) + **Bulwark**, a Next.js JMAP webmail served per-tenant on `mail.<domain>`.
 
 ## Per-mailbox
 
 - Authentication: per-mailbox Argon2id-hashed password stored by Stalwart.
 - Quota: per-mailbox MiB, enforced by Stalwart.
-- Webmail: `https://<primary-mail-domain>/mail/` (Roundcube). SSO bridge in `/jabali-panel/mail/mailboxes` (M6.2 — uses the M22 self-deleting `jabali-sso-*.php` file, not the failed M22 magic-link/mu-plugin path).
+- Webmail: **Bulwark** at `https://mail.<domain>/`. One-click SSO from `/jabali-panel/mail/mailboxes` uses the M22 self-deleting `jabali-sso-*.php` file (not the failed M22 magic-link/mu-plugin path).
 - IMAP / SMTP submission: `imap.<panel-hostname>:993` (TLS), `smtp.<panel-hostname>:465` (TLS) or `:587` (STARTTLS).
 - Autoconfig / autodiscover: Apple `mobileconfig`, Thunderbird `autoconfig.xml`, Outlook `autodiscover.xml` (see [platform/mail-autoconfig.md](./platform/mail-autoconfig.md)).
+- Calendars + contacts: per-mailbox **CalDAV / CardDAV** URLs are surfaced for manual client setup (GH #1039), and the mail vhost routes CalDAV/CardDAV so clients auto-mount.
 
-## Per-domain mail features (M6.5)
+## Mail Domains (GH #1387)
 
-Mail tabs (`/jabali-panel/mail/<tab>`):
+Mail is organised **per domain**, not as one flat page. `/jabali-panel/mail`
+lists your **Mail Domains** — sortable, with SSL + Status columns, a live queue
+count, per-domain Enable / Disable, breadcrumbs, and a **Create Mail Domain**
+button (GH #1479). Click a domain to drill into its accounts and settings.
+
+Per-domain tabs:
 
 - **Mailboxes** — create, change password, set quota, delete.
 - **Forwarders** — forward `alice@example.com` to one or more external addresses.
 - **Autoresponders** — vacation responder per mailbox, with start/end window and subject template.
 - **Catch-all** — send unmatched recipients to a chosen mailbox or `:drop` / `:reject`.
-- **Disclaimer** — append HTML / plaintext disclaimer server-side to outbound mail per domain (HTML coverage validation pending on test VM, ADR-0052).
+- **Disclaimer** — append HTML / plaintext disclaimer server-side to outbound mail per domain (ADR-0052).
 - **Shared Folders** — create IMAP shared folders for the team; manage ACLs.
-- **Logs** — live tail of in / out deliveries for the domain.
+- **CalDAV / CardDAV override** — repoint a domain's calendar + contacts SRV
+  records at an external server instead of the built-in Stalwart DAV (GH #1462).
+- **Logs** and **Statistics** — scoped to the selected domain (sortable Mail Logs
+  columns, GH #1365); the old flat Mail page is retired.
+
+### Mail-only delete
+
+A domain can have **just its mail torn down while the web domain stays** (GH
+#1387) — deletes mailboxes, forwarders, DKIM, and the Stalwart domain entry
+without removing the vhost or DNS zone.
 
 ## Per-domain deliverability (admin)
 

--- a/docs/site/migrations.md
+++ b/docs/site/migrations.md
@@ -4,16 +4,24 @@
 
 ## Supported sources
 
+A source can be ingested from an **uploaded archive** or, for the control-panel
+sources, pulled **live over SSH** (the panel reads the source with the vendor's
+own read-only CLI, then rebuilds destination-side).
+
 | Source | Format | Status |
 |---|---|---|
-| **cPanel** | `cpmove-<user>.tar.gz` | ✅ — preserves MySQL users + bcrypt password hashes (so migrated apps keep working); see "preserve cpanel MySQL users + password hashes" commit. |
-| **DirectAdmin** | DA backup tarball | ✅ — see `docs/user/directadmin-migration.astro` (legacy) for source-side prep notes. |
-| **Hestia** | Hestia `v-backup-user` tarball (`<user>.<ts>.tar[.gz]`) | ✅ — files, DBs, DNS (incl. SRV + CAA), and apps (e.g. Nextcloud) restore end-to-end; the account Contact Name (FNAME/LNAME) carries onto the user. Mail is the Exim→Stalwart subset (see below). |
+| **cPanel** | `cpmove-<user>.tar.gz` or live SSH | ✅ — preserves MySQL users + bcrypt password hashes (so migrated apps keep working); see "preserve cpanel MySQL users + password hashes" commit. |
+| **DirectAdmin** | DA backup tarball or live SSH | ✅ — see `docs/user/directadmin-migration.astro` (legacy) for source-side prep notes. |
+| **Hestia** | Hestia `v-backup-user` tarball (`<user>.<ts>.tar[.gz]`) or live SSH | ✅ — files, DBs, DNS (incl. SRV + CAA), and apps (e.g. Nextcloud) restore end-to-end; the account Contact Name (FNAME/LNAME) carries onto the user. Mail is the Exim→Stalwart subset (see below). |
 | **WHM** | WHM-level dump (multiple `cpmove`s in one) | 🟡 — same caveats as cPanel per-user. |
+| **Plesk** | live SSH (subscriptions) | ✅ (GH #429) — reads databases, DNS, and reseller customers + service plans via `plesk bin` / wp-toolkit read-only CLI, then rebuilds destination-side. |
+| **CloudPanel** | live SSH (site users) | ✅ |
+| **CyberPanel** | live SSH (websites) | ✅ |
+| **Jabali → Jabali** | live SSH (accounts) | ✅ — move accounts between Jabali servers. |
 
 ## Workflow
 
-1. Upload archive to `/jabali-admin/migrations` (or `scp` to `/var/lib/jabali/migrations/incoming/`).
+1. Either upload an archive to `/jabali-admin/migrations` (or `scp` to `/var/lib/jabali/migrations/incoming/`), **or** point the wizard at a **live SSH source** (host, port, credentials) for the control-panel importers.
 2. The pipeline runs four phases:
    - **Analyze** — inspect the archive, list users / domains / DBs / mailboxes / DNS zones / cron jobs.
    - **Fix-perms** — apply chown / chmod normalisations expected by Jabali's per-user pool layout.
@@ -60,6 +68,7 @@ jabali migrate restore --hestiacp --file /path/<user>.<ts>.tar --source-user <us
 
 ## Limitations
 
-- **No live migration**. Each pipeline is "stop-the-world" for the destination user.
-- **No backup-restore from Plesk** (Plesk's backup format isn't supported yet).
+- Each pipeline is **"stop-the-world" for the destination user** while it runs.
+- **Plesk / CloudPanel / CyberPanel / Jabali** are live-SSH-only — the panel
+  reads the source over SSH; there is no offline backup-archive import for them.
 - **No CSF/LFS rule translation**. CrowdSec is the IP-trust source on Jabali; carry over allowlists manually.

--- a/docs/site/notifications.md
+++ b/docs/site/notifications.md
@@ -30,6 +30,9 @@ Built-in (M14 Step 4 and later):
 - `mail_quarantined` — Stalwart / async YARA quarantined a message.
 - `malware_file_hit` — M33 detector hit.
 - `db_root_rotated` — admin rotated DB root password.
+- `ssh_login` — a shell / SFTP login to an account. Per account, the owner can
+  keep a **per-account ignore list** so logins from known hosts / users don't
+  notify (GH #1436).
 
 Stub sources defined but not yet wired: `domain-registrar`, `backup-future-warnings`.
 

--- a/docs/site/operations.md
+++ b/docs/site/operations.md
@@ -51,13 +51,11 @@ Audited (success + failure), announced via M14.
 
 ### Move a domain between users
 
-Not a first-class operation in the UI. The supported path:
-
-1. Backup the old user's `account_full`.
-2. Restore into the new user under a fresh domain name (or temp domain).
-3. Adjust DNS.
-
-(Or: contact upstream — this is on the roadmap.)
+A first-class **Change owner** action reassigns a domain to a different user (GH
+#1238); the vhost, DNS, and mail follow the new owner on the next reconcile. The
+admin can also **rename a tenant's username in place** (GH #1238) — the panel
+re-prefixes that user's MariaDB databases, DB users, and PostgreSQL shadow roles
+to match.
 
 ### Add a new IPv4 to the pool
 

--- a/docs/site/php.md
+++ b/docs/site/php.md
@@ -41,9 +41,43 @@ Each Domain row has a `php_pool_id` foreign key into `php_pools`. The vhost `fas
 
 The package the user is on caps each of these to a maximum the admin chose. Attempts to exceed the cap are clamped on save with a UI warning.
 
-## OpCache + JIT
+### Performance presets (GH #1332)
 
-Recent PHP versions (8.3+) ship JIT. Jabali leaves JIT off by default (silent CPU spikes on some shared workloads) — re-enable per-user in the PHP Settings tab if you know your app benefits.
+PHP Settings offers **per-version Performance tuning presets** — pick a profile
+(e.g. balanced / high-traffic) and the Advanced view shows exactly what each
+preset applies plus a live preview before you save, so a preset is never a black
+box. Domain-scoped limits are labelled as such.
+
+### Per-domain overrides (GH #1332)
+
+Some values are set **per domain** rather than per user, with an **override
+badge** on any domain that differs from the account default:
+
+- `display_errors`, `error_reporting`, and `date.timezone` per domain (GH #1332).
+- Per-domain environment variables passed to the FPM pool.
+- Per-domain log + cron shortcuts and an **OPcache reset** button.
+
+## OPcache + JIT (GH #1332)
+
+Recent PHP versions (8.3+) ship JIT. Jabali leaves JIT off by default (silent CPU
+spikes on some shared workloads). PHP Settings gives **per-version OPcache / JIT
+controls** so you can enable JIT and tune OPcache only on the versions where your
+app benefits, plus a one-click **OPcache reset**.
+
+## Xdebug, Composer, extra extensions (GH #1332)
+
+- **Per-version Xdebug toggle** with safe modes — turn Xdebug on for a single PHP
+  version without slowing every pool (Xdebug is a Zend extension loaded per-slug
+  via a scan dir).
+- **Per-user Composer version selector** — choose which Composer major version
+  the account uses.
+- **Per-version opt-in extra extensions** — a tenant can opt a version into an
+  allow-listed set of extra extensions beyond the server-wide defaults.
+
+## FPM slow log (GH #1332)
+
+Each pool can emit a **per-pool FPM slow log** for requests over a threshold, so a
+slow endpoint is traceable per account without touching the global config.
 
 ## Snuffleupagus
 

--- a/docs/site/platform/components.md
+++ b/docs/site/platform/components.md
@@ -47,7 +47,7 @@ Version pins shown are the values in `install.sh` at the time of writing. Run `j
 | **Adminer** | 6.0.1 | Lighter DB web UI + `jabali-sso-plugin.php` |
 | **WP-CLI** | 2.12.0 | WordPress automation |
 | **GoAccess** | Debian | nginx log analyzer |
-| **Roundcube** | Debian + install snippet | Webmail (served by Bulwark vhost) |
+| **Bulwark** | pinned SHA (vendored) | Next.js JMAP webmail, served per-tenant on `mail.<domain>` |
 | **restic** | Debian | Backup engine (deduplicated, encrypted, multi-destination) |
 | **Go toolchain** | 1.25.1 | Build agent + panel-api |
 | **Node.js** | NodeSource current LTS | Bulwark runtime + UI build |
@@ -82,7 +82,7 @@ Test-only: `DATA-DOG/go-sqlmock`, `alicebob/miniredis/v2`, `stretchr/testify`.
 
 ## In-house patterns shipped under `install/`
 
-- **`jabali-sso-<43-char-nonce>.php`** — self-deleting magic SSO file (M22, ADR-0040; Installatron / Softaculous style). Used by Roundcube webmail and every application install for one-click admin sign-in. 60 s TTL; 256-bit nonce filename; `flock` + `unlink` on first hit.
+- **`jabali-sso-<43-char-nonce>.php`** — self-deleting magic SSO file (M22, ADR-0040; Installatron / Softaculous style). Used by Bulwark webmail and every application install for one-click admin sign-in. 60 s TTL; 256-bit nonce filename; `flock` + `unlink` on first hit.
 - **phpMyAdmin `sso.php`** and **Adminer `jabali-sso-plugin.php`** — adapt the magic-file pattern to the two DB web UIs.
 - **`install/snuffleupagus/rules/`** — server-wide Snuffleupagus baseline rules.
 - **`install/wp-cli.sha256`** / **`install/phpmyadmin.sha256`** — checksum-pinned upstream tarballs.

--- a/docs/site/removed-features.md
+++ b/docs/site/removed-features.md
@@ -34,9 +34,14 @@ Result: the panel does not act as an OIDC provider. If a third-party app needs S
 
 (ADR-0036 was superseded by ADR-0038; ADR-0040 covers the M22 rework.)
 
-### In-panel admin → user impersonation
+### In-panel admin → user impersonation — **restored**
 
-Removed with the M20 Kratos migration. The audit emitter (`AppendImpersonationStart` / `Stop`) is still in `panel-api/internal/audit/events.go` and ADR-0106 reserves the `audit_show_impersonation` server-setting toggle, but **no UI / handler currently mints an admin → user session**. Adding it requires a clean Kratos session-handoff path (so the user sees the impersonation row in their own activity log).
+This was removed with the M20 Kratos migration, but has since been **re-added**.
+Admins can impersonate a tenant through the `/admin/impersonation` routes
+(admin-gated), which mint a scoped, time-bounded impersonation grant; the target
+user sees the impersonation in their own activity log (ADR-0106
+`audit_show_impersonation`). It is no longer a removed feature — this entry is
+kept only to correct earlier docs that listed it as gone.
 
 To act on a user's behalf today, an admin uses the user's own login (or resets the password if needed).
 

--- a/docs/site/removed-features.md
+++ b/docs/site/removed-features.md
@@ -36,14 +36,16 @@ Result: the panel does not act as an OIDC provider. If a third-party app needs S
 
 ### In-panel admin → user impersonation — **restored**
 
-This was removed with the M20 Kratos migration, but has since been **re-added**.
-Admins can impersonate a tenant through the `/admin/impersonation` routes
-(admin-gated), which mint a scoped, time-bounded impersonation grant; the target
-user sees the impersonation in their own activity log (ADR-0106
-`audit_show_impersonation`). It is no longer a removed feature — this entry is
-kept only to correct earlier docs that listed it as gone.
-
-To act on a user's behalf today, an admin uses the user's own login (or resets the password if needed).
+This was removed with the M20 Kratos migration, but has since been **re-added**
+(ADR-0128, act-as; ADR-0015, the JWT claim). Admins can impersonate a tenant
+through the `/admin/impersonation` routes (admin-gated), which mint a scoped,
+**60-minute** act-as grant (server-side TTL; ended explicitly or on expiry).
+There is no dedicated impersonation start/stop audit event, but every mutating
+request made while impersonating is recorded by the unified audit log
+(ADR-0106) with the **target as the subject**, so those actions surface in the
+target's own account activity (`GET /api/v1/me/activity`, subject-scoped and
+IDOR-safe). It is no longer a removed feature — this entry is kept only to
+correct earlier docs that listed it as gone.
 
 ### Refine → TanStack Query + AntD + react-router (M21)
 

--- a/docs/site/resource-limits.md
+++ b/docs/site/resource-limits.md
@@ -46,7 +46,8 @@ A **Package** carries:
 - `cpu_pct`
 - `tasks_max`
 - `req_per_sec`, `req_burst`
-- `max_domains`, `max_mailboxes`, `max_databases`
+- `max_domains`, `max_mailboxes`, `max_databases`, `max_database_users` (JAB-329)
+- `max_ftp_accounts` (FTP/SFTP subaccount cap, when the module is enabled)
 - PHP-INI overrides (`memory_limit`, `upload_max_filesize`, etc.)
 
 Edit packages: `/jabali-admin/packages`. Users on a package get the new limits applied on the next reconciler tick.

--- a/docs/site/security.md
+++ b/docs/site/security.md
@@ -123,9 +123,12 @@ Admin overrides per-user under Users → Edit → Egress.
 - **Country exemption from local MaxMind** (PR #1083) — country-based
   allow/exempt CIDRs are derived from a local MaxMind mmdb plus supplemental
   CIDRs, with no external lookup at request time.
-- **Secret-rotation tooling** (JAB-357) — operator tooling to rotate the
-  database app-user password, the JWT signing secret, and the foundation secret,
-  so a leaked credential can be rolled without a reinstall.
+- **Secret-rotation tooling** (JAB-357) — `jabali secrets rotate <name>`
+  (operator-only) rolls the panel DB app-user password, the Redis panel token,
+  and the PowerDNS DB password live (each with its own verify + rollback), plus
+  the now-vestigial `JWT_SECRET`, so a leaked credential can be rolled without a
+  reinstall. Transient migration source-host credentials are **purged, not
+  rotated**. See [../secret-rotation.md](../secret-rotation.md).
 
 ## CrowdSec test-IP card
 

--- a/docs/site/security.md
+++ b/docs/site/security.md
@@ -26,13 +26,33 @@ ADR-0060. ModSecurity is **removed** (M27 cleanup_modsecurity purges packages + 
 - Rule packs from `hub.crowdsec.net/author/crowdsecurity` (vpatch family for CVE virtual-patching).
 - AppSec install path is **flat** (`/etc/crowdsec/appsec-rules/`) — no `crowdsecurity/` subdir (the install-path scar that purged + reinstalled 170 vpatch rules every update, fixed in PR #69).
 
+### AppSec bot detection (CrowdSec 1.8)
+
+A CrowdSec 1.8 AppSec **bot-detection challenge** is available, **off by default**
+(per-server). It is opt-in and layered:
+
+- **Per-server**: admins enable it under `/jabali-admin/security` → CrowdSec /
+  AppSec (default **OFF**).
+- **Per-domain opt-in** (`scope=selected`): turn the challenge on for chosen
+  domains only.
+- **Per-domain opt-out**: exclude a specific domain from the challenge.
+- **Tenant self-service**: a tenant can toggle bot detection on **their own**
+  domains without an admin.
+
+Because it is default-off and per-domain scoped, enabling it never silently
+challenges traffic on a domain the operator didn't choose.
+
 ## AppArmor
 
 `/jabali-admin/security` → AppArmor — per-profile status (enforce / complain / **missing**).
 
 Jabali ships and manages these daemon profiles: `jabali-panel` (panel API), `jabali-agent`, `jabali-bulwark` (webmail), `stalwart-mail`, and `jabali-fpm-app` (GH #690 — the per-user PHP-FPM/WordPress workload profile, attached to fpm-exec; ships complain-first for the soak, flip to enforce per-host after soak-readiness shows 0 would-deny). A profile that fails to load or is purged is reported as **missing** (red) rather than silently omitted — an absent profile means an unconfined daemon.
 
-New profiles ship in **complain** mode for a 7-day burn-in soak; each profile shows a **soak-readiness** indicator (complain-mode profiles with zero would-deny events are ready to flip to enforce). Complain-mode `apparmor="ALLOWED"` would-deny events are surfaced alongside enforce-mode `DENIED` denials, so a complain-mode profile actively logging violations is not mistaken for a clean state.
+New profiles ship in **complain** mode for a 7-day burn-in soak; each profile shows a **soak-readiness** indicator (complain-mode profiles with zero would-deny events are ready to flip to enforce). Complain-mode `apparmor="ALLOWED"` would-deny events are surfaced alongside enforce-mode `DENIED` denials, so a complain-mode profile actively logging violations is not mistaken for a clean state. A daily timer **auto-promotes** a soak-clean profile from complain to enforce (JAB-349), so hardening advances without a manual flip on every host.
+
+A **degraded-AppArmor** condition (a managed profile that should be enforcing but
+isn't) raises a dashboard alert plus a runtime confinement smoke test (JAB-379),
+so a silently-unconfined daemon is caught rather than assumed safe.
 
 On kernels with broken unix-socket mediation (missing `/sys/kernel/security/apparmor/features/unix`), Jabali deliberately does **not** load the daemon profiles — on fresh install and on `jabali update` alike.
 
@@ -84,6 +104,28 @@ Admin overrides per-user under Users → Edit → Egress.
 - **YARA** — only the `php.yar` rule (clamscan rejects PMF whitelists/* due to libclamav YARA subset restrictions).
 - **Tetragon** — eBPF tripwires; suspicious exec events ingested via `sessionwatcher` → M14 (`file_hit` + quarantine events).
 - **M33.2 mail-yara-async** (ADR-0079) — async post-delivery JMAP-poll YARA scan; NOT MtaHook/MtaMilter.
+- **Quarantine-rate circuit breaker** (JAB-248) — the scanner trips a breaker if the quarantine rate spikes, so a bad signature can't quarantine a tenant's whole tree in a runaway loop.
+
+## Additional hardening
+
+- **Step-up auth for high-risk admin tools** (JAB-380) — the admin File Manager
+  and Root Terminal require a fresh (recent-auth / MFA) re-authentication before
+  they open, so a stolen session alone can't reach a root shell or the whole
+  filesystem.
+- **API-side write allow-list for the admin File Manager** (JAB-367) — writes are
+  checked against an allow-list on the API, not just the UI, so a crafted request
+  can't write outside the permitted paths.
+- **CrowdSec pprof/metrics locked down** (JAB-368) — tenant-uid processes are
+  blocked from CrowdSec's unauthenticated `:6060` pprof / metrics endpoint.
+- **Package disk quota on tenant database storage** (JAB-243) — a tenant's DB
+  storage counts against the hosting-package disk quota, so databases can't be
+  used to bypass the account quota.
+- **Country exemption from local MaxMind** (PR #1083) — country-based
+  allow/exempt CIDRs are derived from a local MaxMind mmdb plus supplemental
+  CIDRs, with no external lookup at request time.
+- **Secret-rotation tooling** (JAB-357) — operator tooling to rotate the
+  database app-user password, the JWT signing secret, and the foundation secret,
+  so a leaked credential can be rolled without a reinstall.
 
 ## CrowdSec test-IP card
 

--- a/docs/site/server-status.md
+++ b/docs/site/server-status.md
@@ -11,6 +11,13 @@ Single page, 5-second polling, errgroup-aggregated.
 - **Queues card** (placeholder — defers to M31.1): mail queue depth, backup queue depth, reconciler tick lag.
 - **Recent panel-api requests**: top 10 by latency.
 
+## Health badge (JAB-373)
+
+The admin header carries a lightweight **Health** badge backed by a cheap
+`?view=health` projection of Server Status (single-flight + short TTL so the
+badge poll can't stampede the box). It gives an at-a-glance green / degraded
+signal without opening the full Server Status page.
+
 ## Per-service controls
 
 Each card has start / stop / restart buttons. Disabled by default — flip the **off-toggle** in Server Settings → General to enable for admins who want to react from the UI instead of SSH.

--- a/docs/site/sftp.md
+++ b/docs/site/sftp.md
@@ -75,6 +75,37 @@ not setuid, an unrecognised mode), the wrapper exits to
 `/usr/sbin/nologin` — it **never** falls through to an unsandboxed shell.
 The user can still SFTP.
 
+## FTP / SFTP subaccounts (GH #1053, #1145)
+
+Beyond the main account login, a tenant can create **FTP/SFTP subaccounts** —
+extra login users scoped to a subdirectory of the account. The whole surface is
+**admin opt-in** (an admin enables it and sets a per-package cap) before tenants
+see it:
+
+- **Tenant self-service** page to add / reset / delete subaccounts, with a
+  **password generator** on the create + reset forms (GH #1053).
+- **Isolation modes**: a lighter **same-uid alias** (shares the account's uid),
+  or **true separate-uid isolation** — a dedicated system user in its own jail
+  with its own quota and ACLs (GH #1145). Separate-uid is the default where a
+  filesystem quota exists; where quota is absent it falls back to off.
+- **vsftpd module**: plain FTP(S) is an **opt-in, PAM-gated** module that stays
+  masked while off (GH #1053). SFTP subaccounts work through the existing `sshd`.
+- **Operator-tunable server limits**: max sessions, per-IP limit, transfer rate
+  (GH #1053).
+- **WebDAV** access on a subaccount (GH #1146) — a per-subaccount `jabali-webdav`
+  worker, so the same scoped directory is reachable over WebDAV as well as
+  FTP/SFTP.
+
+The panel surfaces **observed-vs-desired** FTP state so drift between the DB rows
+and the live system is visible rather than silent.
+
+## SSH TCP forwarding (opt-in)
+
+SFTP/shell users get `AllowTcpForwarding no` by default. An admin can grant a
+**durable per-user opt-in for SSH TCP forwarding** (GH #1229) — e.g. for VS Code
+Remote-SSH — which is firewall-guarded and applied via the sshd `Match` block.
+It is off unless explicitly enabled.
+
 ## Password auth
 
 Disabled by default for panel users. SSH keys are required. Admin can enable password auth per-user via Users → Edit → SSH section, but it is not the default.

--- a/docs/site/sftp.md
+++ b/docs/site/sftp.md
@@ -40,8 +40,10 @@ Server-wide setting (Server Settings → SSH Access), one of:
   setuid `bwrap` binary. Lightweight, no image to build. **This is the
   shipped, working path.**
 - **`nspawn`** — an ephemeral `systemd-nspawn` container off a versioned
-  base image. *Not yet wired in this release; selecting it currently
-  falls back to no-login. Use bubblewrap.*
+  base image. *Not yet wired for login in this release — the mode can be
+  selected and persisted, but the per-user nspawn image path is still unused
+  (`install.sh`: "currently unused; Step 3 follow-up"). Use bubblewrap, the
+  shipped, supported path.*
 
 The mode is a single file, `/etc/jabali/ssh-sandbox-mode`, read fresh on
 every connect — no sshd reload needed to switch.

--- a/docs/site/ssl.md
+++ b/docs/site/ssl.md
@@ -23,9 +23,23 @@ The panel itself runs on a Let's Encrypt cert for the **Panel Hostname** (Server
 
 If issuance fails, the panel falls back to a self-signed cert so the UI stays reachable; the SSL card in Server Settings shows the failure reason. Hit "Retry" or wait for the next reconciler tick.
 
-## Cross-user view (admin)
+## Custom certificates
 
-`/jabali-admin/ssl` lists every cert known to the panel, expiry, last issuance result. Per-row "Retry" forces a fresh attempt.
+Besides Let's Encrypt, a domain can use an **uploaded custom certificate**
+(cert + key + chain). The **Domain Certificate Lifecycle** op (JAB-345) manages
+install / replace / removal with a forward-recovery finalize, and de-tracks the
+Let's Encrypt lineage first so a custom cert doesn't clobber it (or vice-versa on
+removal).
+
+## Cross-user view (admin) — Certificate console
+
+`/jabali-admin/ssl` is the **Certificate console** (redesigned, GH #1355): every
+cert known to the panel with issuer, expiry (Issued + Last-check folded into the
+**Expires** column, GH #1271) and last issuance result. Per row:
+
+- **View Certificate** — inspect the certificate's subject, SANs, issuer, and
+  validity dates (GH #1355).
+- **Retry** — force a fresh issuance attempt.
 
 ## Common failure modes
 

--- a/docs/site/troubleshooting.md
+++ b/docs/site/troubleshooting.md
@@ -68,7 +68,7 @@ Causes, in rough order of likelihood:
 
 1. The mailbox's password changed in the panel but the user is using the old one — reset under Mail → Mailboxes.
 2. Stalwart is down — `systemctl status stalwart-mail`.
-3. The Roundcube SSO bridge clock-skewed (SSO file TTL is 60 s) — sync NTP.
+3. The webmail SSO file expired before it was hit (TTL is 60 s) — sync NTP if the host clock is skewed.
 4. AppArmor in `enforce` blocked something — `journalctl -k | grep DENIED`.
 
 ### SSL cert doesn't issue

--- a/docs/site/updates.md
+++ b/docs/site/updates.md
@@ -32,6 +32,21 @@ jabali update --auto         # for cron / CI; no prompts
 
 If the update fails, `jabali update` prints a hint pointing at `jabali repair --diagnose` (M33 added the hint after a string of recurring deploy scars where the operator needed to run repair next anyway).
 
+## OS security auto-updates (JAB-353)
+
+Separate from `jabali update` (which updates the panel), **OS security
+auto-updates are on by default** via `unattended-upgrades`, so security patches
+for the base system land without operator action. The Update Center reports the
+OS-update state (pending / applied) alongside the panel version.
+
+## Stuck update tasks are reaped
+
+An update run is tracked as a DB row and sealed success/failed when it finishes.
+A run whose status can't be read — the agent is down or too old to answer, or a
+transient unit hangs — is now **backstopped** so it can't spin "running" forever
+in the Tasks indicator (GH #1486): any run older than 2 h is reaped as failed,
+and a pollable run whose status call errors is reaped once clearly stale.
+
 ## What it does *not* update
 
 - The kernel, system packages outside Jabali's drop-ins (use `apt update && apt full-upgrade`).
@@ -40,4 +55,6 @@ If the update fails, `jabali update` prints a hint pointing at `jabali repair --
 
 ## Frequency
 
-There's no auto-update timer enabled by default. The admin runs it manually or sets up their own systemd timer / cron.
+There's no **panel** auto-update timer enabled by default for a self-hosted
+install — the admin runs `jabali update` manually or sets up their own systemd
+timer / cron. (OS *security* patches auto-apply as above.)

--- a/docs/site/user.md
+++ b/docs/site/user.md
@@ -9,14 +9,16 @@ Hosting customers log in at `/jabali-panel`. Pages:
 | Domains | `/jabali-panel/domains` | Your hosted domains; per-domain edit (PHP version, SSL, DNSSEC, redirects, aliases). |
 | DNS | `/jabali-panel/dns` | Records for your zones; per-domain DNSSEC toggle + DS record. |
 | SSL | `/jabali-panel/ssl` | Cert state, force re-issue. |
-| Mail | `/jabali-panel/mail/mailboxes` plus tabs | Mailboxes, Forwarders, Autoresponders, Catch-all, Disclaimer, Shared Folders, Logs. |
-| Databases | `/jabali-panel/databases` | Your MariaDB / PostgreSQL DBs + DB users. SSO into phpMyAdmin / pgAdmin. |
-| PHP Settings | `/jabali-panel/php-settings` | Per-user `memory_limit`, `upload_max_filesize`, `max_execution_time`, `post_max_size`, etc. (within your package's allowed range). |
-| Files | `/jabali-panel/files` | AntD-native file manager (no separate filebrowser daemon). |
+| Mail | `/jabali-panel/mail` | Mail Domains list → per-domain drill-down: Mailboxes, Forwarders, Autoresponders, Catch-all, Disclaimer, Shared Folders, CalDAV/CardDAV, Logs + Statistics. |
+| Databases | `/jabali-panel/databases` | Your MariaDB / PostgreSQL DBs + DB users (tabbed). SSO into phpMyAdmin (MariaDB) / Adminer (PostgreSQL); per-database Download + Restore-from-file. |
+| PHP Settings | `/jabali-panel/php-settings` | Per-user + per-domain `memory_limit`, `upload_max_filesize`, `display_errors`, OPcache/JIT, Xdebug, Composer version, extra extensions (within your package's allowed range). |
+| Files | `/jabali-panel/files` | AntD-native file manager (no separate filebrowser daemon); chunked upload with cancel + live speed, async copy/move/extract progress. |
+| FTP Accounts | `/jabali-panel/ftp` | Create / reset / delete FTP/SFTP subaccounts scoped to a subdirectory (if admin enabled it for your package). |
 | SSH Keys | `/jabali-panel/ssh-keys` | Add / revoke SSH public keys (used for SFTP via `Match Group`). |
-| Cron | `/jabali-panel/cron` | Schedule allowlisted commands (5-field cron) as systemd-user timers. |
+| Cron | `/jabali-panel/cron` | Schedule allowlisted commands (`php`/`wp`/`python`/`node`, or an ordered sequence) as systemd-user timers. |
 | Applications | `/jabali-panel/applications` | One-click install for WP + 14 others on a domain or subdir. |
-| Backups | `/jabali-panel/backups` | Download your `account_full` backup; restore from an earlier snapshot (if admin enabled it for your package). |
+| Backups | `/jabali-panel/backups` | Download your `account_full` backup; restore from a snapshot, or upload a backup archive and restore selected legs (files / DB / mail) yourself. |
+| Notifications | `/jabali-panel/notifications` | Your own notification channels + routing (when the admin has enabled tenant notifications). |
 | Logs | `/jabali-panel/logs` | nginx access + error tails for your domains; FPM error log. |
 | Activity | `/jabali-panel/activity` | Read-only view of audit rows owned by you. |
 
@@ -28,7 +30,7 @@ Admin controls (and you cannot override): disk + bandwidth quota, max mailboxes 
 
 ## Mailbox login
 
-Webmail lives at `https://<primary-mail-domain>/mail/` (Roundcube). One-click SSO from `/jabali-panel/mail/mailboxes` → click a mailbox → "Open Webmail" — uses the M22 self-deleting `jabali-sso-*.php` file (Installatron/Softaculous pattern; 60 s TTL, 256-bit nonce filename, `flock` + `unlink`).
+Webmail is **Bulwark** (Next.js JMAP) at `https://mail.<domain>/`. One-click SSO from a mailbox in `/jabali-panel/mail` → "Open Webmail" — uses the M22 self-deleting `jabali-sso-*.php` file (Installatron/Softaculous pattern; 60 s TTL, 256-bit nonce filename, `flock` + `unlink`).
 
 ## App login
 

--- a/docs/site/user/databases.md
+++ b/docs/site/user/databases.md
@@ -24,16 +24,28 @@ Click **Create database**, supply:
 
 The database count is checked against your package's `max_databases`.
 
-## phpMyAdmin / pgAdmin SSO
+## phpMyAdmin / Adminer SSO
 
-Each row has an **Open phpMyAdmin** (MariaDB) or **Open pgAdmin** (PostgreSQL) button. Clicking it:
+Each row has an **Open phpMyAdmin** (MariaDB) or **Open Adminer** (PostgreSQL) button. Clicking it:
 
 1. Issues a single-use, short-TTL **SSO token** (panel-internal).
 2. Redirects to the web admin URL with the token.
 3. The web admin authenticates as the corresponding **shadow account** (CONTEXT.md: SSO Token Resolution).
 4. The token is consumed and cannot be reused.
 
-You arrive already logged in to phpMyAdmin / pgAdmin with the DB user's privileges.
+You arrive already logged in to phpMyAdmin (MariaDB) / Adminer (PostgreSQL) with the DB user's privileges.
+
+## Download + Restore from file
+
+Each row also has **Download backup** and **Restore from file** (both engines):
+
+- **Download** streams a dump of that one database.
+- **Restore from file** uploads a dump and replaces the whole database. The
+  upload is chunked and async (it beats Cloudflare's ~100 MB origin limit), with
+  a progress modal. PostgreSQL accepts plain-SQL **and** pgAdmin's custom / tar
+  archive formats and shows the real error on failure. Uploaded dumps run through
+  a non-superuser scoped loader into a staging database and only swap onto the
+  live name on success, so a bad upload never wipes your database.
 
 ## Connecting from an application
 
@@ -59,7 +71,7 @@ PHP applications use the same socket path implicitly when host is set to `localh
 
 ## Backups
 
-Database content is included in `account_full` backups. To export ad hoc, use phpMyAdmin's **Export** feature (or `pg_dump` for PostgreSQL via pgAdmin's **Backup** tool).
+Database content is included in `account_full` backups. For a single database, use the per-row **Download backup** / **Restore from file** actions above, or phpMyAdmin's / Adminer's own **Export** feature.
 
 ## Deleting a database
 

--- a/docs/site/user/email.md
+++ b/docs/site/user/email.md
@@ -14,7 +14,7 @@
 
 ## Webmail
 
-`https://<primary-mail-domain>/mail/` provides Roundcube webmail. The Mailboxes tab has a one-click **Open Webmail** button per mailbox that authenticates you via a single-use self-deleting SSO file (M22 pattern; ADR-0040).
+`https://mail.<domain>/` provides **Bulwark** (Next.js JMAP) webmail. The Mailboxes tab has a one-click **Open Webmail** button per mailbox that authenticates you via a single-use self-deleting SSO file (M22 pattern; ADR-0040).
 
 ## IMAP and SMTP submission
 

--- a/docs/site/user/mailboxes.md
+++ b/docs/site/user/mailboxes.md
@@ -16,7 +16,7 @@
 - **Create** — opens the create wizard. Pick the local part, the domain, the quota (within your package's per-mailbox cap), and either supply a password or let the panel generate one (shown once on the success page).
 - **Change password** — generates a new password (shown once) or accepts a supplied one. Stalwart hashes it with Argon2id.
 - **Set quota** — change the per-mailbox disk quota. Reduces are accepted but do not delete existing mail; the mailbox simply rejects new mail until reduced under the limit.
-- **Open webmail** — single-click sign-in to Roundcube via the self-deleting SSO file (60-second TTL, 256-bit nonce filename).
+- **Open webmail** — single-click sign-in to Bulwark webmail via the self-deleting SSO file (60-second TTL, 256-bit nonce filename).
 - **Delete** — destructive. The agent removes the Stalwart account and the mailbox storage.
 
 ## Create wizard caveats

--- a/docs/site/user/postgresql.md
+++ b/docs/site/user/postgresql.md
@@ -5,9 +5,9 @@ PostgreSQL databases are managed under the same [Databases](./databases.md) and 
 ## Differences from MariaDB
 
 - **Connection** — Unix socket path is `/var/run/postgresql` (not `/run/mysqld/`).
-- **Web UI** — pgAdmin instead of phpMyAdmin. Per-row SSO works identically.
+- **Web UI** — Adminer instead of phpMyAdmin. Per-row SSO works identically.
 - **Naming** — same `<username>_<suffix>` prefix policy.
-- **Defaults** — `client_encoding = utf8`, `timezone = UTC`. Override per-database via `ALTER DATABASE … SET …` from pgAdmin or `psql`.
+- **Defaults** — `client_encoding = utf8`, `timezone = UTC`. Override per-database via `ALTER DATABASE … SET …` from Adminer or `psql`.
 - **Roles** — PostgreSQL's role model conflates user and group. The DB-user concept in the panel maps to a PostgreSQL role with `LOGIN` privilege.
 
 ## Connection string
@@ -28,7 +28,7 @@ dbname=<your-username>_<suffix>
 
 ## Extensions
 
-PostgreSQL extensions (`postgis`, `pgvector`, `uuid-ossp`, `pg_trgm`, etc.) are enabled at the engine level by the operator. Once enabled, you may install them in your database from pgAdmin or `psql`:
+PostgreSQL extensions (`postgis`, `pgvector`, `uuid-ossp`, `pg_trgm`, etc.) are enabled at the engine level by the operator. Once enabled, you may install them in your database from Adminer or `psql`:
 
 ```sql
 CREATE EXTENSION pgvector;
@@ -38,7 +38,7 @@ If an extension you need is not enabled, contact your administrator.
 
 ## Backups
 
-PostgreSQL databases are included in `account_full` backups via per-database `pg_dump`. The restore flow uses `psql` to replay the dump.
+PostgreSQL databases are included in `account_full` backups via per-database `pg_dump`. There is also a per-row **Download backup** / **Restore from file** action: plain-SQL dumps replay via `psql`, and pgAdmin custom / tar archives via `pg_restore` — both through a non-superuser scoped loader into a staging database (GH #1045).
 
 ## Tuning
 

--- a/docs/site/user/shared-folders.md
+++ b/docs/site/user/shared-folders.md
@@ -38,7 +38,7 @@ IMAP shared folders work in clients that implement RFC 4314 ACLs and the `Shared
 - Thunderbird: Tools → Account Settings → Server Settings → Advanced → "Show only subscribed folders" off → "Subscribe" the shared folder.
 - Apple Mail: Mailbox → Subscribe and pick the shared folder.
 - Outlook (desktop): supports via the IMAP namespace; older Outlook versions are inconsistent.
-- Roundcube webmail: supported natively when the operator enables the shared-folders plugin.
+- Bulwark webmail: shared folders appear over JMAP once you're subscribed to them.
 
 ## What is and is not shared
 


### PR DESCRIPTION
## Summary

Full-backfill documentation pass: bring the README and `docs/site` guides in
line with what actually ships today. Docs-only — 36 files, no code touched.
Every flipped claim was verified against a primary source (install.sh,
openapi.yaml, panel-agent verbs, `audit.go`, BLUEPRINT, `docs/adr`,
`docs/secret-rotation.md`, panel-ui) before writing.

## Factual corrections (were wrong, now match code)

- **Webmail is Bulwark** (Next.js JMAP), not Roundcube — `mail.md`, `index.md`.
- **PostgreSQL DB admin tool is Adminer**, not pgAdmin — `databases.md`,
  `user/postgresql.md`.
- **SSH-shell default sandbox is `bubblewrap`**, not nspawn. nspawn is
  selectable/persisted but **not yet wired for login** (install.sh marks the
  per-user nspawn image path "currently unused; Step 3 follow-up"); fail-closed
  to `nologin` — `README.md`, `sftp.md`.
- **Admin → user impersonation is restored** (ADR-0128 act-as / ADR-0015 JWT
  claim). 60-minute server-side grant; **no discrete start/stop audit event**
  (the typed emitters are reserved, unimplemented per BLUEPRINT M49) — instead
  mutating requests made while impersonating are recorded with the *target* as
  subject and surface in the target's own `/me/activity` (subject-scoped,
  IDOR-safe). Removed the fabricated `audit_show_impersonation` identifier and
  the mis-cited ADR-0106 — `removed-features.md`, `admin.md`, `README.md`.
- **`jabali-isolator` is not a running service** (absent from install.sh, no
  cmd binary) — dropped from `README.md`.
- **Secret-rotation** names the real rotatable set (panel DB app-user password,
  Redis panel token, PowerDNS DB password, vestigial `JWT_SECRET`; migration
  source creds purged not rotated); dropped the non-existent "foundation
  secret" — `security.md`.
- **Micro-cache is shipped** (per-domain FastCGI, ADR-0108), not planned —
  `domains.md`.
- `docs/site` index: `cli.md` relabelled a cheat-sheet + added the generated
  `cli-reference.md` row, so there's one "full reference", not two.

## New/updated feature coverage

- Backups: whole-server `system_backup`, portable Full Server container
  backups + tenant restore-from-upload; **per-database** Download + Restore.
- Independent Web / Mail / DNS service flags per domain; reverse-proxy;
  per-domain env vars; delete-files / change-owner.
- CrowdSec 1.8 bot detection (default-OFF); AppSec WAF replaces ModSecurity.
- Mail Domains restructure; shared folders; deliverability.
- FTP/SFTP subaccounts (+ separate-uid isolation) and WebDAV.
- PHP settings epic; cron python/node runners; Automation API (opt-in OFF).
- Notification channels (server-wide + tenant-owned) and the event catalog.
- Migration sources: cPanel/DirectAdmin/Hestia/WHM (archive or live SSH) plus
  live-SSH Plesk / CloudPanel / CyberPanel / Jabali→Jabali (GH #429).

## Scope — not touched in this pass (candidates for a follow-up)

This pass prioritised feature-bearing guides with actual drift. Left as-is
(not audited line-by-line here):

- Top-level: `dns.md`, `firewall.md`, `installation.md`, `ip-manager.md`,
  `quickstart.md`, `support.md`, `wordpress.md`.
- Most of `docs/site/admin/*` (per-screen reference pages) — only `appsec`,
  `automation-api`, `backup-restore`, `notifications-events`,
  `hestiacp-migration`, and `admin.md` were updated.
- `docs/site/platform/*` beyond `components.md`; `docs/BLUEPRINT.md`
  (milestone roadmap); the generated `cli-reference.md` (regenerate, never
  hand-edit).

## Test plan

- [x] `docs-only` — no `.go` / `.tsx` / migration files in the diff.
- [x] No docs-build CI job exists (only `monthly-deps.yml`); `docs/site` has no
  astro/site build to break.
- [x] Rebased onto latest `origin/main`; link targets verified to exist
  (`cli-reference.md`, `../secret-rotation.md`, `docs/runbooks/*`).
- [ ] Optional: spot-render a couple of guides if the site build is wired up
  later.

Tracks the broader docs-accuracy effort (GH #1486 was in scope for the
impersonation correction).