### PR TITLE
refactor(logs): shared Domain Log Streams module (JAB-296)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ logs/
 # ...but not the panel-ui source dir that happens to be named "logs"
 !panel-ui/src/shells/admin/logs/
 !panel-ui/src/shells/user/logs/
+!panel-ui/src/components/logs/
 
 # Docker
 .docker/

--- a/panel-ui/src/components/LogStreamModal.tsx
+++ b/panel-ui/src/components/LogStreamModal.tsx
@@ -1,14 +1,9 @@
 import { useTranslation } from "react-i18next";
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Modal, Typography, Button, Space, Spin, theme } from "antd";
-import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { PauseOutlined, PlayCircleOutlined, ClearOutlined } from "@ant-design/icons";
-import {
-  MAX_LOG_LINES,
-  capLogLines,
-  stripTrailingNewline,
-  buildGoAccessHttpUrl,
-} from "../utils/logStream";
+import { buildGoAccessHttpUrl } from "../utils/logStream";
+import { useLogStream } from "./logs/useLogStream";
 
 const { Text } = Typography;
 
@@ -20,168 +15,49 @@ interface LogStreamModalProps {
   logType: "access" | "error" | "goaccess";
 }
 
-// The stream lifecycle stays in this component; the pure pieces it relies on
-// (MAX_LOG_LINES cap, newline trim, GoAccess URL derivation) live in
-// ../utils/logStream so they can be unit-tested (JAB-296).
+// The stream lifecycle (WebSocket connect/close, pause/resume buffering, the
+// ring-buffer cap, and GoAccess polling) lives in ./logs/useLogStream so it can
+// be unit-tested with a fake socket and fake timers (JAB-296, AC5). This
+// component owns only the DOM: auto-scroll for text logs, and the GoAccess
+// iframe plus its scroll preservation across the 10s auto-refresh.
 
 export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: LogStreamModalProps) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [logs, setLogs] = useState<string[]>([]);
-  const [connected, setConnected] = useState(false);
-  const [paused, setPaused] = useState(false);
-  const [connecting, setConnecting] = useState(false);
-  // GoAccess polling cache-buster: refresh the iframe by mutating ?t=<ts>
-  // every 10s. Same cadence as the prior WS-driven render — operators see
-  // identical update latency.
-  const [goaccessTick, setGoaccessTick] = useState(() => Date.now());
-  const wsRef = useRef<WebSocket | null>(null);
+
   const logsEndRef = useRef<HTMLDivElement>(null);
-  const pausedLogsRef = useRef<string[]>([]);
   const goAccessFrameRef = useRef<HTMLIFrameElement>(null);
   const scrollPosRef = useRef<{ top: number; left: number }>({ top: 0, left: 0 });
