### PR TITLE
feat(kratos): regenerate kratos.yml on a panel hostname change (JAB-393)

### DIFF
--- a/panel-agent/internal/commands/kratos_config_rehost.go
+++ b/panel-agent/internal/commands/kratos_config_rehost.go
@@ -58,6 +58,9 @@ var (
 	// kratosRehostReloadFn restarts jabali-kratos after a rewrite. Seam so
 	// unit tests don't spawn systemctl.
 	kratosRehostReloadFn = defaultKratosRehostReload
+	// kratosServiceActiveFn reports whether jabali-kratos is running. Seam so
+	// unit tests don't spawn systemctl.
+	kratosServiceActiveFn = defaultKratosServiceActive
 )
 
 // kratosBaseURLHostRE captures the panel host from the serve.public base_url
@@ -82,6 +85,16 @@ func defaultKratosRehostReload(_ context.Context) error {
 	bg, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	return execCommandContext(bg, "systemctl", "restart", "jabali-kratos").Run()
+}
+
+// defaultKratosServiceActive reports whether jabali-kratos is active. Used on
+// the no-churn path to recover a box where the file already converged but a
+// prior restart failed to bring Kratos up (`is-active --quiet` exits 0 when the
+// service is active).
+func defaultKratosServiceActive() bool {
+	bg, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return execCommandContext(bg, "systemctl", "is-active", "--quiet", "jabali-kratos").Run() == nil
 }
 
 func kratosConfigRehostHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -116,9 +129,25 @@ func kratosConfigRehostHandler(ctx context.Context, params json.RawMessage) (any
 		}
 	}
 	if strings.EqualFold(current, target) {
-		// Idempotent no-churn: config already on the current hostname. No
-		// rewrite, no restart.
-		return kratosConfigRehostResponse{Rewritten: false, Reason: "already current"}, nil
+		// The file is already on the target hostname, so there is nothing to
+		// rewrite. But a converged file does not prove Kratos is running that
+		// config: a previous rewrite whose restart failed leaves the file
+		// correct on disk while Kratos is down (or never picked it up). The
+		// reconciler re-dispatches while its last attempt is unresolved, and if
+		// this path just returned "already current" the restart would never be
+		// retried — Kratos would stay down and the login lockout would persist.
+		// So when the service is not active, restart it here; otherwise it is
+		// already serving the current config and there is genuinely no churn.
+		if kratosServiceActiveFn() {
+			return kratosConfigRehostResponse{Rewritten: false, Reason: "already current"}, nil
+		}
+		if err := kratosRehostReloadFn(ctx); err != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("restart jabali-kratos: %v", err),
+			}
+		}
+		return kratosConfigRehostResponse{Rewritten: false, Reason: "restarted inactive jabali-kratos"}, nil
 	}
 
 	rewritten, n := rewriteKratosHost(data, current, target)

