### PR TITLE
fix(nginx): re-point the :443 landing vhost server_name on a panel hostname change (JAB-389)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7817,6 +7817,10 @@ server {
     listen [::]:443 ssl${_NGX_H2_PARAM};
     listen ${JABALI_SRV_IPV4}:443 ssl${_NGX_H2_PARAM};
     ${_NGX_H2_DIR}
+    # JAB-389: the nginx.panel_landing_rehost agent verb re-points this
+    # server_name on a live panel hostname change. It matches a single-value
+    # `server_name <host>;` on this line — keep it one host, no www. alias, the
+    # semicolon on the same line, or the verb silently no-ops on every rename.
     server_name ${JABALI_SRV_HOSTNAME};
 
     ssl_certificate     ${tls_cert};

--- a/panel-agent/internal/commands/nginx_panel_landing_rehost.go
+++ b/panel-agent/internal/commands/nginx_panel_landing_rehost.go
@@ -1,0 +1,175 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// nginx.panel_landing_rehost re-points the server_name of the panel's :443
+// landing vhost in /etc/nginx/sites-available/jabali-default.conf to the
+// current panel hostname, then reloads nginx (JAB-389).
+//
+// Why it exists: changing the panel FQDN through Settings updates the OS
+// hostname (system.set_hostname) and the panel_certificate rows, and the
+// self-signed panel cert is re-issued by the ssl.panel.selfsign reconciler.
+// But the GH#135 dedicated :443 landing vhost keeps its server_name on the OLD
+// FQDN — it is rendered only by install.sh (install_nginx_default_vhost, at
+// install / `jabali update`). So after a live rename, https://<new-fqdn>/ on
+// :443 no longer matches the landing server{} and falls to the default
+// return-444 block: the browser shows "Secure Connection Failed" even though
+// :8443 and the cert are correct. That is the exact symptom GH#135 fixed for
+// the original hostname, reintroduced by the rename.
+//
+// Scope is server_name ONLY. `root /var/www/<old>` is left as-is (the admin's
+// landing content is preserved; no docroot migration), and the two
+// `return 301 https://mail.<host>/` webmail redirects are left untouched: the
+// panel mail hostname was deliberately decoupled from the FQDN (#1546,
+// renameOnDrift=false), so re-pointing them would send webmail at a name with
+// no vhost and no cert.
+//
+// Why change-time (dispatched by the Settings handler on a hostname change),
+// not a stateless reconciler like kratos.config.rehost / ssl.panel.selfsign:
+// the panel-api daemon's AppArmor profile grants /etc/jabali-panel/** r and
+// /etc/jabali/** r (so those reconcilers can read kratos.yml and panel.crt on
+// disk to detect drift) but NOT /etc/nginx — a reconciler in the confined
+// daemon could not read this vhost. A self-healing reconciler would have to
+// widen the hardened daemon's read surface, which isn't warranted for a
+// landing-page server_name. Boxes already broken by a past rename converge
+// when install.sh's install_nginx_default_vhost next re-renders under `jabali
+// update` (it sources the name from `hostname -f`, which system.set_hostname
+// already set to the new FQDN).
+type nginxPanelLandingRehostParams struct {
+	Hostname string `json:"hostname"`
+}
+
+type nginxPanelLandingRehostResponse struct {
+	Rewritten    bool   `json:"rewritten"`
+	Reason       string `json:"reason,omitempty"`
+	Replacements int    `json:"replacements,omitempty"`
+}
+
+// panelLandingVhostPath is the on-disk default/landing vhost. Overridable in tests.
+var panelLandingVhostPath = "/etc/nginx/sites-available/jabali-default.conf"
+
+// panelLandingServerNameRE captures a server_name directive whose value is a
+// real hostname. `server_name _;` (the two default catch-all blocks in the
+// same file) is skipped because `_` is not in the value character class, so
+// only the GH#135 landing block matches. RE2 has no lookahead — the class
+// exclusion is what does the skipping.
+var panelLandingServerNameRE = regexp.MustCompile(`(?m)^(\s*server_name\s+)([a-zA-Z0-9][a-zA-Z0-9.-]*)(\s*;)`)
+
+// panelLandingServerName returns the value of the first real-hostname
+// server_name directive in the file.
+func panelLandingServerName(data []byte) (string, bool) {
+	m := panelLandingServerNameRE.FindSubmatch(data)
+	if m == nil {
+		return "", false
+	}
+	return string(m[2]), true
+}
+
+func nginxPanelLandingRehostHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p nginxPanelLandingRehostParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	target := strings.ToLower(strings.TrimSpace(p.Hostname))
+	if !sslDomainRegex.MatchString(target) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid hostname %q", p.Hostname),
+		}
+	}
+
+	data, err := os.ReadFile(panelLandingVhostPath)
+	if err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("read %s: %v", panelLandingVhostPath, err),
+		}
+	}
+	current, ok := panelLandingServerName(data)
+	if !ok {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("no landing server_name in %s", panelLandingVhostPath),
+		}
+	}
+	if strings.EqualFold(current, target) {
+		return nginxPanelLandingRehostResponse{Rewritten: false, Reason: "already current"}, nil
+	}
+
+	rewritten, n := rewritePanelLandingServerName(data, current, target)
+	if n == 0 {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("no server_name %q to rewrite", current),
+		}
+	}
+	// Confirm the rewrite converged before touching a live nginx.
+	if h, ok := panelLandingServerName(rewritten); !ok || !strings.EqualFold(h, target) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "refusing to write: landing server_name did not converge to target",
+		}
+	}
+
+	if err := writeFilePreservingMeta(panelLandingVhostPath, rewritten); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("write %s: %v", panelLandingVhostPath, err),
+		}
+	}
+	// nginx cannot test one file in isolation, so validate the whole config
+	// after the swap and roll this file back on failure — a broken
+	// jabali-default.conf would take every :443 vhost down, not just the panel.
+	if out, terr := execCommandContext(ctx, "nginx", "-t").CombinedOutput(); terr != nil {
+		_ = writeFilePreservingMeta(panelLandingVhostPath, data)
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("nginx -t failed after landing server_name rewrite (rolled back): %s", strings.TrimSpace(string(out))),
+		}
+	}
+	if out, rerr := execCommandContext(ctx, "systemctl", "reload", "nginx").CombinedOutput(); rerr != nil {
+		// The file is valid and converged on disk; the next nginx reload from
+		// any domain operation applies it. Surface the reload failure so the
+		// caller logs it.
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("systemctl reload nginx failed: %s", strings.TrimSpace(string(out))),
+		}
+	}
+
+	return nginxPanelLandingRehostResponse{
+		Rewritten:    true,
+		Reason:       current + " -> " + target,
+		Replacements: n,
+	}, nil
+}
+
+// rewritePanelLandingServerName replaces the value of every server_name
+// directive equal to oldHost with newHost, and returns the new bytes plus the
+// replacement count. Anchoring on the whole `server_name <value>;` directive
+// leaves `root /var/www/<oldHost>` and the `mail.<oldHost>` redirects
+// untouched by construction — only server_name is rewritten.
+func rewritePanelLandingServerName(data []byte, oldHost, newHost string) ([]byte, int) {
+	re := regexp.MustCompile(`(?m)^(\s*server_name\s+)` + regexp.QuoteMeta(oldHost) + `(\s*;)`)
+	count := len(re.FindAll(data, -1))
+	if count == 0 {
+		return data, 0
+	}
+	return re.ReplaceAll(data, []byte("${1}"+newHost+"${2}")), count
+}
+
+func init() {
+	Default.Register("nginx.panel_landing_rehost", nginxPanelLandingRehostHandler)
+}