+
+  // Snapshot the iframe scroll before each GoAccess poll swaps the src, so the
+  // onLoad handler below can restore it after the reload.
+  const saveGoAccessScroll = () => {
+    const el = goAccessFrameRef.current?.contentDocument?.scrollingElement;
+    if (el) {
+      scrollPosRef.current = { top: el.scrollTop, left: el.scrollLeft };
+    }
+  };
+
+  const stream = useLogStream({
+    streamUrl,
+    logType,
+    active: visible,
+    onBeforeGoAccessRefresh: saveGoAccessScroll,
+  });
 
   const scrollToBottom = () => {
     logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   useEffect(() => {
-    // GoAccess uses the HTTP-render route (URL-loaded iframe) so the
-    // browser fetches a fresh response with its own relaxed CSP. WS is
-    // for text streaming (access/error) only.
-    if (logType === "goaccess") {
-      return;
-    }
-    if (visible && streamUrl && !wsRef.current) {
-      connectWebSocket();
-    }
-
-    return () => {
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
-      }
-    };
-  }, [visible, streamUrl, logType]);
-
-  // GoAccess polling effect: while the modal is open, bump goaccessTick
-  // every 10s so the iframe's src changes and the browser re-fetches.
-  // No-op when modal hidden or stream URL missing.
-  useEffect(() => {
-    if (logType !== "goaccess" || !visible || !streamUrl) return;
-    const id = setInterval(() => {
-      // Save scroll before refresh so onLoad can restore it.
-      const iframe = goAccessFrameRef.current;
-      const el = iframe?.contentDocument?.scrollingElement;
-      if (el) {
-        scrollPosRef.current = { top: el.scrollTop, left: el.scrollLeft };
-      }
-      setGoaccessTick(Date.now());
-    }, 10000);
-    return () => clearInterval(id);
-  }, [logType, visible, streamUrl]);
-
-  useEffect(() => {
-    if (!paused) {
+    if (!stream.paused) {
       scrollToBottom();
     }
-  }, [logs, paused]);
-
-  // GoAccess iframe content is set declaratively via srcDoc on the
-  // iframe element below — no imperative doc.write needed (the
-  // sandbox="allow-scripts" attribute makes the iframe a unique
-  // origin, which blocks parent contentDocument access).
-
-  const connectWebSocket = () => {
-    if (!streamUrl) return;
-
-    setConnecting(true);
-    const ws = new WebSocket(streamUrl);
-
-    ws.onopen = () => {
-      setConnected(true);
-      setConnecting(false);
-      feedback.message.success("Connected to log stream");
-      console.log("WebSocket connected");
-    };
-
-    ws.onmessage = (event) => {
-      if (!paused) {
-        // For goaccess, only keep the latest HTML message — the
-        // iframe rerenders via srcDoc on the last entry, so growing
-        // the array unbounded would just leak memory.
-        const logLine = event.data;
-        if (logType === "goaccess") {
-          // Save scroll position before triggering the srcDoc update so
-          // the onLoad handler can restore it after the iframe reloads.
-          const iframe = goAccessFrameRef.current;
-          const el = iframe?.contentDocument?.scrollingElement;
-          if (el) {
-            scrollPosRef.current = { top: el.scrollTop, left: el.scrollLeft };
-          }
-          setLogs([logLine]);
-        } else {
-          // Strip trailing CR/LF so the render-time join("\n") doesn't
-          // double-space lines that arrived with their own newline.
-          setLogs(prev => capLogLines([...prev, stripTrailingNewline(logLine)]));
-        }
-      } else {
-        pausedLogsRef.current.push(stripTrailingNewline(event.data));
-        // The paused buffer needs the same ceiling: a stream paused on a busy
-        // log otherwise grows unbounded in memory and then floods the view in
-        // one go when the operator resumes.
-        if (pausedLogsRef.current.length > MAX_LOG_LINES) {
-          pausedLogsRef.current = pausedLogsRef.current.slice(-MAX_LOG_LINES);
-        }
-      }
-    };
-
-    ws.onclose = (event) => {
-      setConnected(false);
-      setConnecting(false);
-      if (event.code === 1000) {
-        feedback.message.info("Log stream ended");
-      } else {
-        feedback.message.error("Connection lost");
-      }
-      console.log("WebSocket closed", event.code, event.reason);
-    };
-
-    ws.onerror = (error) => {
-      setConnecting(false);
-      feedback.message.error("WebSocket connection error");
-      console.error("WebSocket error:", error);
-    };
-
-    wsRef.current = ws;
-  };
+  }, [stream.logs, stream.paused]);
 
   const handleClose = () => {
-    if (wsRef.current) {
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-    setLogs([]);
-    setConnected(false);
-    setPaused(false);
-    pausedLogsRef.current = [];
+    stream.reset();
     onClose();
-  };
-
-  const handlePauseToggle = () => {
-    const newPaused = !paused;
-    setPaused(newPaused);
-
-    if (!newPaused && pausedLogsRef.current.length > 0) {
-      // Resume: add paused logs to display
-      setLogs(prev => capLogLines([...prev, ...pausedLogsRef.current]));
-      pausedLogsRef.current = [];
-    }
-  };
-
-  const handleClearLogs = () => {
-    setLogs([]);
-    pausedLogsRef.current = [];
   };
 
   const renderLogContent = () => {
@@ -189,8 +65,8 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
       // GoAccess iframe loaded via URL (not srcdoc) so the response's
       // own relaxed CSP applies — srcdoc inherits parent CSP which
       // forbids 'unsafe-eval' that GoAccess's templating requires.
-      // Cache-busted by goaccessTick (refreshed every 10s by the
-      // polling effect above); same cadence as the prior WS path.
+      // Cache-busted by goAccessTick (refreshed every 10s by the
+      // polling in useLogStream); same cadence as the prior WS path.
       const httpUrl = streamUrl ? buildGoAccessHttpUrl(streamUrl) : null;
       if (!httpUrl) {
         return (
@@ -206,7 +82,7 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
         );
       }
       const sep = httpUrl.includes("?") ? "&" : "?";
-      const src = `${httpUrl}${sep}t=${goaccessTick}`;
+      const src = `${httpUrl}${sep}t=${stream.goAccessTick}`;
       return (
         <div style={{ width: "100%", height: "100%", position: "relative" }}>
           <iframe
@@ -221,8 +97,7 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
             title={t("logstreammodal.goaccess_dashboard")}
             sandbox="allow-scripts allow-same-origin"
             onLoad={() => {
-              const iframe = goAccessFrameRef.current;
-              const el = iframe?.contentDocument?.scrollingElement;
+              const el = goAccessFrameRef.current?.contentDocument?.scrollingElement;
               if (el && scrollPosRef.current.top > 0) {
                 el.scrollTop = scrollPosRef.current.top;
                 el.scrollLeft = scrollPosRef.current.left;
@@ -248,17 +123,17 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
           borderRadius: "4px"
         }}
       >
-        {logs.length === 0 ? (
+        {stream.logs.length === 0 ? (
           <div style={{ textAlign: "center", padding: "20px", color: "#888" }}>
-            <Spin spinning={connecting}>
+            <Spin spinning={stream.connecting}>
               <div>
-                {connecting ? "Connecting to log stream..." : "Waiting for log data..."}
+                {stream.connecting ? "Connecting to log stream..." : "Waiting for log data..."}
               </div>
             </Spin>
           </div>
         ) : (
           <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordWrap: "break-word" }}>
-            {logs.join("\n")}
+            {stream.logs.join("\n")}
             <div ref={logsEndRef} />
           </pre>
         )}
@@ -290,26 +165,26 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>
           <Space>
             <Button
-              type={paused ? "primary" : "default"}
-              icon={paused ? <PlayCircleOutlined /> : <PauseOutlined />}
-              onClick={handlePauseToggle}
-              disabled={!connected}
+              type={stream.paused ? "primary" : "default"}
+              icon={stream.paused ? <PlayCircleOutlined /> : <PauseOutlined />}
+              onClick={stream.togglePause}
+              disabled={!stream.connected}
             >
-              {paused ? "Resume" : "Pause"}
+              {stream.paused ? "Resume" : "Pause"}
             </Button>
             <Button
               icon={<ClearOutlined />}
-              onClick={handleClearLogs}
+              onClick={stream.clear}
             >
               Clear
             </Button>
-            <Text type={connected ? "success" : "secondary"}>
-              Status: {connecting ? "Connecting..." : connected ? "Connected" : "Disconnected"}
+            <Text type={stream.connected ? "success" : "secondary"}>
+              Status: {stream.connecting ? "Connecting..." : stream.connected ? "Connected" : "Disconnected"}
             </Text>
-            {logs.length > 0 && (
+            {stream.logs.length > 0 && (
               <Text type="secondary">
-                {logs.length} lines {paused && pausedLogsRef.current.length > 0 &&
-                  `(+${pausedLogsRef.current.length} paused)`}
+                {stream.logs.length} lines {stream.paused && stream.bufferedCount > 0 &&
+                  `(+${stream.bufferedCount} paused)`}
               </Text>
             )}
           </Space>

--- a/panel-ui/src/components/logs/buildDomainLogColumns.test.tsx
+++ b/panel-ui/src/components/logs/buildDomainLogColumns.test.tsx
@@ -1,0 +1,91 @@
+// buildDomainLogColumns.test.tsx — neutral Module tests for the scope routing
+// baked into the shared Domain + Actions columns (JAB-296).
+//
+// We read the RowActions `actions` array straight out of the Actions column's
+// render element rather than driving antd's overflow dropdown in happy-dom:
+// only the first action renders as a visible button, the rest hide behind a
+// click-menu whose motion never settles under happy-dom. Inspecting the
+// element's props exercises every log type's onClick without a flaky DOM.
+import { describe, it, expect, vi } from "vitest";
+import type { ReactElement } from "react";
+import { buildDomainLogColumns } from "./buildDomainLogColumns";
+import { ALL_DOMAINS_ROW, type DomainLogRow } from "./domainLogStreams";
+
+type RenderCol = {
+  key?: string;
+  render?: (value: unknown, record: DomainLogRow, index: number) => ReactElement;
+};
+type WiredAction = { key: string; label: string; onClick?: () => void };
+
+function actionsFor(
+  ctx: Parameters<typeof buildDomainLogColumns>[0],
+  record: DomainLogRow,
+): WiredAction[] {
+  const columns = buildDomainLogColumns(ctx) as RenderCol[];
+  const actionsCol = columns.find((c) => c.key === "actions");
+  const el = actionsCol!.render!(undefined, record, 0);
+  return (el.props as { actions: WiredAction[] }).actions;
+}
+
+const realRow: DomainLogRow = { id: "d1", name: "example.com", status: "active" };
+
+describe("buildDomainLogColumns — shape (AC6)", () => {
+  it("wires the three log types with their labels", () => {
+    const actions = actionsFor({ onOpenDomain: vi.fn() }, realRow);
+    expect(actions.map((a) => a.key)).toEqual(["access", "error", "goaccess"]);
+    expect(actions.map((a) => a.label)).toEqual(["Access Log", "Error Log", "Real Time"]);
+  });
+});
+
+describe("admin scope — can open aggregate (AC1)", () => {
+  it("routes the aggregate row to onOpenAggregate, with no domain identity", () => {
+    const onOpenDomain = vi.fn();
+    const onOpenAggregate = vi.fn();
+    const actions = actionsFor({ onOpenDomain, onOpenAggregate }, ALL_DOMAINS_ROW);
+    actions.forEach((a) => a.onClick?.());
+    expect(onOpenAggregate.mock.calls).toEqual([["access"], ["error"], ["goaccess"]]);
+    expect(onOpenDomain).not.toHaveBeenCalled();
+  });
+
+  it("routes a real row to onOpenDomain with its id", () => {
+    const onOpenDomain = vi.fn();
+    const onOpenAggregate = vi.fn();
+    const actions = actionsFor({ onOpenDomain, onOpenAggregate }, realRow);
+    actions.forEach((a) => a.onClick?.());
+    expect(onOpenDomain.mock.calls).toEqual([
+      ["access", "d1"],
+      ["error", "d1"],
+      ["goaccess", "d1"],
+    ]);
+    expect(onOpenAggregate).not.toHaveBeenCalled();
+  });
+});
+
+describe("tenant scope — can NEVER open aggregate (AC2)", () => {
+  it("has no aggregate capability, so even the aggregate row routes to onOpenDomain", () => {
+    // The tenant ctx has no onOpenAggregate member. Even if an aggregate row
+    // somehow reached this scope, the builder cannot emit an aggregate open —
+    // the capability is absent, not merely unused.
+    const onOpenDomain = vi.fn();
+    const actions = actionsFor({ onOpenDomain }, ALL_DOMAINS_ROW);
+    actions.forEach((a) => a.onClick?.());
+    // Called with the row id ("") — a per-domain open, which the server then
+    // rejects for a tenant. It is never an identity-omitting aggregate request.
+    expect(onOpenDomain.mock.calls).toEqual([
+      ["access", ""],
+      ["error", ""],
+      ["goaccess", ""],
+    ]);
+  });
+
+  it("routes a real row to onOpenDomain with its id", () => {
+    const onOpenDomain = vi.fn();
+    const actions = actionsFor({ onOpenDomain }, realRow);
+    actions.forEach((a) => a.onClick?.());
+    expect(onOpenDomain.mock.calls).toEqual([
+      ["access", "d1"],
+      ["error", "d1"],
+      ["goaccess", "d1"],
+    ]);
+  });
+});

--- a/panel-ui/src/components/logs/buildDomainLogColumns.tsx
+++ b/panel-ui/src/components/logs/buildDomainLogColumns.tsx
@@ -1,0 +1,95 @@
+// buildDomainLogColumns — the shared Domain + Actions columns for the
+// per-domain log viewer (JAB-296, ADR-0083). Both the admin DomainLogsTab and
+// the tenant UserLogsPage render the exact same two columns; only the request
+// scope differs, and that difference is carried by the column context, not by
+// each shell hand-rolling its own openStream call.
+//
+// AC1/AC2 live in the ctx discriminant. An AggregateColumnCtx (admin) can open
+// a cross-domain stream on the synthetic aggregate row; a DomainLogColumnCtx
+// (tenant) has no onOpenAggregate member, so no code path here can ever emit an
+// aggregate request in the tenant scope — the capability is absent, not merely
+// unused.
+import { Space, Typography, type TableProps } from "antd";
+import {
+  FileTextOutlined,
+  WarningOutlined,
+  DashboardOutlined,
+} from "@ant-design/icons";
+import { RowActions } from "../RowActions";
+import {
+  type LogType,
+  type DomainLogRow,
+  LOG_STREAM_LABELS,
+  isAggregateRow,
+} from "./domainLogStreams";
+
+const { Text } = Typography;
+
+type DomainLogColumns = NonNullable<TableProps<DomainLogRow>["columns"]>;
+
+// The tenant capability: open a stream for a specific domain, identity always
+// included.
+export interface DomainLogColumnCtx {
+  onOpenDomain: (logType: LogType, domainId: string) => void;
+}
+
+// The admin capability adds the aggregate open. Its presence is what lets the
+// aggregate row do anything; absence (tenant) makes an aggregate request
+// unreachable.
+export interface AggregateColumnCtx extends DomainLogColumnCtx {
+  onOpenAggregate: (logType: LogType) => void;
+}
+
+export function buildDomainLogColumns(
+  ctx: DomainLogColumnCtx | AggregateColumnCtx,
+): DomainLogColumns {
+  const open = (logType: LogType, record: DomainLogRow) => {
+    if ("onOpenAggregate" in ctx && isAggregateRow(record)) {
+      ctx.onOpenAggregate(logType);
+    } else {
+      ctx.onOpenDomain(logType, record.id);
+    }
+  };
+
+  return [
+    {
+      title: "Domain",
+      dataIndex: "name",
+      key: "name",
+      render: (name: string, record: DomainLogRow) => (
+        <Space>
+          <Text strong>{name}</Text>
+          <Text type="secondary">({record.status})</Text>
+        </Space>
+      ),
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_: unknown, record: DomainLogRow) => (
+        <RowActions
+          actions={[
+            {
+              key: "access",
+              label: LOG_STREAM_LABELS.access,
+              icon: <FileTextOutlined />,
+              onClick: () => open("access", record),
+            },
+            {
+              key: "error",
+              label: LOG_STREAM_LABELS.error,
+              icon: <WarningOutlined />,
+              onClick: () => open("error", record),
+            },
+            {
+              key: "goaccess",
+              label: LOG_STREAM_LABELS.goaccess,
+              icon: <DashboardOutlined />,
+              onClick: () => open("goaccess", record),
+            },
+          ]}
+        />
+      ),
+    },
+  ];
+}

--- a/panel-ui/src/components/logs/domainLogStreams.test.ts
+++ b/panel-ui/src/components/logs/domainLogStreams.test.ts
@@ -1,0 +1,62 @@
+// domainLogStreams.test.ts — neutral Module tests for the request-shaping and
+// vocabulary of the per-domain log viewer (JAB-296).
+import { describe, it, expect } from "vitest";
+import {
+  buildLogStreamPayload,
+  isAggregateRow,
+  ALL_DOMAINS_ROW,
+  LOG_STREAM_TITLES,
+  LOG_STREAM_LABELS,
+} from "./domainLogStreams";
+
+describe("buildLogStreamPayload", () => {
+  it("includes domain_id for a per-domain request (admin row or any tenant request)", () => {
+    // AC1: the identified request carries the domain.
+    const payload = buildLogStreamPayload("access", "d1");
+    expect(payload).toEqual({ log_type: "access", domain_id: "d1" });
+    expect(payload).toHaveProperty("domain_id", "d1");
+  });
+
+  it("omits domain_id for an aggregate request (no domainId at all)", () => {
+    // AC1: the aggregate request has no domain identity.
+    const payload = buildLogStreamPayload("error");
+    expect(payload).toEqual({ log_type: "error" });
+    expect(payload).not.toHaveProperty("domain_id");
+  });
+
+  it("treats an empty-string id as a domain request, NOT an aggregate (AC2)", () => {
+    // The aggregate is the ABSENCE of a domainId, not a falsy one. A caller
+    // that passes "" still gets domain_id in the body, so a tenant column ctx
+    // (which always calls with a row id) can never emit an aggregate request.
+    const payload = buildLogStreamPayload("access", "");
+    expect(payload).toEqual({ log_type: "access", domain_id: "" });
+    expect(payload).toHaveProperty("domain_id");
+  });
+});
+
+describe("isAggregateRow", () => {
+  it("is true only for the synthetic aggregate row", () => {
+    expect(isAggregateRow(ALL_DOMAINS_ROW)).toBe(true);
+    expect(isAggregateRow({ id: "d1", name: "example.com", status: "active" })).toBe(false);
+    // An empty id alone does not make a row aggregate — the discriminant is
+    // the explicit flag, not the id.
+    expect(isAggregateRow({ id: "", name: "x", status: "active" })).toBe(false);
+  });
+});
+
+describe("copy (AC6)", () => {
+  it("pins the modal titles", () => {
+    expect(LOG_STREAM_TITLES).toEqual({
+      access: "Access Log Stream",
+      error: "Error Log Stream",
+      goaccess: "GoAccess Real-Time Dashboard",
+    });
+  });
+  it("pins the action labels", () => {
+    expect(LOG_STREAM_LABELS).toEqual({
+      access: "Access Log",
+      error: "Error Log",
+      goaccess: "Real Time",
+    });
+  });
+});

--- a/panel-ui/src/components/logs/domainLogStreams.ts
+++ b/panel-ui/src/components/logs/domainLogStreams.ts
@@ -1,0 +1,72 @@
+// domainLogStreams.ts — the audience-neutral request-shaping pieces of the
+// per-domain log viewer (JAB-296). Extracted out of the admin DomainLogsTab
+// and the tenant UserLogsPage so the "which log types exist", "how a stream
+// request is shaped", and "what an aggregate row is" decisions live in one
+// place with unit tests, instead of being copy-pasted module-locals in two
+// shells that drifted independently.
+
+export type LogType = "access" | "error" | "goaccess";
+
+// A row in the domain table. `aggregate` marks the synthetic "All Domains"
+// row that only the admin surface prepends — see ALL_DOMAINS_ROW. Tenant rows
+// never carry it, which is how the tenant scope is structurally barred from
+// ever asking for an aggregate stream (see buildLogStreamPayload / AC2).
+export interface DomainLogRow {
+  id: string;
+  name: string;
+  status: string;
+  aggregate?: boolean;
+}
+
+// Modal titles, keyed by log type. Kept verbatim from the two shells so the
+// consolidated copy does not shift under either page (AC6).
+export const LOG_STREAM_TITLES: Record<LogType, string> = {
+  access: "Access Log Stream",
+  error: "Error Log Stream",
+  goaccess: "GoAccess Real-Time Dashboard",
+};
+
+// Row-action labels, keyed by log type.
+export const LOG_STREAM_LABELS: Record<LogType, string> = {
+  access: "Access Log",
+  error: "Error Log",
+  goaccess: "Real Time",
+};
+
+// The synthetic aggregate row. Admin prepends it to stream logs across every
+// domain at once; the empty id is never sent as a domain identity — the
+// aggregate request omits domain_id entirely (see buildLogStreamPayload).
+export const ALL_DOMAINS_ROW: DomainLogRow = {
+  id: "",
+  name: "All Domains",
+  status: "system",
+  aggregate: true,
+};
+
+export const isAggregateRow = (row: DomainLogRow): boolean =>
+  row.aggregate === true;
+
+// The POST /logs/access body. An aggregate request is the ABSENCE of
+// domain_id, never an empty string — so it is unrepresentable unless the
+// caller explicitly passes no domainId at all.
+export type LogStreamPayload =
+  | { log_type: LogType }
+  | { log_type: LogType; domain_id: string };
+
+// buildLogStreamPayload shapes the create-stream request.
+//
+// AC1: an aggregate request (domainId === undefined) omits domain identity;
+// a per-domain request (admin row OR any tenant request) includes it.
+//
+// AC2: the aggregate is keyed on `undefined`, NOT on a falsy id. A caller that
+// passes any string — including "" — gets a domain_id in the body, so the
+// tenant surface (whose column ctx always calls with a row id) can never
+// accidentally emit an aggregate request. Only an explicit no-arg call does.
+export function buildLogStreamPayload(
+  logType: LogType,
+  domainId?: string,
+): LogStreamPayload {
+  return domainId === undefined
+    ? { log_type: logType }
+    : { log_type: logType, domain_id: domainId };
+}

--- a/panel-ui/src/components/logs/useDomainLogStreams.test.tsx
+++ b/panel-ui/src/components/logs/useDomainLogStreams.test.tsx
@@ -1,0 +1,115 @@
+// useDomainLogStreams.test.tsx — neutral Module tests for the stream lifecycle
+// (JAB-296): request shaping on open, and the "delete the key exactly once,
+// tolerate an already-expired stream" close (AC3).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { post: vi.fn(), delete: vi.fn() },
+}));
+vi.mock("../../lib/feedback", () => ({
+  feedback: { message: { error: vi.fn() } },
+}));
+
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback";
+import { useDomainLogStreams } from "./useDomainLogStreams";
+
+const mocked = apiClient as unknown as {
+  post: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+const toast = feedback as unknown as { message: { error: ReturnType<typeof vi.fn> } };
+
+const OPENED = {
+  data: { stream_key: "sk1", websocket_url: "wss://host/api/v1/logs/stream/sk1" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.post.mockResolvedValue(OPENED);
+  mocked.delete.mockResolvedValue({});
+});
+
+describe("openStream", () => {
+  it("posts a per-domain request and opens the modal (AC1)", async () => {
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.openStream("access", "d1");
+    });
+    expect(mocked.post).toHaveBeenCalledWith("/logs/access", {
+      log_type: "access",
+      domain_id: "d1",
+    });
+    expect(result.current.modalProps.visible).toBe(true);
+    expect(result.current.modalProps.streamUrl).toBe(OPENED.data.websocket_url);
+    expect(result.current.modalProps.title).toBe("Access Log Stream");
+    expect(result.current.modalProps.logType).toBe("access");
+  });
+
+  it("posts an aggregate request (no domain_id) when called with no domainId (AC1)", async () => {
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.openStream("error");
+    });
+    expect(mocked.post).toHaveBeenCalledWith("/logs/access", { log_type: "error" });
+    expect(result.current.modalProps.title).toBe("Error Log Stream");
+  });
+
+  it("surfaces the server error and stays closed on failure", async () => {
+    mocked.post.mockRejectedValueOnce({ response: { data: { error: "no such domain" } } });
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.openStream("access", "d1");
+    });
+    expect(toast.message.error).toHaveBeenCalledWith("no such domain");
+    expect(result.current.modalProps.visible).toBe(false);
+  });
+});
+
+describe("closeStream (AC3)", () => {
+  it("deletes the stream key once and closes the modal", async () => {
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.openStream("access", "d1");
+    });
+    await act(async () => {
+      await result.current.modalProps.onClose();
+    });
+    expect(mocked.delete).toHaveBeenCalledTimes(1);
+    expect(mocked.delete).toHaveBeenCalledWith("/logs/access/sk1");
+    expect(result.current.modalProps.visible).toBe(false);
+  });
+
+  it("deletes exactly once even when closed twice in rapid succession", async () => {
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.openStream("access", "d1");
+    });
+    const onClose = result.current.modalProps.onClose;
+    await act(async () => {
+      await Promise.all([onClose(), onClose()]);
+    });
+    expect(mocked.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates an already-expired stream (DELETE rejects)", async () => {
+    mocked.delete.mockRejectedValueOnce(new Error("410 gone"));
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.openStream("access", "d1");
+    });
+    await act(async () => {
+      await expect(result.current.modalProps.onClose()).resolves.toBeUndefined();
+    });
+    expect(result.current.modalProps.visible).toBe(false);
+  });
+
+  it("issues no DELETE when nothing was opened", async () => {
+    const { result } = renderHook(() => useDomainLogStreams());
+    await act(async () => {
+      await result.current.modalProps.onClose();
+    });
+    expect(mocked.delete).not.toHaveBeenCalled();
+  });
+});

