### PR TITLE
feat(domains): simplify tenant Add Web Domain flow (GH #1541)

### DIFF
--- a/panel-ui/src/components/dns/DNSZoneInventory.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.tsx
@@ -59,10 +59,13 @@ export interface DnsZoneInventoryAudience {
     message: string;
     description: string;
   };
-  // header is the page title strip (icon + text).
+  // header is the page title strip (icon + text). `extra` is an optional action
+  // rendered opposite the title — the tenant supplies an "Add DNS Zone" button
+  // (GH #1541); the admin adapter omits it (zones there are created via domains).
   header: {
     icon: React.ReactNode;
     title: string;
+    extra?: React.ReactNode;
   };
 }
 
@@ -225,9 +228,21 @@ export const DnsZoneInventory = ({ audience }: { audience: DnsZoneInventoryAudie
   const [activeTab, setActiveTab] = useTabParam<"zones" | "dnssec">("zones");
   return (
     <div>
-      <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
-        {audience.header.icon} {audience.header.title}
-      </Typography.Title>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 16,
+          flexWrap: "wrap",
+          rowGap: 8,
+        }}
+      >
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          {audience.header.icon} {audience.header.title}
+        </Typography.Title>
+        {audience.header.extra}
+      </div>
       <Card
         tabList={[
           { key: "zones", tab: "Zones" },

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.test.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.test.tsx
@@ -1,0 +1,46 @@
+// GH #1541: DNS-only zones are added from the DNS Zones page now (the Domains
+// "Add" split is gone). The page's "Add DNS Zone" button must open the shared
+// Add-domain drawer in dns mode.
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: { mail_enabled: true, dns_enabled: true } }),
+}));
+vi.mock("../../../hooks/useQueries", () => ({
+  useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("../../../lib/feedback", () => ({
+  feedback: {
+    message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    modal: { success: vi.fn(), confirm: vi.fn() },
+  },
+}));
+// Stub the inventory — this adapter test only cares that the header action
+// (Add DNS Zone) is rendered and wired to the drawer.
+vi.mock("../../../components/dns/DNSZoneInventory", () => ({
+  DnsZoneInventory: ({ audience }: { audience: { header: { extra?: ReactNode } } }) => (
+    <div>{audience.header.extra}</div>
+  ),
+}));
+
+import { UserDNSZonesOverviewPage } from "./UserDNSZonesOverviewPage";
+
+describe("UserDNSZonesOverviewPage Add DNS Zone (GH #1541)", () => {
+  it("opens the Add-domain drawer in dns mode", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <UserDNSZonesOverviewPage />
+      </QueryClientProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /add dns zone/i }));
+    // The drawer (dns mode) shows the domain-name input.
+    expect(await screen.findByPlaceholderText("e.g., example.com")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
@@ -2,17 +2,26 @@
 // Module (JAB-299). The page owns only the tenant audience policy: no owner
 // column, tenant domain routes, a plain empty state, and the owner-free DNSSEC
 // tab. All list/query/column behavior lives in components/dns/DNSZoneInventory.
+//
+// GH #1541 (johnnyq): DNS-only zones used to be added from the Domains page
+// "Add" split, which is gone. The "add these later" path now lives here — an
+// "Add DNS Zone" button that opens the shared Add-domain drawer in dns mode.
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Empty } from "antd";
-import { CloudServerOutlined } from "@icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button, Empty } from "antd";
+import { CloudServerOutlined, PlusOutlined } from "@icons";
 
 import {
   DnsZoneInventory,
   type DnsZoneInventoryAudience,
 } from "../../../components/dns/DNSZoneInventory";
+import { UserDomainDrawer } from "../domains/UserDomainDrawer";
 
 export const UserDNSZonesOverviewPage = () => {
   const { t } = useTranslation();
+  const qc = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
 
   const audience: DnsZoneInventoryAudience = {
     showOwner: false,
@@ -29,8 +38,31 @@ export const UserDNSZonesOverviewPage = () => {
       description:
         "Enable signing here, then copy the DS record to your registrar to complete the chain of trust.",
     },
-    header: { icon: <CloudServerOutlined />, title: "DNS" },
+    header: {
+      icon: <CloudServerOutlined />,
+      title: "DNS",
+      extra: (
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>
+          Add DNS Zone
+        </Button>
+      ),
+    },
   };
 
-  return <DnsZoneInventory audience={audience} />;
+  return (
+    <>
+      <DnsZoneInventory audience={audience} />
+      <UserDomainDrawer
+        open={createOpen}
+        mode="dns"
+        onClose={() => {
+          setCreateOpen(false);
+          // The drawer creates via the "domains" resource (invalidates
+          // ["list","domains"]); this page lists ["list","dns/zones"], so refresh
+          // that list explicitly to show the newly added zone.
+          void qc.invalidateQueries({ queryKey: ["list", "dns/zones"] });
+        }}
+      />
+    </>
+  );
 };

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
@@ -1,59 +1,138 @@
-// GH #1409: the Add-domain drawer must default Mail to None when the mail module
-// isn't installed, and to Jabali Mail when it is.
+// UserDomainDrawer — the tenant Add Web Domain flow (GH #1541), plus the mail
+// module gating (GH #1409) and the create-time document root (GH #1413), both
+// reworked by #1541: mail is now an "Add Mail Domain" checkbox and the document
+// root moved under a collapsed "Advanced" section.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const caps = vi.hoisted(() => ({ mail: false }));
+const caps = vi.hoisted(() => ({ mail: false, dns: true }));
+const mutate = vi.hoisted(() => vi.fn());
 vi.mock("../../../hooks/useServerCapabilities", () => ({
-  useServerCapabilities: () => ({ data: { mail_enabled: caps.mail } }),
+  useServerCapabilities: () => ({ data: { mail_enabled: caps.mail, dns_enabled: caps.dns } }),
 }));
 vi.mock("../../../hooks/useQueries", () => ({
-  useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateMutation: () => ({ mutateAsync: mutate, isPending: false }),
+}));
+// Avoid needing an <App> context for the themed toasts / result modal.
+vi.mock("../../../lib/feedback", () => ({
+  feedback: {
+    message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    modal: { success: vi.fn(), confirm: vi.fn() },
+  },
 }));
 
 import { UserDomainDrawer } from "./UserDomainDrawer";
 
-function renderDrawer() {
+function renderDrawer(mode: "web" | "dns" | "mail" = "web") {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <UserDomainDrawer open onClose={() => {}} />
+      <UserDomainDrawer open mode={mode} onClose={() => {}} />
     </QueryClientProvider>,
   );
 }
 
-describe("UserDomainDrawer mail default (GH #1409)", () => {
-  it("defaults Mail to None when the mail module is NOT installed", async () => {
-    caps.mail = false;
-    renderDrawer();
-    // The Select shows its selected option's label; None must be selected.
-    await waitFor(() => expect(screen.getByText("No mail")).toBeInTheDocument());
-    expect(screen.queryByText("Jabali mail (this server)")).not.toBeInTheDocument();
+const submit = () => fireEvent.click(screen.getByRole("button", { name: "Add" }));
+const typeName = async (name: string) => {
+  fireEvent.change(await screen.findByPlaceholderText("e.g., example.com"), {
+    target: { value: name },
   });
+};
 
-  it("defaults Mail to Jabali Mail when the module IS installed", async () => {
+beforeEach(() => {
+  caps.mail = false;
+  caps.dns = true;
+  mutate.mockReset();
+  mutate.mockResolvedValue({ id: "d1" });
+});
+
+describe("UserDomainDrawer Add Mail Domain (GH #1409/#1541)", () => {
+  it("checks Add Mail Domain by default when the mail module IS installed; DNS Template hidden", async () => {
     caps.mail = true;
     renderDrawer();
-    await waitFor(() =>
-      expect(screen.getByText("Jabali mail (this server)")).toBeInTheDocument(),
-    );
+    const cb = await screen.findByRole("checkbox", { name: /add mail domain/i });
+    expect(cb).toBeChecked();
+    expect(cb).not.toBeDisabled();
+    // The external-mail DNS Template is only for the unchecked case.
+    expect(screen.queryByText("DNS Template")).not.toBeInTheDocument();
+  });
+
+  it("unchecks + disables Add Mail Domain and shows the DNS Template when mail is NOT installed", async () => {
+    caps.mail = false;
+    renderDrawer();
+    const cb = await screen.findByRole("checkbox", { name: /add mail domain/i });
+    await waitFor(() => expect(cb).not.toBeChecked());
+    expect(cb).toBeDisabled();
+    expect(screen.getByText("DNS Template")).toBeInTheDocument();
+  });
+
+  it("unchecking Add Mail Domain reveals the DNS Template select", async () => {
+    caps.mail = true;
+    renderDrawer();
+    const cb = await screen.findByRole("checkbox", { name: /add mail domain/i });
+    expect(screen.queryByText("DNS Template")).not.toBeInTheDocument();
+    fireEvent.click(cb);
+    await waitFor(() => expect(screen.getByText("DNS Template")).toBeInTheDocument());
   });
 });
 
-describe("UserDomainDrawer document root (GH #1413)", () => {
-  it("shows the Document root field by default and hides it for a reverse proxy", async () => {
+describe("UserDomainDrawer document root under Advanced (GH #1413/#1541)", () => {
+  it("keeps Document root out of the default form, shows it under Advanced, hides it for a reverse proxy", async () => {
     caps.mail = true;
     renderDrawer();
-    // Present for a normal website.
-    await waitFor(() =>
-      expect(screen.getByLabelText("Document root")).toBeInTheDocument(),
-    );
-    // A reverse-proxy domain has no docroot — toggling it removes the field
-    // (which also drops any typed value from the submitted payload).
+    // Not part of the simple form.
+    expect(screen.queryByLabelText("Document root")).not.toBeInTheDocument();
+    // Expand Advanced → the field registers and renders.
+    fireEvent.click(await screen.findByText("Advanced"));
+    await waitFor(() => expect(screen.getByLabelText("Document root")).toBeInTheDocument());
+    // A reverse-proxy domain has no docroot — toggling it removes the field.
     fireEvent.click(screen.getByRole("checkbox", { name: /set up as a reverse proxy/i }));
     await waitFor(() =>
       expect(screen.queryByLabelText("Document root")).not.toBeInTheDocument(),
     );
+  });
+});
+
+describe("UserDomainDrawer web create payload (GH #1541)", () => {
+  it("Add Mail Domain checked → Jabali mail, auto-www for an apex, no drawer-only fields", async () => {
+    caps.mail = true;
+    caps.dns = true;
+    renderDrawer();
+    await typeName("example.com");
+    submit();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const body = mutate.mock.calls[0][0];
+    expect(body.mail_provider).toBe("jabali");
+    expect(body.manage_dns).toBe(true);
+    expect(body.create_www).toBe(true); // example.com is an apex (two labels)
+    // Drawer-only / dropped fields never reach POST /domains.
+    expect(body).not.toHaveProperty("add_mail");
+    expect(body).not.toHaveProperty("enable_webmail");
+    expect(body).not.toHaveProperty("temp_url_enabled");
+  });
+
+  it("Add Mail Domain unchecked (external mail None) → no Jabali mail, and a subdomain gets no www", async () => {
+    caps.mail = true;
+    caps.dns = true;
+    renderDrawer();
+    await typeName("blog.example.com");
+    fireEvent.click(await screen.findByRole("checkbox", { name: /add mail domain/i }));
+    submit();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const body = mutate.mock.calls[0][0];
+    expect(body.mail_provider).toBe("none"); // DNS Template default
+    expect(body.create_www).toBe(false); // blog.example.com is a subdomain (three labels)
+  });
+
+  it("forces manage_dns false when the DNS module is off (no Add DNS Zone checkbox)", async () => {
+    caps.mail = true;
+    caps.dns = false;
+    renderDrawer();
+    expect(screen.queryByText("Add DNS Zone")).not.toBeInTheDocument();
+    await typeName("example.org");
+    submit();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    expect(mutate.mock.calls[0][0].manage_dns).toBe(false);
   });
 });

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -1,7 +1,18 @@
 // UserDomainDrawer — tenant Add-domain Drawer (replaces the
 // /jabali-panel/domains/create page route).
 import { useTranslation } from "react-i18next";
-import { Button, Checkbox, Drawer, Form, Grid, Input, InputNumber, Select, Space } from "antd";
+import {
+  Button,
+  Checkbox,
+  Collapse,
+  Drawer,
+  Form,
+  Grid,
+  Input,
+  InputNumber,
+  Select,
+  Space,
+} from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
@@ -13,17 +24,19 @@ type UserDomainCreateInput = {
   name: string;
   // GH #1413: optional custom document root at create time (handy for
   // subdomains). Blank = the default …/domains/<name>/public_html. The
-  // server confines a tenant's docroot to this domain's own tree.
+  // server confines a tenant's docroot to this domain's own tree. GH #1541
+  // moved it under the drawer's "Advanced" section (out of the simple form).
   doc_root?: string;
   mail_provider?: string;
   m365_onmicrosoft?: string;
   google_dkim?: string;
-  temp_url_enabled?: boolean;
+  // GH #1541: create_www is no longer a checkbox — it's derived from the domain
+  // (apex ⇒ true, subdomain ⇒ false) and sent as a plain flag.
   create_www?: boolean;
   ssl_mode?: string;
   // GH #1175: reverse-proxy domain. When true the panel reserves a loopback
   // port and proxies the domain to it (no docroot/PHP). The assigned port
-  // comes back on the create response.
+  // comes back on the create response. GH #1541: under "Advanced".
   reverse_proxy?: boolean;
   // GH #1401: optional — the specific local port to proxy to (e.g. your app
   // already listens on 6875). Left blank, the panel auto-assigns a free port.
@@ -33,6 +46,10 @@ type UserDomainCreateInput = {
   // DNS-only zone or mail-only domain; manage_dns=false → external DNS.
   web_enabled?: boolean;
   manage_dns?: boolean;
+  // GH #1541: web-mode "Add Mail Domain" checkbox (default on). A drawer-only
+  // field — never sent to POST /domains. Checked ⇒ mail_provider="jabali";
+  // unchecked ⇒ the "DNS Template" select's external provider (or none).
+  add_mail?: boolean;
   // GH #1479: mail-domain webmail toggle. NOT a create-request field (the model
   // defaults webmail_enabled ON); the drawer only acts on the OFF case, via a
   // follow-up PATCH — setting the tinyint false at create hits GORM's
@@ -41,8 +58,8 @@ type UserDomainCreateInput = {
 };
 type DomainCreated = { id: string; reverse_proxy_port?: number };
 
-// GH #1449: one drawer, three entry points. "web" is the classic Add Web
-// Domain (with opt-outs); "dns" adds a DNS-only zone; "mail" adds a mail-only
+// GH #1449: one drawer, three entry points. "web" is the Add Web Domain flow
+// (with Mail/DNS opt-ins); "dns" adds a DNS-only zone; "mail" adds a mail-only
 // domain. The mode presets web_enabled / mail_provider and hides the fields
 // that don't apply.
 export type DomainDrawerMode = "web" | "dns" | "mail";
@@ -59,11 +76,15 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
   const isWeb = mode === "web";
   const isDNS = mode === "dns";
   const isMail = mode === "mail";
-  // GH #1409: when the mail module isn't installed, Jabali Mail isn't a real
-  // choice — default to None and disable it. `!== false` treats the brief
-  // pre-load state as installed so a mail-enabled server never flickers to None.
+  // GH #1409/#1541: when the mail module isn't installed, "Add Mail Domain"
+  // isn't a real choice — it's unchecked and disabled, and the user can still
+  // add external-mail DNS via the DNS Template select. `!== false` treats the
+  // brief pre-load state as installed so a mail-enabled server never flickers.
   const { data: caps } = useServerCapabilities();
   const mailInstalled = caps?.mail_enabled !== false;
+  const dnsEnabled = caps?.dns_enabled !== false;
+  // GH #1541: "Add Mail Domain" defaults on (matches the checkbox initialValue).
+  const addMail = Form.useWatch("add_mail", form) ?? true;
   const mailProvider =
     Form.useWatch("mail_provider", form) ?? (mailInstalled ? "jabali" : "none");
   const reverseProxy = Form.useWatch("reverse_proxy", form) ?? false;
@@ -77,34 +98,57 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
   useEffect(() => {
     if (!open) return;
     form.resetFields();
-    // Override the static Jabali-Mail default when mail isn't installed.
-    if (!mailInstalled) form.setFieldValue("mail_provider", "none");
-  }, [open, mailInstalled, form]);
+    // GH #1541: with mail not installed, "Add Mail Domain" can't be checked —
+    // uncheck it (the checkbox is also disabled) so the form opens valid and the
+    // DNS Template (external mail) select is available instead.
+    if (isWeb && !mailInstalled) form.setFieldValue("add_mail", false);
+  }, [open, mailInstalled, isWeb, form]);
 
   const handleFinish = async (values: UserDomainCreateInput) => {
     try {
-      // GH #1479: enable_webmail is a drawer-only field, never a create-request
-      // field — carve it out so it never reaches POST /domains.
-      const { enable_webmail: wantWebmail, ...rest } = values;
-      // A reverse-proxy domain has no document root; drop any value the field
-      // may have kept (antd preserves unmounted field values by default) so we
-      // never send a docroot the server would validate but never use.
-      let payload: UserDomainCreateInput = rest.reverse_proxy
-        ? { ...rest, doc_root: undefined }
-        : rest;
-      // GH #1449: a web-off entry (DNS-only zone / mail-only domain) must not
-      // carry web-only fields antd may have kept for hidden inputs.
-      if (!isWeb) {
+      // GH #1479/#1541: enable_webmail and add_mail are drawer-only fields, never
+      // create-request fields. Build each mode's payload explicitly so no such
+      // field (nor a hidden input antd kept) leaks into POST /domains.
+      const wantWebmail = values.enable_webmail;
+      let payload: UserDomainCreateInput;
+      if (isWeb) {
+        const wantMail = values.add_mail ?? true;
+        const isReverse = values.reverse_proxy ?? false;
+        payload = {
+          name: values.name,
+          ssl_mode: values.ssl_mode,
+          // Add Mail Domain checked → Jabali mail on this server; unchecked → the
+          // DNS Template select's external provider (or "none" for no mail).
+          mail_provider: wantMail ? "jabali" : (values.mail_provider ?? "none"),
+          m365_onmicrosoft: values.m365_onmicrosoft,
+          google_dkim: values.google_dkim,
+          // Add DNS Zone. Forced off when the DNS module isn't running (the
+          // checkbox is hidden then) → external DNS.
+          manage_dns: dnsEnabled ? (values.manage_dns ?? true) : false,
+          // GH #1541: auto-create the www record for an apex domain (exactly two
+          // labels, e.g. example.com), never for a subdomain (blog.example.com).
+          // Replaces the old manual "Create www record" checkbox. Heuristic, not
+          // a public-suffix lookup: it under-creates www for multi-part-TLD
+          // apexes (example.co.uk → 3 labels → skipped) but never creates a wrong
+          // www.<subdomain> record. create_www also drives the cert SAN, so it
+          // stays independent of manage_dns.
+          create_www: values.name.split(".").length === 2,
+          // Advanced: a reverse-proxy domain has no document root.
+          reverse_proxy: isReverse,
+          reverse_proxy_port: isReverse ? values.reverse_proxy_port : undefined,
+          doc_root: isReverse ? undefined : values.doc_root,
+        };
+      } else {
+        // GH #1449: a web-off entry (DNS-only zone / mail-only domain) carries
+        // only the fields that apply — never web-only inputs antd may have kept.
         payload = {
           name: values.name,
           web_enabled: false,
           manage_dns: isDNS ? true : values.manage_dns,
-          // GH #1479: the non-web branch is either a DNS-only zone (no mail) or
-          // a mail domain (always Jabali mail — the provider select is hidden in
+          // GH #1479: the non-web branch is either a DNS-only zone (no mail) or a
+          // mail domain (always Jabali mail — the provider select is hidden in
           // mail mode, so values.mail_provider isn't registered).
           mail_provider: isDNS ? "none" : "jabali",
-          m365_onmicrosoft: values.m365_onmicrosoft,
-          google_dkim: values.google_dkim,
           ssl_mode: isDNS ? "none" : values.ssl_mode,
         };
       }
@@ -127,7 +171,7 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
       // GH #1175: the assigned loopback port is the one piece of info the user
       // must act on (bind their app to it), so surface it in a modal that
       // stays until dismissed rather than a toast they might miss.
-      if (values.reverse_proxy && created?.reverse_proxy_port) {
+      if (isWeb && payload.reverse_proxy && created?.reverse_proxy_port) {
         feedback.modal.success({
           title: "Reverse proxy ready",
           content: `Run your app on 127.0.0.1:${created.reverse_proxy_port}. The panel proxies ${values.name} to that port and keeps the vhost in sync across TLS renewals.`,
@@ -141,7 +185,7 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
 
   return (
     <Drawer
-      title={isDNS ? "Add DNS Zone" : isMail ? "Add Mail Domain" : t("userdomaindrawer.add_domain")}
+      title={isDNS ? "Add DNS Zone" : isMail ? "Add Mail Domain" : "Add Web Domain"}
       open={open}
       onClose={onClose}
       width={isDesktop ? 480 : undefined}
@@ -168,47 +212,72 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           <Input placeholder="e.g., example.com" />
         </Form.Item>
 
-        {/* GH #1413: custom document root. Hidden for reverse-proxy domains
-            (they have no docroot). The server confines a tenant's path to this
-            domain's own tree, so pointing at another domain or elsewhere in the
-            home is rejected. */}
-        {isWeb && !reverseProxy && (
+        {(isWeb || isMail) && (
           <Form.Item
-            label={t("userdomaindrawer.document_root")}
-            name="doc_root"
-            tooltip={t("userdomaindrawer.document_root_hint")}
+            label={t("userdomaindrawer.tls_certificate")}
+            name="ssl_mode"
+            initialValue="le"
+            tooltip={t("userdomaindrawer.let_s_encrypt_issues_a_free_trusted_certific")}
           >
-            <Input placeholder="Leave blank for the default (…/public_html)" />
+            <Select
+              options={[
+                { value: "le", label: "Let's Encrypt (recommended)" },
+                { value: "self", label: "Self-signed" },
+                // GH #1479: 'None' is offered for WEB only. A mail domain needs a
+                // real cert on mail.<domain> for IMAPS/SMTPS/autoconfig + webmail,
+                // and the server rejects ssl_mode=none while mail is on
+                // (ssl_none_with_email), so mail mode shows LE / Self-signed only.
+                ...(isWeb ? [{ value: "none", label: "None (HTTP only)" }] : []),
+              ]}
+            />
           </Form.Item>
         )}
 
-        {/* GH #1479 (johnnyq follow-up): the mail-provider select is web-only.
-            On the Create Mail Domain flow it's redundant and self-contradictory
-            (picking "No mail" / an external provider in a "create mail domain"
-            drawer), so mail mode hides it and always provisions Jabali mail —
-            handleFinish forces mail_provider="jabali" for the non-web branch. */}
+        {/* GH #1541: "Add Mail Domain" — the simple way to add Jabali mail while
+            creating the website. Checked by default (disabled + unchecked when the
+            mail module isn't installed). Unchecking reveals the DNS Template select
+            below for external mail providers. */}
         {isWeb && (
-        <Form.Item
-          label={t("userdomaindrawer.mail")}
-          name="mail_provider"
-          initialValue="jabali"
-          tooltip={t("userdomaindrawer.where_this_domain_s_email_is_hosted_none_and")}
-        >
-          <Select
-            options={[
-              {
-                value: "jabali",
-                label: mailInstalled
-                  ? "Jabali mail (this server)"
-                  : "Jabali mail (not installed)",
-                disabled: !mailInstalled,
-              },
-              { value: "none", label: "No mail" },
-              { value: "m365", label: "Microsoft 365" },
-              { value: "google", label: "Google Workspace" },
-            ]}
-          />
-        </Form.Item>
+          <Form.Item name="add_mail" valuePropName="checked" initialValue={true}>
+            <Checkbox disabled={!mailInstalled}>
+              {mailInstalled ? "Add Mail Domain" : "Add Mail Domain (mail module not installed)"}
+            </Checkbox>
+          </Form.Item>
+        )}
+
+        {/* GH #1541: "Add DNS Zone" — host this domain's DNS on this server.
+            Checked by default. Hidden when the DNS module is off (external DNS is
+            then the only option). Reuses the GH #1449 manage_dns flag. */}
+        {isWeb && dnsEnabled && (
+          <Form.Item
+            name="manage_dns"
+            valuePropName="checked"
+            initialValue={true}
+            tooltip="Host this domain's DNS zone on this server. Uncheck if your DNS is managed elsewhere (e.g. your registrar or Cloudflare)."
+          >
+            <Checkbox>Add DNS Zone</Checkbox>
+          </Form.Item>
+        )}
+
+        {/* GH #1541: "DNS Template" — only when Add Mail Domain is unchecked.
+            Sets up the mail DNS records for an external provider (Microsoft 365 /
+            Google Workspace), or nothing. Reuses the mail_provider field; "jabali"
+            is intentionally absent (that's what Add Mail Domain is for). */}
+        {isWeb && !addMail && (
+          <Form.Item
+            label="DNS Template"
+            name="mail_provider"
+            initialValue="none"
+            tooltip="Add DNS records for external mail hosted with Microsoft 365 or Google Workspace. Leave as None if this domain has no mail."
+          >
+            <Select
+              options={[
+                { value: "none", label: "None (no external mail)" },
+                { value: "m365", label: "Microsoft 365" },
+                { value: "google", label: "Google Workspace" },
+              ]}
+            />
+          </Form.Item>
         )}
 
         {mailProvider === "m365" && (
@@ -231,27 +300,6 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           </Form.Item>
         )}
 
-        {(isWeb || isMail) && (
-        <Form.Item
-          label={t("userdomaindrawer.tls_certificate")}
-          name="ssl_mode"
-          initialValue="le"
-          tooltip={t("userdomaindrawer.let_s_encrypt_issues_a_free_trusted_certific")}
-        >
-          <Select
-            options={[
-              { value: "le", label: "Let's Encrypt (recommended)" },
-              { value: "self", label: "Self-signed" },
-              // GH #1479: 'None' is offered for WEB only. A mail domain needs a
-              // real cert on mail.<domain> for IMAPS/SMTPS/autoconfig + webmail,
-              // and the server rejects ssl_mode=none while mail is on
-              // (ssl_none_with_email), so mail mode shows LE / Self-signed only.
-              ...(isWeb ? [{ value: "none", label: "None (HTTP only)" }] : []),
-            ]}
-          />
-        </Form.Item>
-        )}
-
         {/* GH #1479: webmail toggle for mail domains. Default ON (matches the
             model default); unchecking issues a follow-up PATCH after create. */}
         {isMail && (
@@ -265,82 +313,89 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           </Form.Item>
         )}
 
-        {/* GH #1449: opt out of Jabali DNS (run DNS elsewhere). Not shown for
-            the DNS-only flow — there, hosting DNS is the whole point. */}
-        {(isWeb || isMail) && (
+        {/* GH #1449: mail-mode DNS records opt-out (run mail DNS elsewhere). */}
+        {isMail && (
           <Form.Item
             name="manage_dns"
             valuePropName="checked"
             initialValue={true}
-            tooltip={
-              isMail
-                ? "Create this domain's mail DNS records (MX, SPF, DKIM, autodiscover) on this server's DNS. Uncheck if you manage DNS elsewhere — then point MX/SPF/DKIM at this server yourself."
-                : "Host this domain's DNS zone on this server. Uncheck if your DNS is managed elsewhere (e.g. your registrar or Cloudflare)."
-            }
+            tooltip="Create this domain's mail DNS records (MX, SPF, DKIM, autodiscover) on this server's DNS. Uncheck if you manage DNS elsewhere — then point MX/SPF/DKIM at this server yourself."
           >
-            <Checkbox>{isMail ? "Create DNS mail records" : "Manage DNS here"}</Checkbox>
+            <Checkbox>Create DNS mail records</Checkbox>
           </Form.Item>
         )}
 
+        {/* GH #1541: keep the create form to the bare minimum. Document Root and
+            the reverse-proxy option are real but rarely needed at create time, so
+            they live under a collapsed "Advanced" section. Preview URL is dropped
+            entirely — it's a later, per-domain toggle. antd lazily renders the
+            panel body, so these fields register only once Advanced is expanded. */}
         {isWeb && (
-        <Form.Item
-          name="create_www"
-          valuePropName="checked"
-          initialValue={false}
-          tooltip={t("userdomaindrawer.adds_a_www_cname_pointing_at_the_domain_apex")}
-        >
-          <Checkbox>Create www record</Checkbox>
-        </Form.Item>
-        )}
-
-        {isWeb && (
-        <Form.Item
-          name="temp_url_enabled"
-          valuePropName="checked"
-          initialValue={false}
-          tooltip="Serves the site at a preview address under this server's hostname, so you can check it before your domain's DNS points here."
-        >
-          <Checkbox>Enable preview URL</Checkbox>
-        </Form.Item>
-        )}
-
-        {/* GH #1175: reverse-proxy option. The panel reserves a conflict-free
-            loopback port and writes the proxy_pass vhost; the assigned port is
-            shown after the domain is added. */}
-        {isWeb && (
-        <Form.Item
-          name="reverse_proxy"
-          valuePropName="checked"
-          initialValue={false}
-          tooltip="Turns this domain into a reverse proxy instead of a website. The panel reserves a local port and forwards the domain to it — run your own app (a Docker container, Node service, …) on that port. The assigned port is shown after you add the domain."
-        >
-          <Checkbox>Set up as a reverse proxy (run your own app on a local port)</Checkbox>
-        </Form.Item>
-        )}
-
-        {/* GH #1401: let the tenant type their app's port; blank = auto-assign.
-            Server validates it (range + system-port denylist + not-in-use). */}
-        {reverseProxy && (
-          <Form.Item
-            name="reverse_proxy_port"
-            label="Port (optional)"
-            tooltip="The local port your app listens on (e.g. 6875). Leave blank to let the panel pick a free port for you. Ports below 1024, the panel's own ports, and ports used by system services are not allowed."
-            rules={[
+          <Collapse
+            ghost
+            style={{ marginBottom: 16 }}
+            items={[
               {
-                validator: (_, v) =>
-                  v == null || v === "" || (Number.isInteger(v) && v >= 1024 && v <= 65535)
-                    ? Promise.resolve()
-                    : Promise.reject(new Error("Enter a port between 1024 and 65535, or leave blank")),
+                key: "advanced",
+                label: "Advanced",
+                children: (
+                  <>
+                    {/* GH #1413: custom document root. Hidden for reverse-proxy
+                        domains (they have no docroot). The server confines a
+                        tenant's path to this domain's own tree. */}
+                    {!reverseProxy && (
+                      <Form.Item
+                        label={t("userdomaindrawer.document_root")}
+                        name="doc_root"
+                        tooltip={t("userdomaindrawer.document_root_hint")}
+                      >
+                        <Input placeholder="Leave blank for the default (…/public_html)" />
+                      </Form.Item>
+                    )}
+
+                    {/* GH #1175: reverse-proxy option. The panel reserves a
+                        conflict-free loopback port and writes the proxy_pass vhost;
+                        the assigned port is shown after the domain is added. */}
+                    <Form.Item name="reverse_proxy" valuePropName="checked" initialValue={false}>
+                      <Checkbox>
+                        Set up as a reverse proxy (run your own app on a local port)
+                      </Checkbox>
+                    </Form.Item>
+
+                    {/* GH #1401: let the tenant type their app's port; blank =
+                        auto-assign. Server validates it (range + system-port
+                        denylist + not-in-use). */}
+                    {reverseProxy && (
+                      <Form.Item
+                        name="reverse_proxy_port"
+                        label="Port (optional)"
+                        tooltip="The local port your app listens on (e.g. 6875). Leave blank to let the panel pick a free port for you. Ports below 1024, the panel's own ports, and ports used by system services are not allowed."
+                        rules={[
+                          {
+                            validator: (_, v) =>
+                              v == null ||
+                              v === "" ||
+                              (Number.isInteger(v) && v >= 1024 && v <= 65535)
+                                ? Promise.resolve()
+                                : Promise.reject(
+                                    new Error("Enter a port between 1024 and 65535, or leave blank"),
+                                  ),
+                          },
+                        ]}
+                      >
+                        <InputNumber
+                          min={1024}
+                          max={65535}
+                          style={{ width: "100%" }}
+                          placeholder="Auto-assign a free port"
+                        />
+                      </Form.Item>
+                    )}
+                  </>
+                ),
               },
             ]}
-          >
-            <InputNumber
-              min={1024}
-              max={65535}
-              style={{ width: "100%" }}
-              placeholder="Auto-assign a free port"
-            />
-          </Form.Item>
+          />
         )}
 
         <Form.Item>

--- a/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
@@ -93,3 +93,21 @@ describe("UserDomainList DNS action gating (GH #1419)", () => {
     expect(screen.queryByText("DNS")).not.toBeInTheDocument();
   });
 });
+
+// GH #1541: the old "Add" split (Web / DNS / Mail) is replaced by a single
+// "Add Web Domain" button that opens the drawer in web mode.
+describe("UserDomainList Add Web Domain button (GH #1541)", () => {
+  it("shows a single Add Web Domain button that opens the web drawer", async () => {
+    render(
+      <MemoryRouter>
+        <App>
+          <UserDomainList />
+        </App>
+      </MemoryRouter>,
+    );
+    const btn = await screen.findByRole("button", { name: /add web domain/i });
+    fireEvent.click(btn);
+    // The drawer opened in web mode — its domain-name input appears.
+    expect(await screen.findByPlaceholderText("e.g., example.com")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -1,26 +1,22 @@
 // UserDomainList — tenant view of the domains they own. JAB-300: a thin
 // adapter over the shared <DomainInventory> module. This shell owns only the
-// tenant-specific header: the title and the "Add" split (Web / DNS Zone /
-// Mail Domain) that opens the UserDomainDrawer. The table, columns, row
-// actions and lifecycle live in the module, shared byte-for-byte with the
-// admin list.
+// tenant-specific header: the title and the "Add Web Domain" button that opens
+// the UserDomainDrawer. The table, columns, row actions and lifecycle live in
+// the module, shared byte-for-byte with the admin list.
+//
+// GH #1541 (johnnyq): the old "Add" split (Web / DNS Zone / Mail Domain) is
+// gone. Adding a website is the primary action, so it's a single "Add Web
+// Domain" button; mail and DNS are opted into from inside that flow (checkboxes
+// in the drawer) or added later from the Mail Domains / DNS Zones pages.
 import { PlusSquareOutlined, GlobalOutlined } from "@icons";
-import { Button, Card, Dropdown, Space, Typography } from "antd";
+import { Button, Card, Space, Typography } from "antd";
 import { useState } from "react";
 
 import { DomainInventory } from "../../../components/domains/DomainInventory";
-import { UserDomainDrawer, type DomainDrawerMode } from "./UserDomainDrawer";
-import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
+import { UserDomainDrawer } from "./UserDomainDrawer";
 
 export const UserDomainList = () => {
-  const { data: caps } = useServerCapabilities();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  // GH #1449: the same drawer serves three add-flows (web / dns-only / mail-only).
-  const [drawerMode, setDrawerMode] = useState<DomainDrawerMode>("web");
-  const openDrawer = (mode: DomainDrawerMode) => {
-    setDrawerMode(mode);
-    setDrawerOpen(true);
-  };
 
   return (
     <div>
@@ -36,34 +32,19 @@ export const UserDomainList = () => {
         <Typography.Title level={3} style={{ margin: 0 }}>
           <GlobalOutlined /> Domains
         </Typography.Title>
-        {/* GH #1449: Web / DNS / Mail are independent services — offer each as
-            its own add-flow. "Web Domain" keeps the full form (with Mail + DNS
-            opt-outs); the other two add a docroot-less DNS-only zone or a
-            mail-only domain. */}
-        <Dropdown
-          trigger={["click"]}
-          menu={{
-            // GH #1449 + #1417/#1419: only offer a service the server actually
-            // runs — hide "DNS Zone" when the DNS module is off, "Mail Domain"
-            // when mail is off (`!== false` treats the pre-load state as on).
-            items: [
-              { key: "web", label: "Web Domain" },
-              ...(caps?.dns_enabled !== false ? [{ key: "dns", label: "DNS Zone" }] : []),
-              ...(caps?.mail_enabled !== false ? [{ key: "mail", label: "Mail Domain" }] : []),
-            ],
-            onClick: ({ key }) => openDrawer(key as DomainDrawerMode),
-          }}
+        <Button
+          type="primary"
+          icon={<PlusSquareOutlined />}
+          onClick={() => setDrawerOpen(true)}
         >
-          <Button type="primary" icon={<PlusSquareOutlined />}>
-            Add
-          </Button>
-        </Dropdown>
+          Add Web Domain
+        </Button>
       </Space>
 
       <Card>
         <DomainInventory audience={{ kind: "tenant" }} />
       </Card>
-      <UserDomainDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} mode={drawerMode} />
+      <UserDomainDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} mode="web" />
     </div>
   );
 };


### PR DESCRIPTION
## What & why

GH #1541 (johnnyq): rework the tenant add-domain flow so adding a website is a
single, simple action, and Mail / DNS are opted into from inside it (or added
later from their own pages) rather than picked from a dropdown.

> remove the current drop down add and rename the button to add Web Domain …
> there will be checkboxes in add web domain and option if they click Mail
> Domains and DNS Zones to add these later … keeping this portion as simple as
> possible with the bare min config to get up and running.

## Domains page

The old **Add** split (Web Domain / DNS Zone / Mail Domain) is replaced by one
primary **Add Web Domain** button that opens the drawer in web mode. The
standalone Mail / DNS add entries move to their own pages (Mail Domains already
has **Create Mail Domain** from #1479; DNS Zones gets a button here — see below).

## Add Web Domain drawer (web mode)

The default form is now just:

- **Domain Name**
- **TLS Certificate**
- **Add Mail Domain** — checked by default. Checked ⇒ Jabali mail on this server
  (`mail_provider=jabali`). Disabled + unchecked when the mail module isn't
  installed.
- **Add DNS Zone** — checked by default (reuses the #1449 `manage_dns` flag).
  Hidden when the DNS module is off (external DNS is then the only option).
- **DNS Template** — shown only when *Add Mail Domain* is unchecked. Adds the
  mail DNS records for external mail (Microsoft 365 / Google Workspace), or
  none. It reuses the `mail_provider` field; the M365/Google helper inputs are
  unchanged.

**Automatic www record.** The manual "Create www record" checkbox is gone. The
www record is now created automatically for an **apex** domain (two labels, e.g.
`example.com`) and skipped for a **subdomain** (`blog.example.com`). This is a
label-count heuristic, not a public-suffix lookup — there is no PSL library in
the panel — so it *under*-creates www for multi-part-TLD apexes (`example.co.uk`
→ 3 labels → skipped) but **never creates a wrong `www.<subdomain>` record**.
Safe degradation, and www can still be added later. `create_www` also drives the
certificate SAN, so it stays independent of the *Add DNS Zone* choice.

## Deviations from the literal spec (deliberate, per the drawer's "Advanced" decision)

- **Document Root** and the **reverse-proxy** option (+ its port) move under a
  collapsed **Advanced** section rather than being removed. johnnyq asked for
  these to be "later configuration". Document Root has a later editor, but it
  genuinely matters at create time for subdomains (#1413); **reverse proxy is
  create-only** — the PATCH path does not accept `reverse_proxy`, so there is no
  later path to convert a plain web domain into a proxy. Tucking both under
  Advanced keeps the default view minimal while preserving both capabilities at
  create time. Trade-off: a user who wants a reverse proxy must expand Advanced
  to find it.
- **Preview URL** is dropped from create entirely — it's already a later
  per-domain toggle (Enable/Disable preview URL row action).

## DNS Zones page

DNS-only zones were previously created from the Domains "Add" split. With that
gone, the DNS Zones page gets an **Add DNS Zone** button (opens the shared
drawer in dns mode) — this is the "add these later" path johnnyq named. The
shared DNS Zone Inventory module gains an optional `header.extra` slot; the admin
adapter omits it.

## Untouched

- The drawer's **mail** and **dns** modes are otherwise unchanged. (The
  mail-not-installed effect now only touches `add_mail` in web mode; mail mode
  is unreachable when the module is off and already forces `mail_provider=jabali`
  since #1479, so this is a deliberate simplification, not a behavior change.)
- The **admin** domain-create form is out of #1541's tenant scope and untouched.

## Tests

- Rewrote the #1409 mail-gating and #1413 document-root drawer tests for the new
  checkbox + Advanced layout.
- Added web-payload coverage: `mail_provider` mapping (jabali vs external none),
  auto-www apex vs subdomain, and DNS-module-off forcing `manage_dns=false`.
- Added the single **Add Web Domain** button test and the DNS-page **Add DNS
  Zone** button test.
- `tsc -b`, `eslint`, and the domains / dns / mail vitest suites are green (22
  tests across the 5 affected files); the shared `DNSZoneInventory` suite stays
  green (admin audience unaffected).

GH #1541
