### PR TITLE
feat(domains): admin change-owner WebUI (GH #1238)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -17,10 +17,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -61,6 +63,18 @@ type DomainHandlerConfig struct {
 	ManagedIPs repository.ManagedIPRepository
 	// ServerSettings gates the tenant-safe nginx options opt-in (GH #307).
 	ServerSettings repository.ServerSettingsRepository
+	// AppInstalls (GH #1238 chown) backs the change-owner refusal: a domain
+	// with an app install carries the current owner's DB creds in its config,
+	// so re-owning it would leak a live cross-tenant credential. REQUIRED for
+	// the chown route — a nil repo makes the handler 503 rather than silently
+	// skip the security check (fail-closed).
+	AppInstalls repository.ApplicationInstallRepository
+	// AuditEvents records the admin change-owner (GH #1238). Optional — nil
+	// in dev binaries makes the audit a no-op.
+	AuditEvents repository.AuditEventRepository
+	// KratosClient gates the change-owner route behind the JAB-380 recent-auth
+	// step-up (same as rename / the root File Manager).
+	KratosClient *kratosclient.Client
 }
 
 const (
@@ -85,6 +99,12 @@ func RegisterDomainRoutes(g *gin.RouterGroup, cfg DomainHandlerConfig) {
 	domains.PATCH("/:id", h.update)
 	domains.DELETE("/:id", h.delete)
 	domains.GET("/:id/bandwidth", h.bandwidth)
+
+	// GH #1238: reassign a domain to a new tenant (move + re-own the docroot,
+	// repoint the DB row). Admin-only AND behind the JAB-380 recent-auth
+	// step-up — it moves files and hands them to another tenant, mirroring the
+	// user-rename surface. Registered on the base group, not /domains.
+	g.POST("/admin/domains/:id/chown", middleware.RequireAdmin(), h.chown)
 }
 
 type domainHandler struct{ cfg DomainHandlerConfig }

--- a/panel-api/internal/api/domains_chown.go
+++ b/panel-api/internal/api/domains_chown.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+// domains_chown.go — admin action to reassign a domain to a new tenant in place
+// (GH #1238, WebUI follow-up to the `jabali domain chown` CLI).
+//
+// The heavy lifting lives in userops.ChangeDomainOwner (shared with the CLI):
+// the agent moves + re-owns the docroot tree (domain.reown), the panel repoints
+// the DB row (TransferOwner — domain_id survives, so tombstones/SSL/DNS/mail
+// stay), and the reconciler re-binds the PHP pool + re-renders the vhost under
+// the new owner. This handler is the thin admin surface: a data-moving,
+// cross-tenant operation, so it's admin-only AND behind the JAB-380 recent-auth
+// step-up, same as rename.
+//
+// v1 REFUSES a domain that has an app install (its config holds the current
+// owner's DB credentials → cross-tenant leak). That refusal lives in userops
+// and depends on AppInstalls being wired; this handler 503s when it isn't,
+// rather than let the security check fail open.
+
+type chownDomainRequest struct {
+	NewOwnerID string `json:"new_owner_id"`
+}
+
+// chown handles POST /admin/domains/:id/chown { new_owner_id }.
+func (h *domainHandler) chown(c *gin.Context) {
+	// Root-privileged, cross-tenant surface: require a recently-authenticated
+	// interactive session (JAB-380). A stale session gets a 403 the SPA turns
+	// into a re-auth + retry.
+	if !requireRecentAuth(c, h.cfg.KratosClient, stepUpWindow) {
+		return
+	}
+
+	// Fail closed: the cross-tenant-credential refusal in userops is only armed
+	// when AppInstalls is wired. Never let a missing dep silently disable it.
+	if h.cfg.AppInstalls == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "chown_unavailable", "detail": "app-install repository not wired"})
+		return
+	}
+
+	domainID := c.Param("id")
+	if domainID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "domain id required"})
+		return
+	}
+	var req chownDomainRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	if req.NewOwnerID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "new_owner_id required"})
+		return
+	}
+
+	// Moving + re-owning the docroot goes through the agent; bound it so a
+	// wedged agent can't pin the request forever (same 5-min ceiling the CLI
+	// uses).
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Minute)
+	defer cancel()
+
+	domain, err := h.cfg.Domains.FindByID(ctx, domainID)
+	if err != nil || domain == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain not found"})
+		return
+	}
+	newOwner, err := h.cfg.Users.FindByID(ctx, req.NewOwnerID)
+	if err != nil || newOwner == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "new owner not found"})
+		return
+	}
+
+	// Capture the pre-change state for the audit record before userops mutates
+	// the in-memory domain.
+	oldOwnerID := domain.UserID
+	oldDocRoot := domain.DocRoot
+
+	d := userops.Deps{
+		Users:   h.cfg.Users,
+		Domains: h.cfg.Domains,
+		Agent:   h.cfg.Agent,
+		Log:     slog.Default(),
+	}
+	cd := userops.ChownDeps{AppInstalls: h.cfg.AppInstalls}
+	// Unlike rename (which leaves the reconciler nil and waits for the periodic
+	// pass), chown wires it: Reconciler.Schedule is a non-blocking enqueue, so
+	// the docroot/PHP-pool rebind + vhost re-render happen promptly without the
+	// request blocking on a synchronous convergence.
+	//
+	// Typed-nil guard: cfg.Reconciler is a *reconciler.Reconciler; assigning a
+	// nil pointer straight to the ChownReconciler interface yields a non-nil
+	// interface, so userops' `cd.Reconciler != nil` would call Schedule on a nil
+	// receiver and panic. Only wire it when the pointer is actually set.
+	if h.cfg.Reconciler != nil {
+		cd.Reconciler = h.cfg.Reconciler
+	}
+
+	if err := userops.ChangeDomainOwner(ctx, d, cd, domain, newOwner); err != nil {
+		h.auditChown(c, domainID, oldOwnerID, req.NewOwnerID, oldDocRoot, "", models.AuditResultError)
+		// ChangeDomainOwner's errors are user-actionable (already-owner, not a
+		// tenant, has an app install, docroot outside home, agent failure) —
+		// pass the message through so the admin sees exactly why.
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "chown_failed", "detail": err.Error()})
+		return
+	}
+	h.auditChown(c, domainID, oldOwnerID, req.NewOwnerID, oldDocRoot, domain.DocRoot, models.AuditResultOK)
+
+	c.JSON(http.StatusOK, gin.H{
+		"id":       domainID,
+		"user_id":  domain.UserID,
+		"doc_root": domain.DocRoot,
+	})
+}
+
+// auditChown records the admin change-of-owner. The subject is the OLD owner
+// (their asset moved away); the new owner + docroot move land in meta. No-op
+// when the audit repo isn't wired (dev binaries).
+func (h *domainHandler) auditChown(c *gin.Context, domainID, oldOwnerID, newOwnerID, oldDocRoot, newDocRoot, result string) {
+	if h.cfg.AuditEvents == nil {
+		return
+	}
+	meta, _ := json.Marshal(map[string]string{
+		"new_owner_id": newOwnerID,
+		"old_doc_root": oldDocRoot,
+		"new_doc_root": newDocRoot,
+	})
+	subject := oldOwnerID
+	ev := &models.AuditEvent{
+		ID:            ids.NewULID(),
+		TS:            time.Now().UTC(),
+		ActorKind:     models.AuditActorAdmin,
+		SubjectUserID: &subject,
+		Action:        "admin.domain.chown",
+		TargetType:    "domain",
+		TargetID:      domainID,
+		Result:        result,
+		Meta:          meta,
+	}
+	if claims := ginctx.Claims(c); claims != nil && claims.UserID != "" {
+		actor := claims.UserID
+		ev.ActorUserID = &actor
+	}
+	if ip := c.ClientIP(); ip != "" {
+		ev.SourceIP = &ip
+	}
+	if reqID := ginctx.RequestID(c); reqID != "" {
+		ev.RequestID = &reqID
+	}
+	_ = h.cfg.AuditEvents.Create(c.Request.Context(), ev)
+}