--- a/panel-ui/src/components/logs/useDomainLogStreams.ts
+++ b/panel-ui/src/components/logs/useDomainLogStreams.ts
@@ -1,0 +1,89 @@
+// useDomainLogStreams — the audience-neutral stream lifecycle for the
+// per-domain log viewer (JAB-296). Owns the create/close of a stream key and
+// the modal wiring so the admin DomainLogsTab and the tenant UserLogsPage no
+// longer duplicate the same open/close state machine (which had drifted: the
+// admin copy allowed an aggregate open, the tenant copy did not, and both
+// carried the same close bug below).
+import { useRef, useState } from "react";
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import {
+  type LogType,
+  LOG_STREAM_TITLES,
+  buildLogStreamPayload,
+} from "./domainLogStreams";
+
+// The props the neutral LogStreamModal needs. Mirrors its component contract
+// so an adapter can spread {...streams.modalProps} straight onto it.
+export interface LogStreamModalProps {
+  visible: boolean;
+  onClose: () => void;
+  streamUrl: string | null;
+  title: string;
+  logType: LogType;
+}
+
+export interface DomainLogStreams {
+  modalProps: LogStreamModalProps;
+  openStream: (logType: LogType, domainId?: string) => Promise<void>;
+}
+
+export function useDomainLogStreams(): DomainLogStreams {
+  // The active stream key lives in a ref, not state: closeStream reads and
+  // clears it synchronously (see AC3), which a state setter cannot guarantee
+  // between two rapid closes.
+  const streamKeyRef = useRef<string | null>(null);
+  const [streamUrl, setStreamUrl] = useState<string | null>(null);
+  const [streamLogType, setStreamLogType] = useState<LogType>("access");
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const openStream = async (logType: LogType, domainId?: string) => {
+    try {
+      const response = await apiClient.post(
+        "/logs/access",
+        buildLogStreamPayload(logType, domainId),
+      );
+      const { stream_key, websocket_url } = response.data;
+      streamKeyRef.current = stream_key;
+      setStreamUrl(websocket_url);
+      setStreamLogType(logType);
+      setModalVisible(true);
+    } catch (error: unknown) {
+      const msg =
+        error && typeof error === "object" && "response" in error
+          ? // @ts-expect-error axios error shape
+            error.response?.data?.error
+          : undefined;
+      feedback.message.error(msg || "Failed to create log stream");
+    }
+  };
+
+  const closeStream = async () => {
+    // AC3: delete the stream key exactly once. The modal can fire its close in
+    // more than one way (Esc, mask click, the X, a StrictMode double-invoke),
+    // so read the key and null it out BEFORE the await — a second close then
+    // sees no key and issues no DELETE. Tolerate an already-expired stream:
+    // the server may have reaped it, and a 404/410 there is harmless.
+    const key = streamKeyRef.current;
+    streamKeyRef.current = null;
+    setModalVisible(false);
+    setStreamUrl(null);
+    if (!key) return;
+    try {
+      await apiClient.delete(`/logs/access/${key}`);
+    } catch {
+      // Stream already gone server-side; nothing to clean up.
+    }
+  };
+
+  return {
+    modalProps: {
+      visible: modalVisible,
+      onClose: closeStream,
+      streamUrl,
+      title: LOG_STREAM_TITLES[streamLogType],
+      logType: streamLogType,
+    },
+    openStream,
+  };
+}

