### PR TITLE
fix(php): keep the package exec-functions opt-out across pool reconciles (GH #1422)

### DIFF
--- a/panel-api/cmd/server/php_pool_parity_cmd.go
+++ b/panel-api/cmd/server/php_pool_parity_cmd.go
@@ -32,6 +32,9 @@ func phpPoolReconcileDeps() phppoolops.ReconcileDeps {
 		Users:     repository.NewUserRepository(sharedDB),
 		Overrides: repository.NewPHPPoolIniOverrideRepository(sharedDB),
 		Pools:     repository.NewPHPPoolRepository(sharedDB),
+		// GH #1422: carry the package exec-functions opt-out so a CLI pool
+		// reconcile matches the HTTP path and doesn't re-lock disable_functions.
+		Packages: repository.NewPackageRepository(sharedDB),
 	}
 }
 

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -367,6 +367,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// ReconcileUserLimits and ReconcileNginxRateLimits have every
 		// dep they need. Mount path resolved below after deps are set.
 		rec.WithPackages(packageRepo)
+		// GH #1422: the package-flip fan-out re-renders pools through the
+		// override-aware ReconcileViaAgent, which needs the ini-override repo.
+		rec.WithPHPPoolIniOverrides(phpPoolIniOverrideRepo)
 		rec.WithLimitOverrides(limitOverridesRepo)
 		rec.WithDBAdmin(dbAdminRepo)
 		managedIPRepo := repository.NewManagedIPRepository(sharedDB)

--- a/panel-api/internal/api/php_pool_extensions.go
+++ b/panel-api/internal/api/php_pool_extensions.go
@@ -176,7 +176,7 @@ func (h *phpPoolExtensionsHandler) set(c *gin.Context) {
 		return
 	}
 	c.Set("audit_target", "php_extensions:"+pool.PHPVersion)
-	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, h.cfg.Packages, *pool)
 	c.JSON(http.StatusOK, gin.H{"enabled": []string(clean)})
 }
 

--- a/panel-api/internal/api/php_pool_opcache.go
+++ b/panel-api/internal/api/php_pool_opcache.go
@@ -195,7 +195,7 @@ func (h *phpUserTuningHandler) setOpcache(c *gin.Context) {
 	// conf is on disk before the restart below re-reads it.
 	pool.Status = "pending"
 	_ = h.cfg.PHPPools.Update(c.Request.Context(), pool)
-	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
+	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, h.cfg.Packages, *pool)
 	if fresh, err := h.cfg.PHPPools.FindByID(c.Request.Context(), pool.ID); err == nil && fresh != nil && fresh.Status == "error" {
 		detail := ""
 		if fresh.LastError != nil {

--- a/panel-api/internal/api/php_pool_reconcile.go
+++ b/panel-api/internal/api/php_pool_reconcile.go
@@ -25,6 +25,7 @@ func reconcilePHPPoolViaAgent(
 	users repository.UserRepository,
 	overrides repository.PHPPoolIniOverrideRepository,
 	pools repository.PHPPoolRepository,
+	packages repository.PackageRepository,
 	pool models.PHPPool,
 ) {
 	_ = phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
@@ -32,5 +33,8 @@ func reconcilePHPPoolViaAgent(
 		Users:     users,
 		Overrides: overrides,
 		Pools:     pools,
+		// GH #1422: carry the package exec-functions opt-out so a settings/
+		// version reconcile doesn't re-lock disable_functions.
+		Packages: packages,
 	}, pool)
 }

--- a/panel-api/internal/api/php_pool_user_tuning.go
+++ b/panel-api/internal/api/php_pool_user_tuning.go
@@ -341,6 +341,6 @@ func (h *phpUserTuningHandler) applyToPool(c *gin.Context, pool *models.PHPPool,
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, h.cfg.Packages, *pool)
 	c.JSON(http.StatusOK, gin.H{"data": pool})
 }

