### PR TITLE
fix(docker): pass the owner cgroup on tenant install + bring-up so the cross-tenant-slice check stays strict (JAB-364)

### DIFF
--- a/panel-api/internal/api/docker_apps_user.go
+++ b/panel-api/internal/api/docker_apps_user.go
@@ -311,12 +311,19 @@ func (h *userDockerAppHandler) lifecycle(statusOnSuccess string, composeArgs ...
 			defer cancel()
 			params := map[string]any{"slug": app.EffectiveSlug()}
 			// Bring-up lifecycle (start/restart) re-runs `compose up` from the
-			// on-disk compose — make the agent re-validate the tenant gate first
-			// (Gitea #513), the same as install/update/restore.
+			// on-disk compose — make the agent re-validate the tenant safety
+			// profile first (Gitea #513), the SAME as install/update/restore.
+			// Route through the shared helper so tenant_cgroup (the exact owner
+			// slice) is included: passing only tenant_validate/tenant_caps here
+			// silently dropped the Gitea #525 cross-tenant-slice check to the weak
+			// generic-pattern match, so a tampered on-disk compose declaring
+			// ANOTHER tenant's slice would have passed on start/restart (JAB-364).
+			// Fail closed if the safety profile can't be resolved — never bring an
+			// app up unvalidated (Gitea #529).
 			if statusOnSuccess == models.DockerAppStatusRunning {
-				if entry, ok := h.cfg.Catalog.Get(app.Slug); ok {
-					params["tenant_validate"] = true
-					params["tenant_caps"] = dockerapp.TenantCapAllowlist(entry.TenantCaps)
+				if err := h.admin.applyTenantValidateParams(ctx, app, params); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "tenant_validation_unavailable", "detail": firstLineString(err.Error())})
+					return
 				}
 			}
 			if _, err := h.cfg.Agent.Call(ctx, "docker_app."+composeArgs[0], params); err != nil {
@@ -634,9 +641,16 @@ func (h *userDockerAppHandler) install(c *gin.Context) {
 			"volume_owner":                entry.VolumeOwner,
 			"wait_healthy":                true,
 			"healthcheck_timeout_seconds": 300,
-			// M49: agent safety gate before `up`.
-			"tenant_validate": true,
-			"tenant_caps":     dockerapp.TenantCapAllowlist(entry.TenantCaps),
+		}
+		// M49 + Gitea #525: agent safety gate before `up`. The shared helper adds
+		// tenant_validate/tenant_caps AND tenant_cgroup (the exact owner slice), so
+		// the strict cross-tenant-slice check is armed on install too — not only
+		// the weak generic-pattern match (JAB-364). Fail closed if the profile
+		// can't be resolved (Gitea #529): drop the just-created row and refuse.
+		if err := h.admin.applyTenantValidateParams(ctx, app, installParams); err != nil {
+			_ = h.cfg.Repo.Delete(ctx, app.ID)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "tenant_validation_unavailable", "detail": firstLineString(err.Error())})
+			return
 		}
 		appID := app.ID
 		go func() {

--- a/panel-api/internal/api/docker_apps_user_test.go
+++ b/panel-api/internal/api/docker_apps_user_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
@@ -413,6 +415,113 @@ func TestTenantDocker_StartUnderQuotaOK(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("under-quota start = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// dockerCgroupCfg is the shared happy-path cfg for the tenant lifecycle
+// revalidation tests: owner "alice", package under quota, a recording agent.
+func dockerCgroupCfg(t *testing.T, mock *agent.MockClient, status string) UserDockerAppHandlerConfig {
+	t.Helper()
+	return UserDockerAppHandlerConfig{
+		Repo: &fakeDockerRepo{
+			sumBytes: 100 << 20, // under quota
+			owned:    map[string]*models.DockerApp{"a1": {ID: "a1", Slug: "tdemo", UserID: uname("u1"), Status: status}},
+		},
+		Catalog:  tenantCatalog(t),
+		Users:    &fakeUserRepo{user: &models.User{ID: "u1", Username: uname("alice"), PackageID: uname("p1")}},
+		Packages: &fakePkgRepo{pkg: &models.HostingPackage{ID: "p1", MaxDockerApps: 5, DiskQuotaMB: 1024}},
+		Domains:  &fakeDomainRepo{},
+		Agent:    mock,
+	}
+}
+
+func lastAgentParams(t *testing.T, mock *agent.MockClient, command string) map[string]any {
+	t.Helper()
+	var found *agent.MockCall
+	for i := range mock.Calls() {
+		if c := mock.Calls()[i]; c.Command == command {
+			cc := c
+			found = &cc
+		}
+	}
+	if found == nil {
+		t.Fatalf("no agent call recorded for %q; calls=%v", command, mock.Calls())
+	}
+	var p map[string]any
+	if err := json.Unmarshal(found.Params, &p); err != nil {
+		t.Fatalf("unmarshal %q params: %v", command, err)
+	}
+	return p
+}
+
+// JAB-364: tenant start/restart must re-validate the tenant safety profile with
+// the EXACT owner slice (tenant_cgroup), not just tenant_validate/tenant_caps.
+// Omitting tenant_cgroup dropped the agent's Gitea #525 cross-tenant-slice check
+// to the weak generic-pattern match on the bring-up path.
+func TestTenantDocker_BringUpPassesOwnerCgroup(t *testing.T) {
+	for _, verb := range []string{"start", "restart"} {
+		t.Run(verb, func(t *testing.T) {
+			mock := agent.NewMockClient()
+			mock.On("docker_app."+verb, map[string]any{"status": "ok"})
+			r := tenantRouter(t, dockerCgroupCfg(t, mock, models.DockerAppStatusStopped), true)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/docker-apps/a1/"+verb, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s: want 200, got %d (%s)", verb, rec.Code, rec.Body.String())
+			}
+			p := lastAgentParams(t, mock, "docker_app."+verb)
+			if p["tenant_validate"] != true {
+				t.Errorf("%s: tenant_validate = %v, want true", verb, p["tenant_validate"])
+			}
+			if got := p["tenant_cgroup"]; got != "jabali-user-alice.slice" {
+				t.Errorf("%s: tenant_cgroup = %v, want jabali-user-alice.slice", verb, got)
+			}
+			if _, ok := p["tenant_caps"]; !ok {
+				t.Errorf("%s: tenant_caps missing", verb)
+			}
+		})
+	}
+}
+
+// JAB-364 / Gitea #529: if the owner slice can't be resolved (no username), the
+// bring-up must fail closed — never dispatch `compose up` unvalidated.
+func TestTenantDocker_BringUpFailsClosedWhenOwnerUnresolved(t *testing.T) {
+	mock := agent.NewMockClient()
+	mock.On("docker_app.start", map[string]any{"status": "ok"})
+	cfg := dockerCgroupCfg(t, mock, models.DockerAppStatusStopped)
+	cfg.Users = &fakeUserRepo{user: &models.User{ID: "u1", Username: nil, PackageID: uname("p1")}}
+	r := tenantRouter(t, cfg, true)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docker-apps/a1/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "tenant_validation_unavailable") {
+		t.Fatalf("want 500 tenant_validation_unavailable, got %d %s", rec.Code, rec.Body.String())
+	}
+	for _, c := range mock.Calls() {
+		if c.Command == "docker_app.start" {
+			t.Fatal("agent bring-up dispatched despite an unresolved owner slice — must fail closed")
+		}
+	}
+}
+
+// Stop is never a bring-up, so it neither validates nor needs the owner slice.
+func TestTenantDocker_StopDoesNotValidate(t *testing.T) {
+	mock := agent.NewMockClient()
+	mock.On("docker_app.stop", map[string]any{"status": "ok"})
+	r := tenantRouter(t, dockerCgroupCfg(t, mock, models.DockerAppStatusRunning), true)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docker-apps/a1/stop", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stop: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	p := lastAgentParams(t, mock, "docker_app.stop")
+	if _, ok := p["tenant_validate"]; ok {
+		t.Errorf("stop must not set tenant_validate: %v", p)
 	}
 }
 