--- a/panel-ui/src/components/logs/useLogStream.test.tsx
+++ b/panel-ui/src/components/logs/useLogStream.test.tsx
@@ -1,0 +1,196 @@
+// useLogStream.test.tsx — the JAB-296 neutral Module tests for the stream
+// lifecycle (AC5): connect/close transitions, newline-stripped append,
+// pause/resume buffering (which the old .tsx got wrong), the error path, and
+// the GoAccess polling cadence. A fake WebSocket stands in for the browser
+// socket; fake timers drive the GoAccess poll.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("../../lib/feedback", () => ({
+  feedback: {
+    message: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import { feedback } from "../../lib/feedback";
+import { useLogStream } from "./useLogStream";
+
+const toast = feedback as unknown as {
+  message: {
+    success: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+};
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: ((e: { code: number; reason?: string }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  close = vi.fn();
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+}
+
+const lastSocket = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  FakeWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("connect + message (AC5)", () => {
+  it("opens a socket to the stream URL and reports connecting until onopen", () => {
+    const { result } = renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(lastSocket().url).toBe("wss://host/s/1");
+    expect(result.current.connecting).toBe(true);
+    expect(result.current.connected).toBe(false);
+
+    act(() => lastSocket().onopen?.());
+    expect(result.current.connected).toBe(true);
+    expect(result.current.connecting).toBe(false);
+    expect(toast.message.success).toHaveBeenCalledWith("Connected to log stream");
+  });
+
+  it("appends incoming frames with a single trailing newline stripped", () => {
+    const { result } = renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    act(() => lastSocket().onopen?.());
+    act(() => lastSocket().onmessage?.({ data: "GET / 200\n" }));
+    act(() => lastSocket().onmessage?.({ data: "GET /x 404\r\n" }));
+    expect(result.current.logs).toEqual(["GET / 200", "GET /x 404"]);
+  });
+
+  it("does not open a socket for goaccess (iframe-rendered)", () => {
+    renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "goaccess", active: true }),
+    );
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+});
+
+describe("pause / resume buffering (AC5 — the fixed bug)", () => {
+  it("holds frames while paused and flushes them on resume", () => {
+    const { result } = renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    act(() => lastSocket().onopen?.());
+    act(() => lastSocket().onmessage?.({ data: "live-1" }));
+    expect(result.current.logs).toEqual(["live-1"]);
+
+    act(() => result.current.togglePause());
+    expect(result.current.paused).toBe(true);
+
+    // Frames arriving while paused must NOT reach the view. Under the original
+    // stale-closure bug they appended anyway; this is the assertion that fails
+    // if the onmessage handler reads paused state instead of the ref.
+    act(() => lastSocket().onmessage?.({ data: "paused-1" }));
+    act(() => lastSocket().onmessage?.({ data: "paused-2" }));
+    // Frames arriving while paused never reach the view, but the live buffered
+    // count reflects them (drives the "+N paused" indicator).
+    expect(result.current.logs).toEqual(["live-1"]);
+    expect(result.current.bufferedCount).toBe(2);
+
+    // Resume flushes exactly the two buffered frames and clears the count.
+    act(() => result.current.togglePause());
+    expect(result.current.paused).toBe(false);
+    expect(result.current.logs).toEqual(["live-1", "paused-1", "paused-2"]);
+    expect(result.current.bufferedCount).toBe(0);
+  });
+
+  it("clear empties the view and the buffer", () => {
+    const { result } = renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    act(() => lastSocket().onopen?.());
+    act(() => lastSocket().onmessage?.({ data: "a" }));
+    act(() => result.current.clear());
+    expect(result.current.logs).toEqual([]);
+  });
+});
+
+describe("close / error transitions (AC5)", () => {
+  it("treats a clean 1000 close as 'stream ended'", () => {
+    const { result } = renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    act(() => lastSocket().onopen?.());
+    act(() => lastSocket().onclose?.({ code: 1000 }));
+    expect(result.current.connected).toBe(false);
+    expect(toast.message.info).toHaveBeenCalledWith("Log stream ended");
+    expect(toast.message.error).not.toHaveBeenCalled();
+  });
+
+  it("treats an abnormal 1006 close as a lost connection", () => {
+    renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    act(() => lastSocket().onopen?.());
+    act(() => lastSocket().onclose?.({ code: 1006 }));
+    expect(toast.message.error).toHaveBeenCalledWith("Connection lost");
+    expect(toast.message.info).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a socket error", () => {
+    const { result } = renderHook(() =>
+      useLogStream({ streamUrl: "wss://host/s/1", logType: "access", active: true }),
+    );
+    act(() => lastSocket().onerror?.(new Event("error")));
+    expect(toast.message.error).toHaveBeenCalledWith("WebSocket connection error");
+    expect(result.current.connecting).toBe(false);
+  });
+});
+
+describe("GoAccess polling cadence (AC5)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("bumps the tick and snapshots scroll every 10s, not before", () => {
+    const onBeforeGoAccessRefresh = vi.fn();
+    const { result } = renderHook(() =>
+      useLogStream({
+        streamUrl: "wss://host/s/1",
+        logType: "goaccess",
+        active: true,
+        onBeforeGoAccessRefresh,
+      }),
+    );
+    const first = result.current.goAccessTick;
+
+    act(() => vi.advanceTimersByTime(9999));
+    expect(onBeforeGoAccessRefresh).not.toHaveBeenCalled();
+    expect(result.current.goAccessTick).toBe(first);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(onBeforeGoAccessRefresh).toHaveBeenCalledTimes(1);
+    expect(result.current.goAccessTick).not.toBe(first);
+  });
+
+  it("does not poll when inactive", () => {
+    const onBeforeGoAccessRefresh = vi.fn();
+    renderHook(() =>
+      useLogStream({
+        streamUrl: "wss://host/s/1",
+        logType: "goaccess",
+        active: false,
+        onBeforeGoAccessRefresh,
+      }),
+    );
+    act(() => vi.advanceTimersByTime(30000));
+    expect(onBeforeGoAccessRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/panel-ui/src/components/logs/useLogStream.ts
+++ b/panel-ui/src/components/logs/useLogStream.ts
@@ -1,0 +1,178 @@
+// useLogStream — the audience-neutral WebSocket + GoAccess-polling lifecycle
+// behind the LogStreamModal (JAB-296, AC5). Pulled out of the .tsx so the
+// newline handling, the ring-buffer cap, pause/resume buffering, the
+// connect/close transitions, and the GoAccess polling cadence can be exercised
+// with a fake WebSocket and fake timers instead of only living as untestable
+// closures inside a modal. The DOM (auto-scroll, the GoAccess iframe and its
+// scroll preservation) stays in the component; this hook is lifecycle only.
+import { useEffect, useRef, useState } from "react";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import {
+  MAX_LOG_LINES,
+  capLogLines,
+  stripTrailingNewline,
+} from "../../utils/logStream";
+import { type LogType } from "./domainLogStreams";
+
+export type { LogType };
+
+export interface UseLogStreamOptions {
+  streamUrl: string | null;
+  logType: LogType;
+  // Whether the stream should be live (the modal's `visible`). When it goes
+  // false the socket is torn down and the polling interval stops.
+  active: boolean;
+  // Fired synchronously just before each GoAccess poll bumps the tick, so the
+  // component can snapshot the iframe scroll position before the src changes.
+  onBeforeGoAccessRefresh?: () => void;
+}
+
+export interface LogStream {
+  logs: string[];
+  connected: boolean;
+  connecting: boolean;
+  paused: boolean;
+  bufferedCount: number;
+  goAccessTick: number;
+  togglePause: () => void;
+  clear: () => void;
+  // Tear down the socket and reset all display state. The component calls this
+  // when the modal closes, before invoking its own onClose.
+  reset: () => void;
+}
+
+export function useLogStream({
+  streamUrl,
+  logType,
+  active,
+  onBeforeGoAccessRefresh,
+}: UseLogStreamOptions): LogStream {
+  const [logs, setLogs] = useState<string[]>([]);
+  const [connected, setConnected] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [bufferedCount, setBufferedCount] = useState(0);
+  const [goAccessTick, setGoAccessTick] = useState(() => Date.now());
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const pausedLogsRef = useRef<string[]>([]);
+  // The socket's onmessage closure is created once at connect time; reading the
+  // `paused` STATE there would forever see its connect-time value (the original
+  // bug: pausing only relabelled the button, frames kept appending). Read a ref
+  // instead so pause/resume actually gates the live socket.
+  const pausedRef = useRef(false);
+  // The GoAccess pre-refresh callback can change identity every render; hold it
+  // in a ref so the polling effect does not resubscribe (which would reset the
+  // 10s interval before it ever fires).
+  const beforeRefreshRef = useRef(onBeforeGoAccessRefresh);
+  beforeRefreshRef.current = onBeforeGoAccessRefresh;
+
+  useEffect(() => {
+    // GoAccess renders through an HTTP iframe, not a socket — no WS for it.
+    if (logType === "goaccess") return;
+    if (active && streamUrl && !wsRef.current) {
+      setConnecting(true);
+      const ws = new WebSocket(streamUrl);
+
+      ws.onopen = () => {
+        setConnected(true);
+        setConnecting(false);
+        feedback.message.success("Connected to log stream");
+      };
+
+      ws.onmessage = (event) => {
+        const line = stripTrailingNewline(event.data);
+        if (!pausedRef.current) {
+          setLogs((prev) => capLogLines([...prev, line]));
+        } else {
+          // The paused buffer needs the same ceiling: a stream paused on a busy
+          // log otherwise grows unbounded and then floods the view on resume.
+          pausedLogsRef.current.push(line);
+          if (pausedLogsRef.current.length > MAX_LOG_LINES) {
+            pausedLogsRef.current = pausedLogsRef.current.slice(-MAX_LOG_LINES);
+          }
+          setBufferedCount(pausedLogsRef.current.length);
+        }
+      };
+
+      ws.onclose = (event) => {
+        setConnected(false);
+        setConnecting(false);
+        if (event.code === 1000) {
+          feedback.message.info("Log stream ended");
+        } else {
+          feedback.message.error("Connection lost");
+        }
+      };
+
+      ws.onerror = () => {
+        setConnecting(false);
+        feedback.message.error("WebSocket connection error");
+      };
+
+      wsRef.current = ws;
+    }
+
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [active, streamUrl, logType]);
+
+  // GoAccess polling: while live, bump the tick every 10s so the iframe src
+  // changes and the browser re-fetches. Same cadence as the prior WS path.
+  useEffect(() => {
+    if (logType !== "goaccess" || !active || !streamUrl) return;
+    const id = setInterval(() => {
+      beforeRefreshRef.current?.();
+      setGoAccessTick(Date.now());
+    }, 10000);
+    return () => clearInterval(id);
+  }, [logType, active, streamUrl]);
+
+  const togglePause = () => {
+    const next = !pausedRef.current;
+    pausedRef.current = next;
+    setPaused(next);
+    if (!next && pausedLogsRef.current.length > 0) {
+      // Resume: flush the buffered frames into the view, capped.
+      const buffered = pausedLogsRef.current;
+      pausedLogsRef.current = [];
+      setBufferedCount(0);
+      setLogs((prev) => capLogLines([...prev, ...buffered]));
+    }
+  };
+
+  const clear = () => {
+    setLogs([]);
+    pausedLogsRef.current = [];
+    setBufferedCount(0);
+  };
+
+  const reset = () => {
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setLogs([]);
+    setConnected(false);
+    setPaused(false);
+    pausedRef.current = false;
+    pausedLogsRef.current = [];
+    setBufferedCount(0);
+  };
+
+  return {
+    logs,
+    connected,
+    connecting,
+    paused,
+    bufferedCount,
+    goAccessTick,
+    togglePause,
+    clear,
+    reset,
+  };
+}

--- a/panel-ui/src/shells/admin/logs/DomainLogsTab.tsx
+++ b/panel-ui/src/shells/admin/logs/DomainLogsTab.tsx
@@ -1,48 +1,24 @@
 // DomainLogsTab — per-domain web log streams (access / error / GoAccess
-// real-time). Extracted from the old single-purpose LogsPage so it can be
-// one tab of the consolidated Logs & Statistics page.
+// real-time) for the admin. One tab of the consolidated Logs & Statistics
+// page. The stream lifecycle, request shaping, and columns are the neutral
+// Domain Log Streams module (JAB-296); this shell only adds the admin delta:
+// the "All Domains" aggregate row and its cross-domain open capability.
 import { useState } from "react";
-import { RowActions } from "../../../components/RowActions";
-import { Card, Typography, Button, Space, Table } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import {
-  ReloadOutlined,
-  FileTextOutlined,
-  WarningOutlined,
-  DashboardOutlined,
-} from "@ant-design/icons";
+import { Card, Button, Space, Table } from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
 import { LogStreamModal } from "../../../components/LogStreamModal";
-
-const { Text } = Typography;
-
-interface Domain {
-  id: string;
-  name: string;
-  status: string;
-}
-
-type LogType = "access" | "error" | "goaccess";
-
-const titleFor: Record<LogType, string> = {
-  access: "Access Log Stream",
-  error: "Error Log Stream",
-  goaccess: "GoAccess Real-Time Dashboard",
-};
-
-const labelFor: Record<LogType, string> = {
-  access: "Access Log",
-  error: "Error Log",
-  goaccess: "Real Time",
-};
+import {
+  type DomainLogRow,
+  ALL_DOMAINS_ROW,
+} from "../../../components/logs/domainLogStreams";
+import { useDomainLogStreams } from "../../../components/logs/useDomainLogStreams";
+import { buildDomainLogColumns } from "../../../components/logs/buildDomainLogColumns";
 
 export const DomainLogsTab = () => {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const [streamKey, setStreamKey] = useState<string | null>(null);
-  const [streamUrl, setStreamUrl] = useState<string | null>(null);
-  const [streamLogType, setStreamLogType] = useState<LogType>("access");
-  const [modalVisible, setModalVisible] = useState(false);
+  const streams = useDomainLogStreams();
 
   const { data: domainsData, isLoading } = useQuery({
     queryKey: ["domains", refreshTrigger],
@@ -52,74 +28,16 @@ export const DomainLogsTab = () => {
     },
   });
 
-  const domains: Domain[] = domainsData?.data || [];
+  const domains: DomainLogRow[] = domainsData?.data || [];
 
-  const openStream = async (logType: LogType, domainId?: string) => {
-    try {
-      const payload: { log_type: LogType; domain_id?: string } = { log_type: logType };
-      if (domainId) payload.domain_id = domainId;
-
-      const response = await apiClient.post("/logs/access", payload);
-      const { stream_key, websocket_url } = response.data;
-
-      setStreamKey(stream_key);
-      setStreamUrl(websocket_url);
-      setStreamLogType(logType);
-      setModalVisible(true);
-    } catch (error: unknown) {
-      const msg =
-        error && typeof error === "object" && "response" in error
-          ? // @ts-expect-error axios error shape
-            error.response?.data?.error
-          : undefined;
-      feedback.message.error(msg || "Failed to create log stream");
-    }
-  };
-
-  const handleStreamClose = async () => {
-    if (streamKey) {
-      try {
-        await apiClient.delete(`/logs/access/${streamKey}`);
-      } catch {
-        // Stream may have expired server-side; harmless.
-      }
-      setStreamKey(null);
-      setStreamUrl(null);
-    }
-    setModalVisible(false);
-  };
-
-  const tableData: Domain[] = [
-    { id: "", name: "All Domains", status: "system" },
-    ...domains,
-  ];
-
-  const columns = [
-    {
-      title: "Domain",
-      dataIndex: "name",
-      key: "name",
-      render: (name: string, record: Domain) => (
-        <Space>
-          <Text strong>{name}</Text>
-          <Text type="secondary">({record.status})</Text>
-        </Space>
-      ),
-    },
-    {
-      title: "Actions",
-      key: "actions",
-      render: (_: unknown, record: Domain) => (
-        <RowActions
-          actions={[
-            { key: "access", label: labelFor.access, icon: <FileTextOutlined />, onClick: () => openStream("access", record.id || undefined) },
-            { key: "error", label: labelFor.error, icon: <WarningOutlined />, onClick: () => openStream("error", record.id || undefined) },
-            { key: "goaccess", label: labelFor.goaccess, icon: <DashboardOutlined />, onClick: () => openStream("goaccess", record.id || undefined) },
-          ]}
-        />
-      ),
-    },
-  ];
+  // Admin delta: the synthetic aggregate row, and the capability to open a
+  // cross-domain stream on it. onOpenAggregate is what makes the aggregate
+  // reachable here (and, by its absence, unreachable in the tenant scope).
+  const tableData: DomainLogRow[] = [ALL_DOMAINS_ROW, ...domains];
+  const columns = buildDomainLogColumns({
+    onOpenDomain: streams.openStream,
+    onOpenAggregate: (logType) => streams.openStream(logType),
+  });
 
   return (
     <div>
@@ -144,13 +62,7 @@ export const DomainLogsTab = () => {
         />
       </Card>
 
-      <LogStreamModal
-        visible={modalVisible}
-        onClose={handleStreamClose}
-        streamUrl={streamUrl}
-        title={titleFor[streamLogType]}
-        logType={streamLogType}
-      />
+      <LogStreamModal {...streams.modalProps} />
     </div>
   );
 };

--- a/panel-ui/src/shells/user/logs/UserLogsPage.tsx
+++ b/panel-ui/src/shells/user/logs/UserLogsPage.tsx
@@ -1,49 +1,28 @@
-import { useState } from "react";
-import { RowActions } from "../../../components/RowActions";
+// UserLogsPage — the tenant's Logs & Statistics: per-domain web log streams
+// plus account activity. The stream lifecycle, request shaping, and columns
+// are the neutral Domain Log Streams module (JAB-296); this shell adds the
+// tenant deltas: the outer Domain-logs / Account-activity tabs, the ?domain=
+// focus filter (GH #1332), and — by using the domain-only column context — the
+// structural guarantee that no request here ever omits domain identity (AC2).
 import { Card, Typography, Button, Space, Table, Tabs } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import {
-  ReloadOutlined,
-  FileTextOutlined,
-  WarningOutlined,
-  DashboardOutlined,
-} from "@ant-design/icons";
+import { ReloadOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
 import { LogStreamModal } from "../../../components/LogStreamModal";
 import { AccountActivity } from "../activity/AccountActivity";
 import { useSearchParams } from "react-router";
+import { useState } from "react";
+import { type DomainLogRow } from "../../../components/logs/domainLogStreams";
+import { useDomainLogStreams } from "../../../components/logs/useDomainLogStreams";
+import { buildDomainLogColumns } from "../../../components/logs/buildDomainLogColumns";
 
-const { Title, Text } = Typography;
-
-interface Domain {
-  id: string;
-  name: string;
-  status: string;
-}
-
-type LogType = "access" | "error" | "goaccess";
-
-const titleFor: Record<LogType, string> = {
-  access: "Access Log Stream",
-  error: "Error Log Stream",
-  goaccess: "GoAccess Real-Time Dashboard",
-};
-
-const labelFor: Record<LogType, string> = {
-  access: "Access Log",
-  error: "Error Log",
-  goaccess: "Real Time",
-};
+const { Title } = Typography;
 
 export const UserLogsPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = searchParams.get("tab") === "activity" ? "activity" : "domains";
   const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const [streamKey, setStreamKey] = useState<string | null>(null);
-  const [streamUrl, setStreamUrl] = useState<string | null>(null);
-  const [streamLogType, setStreamLogType] = useState<LogType>("access");
-  const [modalVisible, setModalVisible] = useState(false);
+  const streams = useDomainLogStreams();
 
   const { data: domainsData, isLoading } = useQuery({
     queryKey: ["user-domains", refreshTrigger],
@@ -53,7 +32,7 @@ export const UserLogsPage = () => {
     },
   });
 
-  const domains: Domain[] = domainsData?.data || [];
+  const domains: DomainLogRow[] = domainsData?.data || [];
 
   // GH #1332 item 7: the per-domain PHP Settings page links here with
   // ?domain=<id> to jump straight to that site's logs. Filter to it (and offer
@@ -67,66 +46,9 @@ export const UserLogsPage = () => {
   const isFilteredToDomain =
     !!focusDomainId && shownDomains.length < domains.length;
 
-  const openStream = async (logType: LogType, domainId: string) => {
-    try {
-      const response = await apiClient.post("/logs/access", {
-        log_type: logType,
-        domain_id: domainId,
-      });
-      const { stream_key, websocket_url } = response.data;
-      setStreamKey(stream_key);
-      setStreamUrl(websocket_url);
-      setStreamLogType(logType);
-      setModalVisible(true);
-    } catch (error: unknown) {
-      const msg =
-        error && typeof error === "object" && "response" in error
-          ? // @ts-expect-error axios error shape
-            error.response?.data?.error
-          : undefined;
-      feedback.message.error(msg || "Failed to create log stream");
-    }
-  };
-
-  const handleStreamClose = async () => {
-    if (streamKey) {
-      try {
-        await apiClient.delete(`/logs/access/${streamKey}`);
-      } catch {
-        // Stream may have expired server-side; harmless.
-      }
-      setStreamKey(null);
-      setStreamUrl(null);
-    }
-    setModalVisible(false);
-  };
-
-  const columns = [
-    {
-      title: "Domain",
-      dataIndex: "name",
-      key: "name",
-      render: (name: string, record: Domain) => (
-        <Space>
-          <Text strong>{name}</Text>
-          <Text type="secondary">({record.status})</Text>
-        </Space>
-      ),
-    },
-    {
-      title: "Actions",
-      key: "actions",
-      render: (_: unknown, record: Domain) => (
-        <RowActions
-          actions={[
-            { key: "access", label: labelFor.access, icon: <FileTextOutlined />, onClick: () => openStream("access", record.id) },
-            { key: "error", label: labelFor.error, icon: <WarningOutlined />, onClick: () => openStream("error", record.id) },
-            { key: "goaccess", label: labelFor.goaccess, icon: <DashboardOutlined />, onClick: () => openStream("goaccess", record.id) },
-          ]}
-        />
-      ),
-    },
-  ];
+  // Domain-only context: no onOpenAggregate, so the tenant scope cannot reach
+  // an aggregate request — every open carries this domain's id.
+  const columns = buildDomainLogColumns({ onOpenDomain: streams.openStream });
 
   const domainLogsTab = (
     <>
@@ -173,13 +95,7 @@ export const UserLogsPage = () => {
         ]}
       />
 
-      <LogStreamModal
-        visible={modalVisible}
-        onClose={handleStreamClose}
-        streamUrl={streamUrl}
-        title={titleFor[streamLogType]}
-        logType={streamLogType}
-      />
+      <LogStreamModal {...streams.modalProps} />
     </div>
   );
 };


### PR DESCRIPTION
## What & why

Consolidates the per-domain **Domain Log Streams** feature into one neutral module (ADR-0083 audience policy, JAB-296). The admin `DomainLogsTab` and the tenant `UserLogsPage` had each hand-rolled the same open/close state machine, request shaping, titles/labels, and Domain + Actions columns — and the two copies had drifted. This extracts the shared behavior and leaves each shell only its own composition.

Foundation PR #1496 already moved `LogStreamModal` to `components/` and extracted the pure stream pieces (`utils/logStream.ts`: newline trim, ring-buffer cap, GoAccess URL). This PR completes the remaining ACs.

## Commits

1. **Shared module** (`components/logs/`): `useDomainLogStreams` (stream open/close + modal props), `buildLogStreamPayload` (request shaping), `buildDomainLogColumns` (scope-aware columns). Both shells rewired thin.
2. **`useLogStream`**: the WebSocket + GoAccess-polling lifecycle pulled out of `LogStreamModal` so it can be tested with a fake socket and fake timers. The component keeps only the DOM (auto-scroll, the GoAccess iframe + scroll preservation).

## Two bugs the AC tests exposed (not refactor incidentals)

- **Double DELETE on rapid close (AC3):** the old `handleStreamClose` read the stream key from a closure, awaited the DELETE, then cleared — so two close events (Esc + mask + X, or a StrictMode double-invoke) both saw the key and issued two DELETEs. Fixed by reading and nulling the key *synchronously* before the await.
- **Stale-`paused` closure (AC5):** the socket's `onmessage` read the `paused` **state** captured once at connect time (effect deps are `[visible, streamUrl, logType]`, not `paused`), so pausing only relabelled the button while frames kept appending and nothing accumulated in the paused buffer. Fixed by reading a `pausedRef`.

## Behavior notes for reviewers

- **Close reorder (normalization):** the modal now dismisses immediately and issues the DELETE in the background; before, it lingered open until the DELETE resolved.
- **Dead-branch removal:** `onmessage`'s `goaccess` path never ran — the effect returns before opening a socket for goaccess, which renders through the HTTP iframe. Removed. GoAccess frame handling is unchanged (iframe + 10s poll).
- The `(+N paused)` indicator is now backed by reactive state, so it updates live (it read a ref before and, with pausing broken, was never reachable).

## AC coverage

| AC | How |
|----|-----|
| 1 — admin aggregate omits domain identity; admin row + tenant include it | `buildLogStreamPayload` keys the aggregate on the **absence** of a domain id; tested + falsified |
| 2 — tenant scope can never emit an aggregate request | column context discriminant: the tenant ctx has no `onOpenAggregate` member, so no code path can reach it (absence, not disuse); tested + falsified. Mirrors the panel-api guard at `logs.go:213` that already 400s a domain-less request from a non-admin |
| 3 — close deletes a key exactly once, tolerates an expired stream | `useDomainLogStreams.closeStream` sync read-and-null + swallow; tested (double-close → one DELETE, DELETE-rejects → clean) + falsified |
| 4 — refresh refetches domains without leaking streams | structural: stream state lives in the hook; each shell keeps its own `useQuery` (`"domains"` / `"user-domains"`) + `refreshTrigger`, which never touch stream state |
| 5 — WS newline, cap, pause/resume, error, GoAccess polling have neutral Module tests | pure pieces in #1496 (`logStream.test.ts`) + 10 `useLogStream` tests here (connect/append/strip, pause-holds-then-resume-flushes, 1000-vs-1006 close, socket error, 10s poll) |
| 6 — admin and tenant wrappers preserve existing tabs and copy | titles/labels pinned by test; `LogsPage.tsx` untouched; `UserLogsPage` keeps its Domain-logs / Account-activity tabs and `?domain=` focus filter |

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on all touched files
- [x] `vitest` — full suite 631/631; 28 new module tests (18 + 10)
- [x] 4 guards falsified with attributable reds, then reverted (AC1 payload, AC2 ctx routing, AC3 sync key-null, AC5 pausedRef)
- [x] `vite build` clean
- [x] rebased onto latest `origin/main`, re-ran tsc + logs suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
