### PR TITLE
fix(panel-cert): don't cascade the panel mail cert on a hostname change (JAB-389)

### DIFF
--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -436,7 +436,15 @@ func panelCertSyntheticRows(ctx context.Context, cfg SSLHandlerConfig) []reposit
 		}
 		domainName := primary.Name
 		if pc.Kind == models.PanelCertKindMail {
+			// Show the name the mail cert was actually pursued for. Since
+			// JAB-389 the mail row stays pinned to the hostname it was seeded
+			// with and no longer follows a panel access-hostname change, so
+			// the stored pc.Hostname — not a fresh derivation from the current
+			// panel primary — is the truthful label.
 			domainName = models.PanelMailHostname(primary.Name)
+			if pc.Hostname != "" {
+				domainName = pc.Hostname
+			}
 		}
 		out = append(out, repository.SSLCertificateWithDomain{
 			ID:           "panel-cert:" + pc.Kind,

--- a/panel-api/internal/repository/panel_certificate_repository.go
+++ b/panel-api/internal/repository/panel_certificate_repository.go
@@ -74,10 +74,14 @@ func (r *panelCertRepo) ListAll(ctx context.Context) ([]*models.PanelCertificate
 	return rows, nil
 }
 
-func (r *panelCertRepo) ensureOne(ctx context.Context, kind, hostname string) (*models.PanelCertificate, error) {
+// ensureOne loads (or creates) the row for kind. When the row already
+// exists and renameOnDrift is true, its hostname is re-synced to the
+// current value on drift; when renameOnDrift is false the existing
+// hostname is left exactly as seeded (JAB-389 — see EnsureDefault).
+func (r *panelCertRepo) ensureOne(ctx context.Context, kind, hostname string, renameOnDrift bool) (*models.PanelCertificate, error) {
 	existing, err := r.GetByKind(ctx, kind)
 	if err == nil {
-		if existing.Hostname != hostname && hostname != "" {
+		if renameOnDrift && existing.Hostname != hostname && hostname != "" {
 			existing.Hostname = hostname
 			if uerr := r.Upsert(ctx, existing); uerr != nil {
 				return nil, uerr
@@ -102,11 +106,20 @@ func (r *panelCertRepo) ensureOne(ctx context.Context, kind, hostname string) (*
 }
 
 func (r *panelCertRepo) EnsureDefault(ctx context.Context, hostname string) (*models.PanelCertificate, error) {
-	host, err := r.ensureOne(ctx, models.PanelCertKindHostname, hostname)
+	// The hostname cert tracks the panel FQDN: on a hostname change it must
+	// follow so the panel keeps serving a cert for the name it answers on.
+	host, err := r.ensureOne(ctx, models.PanelCertKindHostname, hostname, true)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := r.ensureOne(ctx, models.PanelCertKindMail, models.PanelMailHostname(hostname)); err != nil {
+	// JAB-389: the mail cert is SEEDED from the panel hostname at creation
+	// (mail.<hostname>) but is never renamed afterwards. Changing the panel
+	// access hostname must not silently cascade the panel mail cert to
+	// mail.<new-fqdn> and start pursuing a new Let's Encrypt cert for it —
+	// the operator may deliberately keep mail on the original name. The mail
+	// identity stays pinned to whatever it was seeded with; changing it is a
+	// separate, deliberate action (JAB-390), not a side effect of a rename.
+	if _, err := r.ensureOne(ctx, models.PanelCertKindMail, models.PanelMailHostname(hostname), false); err != nil {
 		return nil, err
 	}
 	return host, nil

--- a/panel-api/internal/repository/panel_certificate_repository_test.go
+++ b/panel-api/internal/repository/panel_certificate_repository_test.go
@@ -73,6 +73,46 @@ func TestPanelCert_EnsureDefault_CreatesBothKinds(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestPanelCert_EnsureDefault_DoesNotRenameMailRow is the JAB-389 guard:
+// when the panel hostname changes and both rows already exist, the hostname
+// row is re-synced to the new FQDN (so the panel cert follows) but the mail
+// row is left exactly as seeded — no silent cascade to mail.<new-fqdn>.
+//
+// The assertion is structural: sqlmock runs in strict-ordered mode, so the
+// only writes it tolerates are the hostname row's re-sync. If ensureOne ever
+// renamed the mail row, its SELECT+UPDATE would have no matching expectation
+// and the test fails. Reverting the renameOnDrift guard reds this test.
+func TestPanelCert_EnsureDefault_DoesNotRenameMailRow(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewPanelCertificateRepository(gdb)
+
+	hostRow := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"kind", "id", "hostname", "status", "cert_pem_path"}).
+			AddRow("hostname", 1, "old.example.com", "issued", "/etc/jabali/tls/panel.crt")
+	}
+
+	// hostname kind exists at the OLD name -> drift -> re-synced to the new FQDN.
+	mock.ExpectQuery(pcSelect).WithArgs("hostname", 1).WillReturnRows(hostRow())
+	// Upsert re-reads the row, then updates it.
+	mock.ExpectQuery(pcSelect).WithArgs("hostname", 1).WillReturnRows(hostRow())
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .panel_certificate. SET .* WHERE kind = ?`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	// mail kind exists at the ORIGINAL mail name. No UPDATE is expected: the
+	// derived mail.new.example.com differs, but the mail row is never renamed.
+	mock.ExpectQuery(pcSelect).WithArgs("mail", 1).WillReturnRows(
+		sqlmock.NewRows([]string{"kind", "id", "hostname", "status", "cert_pem_path"}).
+			AddRow("mail", 1, "mail.old.example.com", "issued", "/etc/jabali/tls/panel-mail.crt"))
+
+	host, err := repo.EnsureDefault(context.Background(), "new.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "new.example.com", host.Hostname, "hostname row must follow the FQDN change")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPanelCert_ListAll(t *testing.T) {
 	t.Parallel()
 	gdb, mock, raw := newMockDB(t)


### PR DESCRIPTION
## What & why

JAB-389 defect 2: changing the panel access hostname silently cascaded the panel's own mail certificate to `mail.<new-fqdn>`. On the reporter's box, renaming `aramapp.com → mx.aramapp.com` renamed the panel mail cert `mail.aramapp.com → mail.mx.aramapp.com`, and the panel-cert reconciler then began pursuing a fresh Let's Encrypt cert for the new name — even though the operator deliberately kept mail on `mail.aramapp.com` (the hosted domain's own mail vhost correctly stayed there). There was no way to keep the panel mail hostname decoupled from the access FQDN.

Root cause: `EnsureDefault` re-derives the `kind=mail` row's hostname from the current FQDN (`PanelMailHostname(hostname)`) on every reconcile tick, and `ensureOne` re-synced any drift onto the row. The reconciler uses `row.Hostname` as the cert subject, so the rename directly drove a new issuance.

## Fix

`ensureOne` gains a `renameOnDrift` flag:

- **hostname cert** — `renameOnDrift = true`. It must keep following the FQDN so the panel serves a cert for the name it answers on (this is defect 1's correct behavior; the self-signed regeneration itself already shipped in #1351).
- **mail cert** — `renameOnDrift = false`. Seeded from the panel hostname at creation (`mail.<hostname>`), never renamed afterwards. A panel access-hostname change no longer touches it. Changing the mail identity stays a separate, deliberate action (JAB-390), not a side effect of a rename.

Second commit: the admin SSL table's synthetic mail row derived its label from the *current* panel primary, which was truthful only because the row used to be re-synced every tick. With the row now pinned, that display would mislabel a kept `mail.<old>` cert as `mail.<new>` — telling the operator the wrong name has a cert. It now shows the stored `pc.Hostname` (the name the cert was actually pursued for).

## Scope — what this PR does and does not close

JAB-389 lists **two** defects. This PR closes defect 2. Defect 1 status:

- **Self-signed panel cert regeneration on `:8443`** — already shipped in #1351 (`reconcilePanelSelfSignedCert` + the `ssl.panel.selfsign` agent verb; drilled on the .86 box). The panel now regenerates its self-signed cert for the new FQDN independent of Let's Encrypt.
- **`:8443` `server_name`** — the panel API vhost is `server_name _;` (`install/nginx/jabali-panel-vhost.conf.tmpl:34`), a catch-all that already matches any hostname, so there is nothing to re-render there.
- **The `:443` branded landing / default vhost `server_name`** (`install.sh:7820`, `server_name ${JABALI_SRV_HOSTNAME}` + the `/var/www/<hostname>` docroot) — this is the "nginx panel default vhost server_name stayed aramapp.com" the reporter observed, and it is **still open**. It is template-owned by install.sh and porting it to a live agent verb + reconciler (plus the docroot rename) is its own slice with real drift risk. **JAB-389 stays open for this remaining item.**

## Not box-drilled — and why

No box drill for this change. The diff is a boolean guard at a private repository seam; the sqlmock test asserts the exact SQL the reconciler emits through the real gorm/MySQL dialect and reds on revert. A live hostname flip would primarily re-exercise #1351's already-drilled self-signed regen + panel restart (not this diff) and risks the kratos lockout noted below — marginal evidence for real disruption. The falsified unit test is the coverage.

## Follow-ups surfaced (not filed — operator's call)

- **kratos.yml is not regenerated on a hostname change → full login lockout.** Rendered only by install.sh from `install/kratos.yml.tmpl` (install / `jabali update`); `system.set_hostname` doesn't touch it, so `base_url` / `allowed_origins` / return URLs keep the old FQDN and the SPA can't reach the identity service after a rename. This is the most severe gap around hostname changes and deserves its own high-priority ticket.
- `system_set_hostname.go:66-68` appends `127.0.1.1 <hostname>` to `/etc/hosts`, which can shadow public DNS and block Let's Encrypt routability for the new name.
- The `:443` landing/default vhost re-render above.
- `panel_certificate_reconciler.go:71-75` gates mail issuance on whether email is enabled for `settings.Hostname`'s domain, not the pinned mail row's domain; with pinning this can idle a fresh `mail.<old>` issuance if email isn't enabled on the new primary. Pre-existing, affects only pending rows.

## Test plan

- [x] `go build ./...` (panel-api) — clean; no other caller of `ensureOne` (both are in `EnsureDefault`)
- [x] `go vet ./internal/repository/ ./internal/reconciler/` — clean
- [x] `go test -race ./internal/repository/ ./internal/api/` — pass
- [x] New guard `TestPanelCert_EnsureDefault_DoesNotRenameMailRow`: asserts `EnsureDefault` re-syncs the hostname row but issues no write against the mail row on an FQDN change (sqlmock strict-ordered)
- [x] Falsified: reverting the `renameOnDrift` guard reds the new test with the unexpected mail-row query
- [x] rebased onto latest `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