--- a/panel-agent/internal/commands/nginx_panel_landing_rehost_test.go
+++ b/panel-agent/internal/commands/nginx_panel_landing_rehost_test.go
@@ -1,0 +1,217 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// panelLandingFixture is a jabali-default.conf shaped like install.sh's
+// install_nginx_default_vhost output: a :80 redirect block and a :443 default
+// block (both `server_name _;`), then the GH#135 dedicated :443 landing vhost
+// carrying the real hostname in server_name, root and the mail redirects. Only
+// the landing server_name must ever change.
+func panelLandingFixture(host string) string {
+	return `server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    server_name _;
+
+    ssl_certificate     /etc/jabali/tls/panel.crt;
+    ssl_certificate_key /etc/jabali/tls/panel.key;
+
+    location / {
+        include /etc/nginx/jabali-catchall.conf;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name ` + host + `;
+
+    ssl_certificate     /etc/jabali/tls/panel.crt;
+    ssl_certificate_key /etc/jabali/tls/panel.key;
+
+    root  /var/www/` + host + `;
+    index index.php index.html;
+
+    location = /webmail  { return 301 https://mail.` + host + `/; }
+    location = /webmail/ { return 301 https://mail.` + host + `/; }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+`
+}
+
+// withPanelLandingVhost points the verb at a temp jabali-default.conf for the
+// duration of one non-parallel test.
+func withPanelLandingVhost(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jabali-default.conf")
+	if contents != "" {
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prev := panelLandingVhostPath
+	panelLandingVhostPath = path
+	t.Cleanup(func() { panelLandingVhostPath = prev })
+	return path
+}
+
+func callLandingRehost(t *testing.T, hostname string) (nginxPanelLandingRehostResponse, error) {
+	t.Helper()
+	raw, err := nginxPanelLandingRehostHandler(context.Background(), json.RawMessage(`{"hostname":"`+hostname+`"}`))
+	if err != nil {
+		return nginxPanelLandingRehostResponse{}, err
+	}
+	b, _ := json.Marshal(raw)
+	var resp nginxPanelLandingRehostResponse
+	if uerr := json.Unmarshal(b, &resp); uerr != nil {
+		t.Fatalf("unmarshal response: %v", uerr)
+	}
+	return resp, nil
+}
+
+func TestRewritePanelLandingServerName(t *testing.T) {
+	t.Parallel()
+	in := panelLandingFixture("old.example.com")
+	out, n := rewritePanelLandingServerName([]byte(in), "old.example.com", "mx.example.com")
+	s := string(out)
+	if n != 1 {
+		t.Fatalf("replacements = %d, want 1 (only the one non-`_` server_name)", n)
+	}
+	if !strings.Contains(s, "server_name mx.example.com;") {
+		t.Errorf("landing server_name not rewritten:\n%s", s)
+	}
+	if strings.Count(s, "server_name _;") != 2 {
+		t.Errorf("the two catch-all `server_name _;` blocks must be untouched:\n%s", s)
+	}
+	// root and the mail redirects keep the OLD host by construction — server_name only.
+	if !strings.Contains(s, "root  /var/www/old.example.com;") {
+		t.Errorf("root docroot must be left on the old host (no docroot migration):\n%s", s)
+	}
+	if strings.Count(s, "https://mail.old.example.com/;") != 2 {
+		t.Errorf("mail webmail redirects must be left untouched (#1546 decoupling):\n%s", s)
+	}
+	if strings.Contains(s, "https://mail.mx.example.com/") {
+		t.Errorf("mail redirect was wrongly re-pointed to the new host")
+	}
+}
+
+func TestNginxPanelLandingRehost_Rewrites(t *testing.T) {
+	// execCommandContext is the always-exit-0 stub from TestMain, so nginx -t
+	// and reload both "succeed" — this asserts the file mutation only.
+	path := withPanelLandingVhost(t, panelLandingFixture("old.example.com"))
+
+	resp, err := callLandingRehost(t, "mx.example.com")
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !resp.Rewritten || resp.Replacements != 1 {
+		t.Fatalf("resp = %+v, want rewritten with 1 replacement", resp)
+	}
+	out, _ := os.ReadFile(path)
+	s := string(out)
+	if !strings.Contains(s, "server_name mx.example.com;") {
+		t.Errorf("new server_name not on disk:\n%s", s)
+	}
+	if strings.Contains(s, "server_name old.example.com;") {
+		t.Errorf("old server_name survived on disk")
+	}
+	if strings.Count(s, "server_name _;") != 2 {
+		t.Errorf("catch-all blocks mutated")
+	}
+	if !strings.Contains(s, "root  /var/www/old.example.com;") || strings.Count(s, "https://mail.old.example.com/;") != 2 {
+		t.Errorf("root or mail redirects were changed (must stay on old host):\n%s", s)
+	}
+	// Mode preserved by the atomic write.
+	if fi, _ := os.Stat(path); fi.Mode().Perm() != 0o644 {
+		t.Errorf("mode = %o, want 644", fi.Mode().Perm())
+	}
+}
+
+func TestNginxPanelLandingRehost_NoChurnWhenCurrent(t *testing.T) {
+	path := withPanelLandingVhost(t, panelLandingFixture("mx.example.com"))
+	before, _ := os.ReadFile(path)
+
+	resp, err := callLandingRehost(t, "mx.example.com") // already current
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if resp.Rewritten {
+		t.Fatalf("expected no rewrite when server_name already current, got %+v", resp)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("file mutated on the no-churn path")
+	}
+}
+
+func TestNginxPanelLandingRehost_RejectsInvalidHost(t *testing.T) {
+	path := withPanelLandingVhost(t, panelLandingFixture("old.example.com"))
+	before, _ := os.ReadFile(path)
+
+	if _, err := nginxPanelLandingRehostHandler(context.Background(), json.RawMessage(`{"hostname":"bad host!!"}`)); err == nil {
+		t.Fatal("expected error for invalid hostname")
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("file mutated on invalid hostname")
+	}
+}
+
+func TestNginxPanelLandingRehost_MissingServerName(t *testing.T) {
+	// A file with only `server_name _;` blocks has no landing host to rehost.
+	onlyCatchAll := "server {\n    listen 443 ssl default_server;\n    server_name _;\n}\n"
+	withPanelLandingVhost(t, onlyCatchAll)
+	if _, err := callLandingRehost(t, "mx.example.com"); err == nil {
+		t.Fatal("expected error when no landing server_name is present")
+	}
+}
+
+func TestNginxPanelLandingRehost_MissingFile(t *testing.T) {
+	withPanelLandingVhost(t, "") // no file written
+	if _, err := callLandingRehost(t, "mx.example.com"); err == nil {
+		t.Fatal("expected error for missing jabali-default.conf")
+	}
+}
+
+func TestNginxPanelLandingRehost_NginxTestFailureRollsBack(t *testing.T) {
+	path := withPanelLandingVhost(t, panelLandingFixture("old.example.com"))
+	before, _ := os.ReadFile(path)
+
+	// Make `nginx -t` fail (exit 1) but leave everything else succeeding. A
+	// broken jabali-default.conf must be rolled back to the original bytes.
+	prev := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name == "nginx" && len(args) > 0 && args[0] == "-t" {
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { execCommandContext = prev })
+
+	if _, err := callLandingRehost(t, "mx.example.com"); err == nil {
+		t.Fatal("expected error when nginx -t fails")
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatalf("file not rolled back after nginx -t failure:\n%s", string(after))
+	}
+}

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -809,6 +809,21 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 				h.cfg.Log.Error("agent set_hostname failed", "err", err)
 			}
 		}()