### PR DESCRIPTION
## What

Route the tenant Docker HTTP path (install + start/restart bring-up) through the shared, fail-closed `applyTenantValidateParams` helper so the agent receives `tenant_cgroup` — the exact owner slice `jabali-user-<owner>.slice` — on those transitions.

## Why (the security gap)

The agent's tenant compose validation (`runTenantComposeValidation`) enforces the **strict** Gitea #525 check — "`cgroup_parent` must equal the owner's slice" — only when it is handed that expected slice via `tenant_cgroup`. Without it, validation silently degrades to the **weak** generic pattern ("is *some* `jabali-user-*.slice`").

The tenant HTTP handler built its agent params by hand and set only `tenant_validate` + `tenant_caps` — never `tenant_cgroup`. So on a tenant install and on every tenant start/restart, a tampered on-disk compose declaring **another tenant's** slice would have passed validation, applying that tenant's M18 cpu/mem limits, loopback isolation, egress firewall and audit attribution to the wrong owner. The admin HTTP path, the CLI parity path, and the update/restore paths all already pass `tenant_cgroup`; only this surface omitted it.

## The fix

Both tenant sites now call the admin handler's existing `applyTenantValidateParams` (reachable via the tenant handler's `admin` sub-handler — already reused for `resolvePorts`/`readInstallEnv`). It sets `tenant_validate` + `tenant_caps` + `tenant_cgroup` together and **fails closed** (Gitea #529, `tenant_validation_unavailable`, HTTP 500 — matching every admin call site) when the owner slice can't be resolved, so an app is never brought up or installed unvalidated. This also deletes the hand-rolled param duplication, matching JAB-364's "admin, tenant and CLI become thin adapters over one lifecycle" direction.

## Scope — one AC half

This is the **isolation-revalidation-on-transition** half of JAB-364 AC1. The loopback / no-privileged / bind-containment re-validation already ran on bring-up via `tenant_validate` (Gitea #513); the missing piece was the exact owner slice. The **resource-cap re-clamp** half of AC1, plus AC3 (vhost removal) and AC4 (retryable failed state), remain open on the parent ticket.

## Agent unchanged — no box

The agent already accepts and enforces `tenant_cgroup`; this is panel-only param plumbing onto an already-validated, already-tested agent path. No box drill.

## Test plan

- `TestTenantDocker_BringUpPassesOwnerCgroup` — start and restart both dispatch `docker_app.{start,restart}` carrying `tenant_validate=true`, `tenant_cgroup="jabali-user-alice.slice"`, and `tenant_caps`.
- `TestTenantDocker_BringUpFailsClosedWhenOwnerUnresolved` — owner username unresolvable → HTTP 500 `tenant_validation_unavailable`, and **no** `docker_app.start` is dispatched.
- `TestTenantDocker_StopDoesNotValidate` — stop carries no `tenant_validate` (never re-runs `compose up`).
- Both new guards were falsified before landing. Full `panel-api/internal/api` suite green, `go vet` clean, panel-api builds.
- **Known gap (stated):** the install site has no HTTP-level test — its happy path wires ports, domain attach and an async install goroutine. Mitigation: install and bring-up call the *identical* `applyTenantValidateParams`; the helper's cgroup resolution + fail-closed are covered by `docker_apps_tenant_rerender_test.go`, and the bring-up HTTP test proves the tenant handler routes through it.
- **Cleanup note:** the install fail-closed uses a bare `Repo.Delete`, identical to the sibling `env_materialise_failed` / `render_failed` paths at the same depth (both after port-create + domain-attach) — matches the house pattern; any domain-attach leak there is pre-existing and shared, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