--- a/panel-api/internal/api/php_pool_xdebug.go
+++ b/panel-api/internal/api/php_pool_xdebug.go
@@ -104,6 +104,6 @@ func (h *phpXdebugHandler) set(c *gin.Context) {
 		return
 	}
 	c.Set("audit_target", "php_xdebug:"+pool.PHPVersion)
-	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, *pool)
+	go reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, h.cfg.Packages, *pool)
 	c.JSON(http.StatusOK, gin.H{"enabled": pool.XdebugEnabled})
 }

--- a/panel-api/internal/api/php_pools.go
+++ b/panel-api/internal/api/php_pools.go
@@ -869,5 +869,5 @@ func (h *phpPoolHandler) deleteIniOverride(c *gin.Context) {
 // Implementation lives in php_pool_reconcile.go so the user-driven
 // /domains/:id/php-pool path can share it without depending on phpPoolHandler.
 func (h *phpPoolHandler) reconcilePoolAsync(pool models.PHPPool) {
-	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, pool)
+	reconcilePHPPoolViaAgent(h.cfg.Agent, h.cfg.Users, h.cfg.PHPPoolIniOverrides, h.cfg.PHPPools, h.cfg.Packages, pool)
 }

--- a/panel-api/internal/phppoolops/phppoolops.go
+++ b/panel-api/internal/phppoolops/phppoolops.go
@@ -161,6 +161,12 @@ type ReconcileDeps struct {
 	Users     repository.UserRepository
 	Overrides repository.PHPPoolIniOverrideRepository
 	Pools     repository.PHPPoolRepository
+	// Packages resolves the user's hosting package so this reconcile can carry
+	// the GH #402 per-package disable_functions opt-out (GH #1422). Optional: a
+	// nil repo (or a user with no package / a package without the flag) leaves
+	// the key off, so the agent applies its #401 command-exec lockdown default.
+	// Fail-closed — a missing wiring can only keep the lockdown, never lift it.
+	Packages repository.PackageRepository
 }
 
 // ReconcileViaAgent fires php.pool.apply for pool, then writes the resulting
@@ -215,7 +221,7 @@ func ReconcileViaAgent(deps ReconcileDeps, pool models.PHPPool) error {
 	}
 	slug := models.PoolSlug(username, pool.PHPVersion, isDefault)
 