--- a/panel-agent/internal/commands/kratos_config_rehost.go
+++ b/panel-agent/internal/commands/kratos_config_rehost.go
@@ -1,0 +1,232 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// kratos.config.rehost rewrites the panel hostname throughout
+// /etc/jabali-panel/kratos.yml and restarts jabali-kratos, so a panel
+// hostname/FQDN change actually reaches the identity service (JAB-393).
+//
+// Why it exists: changing the panel FQDN through Settings updates the OS
+// hostname and the server_settings / panel_certificate rows, but nothing
+// regenerates kratos.yml — it is rendered only by install.sh from
+// install/kratos.yml.tmpl (at install / `jabali update`). So after a live
+// rename Kratos keeps emitting URLs for, and allowing CORS only from, the OLD
+// origin. The SPA now runs on the new origin, its cross-origin call to the
+// stale base_url is CORS-blocked, and the login page shows "Network error —
+// could not reach identity service": a full login lockout.
+//
+// Why a targeted rewriter, not a template renderer: kratos.yml.tmpl
+// substitutes seven values — three database credentials, two Kratos secrets,
+// the panel hostname and the port suffix. Only the hostname changes here.
+// Re-rendering would have to recover the DB credentials and secrets, and a
+// wrong cookie secret logs every user out. Rewriting only the host token
+// preserves the DSN, the secrets and the port suffix byte-for-byte. The panel
+// FQDN never appears in the unix-socket DSN, so a host rewrite cannot corrupt
+// the DB credentials.
+//
+// The host appears in two shapes in the rendered file: the https://<host>
+// origins/URLs, and the bare webauthn/passkey rp.id ("<host>"). Both are
+// rewritten — the WebAuthn origin check requires the origin and the RP id to
+// stay consistent. This invalidates passkeys bound to the old registrable
+// domain, which is inherent to any genuine domain change, not a regression.
+type kratosConfigRehostParams struct {
+	Hostname string `json:"hostname"`
+}
+
+type kratosConfigRehostResponse struct {
+	Rewritten    bool   `json:"rewritten"`
+	Reason       string `json:"reason,omitempty"`
+	Replacements int    `json:"replacements,omitempty"`
+}
+
+var (
+	// kratosConfigPath is the rendered Kratos config. Overridable in tests.
+	kratosConfigPath = "/etc/jabali-panel/kratos.yml"
+	// kratosRehostReloadFn restarts jabali-kratos after a rewrite. Seam so
+	// unit tests don't spawn systemctl.
+	kratosRehostReloadFn = defaultKratosRehostReload
+)
+
+// kratosBaseURLHostRE captures the panel host from the serve.public base_url
+// line, e.g. `base_url: "https://mx.example.com:8443/.ory/"` -> mx.example.com.
+var kratosBaseURLHostRE = regexp.MustCompile(`(?m)^\s*base_url:\s*"https://([a-zA-Z0-9.-]+)(?::[0-9]+)?/`)
+
+// kratosConfigBaseURLHost returns the host from the first base_url line.
+func kratosConfigBaseURLHost(data []byte) (string, bool) {
+	m := kratosBaseURLHostRE.FindSubmatch(data)
+	if m == nil {
+		return "", false
+	}
+	return string(m[1]), true
+}
+
+// defaultKratosRehostReload restarts jabali-kratos on a detached, bounded
+// context. Detached from the RPC ctx so a slow restart isn't cancelled
+// mid-flight. The panel does NOT depend on jabali-kratos (no Requires/BindsTo),
+// so this does not cascade the panel down; Kratos sessions are MariaDB-backed
+// and the cookie secret is preserved, so users stay signed in across it.
+func defaultKratosRehostReload(_ context.Context) error {
+	bg, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	return execCommandContext(bg, "systemctl", "restart", "jabali-kratos").Run()
+}
+
+func kratosConfigRehostHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p kratosConfigRehostParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	target := strings.ToLower(strings.TrimSpace(p.Hostname))
+	if !sslDomainRegex.MatchString(target) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid hostname %q", p.Hostname),
+		}
+	}
+
+	data, err := os.ReadFile(kratosConfigPath)
+	if err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("read %s: %v", kratosConfigPath, err),
+		}
+	}
+
+	current, ok := kratosConfigBaseURLHost(data)
+	if !ok {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "could not find serve.public.base_url host in kratos.yml",
+		}
+	}
+	if strings.EqualFold(current, target) {
+		// Idempotent no-churn: config already on the current hostname. No
+		// rewrite, no restart.
+		return kratosConfigRehostResponse{Rewritten: false, Reason: "already current"}, nil
+	}
+
+	rewritten, n := rewriteKratosHost(data, current, target)
+	if n == 0 {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("no occurrences of host %q to rewrite", current),
+		}
+	}
+	// Validate the result before touching disk. A corrupt or half-rewritten
+	// kratos.yml is itself a lockout, so refuse to write anything that failed
+	// to converge: no unresolved template placeholder may appear, and the
+	// base_url host must now be the target.
+	if bytes.Contains(rewritten, []byte("{{.")) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "refusing to write: unresolved template placeholder in kratos.yml",
+		}
+	}
+	if h, ok := kratosConfigBaseURLHost(rewritten); !ok || !strings.EqualFold(h, target) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "refusing to write: base_url host did not converge to target",
+		}
+	}
+
+	if err := writeFilePreservingMeta(kratosConfigPath, rewritten); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("write %s: %v", kratosConfigPath, err),
+		}
+	}
+
+	if err := kratosRehostReloadFn(ctx); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("restart jabali-kratos: %v", err),
+		}
+	}
+
+	return kratosConfigRehostResponse{
+		Rewritten:    true,
+		Reason:       current + " -> " + target,
+		Replacements: n,
+	}, nil
+}
+
+// hostTokenBoundary matches a character that is NOT part of a hostname; a host
+// token is a maximal run bounded by one of these (or a string edge) on each
+// side. Anchoring on it makes the rewrite superstring-safe: replacing
+// "example.com" never touches the "example.com" inside "mx.example.com"
+// (the leading '.' is a hostname character), in either the rename or the
+// drift-heal-back direction.
+const hostTokenBoundary = `[^a-zA-Z0-9.-]`
+
+// rewriteKratosHost replaces every whole-token occurrence of oldHost with
+// newHost and returns the new bytes plus the replacement count. It rewrites
+// both the https://<host> URLs and the bare webauthn/passkey rp.id "<host>",
+// and leaves everything else (the DSN, secrets, port suffix) byte-for-byte.
+func rewriteKratosHost(data []byte, oldHost, newHost string) ([]byte, int) {
+	re := regexp.MustCompile(`(^|` + hostTokenBoundary + `)` + regexp.QuoteMeta(oldHost) + `(` + hostTokenBoundary + `|$)`)
+	count := len(re.FindAll(data, -1))
+	if count == 0 {
+		return data, 0
+	}
+	return re.ReplaceAll(data, []byte("${1}"+newHost+"${2}")), count
+}
+
+// writeFilePreservingMeta writes data to path atomically (temp file in the same
+// directory + rename) while preserving the original file's permission bits and
+// owner/group. A truncated kratos.yml is a lockout, so the rename swap is the
+// minimum bar, not extra defense.
+func writeFilePreservingMeta(path string, data []byte) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".kratos-rehost-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Removed on any early-return path; a no-op once the rename succeeds.
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, fi.Mode().Perm()); err != nil {
+		return err
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if err := os.Chown(tmpName, int(st.Uid), int(st.Gid)); err != nil {
+			return err
+		}
+	}
+	return os.Rename(tmpName, path)
+}
+
+func init() {
+	Default.Register("kratos.config.rehost", kratosConfigRehostHandler)
+}

