### PR TITLE
fix(databases): hide inert PostgreSQL grant controls; canonicalise grant updates (GH #1415)

### DIFF
--- a/panel-api/internal/api/database_users.go
+++ b/panel-api/internal/api/database_users.go
@@ -172,6 +172,21 @@ func CanonicalDBGrant(privileges []string, level string) (canonical, computedLev
 	return canonical, computedLevel, nil
 }
 
+// coerceEngineGrant collapses a PostgreSQL grant to full access (rw/ALL)
+// regardless of the requested level. The agent runs GRANT ALL on the target
+// database (ADR-0091 / GH #1406) — read-only and per-privilege grants aren't
+// honoured — so storing anything else would leave a label that lies about the
+// access actually held (GH #1415). The admin UI already hides those controls
+// for postgres; coercing here (rather than rejecting) keeps the stored label
+// honest for any direct API caller too, without breaking one that still passes
+// a level. MariaDB is unchanged.
+func coerceEngineGrant(engine, canonical, level string) (string, string) {
+	if engine == "postgres" {
+		return "ALL", "rw"
+	}
+	return canonical, level
+}
+
 // ---- Request/Response types ----
 
 type createDatabaseUserRequest struct {
@@ -610,6 +625,8 @@ func (h *databaseUserHandler) addGrant(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
+	// A postgres grant is always full-access whatever level was requested.
+	canonicalPrivileges, computedGrantLevel = coerceEngineGrant(du.Engine, canonicalPrivileges, computedGrantLevel)
 
 	db, err := h.cfg.Databases.FindByID(ctx, req.DatabaseID)
 	if err != nil {
@@ -953,28 +970,12 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 		return
 	}
 
-	// Determine privileges to use: either from privileges array or fallback to grant_level.
-	var canonicalPrivileges string
-	if len(req.Privileges) > 0 {
-		// Validate and normalize privileges.
-		var err error
-		canonicalPrivileges, err = privilegesToCanonicalString(req.Privileges)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_privileges", "detail": err.Error()})
-			return
-		}
-	} else if req.GrantLevel != "" {
-		// Legacy path: translate grant_level to privileges.
-		if req.GrantLevel == "rw" {
-			canonicalPrivileges = "ALL"
-		} else if req.GrantLevel == "ro" {
-			canonicalPrivileges = "SELECT"
-		} else {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grant_level", "detail": "grant_level must be 'rw' or 'ro'"})
-			return
-		}
-	} else {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "missing_privileges", "detail": "either privileges or grant_level must be provided"})
+	// Canonicalise the privilege set + compute the stored grant_level via the
+	// shared helper (GH #1415) so this PATCH path validates and normalises
+	// exactly like addGrant + the operator CLI and can never drift.
+	canonicalPrivileges, computedGrantLevel, err := CanonicalDBGrant(req.Privileges, req.GrantLevel)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grant", "detail": err.Error()})
 		return
 	}
 
@@ -1001,9 +1002,13 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
+	// A postgres grant is always full-access whatever level was requested.
+	canonicalPrivileges, computedGrantLevel = coerceEngineGrant(du.Engine, canonicalPrivileges, computedGrantLevel)
 