-	_, aerr := deps.Agent.Call(ctx, "php.pool.apply", map[string]any{
+	params := map[string]any{
 		"username":                          username,
 		"slug":                              slug,
 		"additive":                          !isDefault,
@@ -233,7 +239,22 @@ func ReconcileViaAgent(deps ReconcileDeps, pool models.PHPPool) error {
 		"admin_flags":                       adminFlags,
 		"extra_extensions":                  []string(pool.ExtraExtensions),
 		"xdebug_enabled":                    pool.XdebugEnabled,
-	})
+	}
+
+	// GH #1422: carry the GH #402 per-package disable_functions opt-out on this
+	// path too. Without it, any pool reconcile driven from here (a PHP settings
+	// save, a version assign, an Xdebug/extension/tuning change) re-applied the
+	// #401 command-exec lockdown and silently re-broke shell_exec/proc_open for
+	// an exec-enabled package. Mirror reconciler.applyPHPPool: send "" only when
+	// the user's package opts out; omit the key otherwise so the agent keeps its
+	// safe default. Fail-closed — nil Packages / no package / flag off => no key.
+	if deps.Packages != nil && user != nil && user.PackageID != nil && *user.PackageID != "" {
+		if pkg, perr := deps.Packages.FindByID(ctx, *user.PackageID); perr == nil && pkg != nil && pkg.PHPExecEnabled {
+			params["disable_functions"] = ""
+		}
+	}
+
+	_, aerr := deps.Agent.Call(ctx, "php.pool.apply", params)
 	if aerr != nil {
 		pool.Status = "error"
 		msg := fmt.Sprintf("agent failed: %v", aerr)

--- a/panel-api/internal/phppoolops/phppoolops_test.go
+++ b/panel-api/internal/phppoolops/phppoolops_test.go
@@ -165,7 +165,73 @@ func (f *fakePools) Update(_ context.Context, p *models.PHPPool) error {
 	return nil
 }
 
+type fakePackages struct {
+	repository.PackageRepository
+	pkg *models.HostingPackage
+}
+
+func (f *fakePackages) FindByID(_ context.Context, _ string) (*models.HostingPackage, error) {
+	return f.pkg, nil
+}
+
 func username(s string) *string { return &s }
+
+func pkgID(s string) *string { return &s }
+
+// GH #1422: the settings/version reconcile path must carry the GH #402 exec
+// opt-out. An exec-enabled package sends disable_functions=""; anything else
+// (flag off, no package, or — the fail-closed case — no Packages wiring) MUST
+// leave the key ABSENT so the agent keeps the #401 command-exec lockdown.
+func TestReconcileViaAgent_DisableFunctionsByPackage(t *testing.T) {
+	pool := models.PHPPool{ID: "P1", UserID: "U1", PHPVersion: "8.3", PmMode: "ondemand"}
+	pkgRef := "pkg-1"
+	execUser := func() *models.User {
+		return &models.User{ID: "U1", Username: username("alice"), PackageID: pkgID(pkgRef)}
+	}
+
+	t.Run("exec-enabled package sends empty opt-out", func(t *testing.T) {
+		ag := &fakeAgent{}
+		err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+			Agent:     ag,
+			Users:     &fakeUsers{user: execUser()},
+			Overrides: &fakeOverrides{},
+			Pools:     &fakePools{list: []models.PHPPool{pool}},
+			Packages:  &fakePackages{pkg: &models.HostingPackage{ID: pkgRef, PHPExecEnabled: true}},
+		}, pool)
+		require.NoError(t, err)
+		v, ok := ag.params["disable_functions"]
+		require.True(t, ok, "exec-enabled package must send the disable_functions key")
+		assert.Equal(t, "", v, "exec-enabled package opts out with an empty value")
+	})
+
+	t.Run("non-exec package omits the key", func(t *testing.T) {
+		ag := &fakeAgent{}
+		err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+			Agent:     ag,
+			Users:     &fakeUsers{user: execUser()},
+			Overrides: &fakeOverrides{},
+			Pools:     &fakePools{list: []models.PHPPool{pool}},
+			Packages:  &fakePackages{pkg: &models.HostingPackage{ID: pkgRef, PHPExecEnabled: false}},
+		}, pool)
+		require.NoError(t, err)
+		_, ok := ag.params["disable_functions"]
+		assert.False(t, ok, "a non-exec package must NOT send the key (agent applies its safe default)")
+	})
+
+	t.Run("nil Packages is fail-closed", func(t *testing.T) {
+		ag := &fakeAgent{}
+		err := phppoolops.ReconcileViaAgent(phppoolops.ReconcileDeps{
+			Agent:     ag,
+			Users:     &fakeUsers{user: execUser()}, // package set, but no repo to resolve it
+			Overrides: &fakeOverrides{},
+			Pools:     &fakePools{list: []models.PHPPool{pool}},
+			// Packages omitted on purpose.
+		}, pool)
+		require.NoError(t, err)
+		_, ok := ag.params["disable_functions"]
+		assert.False(t, ok, "missing Packages wiring must never lift the lockdown")
+	})
+}
 
 func TestReconcileViaAgent_DefaultPool_UsesBareUsernameSlug(t *testing.T) {
 	ag := &fakeAgent{}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/nginxrules"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler/phases"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/redirects"
@@ -55,6 +56,15 @@ type Reconciler struct {
 	dbAdmin      repository.DBAdminRepository
 	log          *slog.Logger
 	interval     time.Duration
+
+	// phpPoolIniOverrides backs the GH #1422 package-flip fan-out. When set,
+	// ReapplyPHPPoolForUser routes every pool through phppoolops.ReconcileViaAgent
+	// (the same override-aware apply the settings/version-save path already uses),
+	// so a flip of php_exec_enabled carries BOTH the tenant's php_admin_value
+	// overrides AND the GH #402 disable_functions opt-out. Nil = the fan-out is a
+	// fail-closed no-op (pools converge on the next settings-save) rather than an
+	// override-blind re-render that would wipe those overrides.
+	phpPoolIniOverrides repository.PHPPoolIniOverrideRepository
 
 	// JAB-235 DNS-01 routing state — see dns01_routing.go.
 	dns01State
@@ -464,6 +474,15 @@ func (r *Reconciler) WithSSLCerts(sslCerts repository.SSLCertificateRepository) 
 // Call this before using PHP pool reconciliation.
 func (r *Reconciler) WithPHPPools(phpPools repository.PHPPoolRepository) *Reconciler {
 	r.phpPools = phpPools
+	return r
+}
+
+// WithPHPPoolIniOverrides injects the per-pool ini-override repository so the
+// GH #1422 package-flip fan-out (ReapplyPHPPoolForUser) can re-render pools
+// through the override-aware phppoolops.ReconcileViaAgent path. Optional: nil
+// leaves the fan-out a fail-closed no-op rather than an override-blind wipe.
+func (r *Reconciler) WithPHPPoolIniOverrides(overrides repository.PHPPoolIniOverrideRepository) *Reconciler {
+	r.phpPoolIniOverrides = overrides
 	return r
 }
 
@@ -1545,30 +1564,57 @@ func (r *Reconciler) reconcileMysqlAdminShadow(ctx context.Context) {
 	}
 }
 
-// ReapplyPHPPoolForUser re-renders a single user's pool from the current
-// template + package state (GH #402 per-package disable_functions opt-out).
-// Used by the package-update fan-out so an admin flipping php_exec_enabled
-// takes effect immediately instead of waiting for the next sweep. No-op when
-// the user has no pool. Implements api.PackagePHPPoolReconciler.
+// ReapplyPHPPoolForUser re-renders ALL of a user's PHP pools from current
+// template + package state (GH #402 per-package disable_functions opt-out, GH
+// #1422). Used by the package-update fan-out so an admin flipping
+// php_exec_enabled takes effect immediately — on every pool, including a domain
+// pinned to a non-default PHP version — instead of waiting for the next sweep
+// (which skips a healthy pool). Each pool is re-applied through the same
+// override-aware phppoolops.ReconcileViaAgent the settings/version-save path
+// uses, so tenant php_admin_value overrides survive the flip. No-op when the
+// user has no pool. Implements api.PackagePHPPoolReconciler.
 func (r *Reconciler) ReapplyPHPPoolForUser(ctx context.Context, userID string) error {
 	if r.phpPools == nil || r.users == nil {
 		return nil
 	}
-	user, err := r.users.FindByID(ctx, userID)
-	if err != nil || user == nil {
-		return err
+	// GH #1422: route the fan-out through phppoolops.ReconcileViaAgent — the
+	// override-aware apply the settings/version-save path already uses. It carries
+	// the tenant's php_admin_value overrides alongside the GH #402
+	// disable_functions opt-out. Fail-closed: without the overrides repo we do NOT
+	// fall back to the override-blind applyPHPPool (that re-renders a pool with no
+	// php_admin_value lines and would wipe a versioned pool's overrides on a flag
+	// flip); the pool instead converges on the user's next PHP-settings save, which
+	// routes through this same override-aware path.
+	if r.phpPoolIniOverrides == nil {
+		r.log.Warn("ReapplyPHPPoolForUser: ini-override repo not wired; skipping fan-out (pools converge on next settings save)", "user_id", userID)
+		return nil
 	}
-	pool, err := r.phpPools.FindByUserID(ctx, userID)
+	// Re-render EVERY pool, not just the default: a flip of php_exec_enabled must
+	// reach a domain pinned to a non-default PHP version too, and the periodic
+	// sweep skips a healthy pool. ReconcileViaAgent loads the user and derives each
+	// pool's isDefault itself (list[0] by created_at ASC), so no bookkeeping here.
+	pools, err := r.phpPools.ListByUserID(ctx, userID)
 	if err != nil {
 		if err == repository.ErrNotFound {
 			return nil
 		}
 		return err
 	}
-	if pool == nil {
-		return nil
+	deps := phppoolops.ReconcileDeps{
+		Agent:     r.agent,
+		Users:     r.users,
+		Overrides: r.phpPoolIniOverrides,
+		Pools:     r.phpPools,
+		Packages:  r.packages,
 	}
-	r.applyPHPPool(ctx, user, pool, true)
+	for i := range pools {
+		if aerr := phppoolops.ReconcileViaAgent(deps, pools[i]); aerr != nil {
+			// Continue on a per-pool failure so a sibling pool is not abandoned;
+			// ReconcileViaAgent has already persisted this pool's error status.
+			r.log.Error("ReapplyPHPPoolForUser: pool re-apply failed",
+				"user_id", userID, "pool_id", pools[i].ID, "err", aerr)
+		}
+	}
 	return nil
 }
 

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -576,7 +576,9 @@ func (f *fakeUserRepo) Update(ctx context.Context, u *models.User) error {
 	return nil
 }
 
-func (f *fakeUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+func (f *fakeUserRepo) UpdateComposerChannel(ctx context.Context, id string, channel *string) error {
+	return nil
+}
 
 func (f *fakeUserRepo) UpdateCLIPHPVersion(context.Context, string, *string) error { return nil }
 
@@ -2240,6 +2242,17 @@ func (f *fakePackageRepoMin) Update(context.Context, *models.HostingPackage) err
 func (f *fakePackageRepoMin) Delete(context.Context, string) error                 { return nil }
 func (f *fakePackageRepoMin) EnsureDefaults(context.Context) error                 { return nil }
 
+// fakeIniOverrideRepo is a minimal PHPPoolIniOverrideRepository that serves
+// per-pool overrides from a map; ReconcileViaAgent only calls ListByPool.
+type fakeIniOverrideRepo struct {
+	repository.PHPPoolIniOverrideRepository
+	byPool map[string][]models.PHPPoolIniOverride
+}
+
+func (f *fakeIniOverrideRepo) ListByPool(_ context.Context, poolID string) ([]models.PHPPoolIniOverride, error) {
+	return f.byPool[poolID], nil
+}
+
 func applyCallParams(t *testing.T, agent *fakeAgent) map[string]any {
 	t.Helper()
 	for _, call := range agent.calls {
@@ -2265,6 +2278,10 @@ func newPoolReconcilerWithPkg(pkg *models.HostingPackage, packageID *string) (*R
 	phpPoolRepo.pools["pool-1"] = &models.PHPPool{ID: "pool-1", UserID: "user-1", PHPVersion: "8.4", PmMode: "ondemand", Status: "pending"}
 	r := New(&fakeDomainRepo{domains: make(map[string]*models.Domain)}, userRepo, agent, log, Config{Interval: time.Second}).
 		WithPHPPools(phpPoolRepo)
+	// Wire an empty ini-override repo so the GH #1422 fan-out routes through the
+	// override-aware ReconcileViaAgent (a nil repo makes it a fail-closed no-op).
+	// applyPHPPool-driven tests ignore overrides, so an empty repo is harmless.
+	r.WithPHPPoolIniOverrides(&fakeIniOverrideRepo{byPool: map[string][]models.PHPPoolIniOverride{}})
 	if pkg != nil {
 		r.WithPackages(&fakePackageRepoMin{pkgs: map[string]*models.HostingPackage{pkg.ID: pkg}})
 	}
@@ -2291,6 +2308,57 @@ func TestApplyPHPPool_DisableFunctionsByPackage(t *testing.T) {
 	p2 := applyCallParams(t, agent2)
 	_, ok2 := p2["disable_functions"]
 	require.False(t, ok2, "default package must NOT send disable_functions (agent uses safe default)")
+}
+
+// GH #1422: flipping php_exec_enabled must reach a domain pinned to a
+// non-default PHP version. The fan-out (ReapplyPHPPoolForUser) used to touch
+// only the default pool, so a versioned pool never got the opt-out — and the
+// periodic sweep skips a healthy pool, so it never self-healed either. Assert
+// EVERY pool the user has is re-applied with disable_functions="".
+func TestReapplyPHPPoolForUser_AllPoolsGetExecOptOut(t *testing.T) {
+	pkgID := "pkg-1"
+	r, agent, poolRepo := newPoolReconcilerWithPkg(
+		&models.HostingPackage{ID: pkgID, Name: "exec", PHPExecEnabled: true}, &pkgID)
+
+	// Default pool (pool-1) is seeded by the harness at zero-time. Add a
+	// versioned pool created later so ListByUserID orders it after the default.
+	poolRepo.pools["pool-1"].CreatedAt = time.Unix(1000, 0)
+	poolRepo.pools["pool-2"] = &models.PHPPool{
+		ID: "pool-2", UserID: "user-1", PHPVersion: "8.2", PmMode: "ondemand",
+		Status: "active", CreatedAt: time.Unix(2000, 0),
+	}
+
+	// Regression teeth (GH #1422): the versioned pool carries a tenant
+	// php_admin_value override. Routing the fan-out through the override-aware
+	// ReconcileViaAgent must preserve it — the old override-blind applyPHPPool
+	// re-rendered the pool with no php_admin_value lines and wiped it on a flip.
+	r.WithPHPPoolIniOverrides(&fakeIniOverrideRepo{byPool: map[string][]models.PHPPoolIniOverride{
+		"pool-2": {{Directive: "memory_limit", Value: "512M", Kind: "value"}},
+	}})
+
+	require.NoError(t, r.ReapplyPHPPoolForUser(context.Background(), "user-1"))
+
+	applies := filterCallsByPrefix(agent.calls, "php.pool.apply")
+	require.Len(t, applies, 2, "both the default and the versioned pool must be re-applied")
+
+	byVersion := map[string]map[string]any{}
+	for _, call := range applies {
+		p, ok := call.params.(map[string]any)
+		require.True(t, ok)
+		// Every pool in the fan-out carries the exec opt-out.
+		v, has := p["disable_functions"]
+		require.True(t, has, "every pool in the fan-out must carry the opt-out key; params=%v", p)
+		require.Equal(t, "", v, "exec-enabled package opts every pool out")
+		byVersion[p["php_version"].(string)] = p
+	}
+	require.Contains(t, byVersion, "8.4", "default pool (8.4) re-applied")
+	require.Contains(t, byVersion, "8.2", "versioned pool (8.2) re-applied")
+
+	// The versioned pool's override survives the flip (no wipe); the default
+	// pool, which has no override, carries none (per-pool targeting).
+	require.Equal(t, []map[string]string{{"name": "memory_limit", "value": "512M"}},
+		byVersion["8.2"]["admin_values"], "versioned pool's php_admin_value override must survive the flip")
+	require.Empty(t, byVersion["8.4"]["admin_values"], "default pool has no override; none should be sent")
 }
 
 // TestReconcileVersionedPHPPools verifies GH #329: a versioned pool with a
@@ -2454,6 +2522,7 @@ func (f *fakeUserRepo) UpdateShadowDBUsernames(context.Context, string, *string,
 	return nil
 }
 
-
 // ListByZoneIDs added for the JAB-374 batch interface method.
-func (m *fakeDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }
+func (m *fakeDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## What & why

GH #1422 — enabling **"Allow PHP exec functions (proc_open / shell_exec)"** on a hosting package (`php_exec_enabled`, GH #402) did not take effect: `shell_exec()` stayed undefined, and the setting was lost whenever a domain's PHP settings were saved or a new PHP version was assigned. Two independent gaps, both around the GH #402 `disable_functions` opt-out that `reconciler.applyPHPPool` already carried.

## Fix 1 — settings/version reconcile path never sent the opt-out

`phppoolops.ReconcileViaAgent` drives **every non-sweep pool apply** — a PHP-settings save, a version assign, an Xdebug / extension / tuning / opcache change. It never sent `disable_functions`, so each of those re-applied the #401 command-exec lockdown and silently re-broke `shell_exec`/`proc_open` for an exec-enabled package.

- Add a `Packages` repo to `ReconcileDeps`; send `disable_functions=""` only when the user's package opts out (exact mirror of `applyPHPPool`).
- **Fail-closed**: nil `Packages` repo, no package, or the flag off ⇒ key omitted ⇒ agent keeps its safe #401 default. A missing wiring can never *lift* the lockdown.
- Threaded through the one HTTP chokepoint (`reconcilePHPPoolViaAgent`; its 5 callers pass the already-wired `h.cfg.Packages`) and the operator CLI reconcile deps.

## Fix 2 — package-flip fan-out was default-only *and* override-blind

`reconciler.ReapplyPHPPoolForUser` (the admin-flips-a-package fan-out) re-applied only the user's **default** pool, and did so through the override-blind `applyPHPPool` (which renders a pool from params with no `php_admin_value` lines). Consequences:

- A domain pinned to a **non-default PHP version** never got the opt-out on a flip — and the 60s sweep skips a healthy pool, so it never self-healed.
- Every flip silently **wiped the default pool's tenant ini overrides**.

Route the whole fan-out through the same override-aware `phppoolops.ReconcileViaAgent` the settings/version-save path uses, **per pool** (default + versioned). It carries the tenant's `php_admin_value`/`php_admin_flag` overrides **and** the opt-out. This also fixes, by construction, the pre-existing default-pool override wipe on a package edit.

- **Fail-closed**: without the ini-override repo wired, the fan-out is a no-op (pools converge on the user's next settings-save via the same override-aware path) — never a fall-back to the override-blind wipe.
- Reconciler gains a nil-safe `WithPHPPoolIniOverrides` option, wired in `serve.go` from the repo already constructed there. No sweep behavior changes (only the fan-out is rerouted); `ReconcileViaAgent` writes status `ready`, which the sweep already treats as steady-state and skips.

## Security / scope

- **Tenant reach unchanged.** `php_exec_enabled` is an admin-only package field, and the only opt-out channel is the panel-controlled `disable_functions` param — tenant `admin_values` still rejects `disable_functions` (`forbiddenDirectives`). A tenant has no path to lift the lockdown.
- **Seen, not touched:** the cpanel-migration provision (`migrate/cpanel/restore_extras.go`) builds `php.pool.apply` directly without the flag — one-shot at migration time, out of scope here.
- **Known, pre-existing, out of scope:** the periodic sweep's pending/error rebuild (`ReconcilePHPPools` / `reconcileVersionedPHPPools`) still re-applies via the override-blind `applyPHPPool` — a transient override wipe that self-heals on the next settings-save. Filing a separate follow-up to route the sweep through the override-aware path too.

## Tests

- `phppoolops` — `ReconcileViaAgent` sends `""` for an exec package, omits the key for a non-exec package, and (fail-closed) omits it when `Packages` is nil even with a package set.
- `reconciler` — `ReapplyPHPPoolForUser` re-applies **both** a default and a versioned pool, each carrying the opt-out, **and** the versioned pool's `php_admin_value` override survives the flip (proves no wipe).
- `go build ./panel-api/...`, `go vet`, affected-package suites, and `-race` on `reconciler` + `phppoolops` all green; OpenAPI coverage gate passes (no new routes).

## Manual box-drill (TODO before merge)

On a box with an exec-enabled package and a versioned-pool domain carrying an ini override (e.g. `memory_limit`):

1. Save any PHP setting on a domain of that package → `grep disable_functions /etc/php/*/fpm/pool.d/jabali-<user>*.conf` shows **no** `disable_functions` line, and `<?php echo shell_exec('id'); ?>` runs via FPM.
2. Toggle the package flag off→on → confirm the versioned pool's `php_admin_value[memory_limit]` line is still present (override survived the flip) and exec is available.

GH #1422