--- a/panel-agent/internal/commands/kratos_config_rehost_test.go
+++ b/panel-agent/internal/commands/kratos_config_rehost_test.go
@@ -144,7 +144,9 @@ func TestRewriteKratosHost(t *testing.T) {
 }
 
 // withKratosRehostSeams points the verb at a temp kratos.yml and a recording
-// reload fn for the duration of one (non-parallel) test.
+// reload fn for the duration of one (non-parallel) test. Kratos is reported
+// active by default; tests exercising the inactive-recovery path override
+// kratosServiceActiveFn after calling this (the cleanup restores it).
 func withKratosRehostSeams(t *testing.T, contents string, reloadErr error) (path string, restarts *int) {
 	t.Helper()
 	dir := t.TempDir()
@@ -155,10 +157,15 @@ func withKratosRehostSeams(t *testing.T, contents string, reloadErr error) (path
 		}
 	}
 	n := 0
-	prevPath, prevReload := kratosConfigPath, kratosRehostReloadFn
+	prevPath, prevReload, prevActive := kratosConfigPath, kratosRehostReloadFn, kratosServiceActiveFn
 	kratosConfigPath = path
 	kratosRehostReloadFn = func(context.Context) error { n++; return reloadErr }
-	t.Cleanup(func() { kratosConfigPath = prevPath; kratosRehostReloadFn = prevReload })
+	kratosServiceActiveFn = func() bool { return true }
+	t.Cleanup(func() {
+		kratosConfigPath = prevPath
+		kratosRehostReloadFn = prevReload
+		kratosServiceActiveFn = prevActive
+	})
 	return path, &n
 }
 
@@ -214,6 +221,32 @@ func TestKratosConfigRehostHandler_NoChurnWhenCurrent(t *testing.T) {
 	}
 	if *restarts != 0 {
 		t.Fatalf("restarts = %d, want 0 (no churn)", *restarts)
+	}
+}
+
+func TestKratosConfigRehostHandler_NoChurnRestartsInactiveKratos(t *testing.T) {
+	// The file already carries the target hostname, so there is nothing to
+	// rewrite — but Kratos is down (a prior rewrite's restart failed). The verb
+	// must restart it so the reconciler's retry actually recovers the lockout,
+	// rather than reporting "already current" and leaving Kratos down forever.
+	path, restarts := withKratosRehostSeams(t, kratosFixture(kratosFixtureHost), nil)
+	kratosServiceActiveFn = func() bool { return false }
+	before, _ := os.ReadFile(path)
+
+	resp, err := callRehost(t, kratosFixtureHost) // same host as the file
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if resp.Rewritten {
+		t.Fatalf("expected no rewrite (file already current), got %+v", resp)
+	}
+	if *restarts != 1 {
+		t.Fatalf("restarts = %d, want 1 (inactive Kratos must be restarted)", *restarts)
+	}
+	// The file must be left byte-for-byte — no rewrite happened.
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("file mutated on the no-churn recovery path")
 	}
 }
 