+		// JAB-389: the GH#135 dedicated :443 landing vhost keeps its server_name
+		// on the old FQDN after a rename (install.sh renders it; nothing
+		// re-renders it live), so https://<new-fqdn>/ falls to the return-444
+		// default block. Re-point it to the new hostname. Dispatched
+		// independently of set_hostname — the DB row is the truth, so the
+		// landing vhost should track it even if hostnamectl failed.
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if _, err := h.cfg.Agent.Call(bgCtx, "nginx.panel_landing_rehost", map[string]any{
+				"hostname": current.Hostname,
+			}); err != nil {
+				h.cfg.Log.Error("agent nginx.panel_landing_rehost failed", "err", err)
+			}
+		}()
 	}
 
 	// Optional-module lifecycle (JAB-294). settingsops.ModuleEffects is the single

--- a/panel-api/internal/api/server_settings_landing_rehost_test.go
+++ b/panel-api/internal/api/server_settings_landing_rehost_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-389: a hostname change must re-point the GH#135 :443 landing vhost's
+// server_name to the new FQDN via the agent, alongside system.set_hostname —
+// otherwise https://<new-fqdn>/ falls to the return-444 default block. The
+// dispatch is an async best-effort goroutine, so wait for it.
+func TestServerSettingsPatch_HostnameChange_DispatchesLandingRehost(t *testing.T) {
+	existing := &models.ServerSettings{
+		ID:              1,
+		Hostname:        "old.example.com",
+		PublicIPv4:      "192.0.2.1",
+		SSHPort:         22,
+		SSHPasswordAuth: false,
+	}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	mockAgent := agent.NewMockClient()
+	mockAgent.On("system.set_hostname", map[string]any{"status": "ok"})
+	mockAgent.On("nginx.panel_landing_rehost", map[string]any{"status": "ok"})
+
+	r := settingsRouter(true, mockRepo, mockAgent)
+
+	body, _ := json.Marshal(map[string]any{"hostname": "new.example.com"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var params map[string]any
+	require.Eventually(t, func() bool {
+		for _, c := range mockAgent.Calls() {
+			if c.Command == "nginx.panel_landing_rehost" {
+				require.NoError(t, json.Unmarshal(c.Params, &params))
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "nginx.panel_landing_rehost was never dispatched")
+
+	require.Equal(t, "new.example.com", params["hostname"], "landing rehost must carry the new hostname (the DB truth)")
+}
+
+// A PATCH that does not change the hostname must NOT dispatch the landing
+// rehost — the gate is the hostname transition, same as system.set_hostname.
+func TestServerSettingsPatch_NoHostnameChange_SkipsLandingRehost(t *testing.T) {
+	existing := &models.ServerSettings{
+		ID:              1,
+		Hostname:        "keep.example.com",
+		PublicIPv4:      "192.0.2.1",
+		SSHPort:         22,
+		SSHPasswordAuth: false,
+	}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	mockAgent := agent.NewMockClient()
+
+	r := settingsRouter(true, mockRepo, mockAgent)
+
+	// Same hostname, different benign field → hostname gate stays closed.
+	body, _ := json.Marshal(map[string]any{"hostname": "keep.example.com"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Give any (erroneous) async dispatch time to land, then assert it did not.
+	time.Sleep(50 * time.Millisecond)
+	for _, c := range mockAgent.Calls() {
+		if c.Command == "nginx.panel_landing_rehost" {
+			t.Fatalf("landing rehost dispatched on a no-op hostname change")
+		}
+	}
+}


### PR DESCRIPTION
## What

When the panel FQDN is changed live through Settings, `system.set_hostname`
updates the OS hostname and the `panel_certificate` rows are re-issued, but the
GH#135 dedicated `:443` landing vhost in
`/etc/nginx/sites-available/jabali-default.conf` keeps its `server_name` on the
**old** FQDN. That block is rendered only by `install.sh`
(`install_nginx_default_vhost`, at install / `jabali update`), so nothing
re-points it on a live rename. Result: `https://<new-fqdn>/` on `:443` no longer
matches the landing `server{}` and falls through to the default return-444
block — the browser shows "Secure Connection Failed" even though `:8443` and the
cert are correct. This is exactly the symptom GH#135 fixed for the original
hostname, reintroduced by the rename.

Note: the ticket framed this as a `:8443 server_name` gap. That is not where the
bug is — the `:8443` panel vhost template is `server_name _;` (a catch-all, it
matches any name). The stale artifact is the GH#135 **`:443`** landing block.

## Change

New agent verb `nginx.panel_landing_rehost` (root; the agent may write
`/etc/nginx`). It does a **targeted `server_name`-directive rewrite** of
`jabali-default.conf` to the current panel hostname, then `nginx -t` and reload,
with rollback-to-original-bytes if `nginx -t` fails (a broken
`jabali-default.conf` would take every `:443` vhost down, not just the panel).

The Settings handler dispatches it as a best-effort async goroutine on a
hostname change, alongside the existing `system.set_hostname` dispatch. The
dispatch is gated on the hostname transition and carries the new hostname (the
DB truth), independent of whether `set_hostname` succeeds.

### Scope is `server_name` only — deliberately

- `root /var/www/<old>` is left as-is: the admin's landing content is preserved,
  no docroot migration.
- The two `return 301 https://mail.<host>/` webmail redirects are left
  untouched. The panel mail hostname was deliberately decoupled from the FQDN in
  #1546 (`renameOnDrift=false`); re-pointing them would send webmail at a name
  with no vhost and no cert. Anchoring the regex on the whole
  `server_name <value>;` directive leaves both `root` and the `mail.` redirects
  out by construction.
- The two `server_name _;` catch-all blocks in the same file are skipped because
  `_` is not in the hostname value character class.

### Why change-time dispatch, not a stateless reconciler

The other hostname-drift reconcilers (`kratos.config.rehost`,
`ssl.panel.selfsign`) live in the confined `panel-api` daemon. That daemon's
AppArmor profile (`install/apparmor/usr.local.bin.jabali-panel-api`) grants
`/etc/jabali-panel/** r` and `/etc/jabali/** r` — so those reconcilers can read
`kratos.yml` and `panel.crt` on disk to detect drift — but it does **not** grant
`/etc/nginx`. A reconciler in the daemon could not read this vhost at all.
Making it a self-healing reconciler would require widening the hardened daemon's
read surface to `/etc/nginx r`, which isn't warranted for a landing-page
`server_name` (and carries the AppArmor flip-timer deployment subtlety from
JAB-349). So this ships as change-time dispatch from the handler instead. If we
later decide the self-heal is worth it, granting `/etc/nginx r` to the panel-api
profile is the deliberate follow-up.

### Already-broken boxes

A box already broken by a past rename converges when `install.sh`'s
`install_nginx_default_vhost` next re-renders the file under `jabali update` (it
sources the name from `hostname -f`, which `system.set_hostname` already set to
the new FQDN). Whether that re-render happens on a no-new-release update depends
on the self-updater's version gate, which this PR does not touch.

## Guard tests (all falsified before landing)

- `nginx -t` failure rolls the file back to the original bytes.
- Rewrite touches `server_name` only — `root`, the `mail.` redirects, and the
  two `server_name _;` catch-alls are asserted unchanged.
- No-churn when the `server_name` is already current (byte-identical file).
- Invalid hostname and missing/`_`-only file are rejected without mutating.
- Handler dispatches the verb with the new hostname on a change, and does NOT
  dispatch on a no-op hostname PATCH.

## Box drill (.60)

Verified the regex against `.60`'s real `jabali-default.conf`: extracts
`mx.jabali-panel.com`, exactly 1 replacement, `_` / `root` / `mail` preserved,
and the heal-back is byte-identical. Ran a live nginx drill (`nginx -t` + reload
+ restore byte-identical). The return-444 fall-through symptom did not reproduce
on `.60` because its catch-all serves a branded 200 and the panel name has extra
vhost coverage there; the symptom logic rests on the unit tests and the GH#135
rationale.

## Not in this PR

- `/etc/hosts` `127.0.1.1` line still points at the old FQDN after a rename
  (separate concern, unfiled). JAB-389 stays open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
