### PR TITLE
perf(mail): server-paginate the tenant mailbox Workspace (JAB-370)

### DIFF
--- a/panel-api/internal/api/mailboxes.go
+++ b/panel-api/internal/api/mailboxes.go
@@ -83,6 +83,11 @@ func RegisterMailboxRoutes(g *gin.RouterGroup, cfg MailboxHandlerConfig) {
 
 	g.GET("/admin/mailboxes", middleware.RequireAdmin(), h.listAllAdmin)
 
+	// JAB-370 Workspace projection: the caller's own mailboxes across all their
+	// domains in one owner-scoped, server-paginated query — replacing the
+	// per-domain page_size=200 fan-out the tenant Mailboxes tab used to do.
+	g.GET("/me/mailboxes", h.listWorkspace)
+
 	mbox := g.Group("/mailboxes")
 	mbox.GET("/:mbid", h.get)
 	mbox.PATCH("/:mbid", h.update)
@@ -657,6 +662,62 @@ func (h *mailboxHandler) listAllAdmin(c *gin.Context) {
 		resp["page_size"] = pageSize
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// workspaceMailboxResponse is a directory row for the tenant Workspace. It is
+// the admin row minus the owner columns — every row belongs to the caller, so
+// owner_user_id / user_username would be redundant (and the caller's own id has
+// no place being echoed back on a self-scoped list).
+type workspaceMailboxResponse struct {
+	mailboxResponse
+	DomainName string `json:"domain_name"`
+}
+
+// listWorkspace serves GET /api/v1/me/mailboxes — the caller's own mailboxes
+// across every domain they own, server-paginated (JAB-370 Workspace
+// projection). It replaces the tenant Mailboxes tab's per-domain
+// page_size=200 fan-out (one request per domain, silently truncating any domain
+// past 200) with one owner-scoped constant query.
+//
+// Isolation-critical: the owner scope is taken from the Kratos session, never
+// from a request parameter. Unlike listAllAdmin there is NO ?user_id — a tenant
+// cannot widen the query to another user's mailboxes. Always paginated (the tab
+// is the only consumer), so page/page_size always ride the envelope.
+func (h *mailboxHandler) listWorkspace(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	page, pageSize, opts := parseListOptions(c, defaultMailboxesPageSize, maxMailboxesPageSize)
+
+	rows, total, err := h.cfg.Mailboxes.ListDirectoryPage(ctx, opts, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	out := make([]workspaceMailboxResponse, 0, len(rows))
+	for _, r := range rows {
+		// System rows are already excluded in SQL; the guard stays as a
+		// defence-in-depth belt in case the projection ever changes.
+		if r.Mailbox.System {
+			continue
+		}
+		out = append(out, workspaceMailboxResponse{
+			mailboxResponse: toMailboxResponse(r.Mailbox),
+			DomainName:      r.DomainName,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data":      out,
+		"total":     total,
+		"page":      page,
+		"page_size": pageSize,
+	})
 }
 
 func toMailboxResponse(mb models.Mailbox) mailboxResponse {

--- a/panel-api/internal/api/mailboxes_workspace_test.go
+++ b/panel-api/internal/api/mailboxes_workspace_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// TestListWorkspace_ForcesOwnerScopeFromClaims: GET /me/mailboxes scopes the
+// directory query to the caller's own user id (from the session), parses the
+// page params, and echoes the paginated envelope.
+func TestListWorkspace_ForcesOwnerScopeFromClaims(t *testing.T) {
+	fake := &dirCaptureMbxRepo{
+		rows: []repository.MailboxWithDomain{{
+			Mailbox:    models.Mailbox{ID: "mb1", EmailCached: "alice@example.com"},
+			DomainName: "example.com", OwnerUserID: "u1", UserUsername: "alice",
+		}},
+		total: 42,
+	}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/me/mailboxes?page=2&page_size=10&q=ali&sort=domain&order=desc")
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: false})
+
+	h.listWorkspace(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "u1", fake.gotOwner, "owner scope must come from the session")
+	require.Equal(t, 10, fake.gotOpts.Limit)
+	require.Equal(t, 10, fake.gotOpts.Offset) // (2-1)*10
+	require.Equal(t, "ali", fake.gotOpts.Search)
+	require.Equal(t, "domain", fake.gotOpts.Sort)
+	require.Equal(t, "desc", fake.gotOpts.Order)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.EqualValues(t, 42, body["total"])
+	require.EqualValues(t, 2, body["page"])
+	require.EqualValues(t, 10, body["page_size"])
+	require.Len(t, body["data"], 1)
+
+	// The row must not leak owner columns — a self-scoped list has no use for them.
+	row := body["data"].([]any)[0].(map[string]any)
+	require.Equal(t, "example.com", row["domain_name"])
+	_, hasOwner := row["owner_user_id"]
+	require.False(t, hasOwner, "workspace rows must not carry owner_user_id")
+}
+
+// TestListWorkspace_IgnoresClientOwnerParam is the isolation guard: a tenant
+// cannot widen the query to another user's mailboxes by passing ?user_id. The
+// owner forwarded to the repo stays the session's user id, never the parameter.
+// Falsify by making listWorkspace read c.Query("user_id") → gotOwner becomes u2.
+func TestListWorkspace_IgnoresClientOwnerParam(t *testing.T) {
+	fake := &dirCaptureMbxRepo{}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/me/mailboxes?user_id=u2&owner=u2")
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: false})
+
+	h.listWorkspace(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "u1", fake.gotOwner, "a client-supplied user_id must never widen the owner scope")
+}
+
+// TestListWorkspace_Unauthenticated: without a session the handler returns 401
+// and never touches the repo.
+func TestListWorkspace_Unauthenticated(t *testing.T) {
+	fake := &dirCaptureMbxRepo{}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/me/mailboxes")
+	// No SetClaims.
+
+	h.listWorkspace(c)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Empty(t, fake.gotOwner)
+	require.Zero(t, fake.gotOpts.Limit)
+}
+
+// TestListWorkspace_AlwaysPaginated: unlike listAllAdmin, the workspace list is
+// always bounded (the tab is its only consumer), so even with no page params
+// the repo gets a bounded read and the envelope carries page/page_size — no
+// unbounded response can silently truncate at the client.
+func TestListWorkspace_AlwaysPaginated(t *testing.T) {
+	fake := &dirCaptureMbxRepo{total: 3}
+	h := &mailboxHandler{cfg: MailboxHandlerConfig{Mailboxes: fake}}
+	c, w := newAdminMailboxTestCtx("/me/mailboxes")
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"})
+
+	h.listWorkspace(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, defaultMailboxesPageSize, fake.gotOpts.Limit, "workspace read must stay bounded")
+	require.Zero(t, fake.gotOpts.Offset)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.EqualValues(t, 1, body["page"])
+	require.EqualValues(t, defaultMailboxesPageSize, body["page_size"])
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3896,6 +3896,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/mailboxes:
+    get:
+      tags: [Me]
+      summary: List the caller's own mailboxes across every domain, server-paginated (JAB-370)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/nav-counts:
     get:
       tags: [Me]

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -97,10 +97,35 @@ func (r *mailboxRepo) FindByEmail(ctx context.Context, email string) (*models.Ma
 
 // mailboxListCols — free-text search matches local_part and the cached
 // full address so a query for "alice" or "alice@example.com" both hit.
+// Sort accepts both the bare table columns (raw callers: CLI, MCP
+// list_mailboxes) and — after mailboxListSortKeys translates them — the same
+// clean keys the directory speaks, so a shared front-end can drive either
+// endpoint (JAB-370). display_name and is_disabled are the two columns the
+// clean keys need that the raw list never sorted on.
 var mailboxListCols = ListCols{
 	Search:      []string{"local_part", "email_cached"},
-	Sort:        []string{"local_part", "email_cached", "created_at", "quota_bytes", "last_usage_bytes"},
+	Sort:        []string{"local_part", "email_cached", "display_name", "created_at", "quota_bytes", "last_usage_bytes", "is_disabled"},
 	DefaultSort: "created_at",
+}
+
+// mailboxListSortKeys is the single-table twin of mailboxDirectorySortKeys: it
+// maps the clean API sort keys the mailbox front-end sends
+// (?sort=email|name|usage|status|created_at) to the BARE mailboxes columns
+// ListByDomainID orders on — this endpoint is one table, so no qualification is
+// needed. "usage" maps to last_usage_bytes to match the directory's meaning of
+// the key (the Usage column) even though the same table also carries
+// quota_bytes. Keys that only exist on the directory JOIN (domain, owner) are
+// absent, so pickSort falls back to the default order for them — harmless here
+// since the drill-down hides the Domain column anyway. Unlike the directory
+// (which REPLACES opts.Sort), this is a PASS-THROUGH: a raw column a CLI/MCP
+// caller sends (created_at, quota_bytes, local_part) is left untouched and
+// re-validated by the allowlist, so no existing caller changes behaviour.
+var mailboxListSortKeys = map[string]string{
+	"email":      "email_cached",
+	"name":       "display_name",
+	"usage":      "last_usage_bytes",
+	"status":     "is_disabled",
+	"created_at": "created_at",
 }
 
 func (r *mailboxRepo) ListByDomainID(ctx context.Context, domainID string, opts ListOptions) ([]models.Mailbox, int64, error) {
@@ -119,6 +144,9 @@ func (r *mailboxRepo) ListByDomainID(ctx context.Context, domainID string, opts 
 	}
 	if opts.Sort == "" && opts.Order == "" {
 		opts.Order = "desc"
+	}
+	if col, ok := mailboxListSortKeys[strings.ToLower(strings.TrimSpace(opts.Sort))]; ok {
+		opts.Sort = col // clean key → bare column; a raw column is left as-is
 	}
 	q := applyListOptions(base.Session(&gorm.Session{}), opts, mailboxListCols)
 	if err := q.Find(&rows).Error; err != nil {

--- a/panel-api/internal/repository/mailbox_repository_test.go
+++ b/panel-api/internal/repository/mailbox_repository_test.go
@@ -183,6 +183,52 @@ func TestMailboxRepository_ListByDomainID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestMailboxRepository_ListByDomainID_TranslatesFriendlySort proves the
+// per-domain drill-down understands the SAME clean sort keys the directory does
+// (JAB-370): a shared front-end sends ?sort=email|name|usage|status and the
+// endpoint orders on the matching bare column instead of silently falling back
+// to created_at (the regression this guards). Falsify by deleting the
+// mailboxListSortKeys lookup in ListByDomainID → "email" no longer whitelists,
+// pickSort drops to DefaultSort, and the email/status expectations redden.
+func TestMailboxRepository_ListByDomainID_TranslatesFriendlySort(t *testing.T) {
+	cols := []string{"id", "domain_id", "local_part", "email_cached", "password_hash",
+		"quota_bytes", "is_disabled", "last_usage_bytes", "last_usage_at", "created_at", "updated_at"}
+	now := time.Now()
+
+	cases := []struct {
+		name    string
+		sort    string
+		orderBy string // the column the ORDER BY must carry
+	}{
+		{"email clean key", "email", "email_cached"},
+		{"name clean key", "name", "display_name"},
+		{"usage clean key", "usage", "last_usage_bytes"},
+		{"status clean key", "status", "is_disabled"},
+		{"raw column passes through", "quota_bytes", "quota_bytes"},
+		{"unknown directory-only key falls back", "domain", "created_at"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, raw := newMockDB(t)
+			defer raw.Close()
+			repo := NewMailboxRepository(db)
+
+			mock.ExpectQuery("SELECT count.* FROM `mailboxes`.*WHERE domain_id = \\?").
+				WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+			mock.ExpectQuery("SELECT .* FROM `mailboxes`.*WHERE domain_id = \\?.*ORDER BY " + tc.orderBy + " ASC").
+				WillReturnRows(sqlmock.NewRows(cols).
+					AddRow("mb1", "dom1", "alice", "alice@example.com", "h1", uint64(1<<30), false, uint64(0), nil, now, now),
+				)
+
+			rows, total, err := repo.ListByDomainID(context.Background(), "dom1", ListOptions{Sort: tc.sort, Order: "asc"})
+			require.NoError(t, err)
+			require.Equal(t, int64(1), total)
+			require.Len(t, rows, 1)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 // TestMailboxRepository_ListByDomainID_ExcludeSystem verifies that the
 // GH #1056 opt filters the JAB-230 relay out of BOTH the count and the row
 // query — otherwise the paginated list would show N-1 rows against a total of

--- a/panel-ui/src/hooks/useMailboxes.ts
+++ b/panel-ui/src/hooks/useMailboxes.ts
@@ -235,6 +235,11 @@ export function useCreateMailbox(): UseMutationResult<
       // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
       // delete / create refreshes the visible page.
       qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
+      // JAB-370 Workspace: the tenant Mailboxes tab is now server-paginated via
+      // useTableURL({ resource: "me/mailboxes" }), keyed ["list", "me/mailboxes",
+      // …params]. Prefix-invalidate it so a create/edit/delete refreshes the
+      // visible page instead of leaving a stale (or ghost) row.
+      qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
     },
   });
 }
@@ -256,6 +261,11 @@ export function useDeleteMailbox(): UseMutationResult<
       // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
       // delete / create refreshes the visible page.
       qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
+      // JAB-370 Workspace: the tenant Mailboxes tab is now server-paginated via
+      // useTableURL({ resource: "me/mailboxes" }), keyed ["list", "me/mailboxes",
+      // …params]. Prefix-invalidate it so a create/edit/delete refreshes the
+      // visible page instead of leaving a stale (or ghost) row.
+      qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
       // JAB-333: a deleted mailbox also disappears from the tenant screen's
       // group-membership and autoresponder panels — invalidate those shared
       // keys so they don't render a ghost row until the next refetch.
@@ -329,6 +339,11 @@ export function useUpdateMailbox(): UseMutationResult<
       // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
       // delete / create refreshes the visible page.
       qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
+      // JAB-370 Workspace: the tenant Mailboxes tab is now server-paginated via
+      // useTableURL({ resource: "me/mailboxes" }), keyed ["list", "me/mailboxes",
+      // …params]. Prefix-invalidate it so a create/edit/delete refreshes the
+      // visible page instead of leaving a stale (or ghost) row.
+      qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
     },
   });
 }

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -6,6 +6,7 @@
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { Button, Empty, Form, Modal, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
+import type { TableProps } from "antd";
 import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../../components/RowActions";
 import { SearchableTableStringQ } from "../../../../components/SearchableTable";
@@ -36,6 +37,7 @@ import {
   useMailboxWebmail,
 } from "../../../../components/mail/mailboxInventory";
 import { useListQuery } from "../../../../hooks/useQueries";
+import { useTableURL } from "../../../../hooks/useTableURL";
 import type { Domain } from "../../../../components/domains/types";
 import { PasswordInput } from "../../../../components/PasswordInput";
 import { EditMailboxModal } from "../../../../components/mail/EditMailboxModal";
@@ -53,7 +55,7 @@ type GroupMembership = {
 // cross-domain view (unchanged).
 export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   const { t } = useTranslation();
-  const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
+  const { items: domains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
   });
@@ -63,16 +65,18 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
     [domains, domainId],
   );
 