--- a/panel-agent/internal/commands/kratos_config_rehost_test.go
+++ b/panel-agent/internal/commands/kratos_config_rehost_test.go
@@ -1,0 +1,254 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A rendered kratos.yml fragment carrying every shape the panel host appears
+// in: the https://<host> URLs (base_url, cors origin, return URLs, ui_url,
+// webauthn origins) AND the bare webauthn/passkey rp.id. The DSN (a unix
+// socket, no host) and the secrets must survive a rehost byte-for-byte.
+const kratosFixtureHost = "old.example.com"
+
+func kratosFixture(host string) string {
+	return `dsn: "mysql://kratosuser:s3cr3tpw@unix(/var/run/mysqld/mysqld.sock)/kratosdb?parseTime=true"
+
+serve:
+  public:
+    base_url: "https://` + host + `:8443/.ory/"
+    cors:
+      allowed_origins:
+        - "https://` + host + `:8443"
+
+selfservice:
+  default_browser_return_url: "https://` + host + `:8443/dashboard"
+  allowed_return_urls:
+    - "https://` + host + `:8443"
+    - "https://` + host + `:8443/login"
+  methods:
+    passkey:
+      config:
+        rp:
+          id: "` + host + `"
+          origins:
+            - "https://` + host + `:8443"
+    webauthn:
+      config:
+        rp:
+          id: "` + host + `"
+          origins:
+            - "https://` + host + `:8443"
+  flows:
+    login:
+      ui_url: "https://` + host + `:8443/login"
+
+secrets:
+  cookie:
+    - deadbeefcafe0000deadbeefcafe0000
+  default:
+    - 00000000111122223333444455556666
+`
+}
+
+func TestKratosConfigBaseURLHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		in       string
+		wantHost string
+		wantOK   bool
+	}{
+		{"with port", `    base_url: "https://mx.example.com:8443/.ory/"`, "mx.example.com", true},
+		{"portless", `    base_url: "https://mx.example.com/.ory/"`, "mx.example.com", true},
+		{"no base_url", "serve:\n  public:\n    host: unix:/run/x.sock\n", "", false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := kratosConfigBaseURLHost([]byte(tt.in))
+			if ok != tt.wantOK || got != tt.wantHost {
+				t.Fatalf("got (%q,%v), want (%q,%v)", got, ok, tt.wantHost, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestRewriteKratosHost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rewrites every shape, preserves DSN and secrets", func(t *testing.T) {
+		t.Parallel()
+		in := kratosFixture(kratosFixtureHost)
+		out, n := rewriteKratosHost([]byte(in), kratosFixtureHost, "new.host.com")
+		s := string(out)
+		// base_url + cors origin + return_url + return_url/login + ui_url +
+		// ui_url + passkey rp.id + passkey origin + webauthn rp.id + webauthn origin = 10.
+		if n != 10 {
+			t.Fatalf("replacements = %d, want 10", n)
+		}
+		if strings.Contains(s, kratosFixtureHost) {
+			t.Fatalf("old host still present:\n%s", s)
+		}
+		if !strings.Contains(s, `base_url: "https://new.host.com:8443/.ory/"`) {
+			t.Errorf("base_url not rewritten:\n%s", s)
+		}
+		if !strings.Contains(s, `id: "new.host.com"`) {
+			t.Errorf("webauthn/passkey rp.id not rewritten")
+		}
+		// Port suffix preserved on URLs.
+		if !strings.Contains(s, `https://new.host.com:8443/login`) {
+			t.Errorf("port suffix not preserved on ui_url")
+		}
+		// DSN + secrets byte-for-byte.
+		if !strings.Contains(s, `mysql://kratosuser:s3cr3tpw@unix(/var/run/mysqld/mysqld.sock)/kratosdb?parseTime=true`) {
+			t.Errorf("DSN mutated")
+		}
+		if !strings.Contains(s, "deadbeefcafe0000deadbeefcafe0000") || !strings.Contains(s, "00000000111122223333444455556666") {
+			t.Errorf("secrets mutated")
+		}
+	})
+
+	t.Run("superstring safe both directions", func(t *testing.T) {
+		t.Parallel()
+		in := "a: \"https://example.com:8443\"\nb: \"https://mx.example.com:8443\"\n"
+		// Rename example.com -> z.com must NOT touch mx.example.com.
+		out, n := rewriteKratosHost([]byte(in), "example.com", "z.com")
+		s := string(out)
+		if n != 1 {
+			t.Fatalf("replacements = %d, want 1", n)
+		}
+		if !strings.Contains(s, `https://z.com:8443`) || !strings.Contains(s, `https://mx.example.com:8443`) {
+			t.Fatalf("superstring boundary broken:\n%s", s)
+		}
+		// Heal-back direction: mx.example.com -> example.com.
+		in2 := "a: \"https://mx.example.com:8443\"\n"
+		out2, n2 := rewriteKratosHost([]byte(in2), "mx.example.com", "example.com")
+		if n2 != 1 || !strings.Contains(string(out2), `https://example.com:8443`) {
+			t.Fatalf("heal-back failed: n=%d out=%q", n2, out2)
+		}
+	})
+
+	t.Run("no occurrences", func(t *testing.T) {
+		t.Parallel()
+		out, n := rewriteKratosHost([]byte("nothing here\n"), "absent.example.com", "x.com")
+		if n != 0 || string(out) != "nothing here\n" {
+			t.Fatalf("expected no-op, got n=%d out=%q", n, out)
+		}
+	})
+}
+
+// withKratosRehostSeams points the verb at a temp kratos.yml and a recording
+// reload fn for the duration of one (non-parallel) test.
+func withKratosRehostSeams(t *testing.T, contents string, reloadErr error) (path string, restarts *int) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "kratos.yml")
+	if contents != "" {
+		if err := os.WriteFile(path, []byte(contents), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n := 0
+	prevPath, prevReload := kratosConfigPath, kratosRehostReloadFn
+	kratosConfigPath = path
+	kratosRehostReloadFn = func(context.Context) error { n++; return reloadErr }
+	t.Cleanup(func() { kratosConfigPath = prevPath; kratosRehostReloadFn = prevReload })
+	return path, &n
+}
+
+func callRehost(t *testing.T, hostname string) (kratosConfigRehostResponse, error) {
+	t.Helper()
+	raw, err := kratosConfigRehostHandler(context.Background(), json.RawMessage(`{"hostname":"`+hostname+`"}`))
+	if err != nil {
+		return kratosConfigRehostResponse{}, err
+	}
+	// The handler returns the typed struct as `any`; round-trip through JSON to
+	// assert on it the way the wire would.
+	b, _ := json.Marshal(raw)
+	var resp kratosConfigRehostResponse
+	if uerr := json.Unmarshal(b, &resp); uerr != nil {
+		t.Fatalf("unmarshal response: %v", uerr)
+	}
+	return resp, nil
+}
+
+func TestKratosConfigRehostHandler_RewritesAndRestarts(t *testing.T) {
+	path, restarts := withKratosRehostSeams(t, kratosFixture(kratosFixtureHost), nil)
+
+	resp, err := callRehost(t, "new.host.com")
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !resp.Rewritten || resp.Replacements != 10 {
+		t.Fatalf("resp = %+v, want rewritten with 10 replacements", resp)
+	}
+	if *restarts != 1 {
+		t.Fatalf("restarts = %d, want 1", *restarts)
+	}
+	out, _ := os.ReadFile(path)
+	if strings.Contains(string(out), kratosFixtureHost) {
+		t.Fatalf("old host survived on disk")
+	}
+	// Mode preserved by the atomic write.
+	fi, _ := os.Stat(path)
+	if fi.Mode().Perm() != 0o640 {
+		t.Errorf("mode = %o, want 640", fi.Mode().Perm())
+	}
+}
+
+func TestKratosConfigRehostHandler_NoChurnWhenCurrent(t *testing.T) {
+	_, restarts := withKratosRehostSeams(t, kratosFixture(kratosFixtureHost), nil)
+
+	resp, err := callRehost(t, kratosFixtureHost) // same host
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if resp.Rewritten {
+		t.Fatalf("expected no rewrite when host already current")
+	}
+	if *restarts != 0 {
+		t.Fatalf("restarts = %d, want 0 (no churn)", *restarts)
+	}
+}
+
+func TestKratosConfigRehostHandler_RejectsInvalidHost(t *testing.T) {
+	path, restarts := withKratosRehostSeams(t, kratosFixture(kratosFixtureHost), nil)
+	before, _ := os.ReadFile(path)
+
+	if _, err := kratosConfigRehostHandler(context.Background(), json.RawMessage(`{"hostname":"bad host!!"}`)); err == nil {
+		t.Fatal("expected error for invalid hostname")
+	}
+	if *restarts != 0 {
+		t.Fatalf("restarts = %d, want 0", *restarts)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("file mutated on invalid hostname")
+	}
+}
+
+func TestKratosConfigRehostHandler_MissingFile(t *testing.T) {
+	_, restarts := withKratosRehostSeams(t, "", nil) // no file written
+	if _, err := callRehost(t, "new.host.com"); err == nil {
+		t.Fatal("expected error for missing kratos.yml")
+	}
+	if *restarts != 0 {
+		t.Fatalf("restarts = %d, want 0", *restarts)
+	}
+}
+
+func TestKratosConfigRehostHandler_RestartFailurePropagates(t *testing.T) {
+	_, restarts := withKratosRehostSeams(t, kratosFixture(kratosFixtureHost), context.DeadlineExceeded)
+	if _, err := callRehost(t, "new.host.com"); err == nil {
+		t.Fatal("expected restart failure to propagate")
+	}
+	if *restarts != 1 {
+		t.Fatalf("restarts = %d, want 1 (attempted)", *restarts)
+	}
+}

--- a/panel-api/internal/reconciler/kratos_hostname_reconciler.go
+++ b/panel-api/internal/reconciler/kratos_hostname_reconciler.go
@@ -1,0 +1,71 @@
+package reconciler
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+// kratosConfigPath is the rendered Kratos config on the box. panel-api can read
+// it: its AppArmor profile allows `/etc/jabali-panel/** r`, and the file is
+// root:<service-user> mode 0640 while panel-api runs as the service user.
+const kratosConfigPath = "/etc/jabali-panel/kratos.yml"
+
+// kratosBaseURLHostRE captures the panel host from the serve.public base_url
+// line, mirroring the agent verb's extractor.
+var kratosBaseURLHostRE = regexp.MustCompile(`(?m)^\s*base_url:\s*"https://([a-zA-Z0-9.-]+)(?::[0-9]+)?/`)
+
+// reconcileKratosHostname converges kratos.yml's panel hostname to
+// server_settings.hostname (JAB-393). Changing the panel FQDN never regenerates
+// kratos.yml — it is rendered only by install.sh — so Kratos keeps emitting
+// URLs for, and allowing CORS only from, the OLD origin, which CORS-blocks
+// every login (a full lockout). This reads the base_url host on disk (disk is
+// the convergence signal, the same way the panel-cert reconciler reads the
+// cert) and dispatches kratos.config.rehost on drift. Being stateless, it also
+// self-heals a box already broken by a past rename and re-heals after a
+// `jabali update` re-renders kratos.yml from a stale config.toml hostname.
+func (r *Reconciler) reconcileKratosHostname(ctx context.Context) {
+	if r.agent == nil || r.serverSettings == nil || r.readKratosConfigFile == nil {
+		return
+	}
+	settings, err := r.serverSettings.Get(ctx)
+	if err != nil || settings == nil || settings.Hostname == "" {
+		return
+	}
+	data, err := r.readKratosConfigFile(kratosConfigPath)
+	if err != nil {
+		// A rewriter has nothing to fix if the config is missing/unreadable.
+		r.warnKratosRehostOnce("read kratos.yml: " + err.Error())
+		return
+	}
+	m := kratosBaseURLHostRE.FindSubmatch(data)
+	if m == nil {
+		r.warnKratosRehostOnce("kratos.yml has no serve.public.base_url host")
+		return
+	}
+	current := string(m[1])
+	if strings.EqualFold(current, settings.Hostname) {
+		r.kratosRehostLastErr = ""
+		return
+	}
+	if _, err := r.agent.Call(ctx, "kratos.config.rehost", map[string]any{
+		"hostname": settings.Hostname,
+	}); err != nil {
+		r.warnKratosRehostOnce("kratos.config.rehost dispatch failed: " + err.Error())
+		return
+	}
+	r.kratosRehostLastErr = ""
+	r.log.Info("kratos hostname rehost dispatched", "from", current, "to", settings.Hostname)
+}
+
+// warnKratosRehostOnce logs a rehost problem at Warn only when it changes,
+// then at Debug while it persists — so a mid-rollout agent without the verb, or
+// a persistently unreadable config, doesn't spam Warn every tick.
+func (r *Reconciler) warnKratosRehostOnce(detail string) {
+	if r.kratosRehostLastErr == detail {
+		r.log.Debug("kratos hostname rehost still blocked", "detail", detail)
+		return
+	}
+	r.kratosRehostLastErr = detail
+	r.log.Warn("kratos hostname rehost", "detail", detail)
+}

--- a/panel-api/internal/reconciler/kratos_hostname_reconciler.go
+++ b/panel-api/internal/reconciler/kratos_hostname_reconciler.go
@@ -44,8 +44,13 @@ func (r *Reconciler) reconcileKratosHostname(ctx context.Context) {
 		return
 	}
 	current := string(m[1])
-	if strings.EqualFold(current, settings.Hostname) {
-		r.kratosRehostLastErr = ""
+	// Dispatch on drift. Also dispatch when a prior attempt is still unresolved
+	// (r.kratosRehostLastErr set) even though the file already matches: a rewrite
+	// whose restart failed leaves the file converged but Kratos down, and the
+	// verb's no-churn path restarts an inactive Kratos. Short-circuiting on the
+	// converged file alone would never retry that restart, so the login lockout
+	// would persist until an unrelated restart.
+	if strings.EqualFold(current, settings.Hostname) && r.kratosRehostLastErr == "" {
 		return
 	}
 	if _, err := r.agent.Call(ctx, "kratos.config.rehost", map[string]any{

--- a/panel-api/internal/reconciler/kratos_hostname_reconciler_test.go
+++ b/panel-api/internal/reconciler/kratos_hostname_reconciler_test.go
@@ -1,0 +1,105 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+type fakeKratosRehostAgent struct {
+	calls []map[string]any
+	fail  bool
+}
+
+func (f *fakeKratosRehostAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	if method != "kratos.config.rehost" {
+		return nil, nil
+	}
+	m, _ := params.(map[string]any)
+	f.calls = append(f.calls, m)
+	if f.fail {
+		return nil, errors.New("agent down")
+	}
+	return json.RawMessage(`{"rewritten":true}`), nil
+}
+
+func kratosReconcilerFixture(host string) []byte {
+	return []byte("serve:\n  public:\n    base_url: \"https://" + host + ":8443/.ory/\"\n")
+}
+
+func newKratosRehostReconciler(hostname string, read func(string) ([]byte, error), a *fakeKratosRehostAgent) *Reconciler {
+	return &Reconciler{
+		agent:                a,
+		serverSettings:       &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: hostname}},
+		readKratosConfigFile: read,
+		log:                  slog.New(slog.DiscardHandler),
+	}
+}
+
+func TestReconcileKratosHostname_DriftDispatches(t *testing.T) {
+	a := &fakeKratosRehostAgent{}
+	r := newKratosRehostReconciler("new.host.com",
+		func(string) ([]byte, error) { return kratosReconcilerFixture("old.example.com"), nil }, a)
+
+	r.reconcileKratosHostname(context.Background())
+
+	if len(a.calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(a.calls))
+	}
+	if a.calls[0]["hostname"] != "new.host.com" {
+		t.Fatalf("dispatched hostname = %v, want new.host.com", a.calls[0]["hostname"])
+	}
+}
+
+func TestReconcileKratosHostname_NoDriftNoDispatch(t *testing.T) {
+	a := &fakeKratosRehostAgent{}
+	// kratos.yml already on the current hostname (case-insensitive).
+	r := newKratosRehostReconciler("New.Host.Com",
+		func(string) ([]byte, error) { return kratosReconcilerFixture("new.host.com"), nil }, a)
+
+	r.reconcileKratosHostname(context.Background())
+
+	if len(a.calls) != 0 {
+		t.Fatalf("calls = %d, want 0 (no drift)", len(a.calls))
+	}
+}
+
+func TestReconcileKratosHostname_UnreadableNoDispatch(t *testing.T) {
+	a := &fakeKratosRehostAgent{}
+	r := newKratosRehostReconciler("new.host.com",
+		func(string) ([]byte, error) { return nil, errors.New("permission denied") }, a)
+
+	r.reconcileKratosHostname(context.Background())
+
+	if len(a.calls) != 0 {
+		t.Fatalf("calls = %d, want 0 (unreadable config must not dispatch a rewriter)", len(a.calls))
+	}
+}
+
+func TestReconcileKratosHostname_NoBaseURLNoDispatch(t *testing.T) {
+	a := &fakeKratosRehostAgent{}
+	r := newKratosRehostReconciler("new.host.com",
+		func(string) ([]byte, error) { return []byte("serve:\n  public:\n    host: unix:/run/x.sock\n"), nil }, a)
+
+	r.reconcileKratosHostname(context.Background())
+
+	if len(a.calls) != 0 {
+		t.Fatalf("calls = %d, want 0 (no base_url to compare)", len(a.calls))
+	}
+}
+
+func TestReconcileKratosHostname_EmptyHostnameNoDispatch(t *testing.T) {
+	a := &fakeKratosRehostAgent{}
+	r := newKratosRehostReconciler("",
+		func(string) ([]byte, error) { return kratosReconcilerFixture("old.example.com"), nil }, a)
+
+	r.reconcileKratosHostname(context.Background())
+
+	if len(a.calls) != 0 {
+		t.Fatalf("calls = %d, want 0 (empty settings hostname)", len(a.calls))
+	}
+}

--- a/panel-api/internal/reconciler/kratos_hostname_reconciler_test.go
+++ b/panel-api/internal/reconciler/kratos_hostname_reconciler_test.go
@@ -68,6 +68,26 @@ func TestReconcileKratosHostname_NoDriftNoDispatch(t *testing.T) {
 	}
 }
 