-	// No-op: same privileges
-	if grant.Privileges == canonicalPrivileges {
+	// No-op only when both the privilege set AND the stored level already match
+	// — a row whose grant_level drifted from its privileges (e.g. an old
+	// custom-stamped PG grant) must fall through so UpdateLevel repairs it.
+	if grant.Privileges == canonicalPrivileges && grant.GrantLevel == computedGrantLevel {
 		c.JSON(http.StatusOK, grantResponse{
 			ID:           grant.ID,
 			DatabaseID:   grant.DatabaseID,
@@ -1039,7 +1044,10 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 		_, err = h.cfg.Agent.Call(agentCtx, "db_user.revoke", map[string]any{
 			"db_name":      db.Name,
 			"db_user_name": du.Username,
-			"grant_level":  grant.GrantLevel,
+			// Revoke the OLD grant by its stored privileges. grant_level is
+			// "custom" for granular grants, which the agent's legacy fallback
+			// rejects — sending privileges mirrors addGrant (GH #1415).
+			"privileges": strings.Split(grant.Privileges, ","),
 		})
 	}
 	if err != nil {
@@ -1060,7 +1068,10 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 		_, err = h.cfg.Agent.Call(agentCtx, "db_user.grant", map[string]any{
 			"db_name":      db.Name,
 			"db_user_name": du.Username,
-			"grant_level":  req.GrantLevel,
+			// Grant the canonical privilege set. req.GrantLevel is empty when
+			// the request carried a privileges array, which would send an
+			// empty grant to the agent — mirror addGrant (GH #1415).
+			"privileges": strings.Split(canonicalPrivileges, ","),
 		})
 	}
 	if err != nil {
@@ -1086,6 +1097,13 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 
 	// Update privileges in database
 	if err := h.cfg.DatabaseGrants.UpdatePrivileges(ctx, grant.ID, canonicalPrivileges); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	// UpdatePrivileges hard-codes grant_level="custom"; persist the computed
+	// level so the stored label matches the privilege set (rw for ALL, ro for
+	// SELECT), instead of always reading back "custom" (GH #1415).
+	if err := h.cfg.DatabaseGrants.UpdateLevel(ctx, grant.ID, computedGrantLevel); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}

--- a/panel-api/internal/api/database_users_grant_update_test.go
+++ b/panel-api/internal/api/database_users_grant_update_test.go
@@ -1,0 +1,249 @@
+package api
+
+// GH #1415 — the PATCH /database-user-grants/:id path used to hand-roll its own
+// privilege validation, send the request's (often empty) grant_level to the
+// agent, and persist only privileges — leaving grant_level stuck at "custom".
+// These tests pin the fixed behaviour: it now mirrors addGrant via
+// CanonicalDBGrant, grants/revokes by the canonical privilege set, and persists
+// the computed level.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type guAgentCall struct {
+	cmd    string
+	params map[string]any
+}
+
+type guCapturingAgent struct{ calls []guAgentCall }
+
+func (a *guCapturingAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	m, _ := params.(map[string]any)
+	a.calls = append(a.calls, guAgentCall{cmd: cmd, params: m})
+	return json.RawMessage(`{}`), nil
+}
+
+func (a *guCapturingAgent) find(cmd string) (map[string]any, bool) {
+	for _, c := range a.calls {
+		if c.cmd == cmd {
+			return c.params, true
+		}
+	}
+	return nil, false
+}
+
+type guGrantsRepo struct {
+	repository.DatabaseUserGrantRepository
+	grant          *models.DatabaseUserGrant
+	created        *models.DatabaseUserGrant
+	updatedPrivs   string
+	updatedLevel   string
+	updatedLevelOK bool
+}
+
+func (r *guGrantsRepo) FindByID(_ context.Context, _ string) (*models.DatabaseUserGrant, error) {
+	g := *r.grant
+	return &g, nil
+}
+
+func (r *guGrantsRepo) FindByDBAndDBUser(_ context.Context, _, _ string) (*models.DatabaseUserGrant, error) {
+	return nil, nil // no existing grant — addGrant proceeds
+}
+
+func (r *guGrantsRepo) Create(_ context.Context, g *models.DatabaseUserGrant) error {
+	r.created = g
+	return nil
+}
+
+func (r *guGrantsRepo) UpdatePrivileges(_ context.Context, _, privileges string) error {
+	r.updatedPrivs = privileges
+	// Mirror the real repo, which stamps grant_level="custom" on a privilege
+	// update regardless of the actual set.
+	r.grant.Privileges = privileges
+	r.grant.GrantLevel = "custom"
+	return nil
+}
+
+func (r *guGrantsRepo) UpdateLevel(_ context.Context, _, level string) error {
+	r.updatedLevel = level
+	r.updatedLevelOK = true
+	r.grant.GrantLevel = level
+	return nil
+}
+
+type guDBUsersRepo struct {
+	repository.DatabaseUserRepository
+	du *models.DatabaseUser
+}
+
+func (r *guDBUsersRepo) FindByID(_ context.Context, _ string) (*models.DatabaseUser, error) {
+	return r.du, nil
+}
+
+type guDatabasesRepo struct {
+	repository.DatabaseRepository
+	db *models.Database
+}
+
+func (r *guDatabasesRepo) FindByID(_ context.Context, _ string) (*models.Database, error) {
+	return r.db, nil
+}
+
+func guHandler(ag *guCapturingAgent, grant *models.DatabaseUserGrant, engine string) (*databaseUserHandler, *guGrantsRepo) {
+	gr := &guGrantsRepo{grant: grant}
+	h := &databaseUserHandler{cfg: DatabaseUserHandlerConfig{
+		DatabaseGrants: gr,
+		DatabaseUsers:  &guDBUsersRepo{du: &models.DatabaseUser{ID: "du1", UserID: "u1", Username: "app_user", Engine: engine}},
+		Databases:      &guDatabasesRepo{db: &models.Database{ID: "db1", UserID: "u1", Name: "app_db"}},
+		Agent:          ag,
+	}}
+	return h, gr
+}
+
+func patchGrant(h *databaseUserHandler, body string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "g1"}}
+	c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/database-user-grants/g1", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: true})
+	h.updateGrant(c)
+	return w
+}
+
+func postGrant(h *databaseUserHandler, body string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "du1"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/database-users/du1/grants", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: true})
+	h.addGrant(c)
+	return w
+}
+
+// A custom-privileges PATCH on a MariaDB grant must grant/revoke by the
+// canonical privilege set — never the empty grant_level the request omits, and
+// never the stored "custom" level the agent's legacy fallback rejects.
+func TestUpdateGrant_MariaDB_Custom_GrantsByPrivileges(t *testing.T) {
+	ag := &guCapturingAgent{}
+	grant := &models.DatabaseUserGrant{ID: "g1", DatabaseID: "db1", DatabaseUserID: "du1", GrantLevel: "rw", Privileges: "ALL"}
+	h, gr := guHandler(ag, grant, "mariadb")
+
+	w := patchGrant(h, `{"privileges":["SELECT","INSERT"]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	gp, ok := ag.find("db_user.grant")
+	if !ok {
+		t.Fatal("expected a db_user.grant agent call")
+	}
+	if _, hasLevel := gp["grant_level"]; hasLevel {
+		t.Errorf("db_user.grant must not carry grant_level (the empty-level bug); params=%v", gp)
+	}
+	if privs, _ := gp["privileges"].([]string); strings.Join(privs, ",") != "SELECT,INSERT" {
+		t.Errorf("db_user.grant privileges = %v, want [SELECT INSERT]", gp["privileges"])
+	}
+
+	rp, ok := ag.find("db_user.revoke")
+	if !ok {
+		t.Fatal("expected a db_user.revoke agent call")
+	}
+	if _, hasLevel := rp["grant_level"]; hasLevel {
+		t.Errorf("db_user.revoke must not carry grant_level (rejected for custom); params=%v", rp)
+	}
+	if _, hasPrivs := rp["privileges"]; !hasPrivs {
+		t.Errorf("db_user.revoke must carry privileges; params=%v", rp)
+	}
+
+	if gr.updatedPrivs != "SELECT,INSERT" {
+		t.Errorf("persisted privileges = %q, want SELECT,INSERT", gr.updatedPrivs)
+	}
+	if !gr.updatedLevelOK || gr.updatedLevel != "custom" {
+		t.Errorf("persisted grant_level = %q (set=%v), want custom", gr.updatedLevel, gr.updatedLevelOK)
+	}
+}
+
+// A PATCH back to rw (ALL) on a currently-custom grant must persist grant_level
+// "rw", not the hard-coded "custom" UpdatePrivileges alone would leave behind.
+func TestUpdateGrant_MariaDB_RW_PersistsRWLevel(t *testing.T) {
+	ag := &guCapturingAgent{}
+	grant := &models.DatabaseUserGrant{ID: "g1", DatabaseID: "db1", DatabaseUserID: "du1", GrantLevel: "custom", Privileges: "SELECT,INSERT"}
+	h, gr := guHandler(ag, grant, "mariadb")
+
+	w := patchGrant(h, `{"grant_level":"rw"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !gr.updatedLevelOK || gr.updatedLevel != "rw" {
+		t.Errorf("persisted grant_level = %q (set=%v), want rw", gr.updatedLevel, gr.updatedLevelOK)
+	}
+	if gp, _ := ag.find("db_user.grant"); gp != nil {
+		if privs, _ := gp["privileges"].([]string); strings.Join(privs, ",") != "ALL" {
+			t.Errorf("db_user.grant privileges = %v, want [ALL]", gp["privileges"])
+		}
+	}
+}
+
+// A postgres grant is always full-access (the agent runs GRANT ALL), so a
+// PATCH asking for a lower level must still store rw/ALL — the label can't be
+// allowed to claim less access than the role actually holds (GH #1415).
+func TestUpdateGrant_Postgres_CoercedToFullAccess(t *testing.T) {
+	ag := &guCapturingAgent{}
+	// A pre-fix row: privileges already ALL but grant_level drifted to "ro".
+	grant := &models.DatabaseUserGrant{ID: "g1", DatabaseID: "db1", DatabaseUserID: "du1", GrantLevel: "ro", Privileges: "ALL"}
+	h, gr := guHandler(ag, grant, "postgres")
+
+	w := patchGrant(h, `{"grant_level":"ro"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	// Must not no-op on the stale label: the level is repaired to rw.
+	if !gr.updatedLevelOK || gr.updatedLevel != "rw" {
+		t.Errorf("persisted grant_level = %q (set=%v), want rw", gr.updatedLevel, gr.updatedLevelOK)
+	}
+	if gr.updatedPrivs != "ALL" {
+		t.Errorf("persisted privileges = %q, want ALL", gr.updatedPrivs)
+	}
+	// Postgres uses its own grant verb, never db_user.grant.
+	if _, ok := ag.find("db.postgres.grant"); !ok {
+		t.Errorf("expected db.postgres.grant; calls=%v", ag.calls)
+	}
+}
+
+// The same coercion on the creation path: an API caller adding a postgres grant
+// with a read-only request stores full access, matching what the agent does.
+func TestAddGrant_Postgres_CoercedToFullAccess(t *testing.T) {
+	ag := &guCapturingAgent{}
+	h, gr := guHandler(ag, &models.DatabaseUserGrant{}, "postgres")
+
+	w := postGrant(h, `{"database_id":"db1","grant_level":"ro"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if gr.created == nil {
+		t.Fatal("expected a grant to be created")
+	}
+	if gr.created.GrantLevel != "rw" || gr.created.Privileges != "ALL" {
+		t.Errorf("created grant = level %q privs %q, want rw/ALL", gr.created.GrantLevel, gr.created.Privileges)
+	}
+	if _, ok := ag.find("db.postgres.grant"); !ok {
+		t.Errorf("expected db.postgres.grant; calls=%v", ag.calls)
+	}
+}

--- a/panel-ui/src/components/AddGrantModal.test.tsx
+++ b/panel-ui/src/components/AddGrantModal.test.tsx
@@ -1,0 +1,86 @@
+// AddGrantModal.test.tsx — GH #1415.
+//
+// On PostgreSQL the agent runs GRANT ALL regardless of level (ADR-0091), so the
+// "Grant Type" / preset / custom-privilege controls are inert — a read-only or
+// per-privilege choice is silently upgraded to full access. The modal must hide
+// those controls for a postgres user and POST a fixed grant_level "rw", while
+// keeping the full choice for mariadb.
+import { App } from "antd";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AddGrantModal } from "./AddGrantModal";
+
+vi.mock("../apiClient", () => ({ apiClient: { post: vi.fn() } }));
+vi.mock("../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+vi.mock("../hooks/useQueries", () => ({ useListQuery: vi.fn() }));
+
+import { apiClient } from "../apiClient";
+import { useListQuery } from "../hooks/useQueries";
+
+const mockedPost = apiClient.post as unknown as ReturnType<typeof vi.fn>;
+const mockedList = useListQuery as unknown as ReturnType<typeof vi.fn>;
+
+type Db = { id: string; name: string; engine: "mariadb" | "postgres" };
+
+function renderModal(userEngine: "mariadb" | "postgres", items: Db[]) {
+  mockedList.mockReturnValue({ items, isLoading: false });
+  render(
+    <App>
+      <AddGrantModal
+        open
+        userId="du1"
+        username="app_user"
+        excludedDatabaseIds={[]}
+        userEngine={userEngine}
+        onClose={() => {}}
+        onSuccess={() => {}}
+      />
+    </App>,
+  );
+}
+
+describe("AddGrantModal PostgreSQL gate (GH #1415)", () => {
+  beforeEach(() => {
+    mockedPost.mockReset().mockResolvedValue({ data: {} });
+    mockedList.mockReset();
+  });
+
+  it("hides the inert grant controls and POSTs a fixed rw level for postgres", async () => {
+    renderModal("postgres", [{ id: "pg1", name: "pgdb", engine: "postgres" }]);
+
+    // The level/privilege controls must be gone — they aren't honoured on PG.
+    expect(screen.queryByText("Grant Type")).toBeNull();
+    expect(screen.queryByText("Custom Privileges")).toBeNull();
+    expect(screen.queryByText("Read Only (SELECT only)")).toBeNull();
+    // ...and the note explains why.
+    expect(screen.getByText(/full access to the selected database/i)).toBeTruthy();
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("pgdb"));
+    fireEvent.click(screen.getByRole("button", { name: "Grant Access" }));
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalled());
+    const [url, body] = mockedPost.mock.calls[0];
+    expect(url).toBe("/database-users/du1/grants");
+    expect(body).toEqual({ database_id: "pg1", grant_level: "rw" });
+  });
+
+  it("keeps the grant-type controls for mariadb", async () => {
+    renderModal("mariadb", [{ id: "m1", name: "mdb", engine: "mariadb" }]);
+
+    expect(screen.getByText("Grant Type")).toBeTruthy();
+    expect(screen.getByText("Preset Privileges")).toBeTruthy();
+    expect(screen.queryByText(/full access to the selected database/i)).toBeNull();
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("mdb"));
+    fireEvent.click(screen.getByRole("button", { name: "Grant Access" }));
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalled());
+    const [, body] = mockedPost.mock.calls[0];
+    expect(body).toEqual({ database_id: "m1", grant_level: "rw" });
+  });
+});