-  const mailboxResults = useQueries({
-    queries: emailEnabledDomains.map((d) => ({
-      queryKey: ["list", "mailboxes", d.id, { page: 1, pageSize: 200 }],
-      queryFn: async () => {
-        const { data } = await apiClient.get<{ data: Mailbox[]; total: number }>(
-          `/domains/${d.id}/mailboxes?page=1&page_size=200&sort=local_part&order=asc`,
-        );
-        return { items: data.data ?? [], domain: d };
-      },
-    })),
+  // JAB-370 Workspace: the mailbox rows come from ONE owner-scoped,
+  // server-paginated query — GET /me/mailboxes spanning every domain the caller
+  // owns (cross-domain view), or the per-domain endpoint when this tab is
+  // embedded in the Mail Domains drill-down (domainId set). This replaces the
+  // one-request-per-domain fan-out that capped each domain at 200 rows and never
+  // paginated across domains. Search/sort/pagination are all server-authoritative.
+  const resource = domainId ? `domains/${domainId}/mailboxes` : "me/mailboxes";
+  const query = useTableURL<Mailbox & { domain_name?: string }>({
+    resource,
+    defaultSort: "email",
+    defaultOrder: "asc",
+    defaultPageSize: 20,
   });
 
   const membershipResults = useQueries({
@@ -99,16 +103,22 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   }, [membershipResults]);
 
 
-  const rows: MailboxRow[] = useMemo(() => {
-    const out: MailboxRow[] = [];
-    for (const r of mailboxResults) {
-      if (!r.data) continue;
-      for (const mb of r.data.items) {
-        out.push({ ...mb, domain_name: r.data.domain.name });
-      }
-    }
-    return out;
-  }, [mailboxResults]);
+  // The per-domain endpoint returns rows without a domain_name (that column is
+  // hidden in the drill-down anyway); backfill it from the domains list so the
+  // Calendar/contacts modal still has a domain to build DAV URLs from.
+  const domainNameById = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const d of domains) m[d.id] = d.name;
+    return m;
+  }, [domains]);
+  const rows: MailboxRow[] = useMemo(
+    () =>
+      query.items.map((r) => ({
+        ...r,
+        domain_name: r.domain_name ?? domainNameById[r.domain_id] ?? "",
+      })),
+    [query.items, domainNameById],
+  );
 
   // Per-mailbox automatic-replies (autoresponder) fanout — one GET each,
   // shares the cache with useAutoresponder via the matching query key.