+func TestReconcileKratosHostname_RetriesWhilePriorErrorPending(t *testing.T) {
+	// File already on the current hostname, but a prior dispatch is unresolved
+	// (its restart failed). The reconciler must still re-dispatch so the verb's
+	// inactive-Kratos restart is retried; a converged file alone must not
+	// short-circuit the recovery. On success it clears the pending error.
+	a := &fakeKratosRehostAgent{}
+	r := newKratosRehostReconciler("new.host.com",
+		func(string) ([]byte, error) { return kratosReconcilerFixture("new.host.com"), nil }, a)
+	r.kratosRehostLastErr = "kratos.config.rehost dispatch failed: restart jabali-kratos: timeout"
+
+	r.reconcileKratosHostname(context.Background())
+
+	if len(a.calls) != 1 {
+		t.Fatalf("calls = %d, want 1 (retry while a prior error is pending)", len(a.calls))
+	}
+	if r.kratosRehostLastErr != "" {
+		t.Fatalf("pending error = %q, want cleared after a successful retry", r.kratosRehostLastErr)
+	}
+}
+
 func TestReconcileKratosHostname_UnreadableNoDispatch(t *testing.T) {
 	a := &fakeKratosRehostAgent{}
 	r := newKratosRehostReconciler("new.host.com",

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -97,6 +97,13 @@ type Reconciler struct {
 	// warnings so a mid-rollout agent (missing ssl.panel.selfsign) does not
 	// log at Warn every tick.
 	panelSelfSignLastErr string
+	// readKratosConfigFile reads kratos.yml for the JAB-393 hostname drift
+	// check. Mockable for tests (default os.ReadFile).
+	readKratosConfigFile func(string) ([]byte, error)
+	// kratosRehostLastErr debounces JAB-393 rehost dispatch/read warnings so a
+	// mid-rollout agent (missing kratos.config.rehost) or an unreadable config
+	// does not log at Warn every tick.
+	kratosRehostLastErr string
 	// paused is an atomic flag to pause reconciliation (for SSO key rotation)
 	paused atomic.Bool
 
@@ -508,6 +515,7 @@ func New(domains repository.DomainRepository, users repository.UserRepository, a
 	r.socketReady = r.waitSocketReady
 	// JAB-389: default cert reader for the panel self-signed drift check.
 	r.readCertFile = os.ReadFile
+	r.readKratosConfigFile = os.ReadFile
 	return r
 }
 
@@ -771,6 +779,10 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// before the rest of the loop touches the agent. Cheap noop when
 	// use_le=0 or routability gate fails.
 	r.reconcilePanelCertificate(ctx)
+	// JAB-393: converge kratos.yml's panel hostname to server_settings.hostname
+	// so a panel FQDN change doesn't leave the identity service on the old
+	// origin (a CORS-blocked full login lockout). Cheap noop when they match.
+	r.reconcileKratosHostname(ctx)
 	// JAB-391: converge Stalwart outbound TLS strategies to dane=disable.
 	r.reconcileOutboundMailTLS(ctx)
 	r.reconcileUpdateRuns(ctx)


### PR DESCRIPTION
## Summary

Changing the panel hostname/FQDN never regenerated `/etc/jabali-panel/kratos.yml`. That file is rendered only by `install.sh` from `install/kratos.yml.tmpl` (at install and at `jabali update`), so after a live rename Kratos kept emitting URLs for — and allowing CORS only from — the **old** origin. The SPA now runs on the new origin, its cross-origin call to the stale `base_url` is CORS-blocked, and the login page shows "Network error — could not reach identity service": a **full login lockout** (JAB-393).

This adds an agent verb that rewrites the panel hostname throughout `kratos.yml` and restarts `jabali-kratos`, plus a panel-api reconciler that drives it from the source of truth. It mirrors the panel self-signed-cert convergence pattern (`#1351`): the agent verb does the mutation behind a testable reload seam; the reconciler reads the on-disk artifact, compares it to `server_settings.hostname` (the DB row, which the Settings handler writes before it dispatches `system.set_hostname`), and dispatches on drift. Being stateless it also **self-heals a box already broken by a past rename** — no manual `sed`.

## What changed

**Agent verb `kratos.config.rehost`** (`panel-agent/internal/commands/kratos_config_rehost.go`)
- Reads `kratos.yml`, extracts the current host from `serve.public.base_url`, and rewrites every whole-token occurrence of it to the target host.
- **Targeted rewriter, not a template re-render.** The template substitutes seven values — three DB credentials, two Kratos secrets, the hostname, and the port suffix. Only the hostname changes here. Re-rendering would have to recover the secrets, and a wrong cookie secret logs every user out. Rewriting only the host token leaves the DSN, the secrets, and the port suffix byte-for-byte. The panel FQDN never appears in the unix-socket DSN, so a host rewrite cannot corrupt the DB credentials.
- Rewrites **both shapes** the host appears in: the `https://<host>` origins/URLs and the bare webauthn/passkey `rp.id: "<host>"`. The WebAuthn origin check requires the origin and the RP id to stay consistent, so both must move together.
- Superstring-safe token-boundary rewrite: replacing `example.com` never touches the `example.com` inside `mx.example.com`, in either the rename or the drift-heal-back direction.
- Validates before writing (no unresolved `{{.` placeholder; `base_url` host converged to the target), writes atomically (temp file + rename) preserving mode and owner, then restarts `jabali-kratos` on a detached, bounded context. The panel does not depend on `jabali-kratos`, so the restart does not cascade the panel down; Kratos sessions are MariaDB-backed and the cookie secret is preserved, so users stay signed in across it.
- Idempotent: if the file is already on the target host and Kratos is active, it does nothing.

**Reconciler** (`panel-api/internal/reconciler/kratos_hostname_reconciler.go`)
- Reads `kratos.yml` (panel-api's AppArmor profile allows `/etc/jabali-panel/** r`), compares the `base_url` host to `server_settings.hostname`, and dispatches `kratos.config.rehost` on drift. Warn-once debounce so a mid-rollout agent without the verb doesn't spam the log.

**Restart-failure retry (hardening).** The verb writes the file then restarts. If that restart failed transiently, the file was already converged while Kratos was still down, and the reconciler (which compares only the on-disk host) then saw no drift and never retried — the lockout would persist until an unrelated restart. Closed on both sides: the verb's no-churn path now restarts Kratos if it is not active (a converged file does not prove Kratos is serving it), and the reconciler re-dispatches while its last attempt is unresolved so that retry is actually reached. A successful retry clears the pending state and the loop goes quiet.

## Test plan

- [x] `go test ./panel-agent/internal/commands/ ./panel-api/internal/reconciler/ ./panel-api/internal/api/` — green; `go vet` clean.
- [x] Unit coverage: host extraction (port / portless / absent); rewrite of all shapes with DSN + secrets preserved; superstring safety both directions; handler rewrite+restart, no-churn, invalid-host rejection, missing file, restart-failure propagation; no-churn inactive-Kratos restart; reconciler drift/no-drift/unreadable/no-base_url/empty-hostname/retry-while-pending. Both new hardening guards were falsified before landing.
- [x] **Box drill on the .60 test box.** Drift injected into `kratos.yml` only (`server_settings.hostname` left untouched, so the panel-cert reconciler stayed quiet and did not churn the box's real Let's Encrypt cert). The reconciler read the real file, detected drift, and dispatched the verb; the verb rewrote every host shape including both `rp.id` lines; converged in ~30s with 0 drift left; `640 root:jabali` mode/owner preserved; the DSN was intact; Kratos came back `{"status":"ok"}`; the panel stayed `200` on `:8443` throughout. Box restored to as-found (original binaries + `kratos.yml`), staging cleaned.

## Notes / caveats

- **Passkey invalidation is expected.** Rewriting the webauthn/passkey `rp.id` invalidates passkeys bound to the old registrable domain. That is inherent to any genuine domain change, not a regression.
- **`mail.` webauthn RP-id does not apply here.** The rendered `kratos.yml` has no `mail.` host occurrences, so the JAB-389 "don't follow the FQDN" concern for the mail identity does not arise.
- **`jabali update` flip-flop (follow-up).** `system.set_hostname` runs `hostnamectl` only; it does not update `config.toml`'s `hostname =`. So a `jabali update` re-renders `kratos.yml` from the stale `config.toml` hostname, and this reconciler heals it back on the next tick — it converges, but with an extra Kratos restart. The durable fix is for `system.set_hostname` (or the Settings handler) to also write `config.toml`. Tracked as a follow-up.
- **Other hostname-change gaps remain open** (out of scope here): the `:443` landing vhost `server_name` still stale on rename, and `/etc/hosts` `127.0.1.1` mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