--- a/panel-api/internal/api/domains_chown_test.go
+++ b/panel-api/internal/api/domains_chown_test.go
@@ -1,0 +1,176 @@
+package api
+
+// GH #1238 — admin change-owner endpoint. The chown logic itself is covered in
+// the userops package; these pin the handler's contract: the JAB-380 step-up
+// gate, the fail-closed AppInstalls guard, request validation, not-found paths,
+// and that a userops refusal is surfaced with its message.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- minimal mocks (embed the interface, override only what chown touches) ---
+
+type chownDomainsRepo struct {
+	repository.DomainRepository
+	byID          *models.Domain
+	transferErr   error
+	transferCalls int
+}
+
+func (r *chownDomainsRepo) FindByID(context.Context, string) (*models.Domain, error) {
+	if r.byID == nil {
+		return nil, repository.ErrNotFound
+	}
+	return r.byID, nil
+}
+
+func (r *chownDomainsRepo) TransferOwner(context.Context, string, string, string) error {
+	r.transferCalls++
+	return r.transferErr
+}
+
+type chownUsersRepo struct {
+	repository.UserRepository
+	byID map[string]*models.User
+}
+
+func (r chownUsersRepo) FindByID(_ context.Context, id string) (*models.User, error) {
+	if u, ok := r.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type chownAppInstallsRepo struct {
+	repository.ApplicationInstallRepository
+	install *models.ApplicationInstall
+}
+
+func (r chownAppInstallsRepo) FindByDomainID(context.Context, string) (*models.ApplicationInstall, error) {
+	return r.install, nil
+}
+
+func chownCtx(claims *auth.AccessClaims, id, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/domains/"+id+"/chown", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	if claims != nil {
+		ginctx.SetClaims(c, claims)
+	}
+	return c, w
+}
+
+func TestChown_StepUpRequiredWhenStale(t *testing.T) {
+	stale := &auth.AccessClaims{UserID: "admin1", IsAdmin: true, Source: auth.SourceKratos, AuthenticatedAt: time.Now().Add(-2 * time.Hour)}
+	h := &domainHandler{cfg: DomainHandlerConfig{}} // KratosClient nil: stale fast-path → 403
+	c, w := chownCtx(stale, "d1", `{"new_owner_id":"u2"}`)
+	h.chown(c)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "stepup_required")
+}
+
+func TestChown_AppInstallsNilFailsClosed(t *testing.T) {
+	// AppInstalls unwired must 503, never silently skip the cross-tenant refusal.
+	h := &domainHandler{cfg: DomainHandlerConfig{}}
+	c, w := chownCtx(recentAdmin(), "d1", `{"new_owner_id":"u2"}`)
+	h.chown(c)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "chown_unavailable")
+}
+
+func TestChown_InvalidBody(t *testing.T) {
+	h := &domainHandler{cfg: DomainHandlerConfig{AppInstalls: chownAppInstallsRepo{}}}
+	c, w := chownCtx(recentAdmin(), "d1", `not json`)
+	h.chown(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid_body")
+}
+
+func TestChown_MissingNewOwner(t *testing.T) {
+	h := &domainHandler{cfg: DomainHandlerConfig{AppInstalls: chownAppInstallsRepo{}}}
+	c, w := chownCtx(recentAdmin(), "d1", `{}`)
+	h.chown(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "new_owner_id")
+}
+
+func TestChown_DomainNotFound(t *testing.T) {
+	h := &domainHandler{cfg: DomainHandlerConfig{
+		AppInstalls: chownAppInstallsRepo{},
+		Domains:     &chownDomainsRepo{}, // byID nil → not found
+	}}
+	c, w := chownCtx(recentAdmin(), "ghost", `{"new_owner_id":"u2"}`)
+	h.chown(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "domain not found")
+}
+
+func TestChown_OwnerNotFound(t *testing.T) {
+	dom := &models.Domain{ID: "d1", UserID: "old", DocRoot: "/home/alice/example.com", Name: "example.com"}
+	h := &domainHandler{cfg: DomainHandlerConfig{
+		AppInstalls: chownAppInstallsRepo{},
+		Domains:     &chownDomainsRepo{byID: dom},
+		Users:       chownUsersRepo{byID: map[string]*models.User{}}, // new owner absent
+	}}
+	c, w := chownCtx(recentAdmin(), "d1", `{"new_owner_id":"ghost"}`)
+	h.chown(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "new owner not found")
+}
+
+func TestChown_SurfacesAppInstallRefusal(t *testing.T) {
+	uid := uint32(1002)
+	dom := &models.Domain{ID: "d1", UserID: "old", DocRoot: "/home/alice/example.com", Name: "example.com"}
+	newOwner := &models.User{ID: "new", Username: rsp("bob"), LinuxUID: &uid}
+	h := &domainHandler{cfg: DomainHandlerConfig{
+		// Non-WP app: the refusal is app-type-agnostic — FindByDomainID queries
+		// the unified application_installs table with no app_type filter, so any
+		// catalog app (Drupal, Moodle, …) is covered, not just WordPress.
+		AppInstalls: chownAppInstallsRepo{install: &models.ApplicationInstall{AppType: "drupal"}},
+		Domains:     &chownDomainsRepo{byID: dom},
+		Users:       chownUsersRepo{byID: map[string]*models.User{"new": newOwner}},
+		Agent:       renameStubAgent{},
+	}}
+	c, w := chownCtx(recentAdmin(), "d1", `{"new_owner_id":"new"}`)
+	h.chown(c)
+	// Refused before the agent moves anything → 422 with the user-actionable reason.
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assert.Contains(t, w.Body.String(), "chown_failed")
+	assert.Contains(t, w.Body.String(), "app install")
+}
+
+func TestChown_HappyPath(t *testing.T) {
+	uid := uint32(1002)
+	dom := &models.Domain{ID: "d1", UserID: "old", DocRoot: "/home/alice/example.com", Name: "example.com"}
+	oldOwner := &models.User{ID: "old", Username: rsp("alice")}
+	newOwner := &models.User{ID: "new", Username: rsp("bob"), LinuxUID: &uid}
+	domains := &chownDomainsRepo{byID: dom}
+	h := &domainHandler{cfg: DomainHandlerConfig{
+		AppInstalls: chownAppInstallsRepo{}, // no install → not refused
+		Domains:     domains,
+		Users:       chownUsersRepo{byID: map[string]*models.User{"new": newOwner, "old": oldOwner}},
+		Agent:       renameStubAgent{},
+	}}
+	c, w := chownCtx(recentAdmin(), "d1", `{"new_owner_id":"new"}`)
+	h.chown(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, domains.transferCalls)
+	assert.Contains(t, w.Body.String(), `"user_id":"new"`)
+	assert.Contains(t, w.Body.String(), "/home/bob/example.com")
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5910,6 +5910,25 @@ paths:
         "404": { description: User not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "422": { description: Rename refused — invalid name, a v1 refusal (FTP subaccounts / Python apps / cross-filesystem), or the name is taken, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
 
+  /admin/domains/{id}/chown:
+    post:
+      tags: [Domains]
+      summary: Reassign a domain to a new tenant in place (admin, JAB-380 step-up, GH #1238)
+      description: |
+        Moves + re-owns the docroot to the new owner and repoints the domain row.
+        The domain_id is preserved, so tombstones, the SSL lineage, the DNS zone,
+        and mailboxes stay. v1 refuses a domain that has an app install (its config
+        carries the current owner's database credentials).
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { new_owner_id: { type: string } }, required: [new_owner_id] } } } }
+      responses:
+        "200": { description: Reassigned, content: { application/json: { schema: { type: object, properties: { id: { type: string }, user_id: { type: string }, doc_root: { type: string } } } } } }
+        "403": { description: Recent-auth step-up required (JAB-380), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "404": { description: Domain or new owner not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "422": { description: Change refused — new owner is not a tenant, is already the owner, the domain has an app install, or the docroot is outside the owner's home, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "503": { description: Change-owner not available (app-install repository not wired), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
   /me/ssh-forwarding:
     get:
       tags: [Users]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -715,6 +715,12 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// dropped from GET.
 				ManagedIPs:     deps.ManagedIPs,
 				ServerSettings: deps.ServerSettings,
+				// GH #1238 change-owner (admin, JAB-380 step-up): AppInstalls
+				// arms the cross-tenant-credential refusal, AuditEvents records
+				// it, KratosClient gates the step-up.
+				AppInstalls:  deps.WordPressInstalls,
+				AuditEvents:  repository.NewAuditEventRepository(deps.DB),
+				KratosClient: deps.KratosClient,
 			})
 		}
 		// M36 — per-domain IP allow/deny lists.

--- a/panel-ui/src/components/domains/DomainInventory.tsx
+++ b/panel-ui/src/components/domains/DomainInventory.tsx
@@ -31,6 +31,7 @@ import { DomainIndexButton } from "../../shells/DomainIndexButton";
 import { DomainInfoButton } from "../../shells/DomainInfoButton";
 import { DomainSettingsButton, TenantNginxRulesButton } from "../../shells/DomainSettingsButton";
 import { DomainDocRootModal } from "./DomainDocRootModal";
+import { DomainChownAction } from "../../shells/admin/domains/DomainChownAction";
 
 import { buildDomainDataColumns, type DomainInventoryAudience } from "./domainColumns";
 import { buildDomainMenuItems, type DomainModalType } from "./domainActions";
@@ -225,6 +226,9 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
               currentDocRoot={r.doc_root}
               onClose={() => setActiveModal(null)}
             />
+          )}
+          {activeModal?.domainId === r.id && activeModal.type === "chown" && (
+            <DomainChownAction domain={r} open={true} onClose={() => setActiveModal(null)} />
           )}
         </Space>
       ),