--- a/panel-ui/src/components/AddGrantModal.tsx
+++ b/panel-ui/src/components/AddGrantModal.tsx
@@ -48,6 +48,11 @@ export function AddGrantModal({
   const [form] = Form.useForm<AddGrantInput>();
   const [submitting, setSubmitting] = useState(false);
   const grantType = Form.useWatch("grantType", form);
+  // GH #1415: PostgreSQL grants are always full-access on the target database
+  // (ADR-0091 / GH #1406) — the agent runs GRANT ALL regardless of level, so
+  // read-only and per-privilege selections are inert. Hide those controls and
+  // send a fixed rw level rather than offering a choice that isn't honoured.
+  const isPostgres = userEngine === "postgres";
 
   // Fresh list of databases each open — 200 is plenty for a
   // single-tenant panel; large installs can move to an async select.
@@ -81,7 +86,11 @@ export function AddGrantModal({
         database_id: values.database_id,
       };
 
-      if (values.grantType === "custom" && values.privileges && values.privileges.length > 0) {
+      if (isPostgres) {
+        // Grant controls are hidden for postgres; the agent grants full access
+        // regardless, so send a fixed rw level.
+        payload.grant_level = "rw";
+      } else if (values.grantType === "custom" && values.privileges && values.privileges.length > 0) {
         payload.privileges = values.privileges;
       } else {
         payload.grant_level = values.grant_level || "rw";
@@ -142,32 +151,43 @@ export function AddGrantModal({
           />
         </Form.Item>
 
-        <Form.Item label="Grant Type" name="grantType" rules={[{ required: true }]}>
-          <Radio.Group>
-            <Space direction="vertical" style={{ width: "100%" }}>
-              <Radio value="preset">Preset Privileges</Radio>
-              <Radio value="custom">Custom Privileges</Radio>
-            </Space>
-          </Radio.Group>
-        </Form.Item>
+        {isPostgres ? (
+          <Alert
+            type="info"
+            showIcon
+            title="Full access grant"
+            description="PostgreSQL grants full access to the selected database. Read-only and per-privilege grants aren't supported yet."
+          />
+        ) : (
+          <>
+            <Form.Item label="Grant Type" name="grantType" rules={[{ required: true }]}>
+              <Radio.Group>
+                <Space direction="vertical" style={{ width: "100%" }}>
+                  <Radio value="preset">Preset Privileges</Radio>
+                  <Radio value="custom">Custom Privileges</Radio>
+                </Space>
+              </Radio.Group>
+            </Form.Item>
 
-        {grantType === "preset" && (
-          <Form.Item label="Privilege Level" name="grant_level" rules={[{ required: true }]}>
-            <Radio.Group>
-              <Space direction="vertical">
-                <Radio value="rw">Full Access (all privileges)</Radio>
-                <Radio value="ro">Read Only (SELECT only)</Radio>
-              </Space>
-            </Radio.Group>
-          </Form.Item>
-        )}
+            {grantType === "preset" && (
+              <Form.Item label="Privilege Level" name="grant_level" rules={[{ required: true }]}>
+                <Radio.Group>
+                  <Space direction="vertical">
+                    <Radio value="rw">Full Access (all privileges)</Radio>
+                    <Radio value="ro">Read Only (SELECT only)</Radio>
+                  </Space>
+                </Radio.Group>
+              </Form.Item>
+            )}
 
-        {grantType === "custom" && (
-          <Form.Item label="Custom Privileges" name="privileges">
-            <Checkbox.Group
-              options={AVAILABLE_PRIVILEGES.map((p) => ({ label: p, value: p }))}
-            />
-          </Form.Item>
+            {grantType === "custom" && (
+              <Form.Item label="Custom Privileges" name="privileges">
+                <Checkbox.Group
+                  options={AVAILABLE_PRIVILEGES.map((p) => ({ label: p, value: p }))}
+                />
+              </Form.Item>
+            )}
+          </>
         )}
       </Form>
     </Modal>


### PR DESCRIPTION
## What

Finishes the two follow-ups flagged by PR #1487 (which fixed the Databases-page
crash itself) on GH #1415 — *PostgreSQL permissions can break the Databases
page*. Both are about the same underlying fact: on PostgreSQL the agent runs
`GRANT ALL` on the target database regardless of the requested level
(ADR-0091 / GH #1406), so any read-only or per-privilege choice is not honoured.

### 1. Hide the inert grant controls for PostgreSQL (frontend)

`AddGrantModal` showed a "Grant Type" radio plus preset (Full Access / Read
Only) and custom per-privilege checkboxes for every engine. For a postgres user
those controls did nothing — the agent grants full access whatever you pick — so
a "Read Only" selection was silently upgraded, which is exactly the kind of
confusion the issue is about.

Now, for a postgres user, the modal hides those controls, shows a short note
("PostgreSQL grants full access to the selected database. Read-only and
per-privilege grants aren't supported yet."), and POSTs a fixed
`grant_level: "rw"`. MariaDB is unchanged — full preset/custom choice.

### 2. Canonicalise the PATCH grant path (backend)

`PATCH /database-user-grants/:id` had drifted from `addGrant`:

- it hand-rolled its own privilege validation instead of the shared
  `CanonicalDBGrant` (which `addGrant` and the operator CLI both use);
- it sent the request's `grant_level` to the agent — **empty** when the request
  carried a `privileges` array (an empty grant), and `"custom"` on the revoke
  path, which the agent's legacy rw/ro fallback rejects;
- it persisted privileges only via `UpdatePrivileges`, which hard-codes
  `grant_level="custom"` — so the stored label never matched a rw/ro set.

Fixed to reuse `CanonicalDBGrant`, grant/revoke by the canonical privilege set
(mirroring `addGrant`), and persist the computed level via the existing
`UpdateLevel` setter. The no-op short-circuit now also compares `grant_level`,
so a row whose label drifted from its privileges falls through and gets
repaired rather than short-circuiting on the stale label.

### 3. Keep the stored label honest for PostgreSQL (backend)

The modal now hides the controls, but a direct API caller could still POST
`grant_level:"ro"` (or a custom list) for a postgres role and store that label
while the agent grants ALL — the label would claim *less* access than the role
holds. `coerceEngineGrant` collapses a postgres grant to `rw`/`ALL` in both
`addGrant` and `updateGrant`. It coerces rather than 422s so a caller still
passing a level isn't broken. (The operator CLI already refuses postgres grants
in v1, so this only affects the REST path.)

## Scope / notes

- `PATCH /database-user-grants/:id` has **no UI caller** today (the frontend
  only DELETEs grants), so the backend half is latent-path hardening — but it's
  the exact drift PR #1487 flagged, and it's a clean mirror of `addGrant`.
- **Still open, not in this PR:** the grants repository's `UpdatePrivileges`
  hard-codes `grant_level="custom"`, and `db_user_parity_cmd.go` re-stamps it on
  re-canonicalise. Left alone — changing it touches the parity CLI and isn't in
  #1487's flagged scope.
- No routes or CLI subcommands added — `TestOpenAPICoverage` and the CLI
  reference golden are unaffected. The three old 400 codes replaced by
  `invalid_grant` (matching `addGrant`) aren't referenced in the OpenAPI spec,
  docs, or the UI.

## Test plan

- [x] `go build ./...`, `go vet ./panel-api/...`
- [x] `go test ./panel-api/internal/api/ ./panel-api/cmd/server/ ./panel-api/internal/app/`
- [x] New `database_users_grant_update_test.go`: MariaDB custom PATCH grants by
      privileges (not empty/`custom` `grant_level`); MariaDB rw PATCH persists
      `rw`; postgres add + update coerced to `rw`/`ALL`.
- [x] New `AddGrantModal.test.tsx`: postgres hides controls + POSTs
      `grant_level:"rw"`; mariadb keeps them. `tsc -b` + `eslint` clean.
- [ ] Manual: on a postgres DB user, Add Access shows the note (no level
      radios) and grants full access; on a mariadb user the preset/custom
      choice still works.

GH #1415
