### PR TITLE
fix(mail): hide the mail-provider select in the Create Mail Domain drawer (GH #1479)

### DIFF
--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -99,7 +99,10 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           name: values.name,
           web_enabled: false,
           manage_dns: isDNS ? true : values.manage_dns,
-          mail_provider: isDNS ? "none" : values.mail_provider,
+          // GH #1479: the non-web branch is either a DNS-only zone (no mail) or
+          // a mail domain (always Jabali mail — the provider select is hidden in
+          // mail mode, so values.mail_provider isn't registered).
+          mail_provider: isDNS ? "none" : "jabali",
           m365_onmicrosoft: values.m365_onmicrosoft,
           google_dkim: values.google_dkim,
           ssl_mode: isDNS ? "none" : values.ssl_mode,
@@ -179,7 +182,12 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           </Form.Item>
         )}
 
-        {(isWeb || isMail) && (
+        {/* GH #1479 (johnnyq follow-up): the mail-provider select is web-only.
+            On the Create Mail Domain flow it's redundant and self-contradictory
+            (picking "No mail" / an external provider in a "create mail domain"
+            drawer), so mail mode hides it and always provisions Jabali mail —
+            handleFinish forces mail_provider="jabali" for the non-web branch. */}
+        {isWeb && (
         <Form.Item
           label={t("userdomaindrawer.mail")}
           name="mail_provider"

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -167,6 +167,11 @@ describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
     expect(screen.getByRole("checkbox", { name: /Create DNS mail records/i })).toBeChecked();
     // Domain-name field is there to type into.
     expect(screen.getByPlaceholderText(/example\.com/i)).toBeInTheDocument();
+    // GH #1479 (johnnyq follow-up): the mail-provider select is web-only —
+    // it must NOT appear in the Create Mail Domain drawer (mail is implied).
+    expect(screen.queryByText("No mail")).not.toBeInTheDocument();
+    expect(screen.queryByText("Microsoft 365")).not.toBeInTheDocument();
+    expect(screen.queryByText("Jabali mail (this server)")).not.toBeInTheDocument();
   });
 
   // GH #1479: the mail-mode create posts the right domain shape (web off, mail on


### PR DESCRIPTION
## What & why

Follow-up to GH #1479 (PR #1535, which added the **Create Mail Domain** button on the tenant Mail Domains page). Reviewing it, @johnnyq said:

> Looks great however you don't need the Mail select input here

The shared Add-domain drawer, when opened in **mail mode**, still showed the web-oriented **mail-provider select** (Jabali mail / No mail / Microsoft 365 / Google Workspace). In a drawer whose entire purpose is to create a Jabali mail domain, that control is redundant and self-contradictory — choosing "No mail" or an external provider there makes no sense.

## Change

- **Hide the mail-provider select in mail mode.** Its render guard drops from `(isWeb || isMail)` to `isWeb`.
- **Force `mail_provider="jabali"` for the non-web branch** in `handleFinish` — that branch is either a DNS-only zone (`"none"`) or a mail domain (`"jabali"`). Since the field is no longer rendered in mail mode, `values.mail_provider` isn't registered, so the payload sets it explicitly instead of reading the form.
- The **web** Add-domain flow is untouched — it still offers the full provider select (Jabali / None / M365 / Google), and the M365/Google conditional inputs it drives.

## Tests

- `MailDomainsPage` — the Create Mail Domain drawer no longer renders the provider options ("No mail" / "Microsoft 365" / "Jabali mail (this server)").
- The existing "submits a mail domain" test still asserts `POST /domains` carries `mail_provider: "jabali"`, so the forced value stays covered.
- `tsc -b`, `eslint`, and the full `domains/` + mail-page vitest suites green; web-mode drawer tests (GH #1409/#1413) unaffected.

GH #1479