--- a/panel-ui/src/components/domains/domainActions.test.tsx
+++ b/panel-ui/src/components/domains/domainActions.test.tsx
@@ -45,7 +45,7 @@ describe("buildDomainMenuItems — admin audience", () => {
 
   it("offers the admin item set and none of the tenant-only actions", () => {
     const k = keys(buildDomainMenuItems(row(), ctx({ audience: admin, caps: { dns_enabled: true } })));
-    expect(k).toEqual(["edit", "dns", "info", "redirects", "index", "settings", "caching", "toggle", "delete"]);
+    expect(k).toEqual(["edit", "dns", "info", "redirects", "index", "settings", "caching", "chown", "toggle", "delete"]);
     // tenant-only actions never appear on the admin list
     for (const t of ["directory-privacy", "nginx-options", "rewrite-rules", "document-root", "preview-url", "bot-challenge"]) {
       expect(k).not.toContain(t);

--- a/panel-ui/src/components/domains/domainActions.tsx
+++ b/panel-ui/src/components/domains/domainActions.tsx
@@ -19,6 +19,7 @@ import {
   SafetyOutlined,
   SettingOutlined,
   SwapOutlined,
+  TeamOutlined,
   ThunderboltOutlined,
   ToolOutlined,
 } from "@icons";
@@ -35,7 +36,8 @@ export type DomainModalType =
   | "directory-privacy"
   | "nginx-options"
   | "rewrite-rules"
-  | "document-root";
+  | "document-root"
+  | "chown";
 
 export type DomainMenuCaps =
   | {
@@ -139,6 +141,14 @@ export function buildDomainMenuItems(r: Domain, ctx: DomainMenuCtx): MenuProps["
         icon: <ThunderboltOutlined />,
         label: "Caching",
         onClick: () => onOpenModal(r.id, "caching"),
+      },
+      // GH #1238: reassign the domain to a new tenant. Admin-only; the modal's
+      // POST is behind the JAB-380 step-up.
+      {
+        key: "chown",
+        icon: <TeamOutlined />,
+        label: "Change owner",
+        onClick: () => onOpenModal(r.id, "chown"),
       },
       toggleItem,
       ...deleteItems,

--- a/panel-ui/src/shells/admin/domains/DomainChownAction.test.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainChownAction.test.tsx
@@ -1,0 +1,91 @@
+// GH #1238 — admin change-owner modal. Pins that the owner picker lists only
+// selectable tenants (not admins, not the current owner) and that confirming
+// POSTs to the admin endpoint. apiClient.get (users list) + post are mocked.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+import { apiClient } from "../../../apiClient";
+import { DomainChownAction } from "./DomainChownAction";
+import type { Domain } from "../../../components/domains/types";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+const domain: Domain = {
+  id: "d1",
+  user_id: "old",
+  name: "example.com",
+  doc_root: "/home/alice/example.com",
+  is_enabled: true,
+  nginx_custom_directives: "",
+  created_at: "",
+  updated_at: "",
+};
+
+const usersPayload = {
+  data: {
+    data: [
+      { id: "new", username: "bob", is_admin: false, linux_uid: 1002 },
+      { id: "old", username: "alice", is_admin: false, linux_uid: 1001 },
+      { id: "adm", username: "root", is_admin: true, linux_uid: 0 },
+    ],
+    total: 3,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  mocked.get.mockReset();
+  mocked.post.mockReset();
+});
+
+function renderModal() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <DomainChownAction domain={domain} open onClose={() => {}} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+describe("GH #1238 — DomainChownAction", () => {
+  it("gates the button on a chosen owner and POSTs the new_owner_id on confirm", async () => {
+    mocked.get.mockResolvedValue(usersPayload);
+    renderModal();
+    await screen.findByText("New owner");
+
+    const okBtn = () => screen.getByRole("button", { name: /^Change owner$/ });
+    // No owner picked → disabled.
+    expect(okBtn()).toBeDisabled();
+
+    // Open the picker and choose the only selectable tenant (bob). AntD Select
+    // = mouseDown the combobox to open, then click the option text.
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    const option = await screen.findByText("bob");
+    fireEvent.click(option);
+
+    // The current owner (alice) and the admin (root) are not offered.
+    expect(screen.queryByText("alice")).toBeNull();
+    expect(screen.queryByText("root")).toBeNull();
+
+    expect(okBtn()).not.toBeDisabled();
+
+    mocked.post.mockResolvedValue({ data: {} });
+    fireEvent.click(okBtn());
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/admin/domains/d1/chown", {
+        new_owner_id: "new",
+      }),
+    );
+  });
+});

--- a/panel-ui/src/shells/admin/domains/DomainChownAction.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainChownAction.tsx
@@ -1,0 +1,151 @@
+// DomainChownAction — controlled modal that reassigns a domain to a new tenant
+// (GH #1238, WebUI for `jabali domain chown`).
+//
+// The domain_id is preserved, so the SSL lineage, DNS zone, tombstones and
+// mailboxes stay; the docroot is moved into the new owner's home and re-owned
+// to their uid, and the vhost re-renders on the reconciler's next tick.
+// POST /admin/domains/:id/chown is admin-only AND behind the JAB-380 step-up —
+// a stale session gets a 403 that apiClient turns into a re-auth + retry.
+//
+// v1 refuses a domain that has an app install (its config carries the current
+// owner's DB credentials → cross-tenant leak). The backend returns that as a
+// 422 with a `detail` message, which we surface verbatim.
+import { useMemo, useState } from "react";
+import { Alert, Form, Modal, Select, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../../apiClient";
+import { useListQuery } from "../../../hooks/useQueries";
+import type { Domain } from "../../../components/domains/types";
+
+// The subset of the /users list payload the picker needs.
+type PickableUser = {
+  id: string;
+  username?: string | null;
+  is_admin?: boolean;
+  linux_uid?: number | null;
+};
+
+interface DomainChownActionProps {
+  domain: Domain;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const DomainChownAction = ({ domain, open, onClose }: DomainChownActionProps) => {
+  const qc = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [newOwnerId, setNewOwnerId] = useState<string | undefined>(undefined);
+
+  // Fetch tenants for the picker. The backend is the real gate (it refuses a
+  // non-tenant, an unprovisioned account, or the current owner); the client
+  // filter is just to keep obviously-invalid choices out of the list.
+  const usersQ = useListQuery<PickableUser>({
+    resource: "users",
+    // Scope the fetch to tenants server-side (the list handler honours
+    // ?is_admin=false) so the page cap isn't spent on admin rows we'd filter
+    // out anyway.
+    params: { pageSize: 200, is_admin: false },
+    enabled: open,
+  });
+
+  const options = useMemo(
+    () =>
+      usersQ.items
+        .filter((u) => !u.is_admin && u.id !== domain.user_id)
+        .map((u) => ({
+          value: u.id,
+          // An account without a linux_uid isn't fully provisioned yet — the
+          // backend would 422 it, so disable it and say why.
+          disabled: u.linux_uid == null,
+          label:
+            (u.username ?? u.id) + (u.linux_uid == null ? " (not provisioned yet)" : ""),
+        })),
+    [usersQ.items, domain.user_id],
+  );
+
+  const okDisabled = !newOwnerId;
+
+  const handleClose = () => {
+    setNewOwnerId(undefined);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!newOwnerId) return;
+    setIsLoading(true);
+    try {
+      await apiClient.post(`/admin/domains/${encodeURIComponent(domain.id)}/chown`, {
+        new_owner_id: newOwnerId,
+      });
+      feedback.message.success(
+        `Reassigned "${domain.name}". Its site re-renders under the new owner within about a minute.`,
+      );
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      handleClose();
+    } catch (err: unknown) {
+      // 403 stepup_required is handled globally (apiClient redirects to re-auth).
+      const errMsg =
+        (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data
+          ?.detail ??
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        (err instanceof Error ? err.message : "Change owner failed");
+      feedback.message.error(errMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Change owner"
+      open={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText="Change owner"
+      okButtonProps={{ danger: true, disabled: okDisabled }}
+      confirmLoading={isLoading}
+      destroyOnHidden
+    >
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        Reassigns <b>{domain.name}</b> to another tenant. The document root moves
+        into the new owner's home and is re-owned to their user; the domain keeps
+        its SSL, DNS and mail. The site re-renders under the new owner within
+        about a minute.
+      </Typography.Paragraph>
+
+      <Form layout="vertical">
+        <Form.Item label="New owner">
+          <Select
+            autoFocus
+            showSearch
+            placeholder="Select a tenant"
+            value={newOwnerId}
+            loading={usersQ.isLoading}
+            options={options}
+            optionFilterProp="label"
+            onChange={(v: string) => setNewOwnerId(v)}
+          />
+        </Form.Item>
+      </Form>
+
+      <Alert
+        type="warning"
+        showIcon
+        message="Before you change the owner"
+        description={
+          <ul style={{ margin: 0, paddingInlineStart: 18 }}>
+            <li>
+              Refused (v1) if the domain has an <b>app install</b> (e.g. WordPress) —
+              its config holds the current owner's database credentials. Detach or
+              migrate the app + its database to the new owner first.
+            </li>
+            <li>The files move to the new owner's home and are re-owned to their user.</li>
+            <li>You'll be asked to re-authenticate the first time in a session.</li>
+          </ul>
+        }
+      />
+    </Modal>
+  );
+};


### PR DESCRIPTION
## Summary

The last open piece of GH #1238 (rename tenant + reassign a domain's owner): the
**admin "Change owner" WebUI**. The heavy lifting — `userops.ChangeDomainOwner`
and the `jabali domain chown` CLI — shipped in #1306; this exposes the same
shared function over an HTTP route + a row action, mirroring the user-rename
WebUI (#1346).

## Backend

- `POST /admin/domains/:id/chown {new_owner_id}` — a thin handler over
  `userops.ChangeDomainOwner` (no new business logic; userops untouched).
- Admin-only **and** behind the JAB-380 recent-auth step-up (it moves files and
  hands them to another tenant) — same gate as rename / the root File Manager.
- `DomainHandlerConfig` widened with `AppInstalls`, `AuditEvents`,
  `KratosClient`, wired in `app.go` from the same instances the user routes use.
- **Fail-closed** on the security check: the cross-tenant-credential refusal (a
  domain with an app install carries the current owner's DB creds) lives in
  userops behind `AppInstalls`; the handler returns **503** when `AppInstalls`
  is unwired rather than let it silently skip. The refusal is **catalog-wide** —
  `FindByDomainID` queries the unified `application_installs` table with no
  `app_type` filter, so Drupal/Moodle/etc. are covered, not just WordPress (the
  test uses a non-WP `app_type` to pin this).
- **Typed-nil guard** on the reconciler: a nil `*reconciler.Reconciler` assigned
  to the `ChownReconciler` interface would be non-nil and panic in `Schedule`;
  only wired when set. Unlike rename (nil), chown passes it — `Schedule` is a
  non-blocking enqueue, so the vhost/PHP-pool re-render happens promptly without
  blocking the request.
- Audited `admin.domain.chown` (subject = old owner; new owner + docroot move in
  meta). Documented in `openapi.yaml` (route-coverage golden unchanged).

## Frontend

- Admin-only **"Change owner"** row action (audience-gated in the shared
  `domainActions` builder) opening `DomainChownAction` — a tenant picker that
  excludes admins (server-side `?is_admin=false` + client filter) and the
  current owner, disables unprovisioned accounts, and warns about the app-install
  refusal. Confirm POSTs the endpoint; 403 step-up is handled globally.

## Scope / parity note

Coverage mirrors the shipped `userops.ChangeDomainOwner` / `#1306` CLI exactly —
the WebUI adds no new refusals and no new security surface. Python apps are
tracked in a separate repo and (as in the CLI today) are not part of the
app-install refusal; that is a userops-level decision, left unchanged here so
the CLI and WebUI can't diverge.

## Test plan

- [x] `go build ./panel-api/...`, `go vet` clean.
- [x] Full `go test ./panel-api/...` green (incl. `TestOpenAPICoverage`,
      `cli_reference_test` — no cobra command added, CLI golden intact).
- [x] Handler tests: step-up-when-stale (403), fail-closed AppInstalls (503),
      invalid/missing body (400), domain/owner not-found (404), app-install
      refusal (422, non-WP), happy path (200, TransferOwner called).
- [x] `tsc -b`, `eslint`, and the domains vitest suites green; the picker
      excludes admins + current owner and POSTs `new_owner_id`.
- [x] Rebased onto latest `origin/main` (#1544); re-ran backend + frontend.
- [ ] Box drill (.60): deploy panel + confirm route mounted + gated (401 not
      404), then a real reassign (files move + re-owned, vhost `root /home/<new>`).

Finishes GH #1238.