@@ -187,24 +197,28 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
     if (ok) setResetTarget(null);
   };
 
-  const loading = loadingDomains || mailboxResults.some((r) => r.isLoading);
-  const [search, setSearch] = useState("");
-  const filteredRows = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter(
-      (r) =>
-        r.email.toLowerCase().includes(q) ||
-        (r.domain_name ?? "").toLowerCase().includes(q),
-    );
-  }, [rows, search]);
+  const loading = query.isLoading;
+
+  // Map AntD's per-column sort event onto the server sort/order params. Sortable
+  // columns set `sorter: true` (no local comparator) so sorting is authoritative
+  // across ALL pages, not just the visible one; the repo whitelists the key.
+  const sortOrderFor = (key: string): "ascend" | "descend" | null =>
+    query.params.sort === key ? (query.params.order === "asc" ? "ascend" : "descend") : null;
+  const handleTableChange: TableProps<MailboxRow>["onChange"] = (pag, _filters, sorter, extra) => {
+    if (extra.action === "sort") {
+      const s = Array.isArray(sorter) ? sorter[0] : sorter;
+      if (s?.order && s.columnKey) {
+        query.setParams({ sort: String(s.columnKey), order: s.order === "ascend" ? "asc" : "desc", page: 1 });
+      } else {
+        query.setParams({ sort: undefined, order: undefined, page: 1 });
+      }
+    } else if (extra.action === "paginate" && pag) {
+      query.setParams({ page: pag.current, pageSize: pag.pageSize });
+    }
+  };
 
   if (loading && rows.length === 0) {
     return <Skeleton active paragraph={{ rows: 4 }} />;
-  }
-
-  if (rows.length === 0) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("mailboxestab.no_mailboxes_yet")} />;
   }
 
   return (
@@ -212,19 +226,27 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
       <SearchableTableStringQ<MailboxRow>
         scroll={{ x: "max-content" }}
         rowKey="id"
-        loading={loading && rows.length === 0}
-        dataSource={filteredRows}
+        loading={loading}
+        dataSource={rows}
         searchPlaceholder="Search email, name, domain…"
-        initialSearch={search}
-        onSearchChange={setSearch}
-        pagination={{ defaultPageSize: 20 }}
+        initialSearch={query.params.q}
+        onSearchChange={(q) => query.setParams({ q, page: 1 })}
+        onChange={handleTableChange}
+        pagination={{
+          current: query.params.page,
+          pageSize: query.params.pageSize,
+          total: query.total,
+          showSizeChanger: true,
+        }}
         locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("mailboxestab.no_mailboxes")} /> }}
         columns={[
           {
             title: "Mailbox",
             dataIndex: "email",
+            key: "email",
             ellipsis: true,
-            sorter: (a, b) => a.email.localeCompare(b.email),
+            sorter: true,
+            sortOrder: sortOrderFor("email"),
             render: (v: string, record: MailboxRow) => {
               const fwd = fwdByMailbox[record.id];
               return (
@@ -265,8 +287,9 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
                 {
                   title: "Domain",
                   dataIndex: "domain_name",
-                  sorter: (a: MailboxRow, b: MailboxRow) =>
-                    a.domain_name.localeCompare(b.domain_name),
+                  key: "domain",
+                  sorter: true,
+                  sortOrder: sortOrderFor("domain"),
                   width: 220,
                 },
               ]),
@@ -332,17 +355,22 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
           {
             title: "Usage / Quota",
             dataIndex: "quota_bytes",
+            key: "usage",
             // GH #1358: the column shows space USED (used / quota + fill bar), so
-            // sort by used bytes — not the quota limit, which made the header
-            // arrow a no-op for "sort by usage".
-            sorter: (a, b) => (a.last_usage_bytes ?? 0) - (b.last_usage_bytes ?? 0),
+            // sort by used bytes — not the quota limit. The server "usage" sort
+            // key maps to m.last_usage_bytes (mailboxDirectorySortKeys).
+            sorter: true,
+            sortOrder: sortOrderFor("usage"),
             width: 220,
             render: (_quota: number, row) => renderMailboxQuota(row),
           },
           {
             title: "Last usage",
             dataIndex: "last_usage_at",
-            sorter: (a, b) => (a.last_usage_at ? +new Date(a.last_usage_at) : 0) - (b.last_usage_at ? +new Date(b.last_usage_at) : 0),
+            // Not a server-side sort key (the directory projection sorts by
+            // usage bytes, not last-usage timestamp), so this column is not
+            // sortable under server pagination — a client comparator would only
+            // reorder the visible page and mislead.
             width: 160,
             render: (v: string | null | undefined) =>
               v ? (
@@ -354,7 +382,9 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
           {
             title: "Status",
             dataIndex: "is_disabled",
-            sorter: (a, b) => Number(a.is_disabled) - Number(b.is_disabled),
+            key: "status",
+            sorter: true,
+            sortOrder: sortOrderFor("status"),
             width: 100,
             render: (disabled: boolean) => renderMailboxStatus(disabled),
           },


### PR DESCRIPTION
## What & why (JAB-370 — Mail Inventory Directory, tenant Workspace slice)

The tenant **Mailboxes** tab built its cross-domain list by firing one
`GET /domains/:id/mailboxes?page_size=200` per domain — an N+1 fan-out that
also **silently truncated** any domain past 200 mailboxes, with no
cross-domain pagination, search, or sort. This lands the tenant twin of the
admin Directory slice (#1489): one owner-scoped, server-paginated projection.

## Backend — `GET /me/mailboxes`

A thin adapter over the existing `ListDirectoryPage` repo method (no new repo
query): the owner filter is forced from the Kratos session.

- **Isolation-critical:** unlike the admin directory there is **no `?user_id`**
  parameter. A tenant can never widen the query to another user's mailboxes —
  the owner comes from `claims.UserID`, full stop. Guarded by
  `TestListWorkspace_IgnoresClientOwnerParam` (`?user_id=u2` is ignored; owner
  stays `u1`), which was **falsified**: injecting a `c.Query("user_id")` read
  reddens it.
- System principals (the JAB-230 relay) are excluded in SQL (`WHERE m.system = 0`);
  the projection reuses the qualified-column sort whitelist (avoiding the
  MariaDB 1052 ambiguous-`created_at` trap across the 3-table JOIN) and the
  secret-column-drop select (no `password_hash` / `password_enc`) from the
  earlier directory/security slices.
- Always paginated (the tab is its only consumer), so no unbounded response can
  truncate at the client.

## Frontend — `MailboxesTab` → `useTableURL` server mode

Mirrors the admin Directory slice (#1489): server-authoritative search / sort /
pagination; sortable columns set `sorter: true` against the whitelisted keys
(`email` / `domain` / `usage` / `status`). Create / edit / delete invalidations
now also bust `["list","me/mailboxes"]` so a mutation refreshes the visible page
instead of leaving a stale or ghost row.

The tab keeps its **dual mode** (JAB-1387): unset `domainId` = cross-domain
Workspace via `/me/mailboxes`; set `domainId` (the Mail Domains drill-down) =
the per-domain endpoint, which **also** gains server pagination and loses its
200-row cap. The per-domain rows lack `domain_name`, so it is backfilled from
the domains list for the DAV/Calendar modal.

## Per-domain sort vocabulary unified (regression fix)

Once the shared table drives both endpoints, `ListByDomainID` had to learn the
same clean sort keys the directory speaks. Without it the drill-down's sort
**silently fell back to `created_at`** on every column while the header still
showed a sort arrow — its raw-column whitelist never matched the front-end's
clean keys. `ListByDomainID` now translates `email|name|usage|status` to their
bare `mailboxes` columns (the single-table twin of `mailboxDirectorySortKeys`).
The translation is **pass-through, not replace**: a raw column a CLI/MCP caller
sends (`created_at`, `quota_bytes`, `local_part`) is left untouched and still
whitelist-validated, so no existing caller changes behaviour. The
directory-only keys (`domain`, `owner`) are a no-op here — the drill-down hides
the Domain column. Guarded + falsified by
`TestMailboxRepository_ListByDomainID_TranslatesFriendlySort` (friendly keys →
matching column; raw column passes through; unknown key falls back).

## Behaviour / UX notes reviewers should know

- **"Last usage"** is no longer sortable — it is not a whitelisted server key,
  and a client comparator on a single page would mislead.
- The old zero-rows `Empty` early-return is gone; the table's
  `locale.emptyText` now covers both zero-rows and zero-search-results, keeping
  the search box reachable.
- **Residual N+1 (out of scope):** the per-mailbox autoresponder and
  group-membership decorations are unchanged — they are id-keyed maps looked up
  per row, orthogonal to where the rows come from, and belong to those separate
  features. A Selection follow-up slice.

## Scope

JAB-370 is a multi-slice parent — **stays Backlog**. Shipped: Directory
(#1489) + Workspace (this PR). Remaining: Recent + Selection projections and
both-adapter characterization tests. Documented `GET /me/mailboxes` in
`openapi.yaml`.

## Test plan

- [x] `go test ./panel-api/internal/api/ ./panel-api/internal/repository/` — pass
- [x] Handler guards: owner-forced-from-claims, `?user_id` ignored (falsified),
      401 unauthenticated, always-paginated
- [x] Repo guard: per-domain friendly-sort translation (falsified) + pass-through + fallback
- [x] `go vet` clean
- [x] `tsc -b` clean, `vitest run` 640/640, `vite build` clean
- [ ] **Human spot-check recommended:** I cannot log in to the panel (login is
      password entry, which I am not permitted to do) and no e2e spec drives
      this tab, so a manual look at the Mailboxes tab in **both** modes
      (Workspace + a Mail Domains drill-down) — sort arrows, pagination,
      search, create/edit/delete refresh — is advisable before promoting `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
