### PR TITLE
feat(dns): Add DNS Zone (pointed IP + template) on tenant and admin lists (GH #1540)

### DIFF
--- a/panel-api/internal/api/domain_create_apex_ip_test.go
+++ b/panel-api/internal/api/domain_create_apex_ip_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1540: a DNS-only zone (web off, DNS on) may be created with a
+// tenant-chosen apex IP (the "pointed IP"). createDomainOp persists it on the
+// domain row (DNSApexIPv4) after validating it is a bare IPv4 and that the
+// domain is actually a DNS-only zone — a web domain's apex is panel-managed,
+// and external-DNS publishes nothing here.
+func TestCreateDomainOp_ApexIP(t *testing.T) {
+	uname := "alice"
+	owner := &models.User{ID: "u-alice", Email: "alice@example.com", Username: &uname}
+
+	newH := func() (*domainHandler, *dcDomains) {
+		dom := newDCDomains()
+		h := &domainHandler{cfg: DomainHandlerConfig{Users: newAbUsers(owner), Domains: dom}}
+		return h, dom
+	}
+
+	t.Run("DNS-only with a valid IPv4 apex is persisted", func(t *testing.T) {
+		h, dom := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "zone.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv4:  "203.0.113.10",
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.DNSApexIPv4 == nil || *d.DNSApexIPv4 != "203.0.113.10" {
+			t.Fatalf("DNSApexIPv4 should be 203.0.113.10, got %v", d.DNSApexIPv4)
+		}
+		if len(dom.created) != 1 {
+			t.Fatalf("domain should be created, got %d", len(dom.created))
+		}
+	})
+
+	t.Run("surrounding whitespace is trimmed", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "trim.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv4:  "  198.51.100.7  ",
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.DNSApexIPv4 == nil || *d.DNSApexIPv4 != "198.51.100.7" {
+			t.Fatalf("DNSApexIPv4 should be trimmed to 198.51.100.7, got %v", d.DNSApexIPv4)
+		}
+	})
+
+	t.Run("DNS-only without an apex IP leaves the column NULL", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "noip.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.DNSApexIPv4 != nil {
+			t.Fatalf("DNSApexIPv4 should be nil when no IP is given, got %q", *d.DNSApexIPv4)
+		}
+	})
+
+	t.Run("apex IP on a web domain is rejected", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "web.example.com",
+			MailProvider: models.MailProviderNone,
+			SSLMode:      models.SSLModeNone,
+			DNSApexIPv4:  "203.0.113.10",
+		})
+		if oerr == nil || oerr.Code != "web_enabled_apex_ip" {
+			t.Fatalf("want web_enabled_apex_ip, got %v", oerr)
+		}
+	})
+
+	t.Run("apex IP with DNS off (external DNS) is rejected", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "extdns.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSDisabled:  true,
+			DNSApexIPv4:  "203.0.113.10",
+		})
+		if oerr == nil || oerr.Code != "dns_disabled_apex_ip" {
+			t.Fatalf("want dns_disabled_apex_ip, got %v", oerr)
+		}
+	})
+
+	t.Run("a non-IP apex value is rejected", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "bad.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv4:  "not-an-ip",
+		})
+		if oerr == nil || oerr.Code != "invalid_apex_ip" {
+			t.Fatalf("want invalid_apex_ip, got %v", oerr)
+		}
+	})
+
+	t.Run("an IPv6 apex value is rejected (apex A row is IPv4)", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "v6.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv4:  "2001:db8::1",
+		})
+		if oerr == nil || oerr.Code != "invalid_apex_ip" {
+			t.Fatalf("want invalid_apex_ip, got %v", oerr)
+		}
+	})
+}

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -77,6 +78,13 @@ type createDomainInput struct {
 	// domain. DNSDisabled=true → the panel does not host DNS (external DNS).
 	WebDisabled bool
 	DNSDisabled bool
+	// DNSApexIPv4 (GH #1540) is the apex IP for a DNS-only zone — the "pointed
+	// IP" of the Add DNS Zone flow. Only meaningful when WebDisabled=true and
+	// DNS is on: the panel seeds a single "@ A <ip>" row at zone bootstrap and
+	// leaves it tenant-editable. Empty for every web/mail create (the apex is
+	// panel-managed). Validated in createDomainOp (must be a bare IPv4, web off,
+	// DNS on).
+	DNSApexIPv4 string
 }
 
 // createDomainError carries the exact HTTP shape the inline create() used, so
@@ -131,6 +139,26 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		if strings.TrimSpace(in.DocRoot) != "" {
 			return nil, &createDomainError{http.StatusBadRequest, "web_disabled_no_docroot", "a web-disabled domain has no document root"}
 		}
+	}
+
+	// GH #1540: a DNS-only zone may carry a tenant-chosen apex IP (the "pointed
+	// IP"). It is only meaningful for a web-off zone whose DNS the panel hosts:
+	// a web domain's apex is panel-managed (convergeApexAddrRecords re-asserts
+	// it), and an external-DNS domain (dns off) publishes nothing here. Must be
+	// a bare IPv4 — no CIDR, no port, no IPv6 (the apex A row is IPv4).
+	var dnsApexIPv4 string
+	if raw := strings.TrimSpace(in.DNSApexIPv4); raw != "" {
+		if webEnabled {
+			return nil, &createDomainError{http.StatusBadRequest, "web_enabled_apex_ip", "a web domain's apex IP is managed by the panel — set an apex IP only on a DNS-only zone"}
+		}
+		if !dnsEnabled {
+			return nil, &createDomainError{http.StatusBadRequest, "dns_disabled_apex_ip", "an apex IP requires the panel to host DNS for this domain"}
+		}
+		ip := net.ParseIP(raw)
+		if ip == nil || ip.To4() == nil {
+			return nil, &createDomainError{http.StatusBadRequest, "invalid_apex_ip", "apex IP must be a valid IPv4 address"}
+		}
+		dnsApexIPv4 = ip.String()
 	}
 
 	user, err := h.cfg.Users.FindByID(ctx, in.OwnerID)
@@ -274,6 +302,8 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		// written) state, so a full-service create leaves both zero.
 		WebDisabled: in.WebDisabled,
 		DNSDisabled: in.DNSDisabled,
+		// GH #1540: apex IP for a DNS-only zone (nil for web/mail domains).
+		DNSApexIPv4: strPtrOrNil(dnsApexIPv4),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -146,6 +146,11 @@ type createDomainRequest struct {
 	// the default-on, distinct from an explicit false.
 	WebEnabled *bool `json:"web_enabled"`
 	ManageDNS  *bool `json:"manage_dns"`
+	// IPAddress (GH #1540) is the apex IP of a DNS-only zone — the "pointed IP"
+	// of the Add DNS Zone flow. Only valid when web_enabled=false and DNS is on
+	// (validated in createDomainOp as a bare IPv4). Empty/absent for web and
+	// mail domains, whose apex is panel-managed.
+	IPAddress string `json:"ip_address"`
 }
 
 // normalizeDomainName canonicalizes a domain for storage (GH #884): trim
@@ -771,6 +776,8 @@ func (h *domainHandler) create(c *gin.Context) {
 		// GH #1449: both default ON — only an explicit false opts out.
 		WebDisabled: req.WebEnabled != nil && !*req.WebEnabled,
 		DNSDisabled: req.ManageDNS != nil && !*req.ManageDNS,
+		// GH #1540: apex IP for a DNS-only zone (validated web-off + IPv4 in op).
+		DNSApexIPv4: req.IPAddress,
 	})
 	if oerr != nil {
 		body := gin.H{"error": oerr.Code}

--- a/panel-api/internal/db/migrations/000291_domain_dns_apex_ipv4.down.sql
+++ b/panel-api/internal/db/migrations/000291_domain_dns_apex_ipv4.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE domains
+  DROP COLUMN dns_apex_ipv4;

--- a/panel-api/internal/db/migrations/000291_domain_dns_apex_ipv4.up.sql
+++ b/panel-api/internal/db/migrations/000291_domain_dns_apex_ipv4.up.sql
@@ -1,0 +1,12 @@
+-- GH #1540: "Add DNS Zone" — a DNS-only zone (web_disabled=1) can be created
+-- with a tenant-chosen apex IP (the "pointed IP" johnnyq asked for). A web-off
+-- zone's apex A is deliberately NOT seeded by BootstrapRecords (includeApex=
+-- false) and NOT re-asserted by convergeApexAddrRecords (web-gated), so there
+-- is no managed apex row to carry the address — persist it on the domain row so
+-- the reconciler can seed the single apex A once at zone bootstrap.
+--
+-- Nullable, no default: only DNS-only creates set it; every existing row and
+-- every web/mail create leaves it NULL (the apex is panel-managed or absent).
+-- Read once at zone bootstrap and never written again, so no zero-value scar.
+ALTER TABLE domains
+  ADD COLUMN dns_apex_ipv4 VARCHAR(45) NULL;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -238,6 +238,15 @@ type Domain struct {
 	WebDisabled bool `gorm:"column:web_disabled;type:tinyint(1);not null;default:0" json:"web_disabled"`
 	DNSDisabled bool `gorm:"column:dns_disabled;type:tinyint(1);not null;default:0" json:"dns_disabled"`
 
+	// DNSApexIPv4 (GH #1540) is the tenant-chosen apex IP for a DNS-only zone
+	// (WebDisabled=true, DNS on). A web-off zone's apex A is not seeded by
+	// BootstrapRecords and not re-asserted by convergeApexAddrRecords (both
+	// web-gated), so this address is read ONCE by the reconciler at zone
+	// bootstrap to seed the single "@ A <ip>" row, then never written again —
+	// the tenant edits that row directly afterward. NULL for every web/mail
+	// domain (apex is panel-managed) and every legacy row.
+	DNSApexIPv4 *string `gorm:"column:dns_apex_ipv4;type:varchar(45)" json:"dns_apex_ipv4,omitempty"`
+
 	// IsQuotaSuspended marks domains the M13.1.1 bandwidth reconciler
 	// disabled because their owning user crossed BandwidthQuotaMB.
 	// Disambiguates panel-driven disables from manual operator

--- a/panel-api/internal/reconciler/dns_only_apex_seed_test.go
+++ b/panel-api/internal/reconciler/dns_only_apex_seed_test.go
@@ -1,0 +1,83 @@
+package reconciler
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func strptr(s string) *string { return &s }
+
+// GH #1540: dnsOnlyApexSeed builds the single "@ A <ip>" row for a web-off DNS
+// zone created with a tenant-chosen apex IP. BootstrapRecords skips the apex for
+// a web-off zone, and convergeApexAddrRecords is web-gated, so this seed is the
+// only writer — it must produce a tenant-owned (Managed=false) apex A only when
+// the domain is a web-off zone carrying a non-empty IP.
+func TestDNSOnlyApexSeed(t *testing.T) {
+	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1"}
+	idNew := func() string { return "rec-1" }
+
+	t.Run("web-off zone with an apex IP seeds a tenant-owned @ A", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("203.0.113.10")}
+		rec, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew)
+		if !ok {
+			t.Fatal("expected a seed record")
+		}
+		if rec.Name != "@" || rec.Type != "A" {
+			t.Errorf("want @ A, got %s %s", rec.Name, rec.Type)
+		}
+		if rec.Content != "203.0.113.10" {
+			t.Errorf("content should be the apex IP, got %q", rec.Content)
+		}
+		if rec.ZoneID != "zone-1" {
+			t.Errorf("zone id should be zone-1, got %q", rec.ZoneID)
+		}
+		if rec.Managed {
+			t.Error("a web-off apex is tenant-owned — Managed must be false")
+		}
+		if rec.ManagedBy != nil {
+			t.Error("ManagedBy must be nil")
+		}
+		if !rec.IsEnabled {
+			t.Error("seed must be enabled")
+		}
+		if rec.TTL != models.EffectiveDNSTTL(srv) {
+			t.Errorf("TTL should follow the server default, got %d", rec.TTL)
+		}
+	})
+
+	t.Run("trims surrounding whitespace on the IP", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("  198.51.100.7 ")}
+		rec, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew)
+		if !ok || rec.Content != "198.51.100.7" {
+			t.Fatalf("want trimmed 198.51.100.7, got ok=%v content=%q", ok, rec.Content)
+		}
+	})
+
+	t.Run("web-enabled domain never seeds (apex is panel-managed)", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: false, DNSApexIPv4: strptr("203.0.113.10")}
+		if _, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew); ok {
+			t.Error("a web-enabled domain must not seed a custom apex")
+		}
+	})
+
+	t.Run("nil apex IP does not seed", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: nil}
+		if _, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew); ok {
+			t.Error("a web-off zone without a custom IP must not seed")
+		}
+	})
+
+	t.Run("empty apex IP does not seed", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("   ")}
+		if _, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew); ok {
+			t.Error("a blank custom IP must not seed")
+		}
+	})
+
+	t.Run("nil domain does not seed", func(t *testing.T) {
+		if _, ok := dnsOnlyApexSeed(nil, "zone-1", srv, idNew); ok {
+			t.Error("nil domain must not seed")
+		}
+	})
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2380,6 +2380,38 @@ func (r *Reconciler) resolveListenIPAddress(ctx context.Context, id *uint64, fam
 	return row.Address
 }
 
+// dnsOnlyApexSeed builds the single apex A record for a web-off DNS zone that
+// was created with a tenant-chosen apex IP (GH #1540). A web-off zone's apex is
+// deliberately left unseeded by dnscompile.BootstrapRecords (includeApex=false)
+// and is never re-asserted by convergeApexAddrRecords (web-gated), so this row
+// is seeded ONCE at zone bootstrap and then owned by the tenant. Managed=false
+// (the panel does not reconcile it — an honest flag, no false "managed" badge),
+// ManagedBy nil. Returns ok=false unless the domain is a web-off zone carrying a
+// non-empty apex IP, so callers can seed unconditionally.
+func dnsOnlyApexSeed(domain *models.Domain, zoneID string, srv *models.ServerSettings, idNew func() string) (models.DNSRecord, bool) {
+	if domain == nil || !domain.WebDisabled || domain.DNSApexIPv4 == nil {
+		return models.DNSRecord{}, false
+	}
+	ip := strings.TrimSpace(*domain.DNSApexIPv4)
+	if ip == "" {
+		return models.DNSRecord{}, false
+	}
+	now := time.Now().UTC()
+	return models.DNSRecord{
+		ID:        idNew(),
+		ZoneID:    zoneID,
+		Name:      "@",
+		Type:      "A",
+		Content:   ip,
+		TTL:       models.EffectiveDNSTTL(srv),
+		Priority:  0,
+		Managed:   false,
+		IsEnabled: true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, true
+}
+
 // reconcileDNSZone ensures a domain's DNS zone and records are provisioned
 // on the agent. Called during domain reconciliation to push the zone state
 // to PowerDNS via the agent.
@@ -2432,6 +2464,15 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 			for i := range boots {
 				if err := r.dnsRecords.Create(ctx, &boots[i]); err != nil {
 					r.log.Error("bootstrap record failed", "err", err)
+					return
+				}
+			}
+			// GH #1540: a DNS-only zone created with a tenant-chosen apex IP
+			// seeds its single "@ A <ip>" here — BootstrapRecords skips the apex
+			// for a web-off zone. Tenant-owned (Managed=false), never re-asserted.
+			if seed, ok := dnsOnlyApexSeed(domain, zone.ID, srv, ids.NewULID); ok {
+				if err := r.dnsRecords.Create(ctx, &seed); err != nil {
+					r.log.Error("dns-only apex seed failed", "zone", zone.Name, "err", err)
 					return
 				}
 			}

--- a/panel-ui/src/components/dns/DnsZoneFields.tsx
+++ b/panel-ui/src/components/dns/DnsZoneFields.tsx
@@ -1,0 +1,107 @@
+// DnsZoneFields — the shared body of the "Add DNS Zone" form (GH #1540): the
+// pointed apex IP plus a DNS Template (Default / Microsoft 365 / Google
+// Workspace) and the template's optional helper inputs. Used by both the tenant
+// drawer (UserDomainDrawer, dns mode) and the admin drawer (AdminDNSZoneDrawer),
+// so the two lists offer the same simple form johnnyq asked for.
+//
+// It reads the surrounding <Form> via Form.useFormInstance(), so a parent just
+// drops <DnsZoneFields publicIP={caps?.public_ipv4} /> inside its <Form> — the
+// field names (ip_address, mail_provider, m365_onmicrosoft, google_dkim) match
+// the POST /domains body verbatim.
+import { useEffect } from "react";
+import { Form, Input, Select } from "antd";
+
+// isIPv4 accepts a dotted-quad with every octet in 0–255. The backend
+// (net.ParseIP + To4) is the authority; this only gives the user immediate,
+// friendly validation and blocks an obvious typo before the round-trip.
+const isIPv4 = (value: string): boolean => {
+  const parts = value.trim().split(".");
+  if (parts.length !== 4) return false;
+  return parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
+};
+
+export interface DnsZoneFieldsProps {
+  // The panel's public IPv4, prefilled into the apex IP field so the common
+  // case ("point it at this server") is one click. The user can overwrite it.
+  publicIP?: string;
+}
+
+export const DnsZoneFields = ({ publicIP }: DnsZoneFieldsProps) => {
+  const form = Form.useFormInstance();
+  const template = Form.useWatch("mail_provider", form) ?? "none";
+
+  // Prefill the apex IP with the panel's IP once, and never clobber a value the
+  // user already typed (or one restored on a remount). destroyOnClose remounts
+  // the drawer per open, so this re-runs with an empty field each open.
+  useEffect(() => {
+    if (publicIP && !form.getFieldValue("ip_address")) {
+      form.setFieldValue("ip_address", publicIP);
+    }
+  }, [publicIP, form]);
+
+  return (
+    <>
+      <Form.Item
+        label="IP Address"
+        name="ip_address"
+        // initialValue seeds the panel IP synchronously and, crucially, is what
+        // form.resetFields() restores to — without it a parent drawer that calls
+        // resetFields on open (UserDomainDrawer) would blank the field on reopen.
+        // The effect below is the late-caps-load fallback (caps undefined at mount).
+        initialValue={publicIP}
+        tooltip="The IPv4 address this domain's apex (@) record points to. Prefilled with this server's IP — change it if the site lives elsewhere."
+        rules={[
+          { required: true, message: "IP address is required" },
+          {
+            validator: (_, v) =>
+              !v || isIPv4(v)
+                ? Promise.resolve()
+                : Promise.reject(new Error("Enter a valid IPv4 address (e.g. 203.0.113.10)")),
+          },
+        ]}
+      >
+        <Input placeholder="e.g., 203.0.113.10" />
+      </Form.Item>
+
+      {/* GH #1540: "Template" — Default seeds no mail records (just the apex the
+          user pointed above); Microsoft 365 / Google Workspace add that
+          provider's mail DNS. Jabali Mail is intentionally absent — those
+          records are set by adding a mail domain, which overrides them. Reuses
+          the mail_provider field the backend already understands. */}
+      <Form.Item
+        label="Template"
+        name="mail_provider"
+        initialValue="none"
+        tooltip="Default creates just the domain and its pointed IP. Microsoft 365 or Google Workspace also adds that provider's mail DNS records."
+      >
+        <Select
+          options={[
+            { value: "none", label: "Default (no mail records)" },
+            { value: "m365", label: "Microsoft 365" },
+            { value: "google", label: "Google Workspace" },
+          ]}
+        />
+      </Form.Item>
+
+      {template === "m365" && (
+        <Form.Item
+          label="Microsoft 365 tenant"
+          name="m365_onmicrosoft"
+          tooltip="Optional — your <tenant>.onmicrosoft.com. Adds the Microsoft 365 DKIM CNAMEs for this domain."
+        >
+          <Input placeholder="contoso.onmicrosoft.com (optional)" />
+        </Form.Item>
+      )}
+
+      {template === "google" && (
+        <Form.Item
+          label="Google DKIM value"
+          name="google_dkim"
+          tooltip="Optional — paste the google._domainkey TXT value from the Google Admin console."
+        >
+          <Input.TextArea rows={2} placeholder="v=DKIM1; k=rsa; p=... (optional)" />
+        </Form.Item>
+      )}
+    </>
+  );
+};

--- a/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.test.tsx
+++ b/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.test.tsx
@@ -1,0 +1,80 @@
+// GH #1540: the admin "Add DNS Zone" drawer creates a web-off, DNS-managed
+// domain on behalf of a tenant. It carries the same simple form as the tenant
+// flow (Domain Name / IP / Template) plus an Owner picker.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutate = vi.hoisted(() => vi.fn());
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: { public_ipv4: "192.0.2.1" } }),
+}));
+vi.mock("../../../hooks/useQueries", () => ({
+  useCreateMutation: () => ({ mutateAsync: mutate, isPending: false }),
+}));
+vi.mock("../../../apiClient", () => ({
+  apiClient: {
+    get: vi.fn().mockResolvedValue({
+      data: { data: [{ id: "u1", email: "alice@example.com", username: "alice" }] },
+    }),
+  },
+}));
+vi.mock("../../../lib/feedback", () => ({
+  feedback: {
+    message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    modal: { success: vi.fn() },
+  },
+}));
+
+import { AdminDNSZoneDrawer } from "./AdminDNSZoneDrawer";
+
+function renderDrawer() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AdminDNSZoneDrawer open onClose={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+const add = () => fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+beforeEach(() => {
+  mutate.mockReset();
+  mutate.mockResolvedValue({ id: "d1" });
+});
+
+describe("AdminDNSZoneDrawer (GH #1540)", () => {
+  it("requires an owner", async () => {
+    renderDrawer();
+    fireEvent.change(await screen.findByPlaceholderText("e.g., example.com"), {
+      target: { value: "zone.example.com" },
+    });
+    add();
+    await screen.findByText("Owner is required");
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("sends a web-off DNS-only payload with the owner, prefilled IP and default template", async () => {
+    renderDrawer();
+    // The apex IP is prefilled with the panel's public IPv4.
+    const ip = (await screen.findByPlaceholderText("e.g., 203.0.113.10")) as HTMLInputElement;
+    expect(ip.value).toBe("192.0.2.1");
+    // Pick the owner (first combobox; Template is the second).
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+    fireEvent.click(await screen.findByText("alice@example.com (alice)"));
+    fireEvent.change(screen.getByPlaceholderText("e.g., example.com"), {
+      target: { value: "zone.example.com" },
+    });
+    add();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const body = mutate.mock.calls[0][0];
+    expect(body.user_id).toBe("u1");
+    expect(body.name).toBe("zone.example.com");
+    expect(body.web_enabled).toBe(false);
+    expect(body.manage_dns).toBe(true);
+    expect(body.ssl_mode).toBe("none");
+    expect(body.ip_address).toBe("192.0.2.1");
+    expect(body.mail_provider).toBe("none");
+  });
+});

--- a/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.tsx
+++ b/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.tsx
@@ -1,0 +1,138 @@
+// AdminDNSZoneDrawer — admin "Add DNS Zone" Drawer (GH #1540). johnnyq asked
+// for an Add DNS Zone button on both the tenant and admin DNS-zone lists, with
+// the same simple form: Domain Name / IP Address (prefilled with the panel's
+// IP) / Template. The admin form adds one field the tenant form can't have — an
+// Owner (user) picker — since an admin creates zones on behalf of a tenant.
+//
+// It creates a web-off, DNS-managed domain via POST /domains (resource
+// "domains"), reusing the exact same backend path as the tenant dns-mode drawer
+// and the shared DnsZoneFields body.
+import { useQuery } from "@tanstack/react-query";
+import { Button, Drawer, Form, Grid, Input, Select, Space } from "antd";
+
+import { apiClient } from "../../../apiClient";
+import { feedback } from "../../../lib/feedback";
+import { useCreateMutation } from "../../../hooks/useQueries";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
+import { DnsZoneFields } from "../../../components/dns/DnsZoneFields";
+
+type AdminDNSZoneInput = {
+  name: string;
+  user_id: string;
+  ip_address?: string;
+  mail_provider?: string;
+  m365_onmicrosoft?: string;
+  google_dkim?: string;
+};
+
+type DomainCreated = { id: string };
+
+export interface AdminDNSZoneDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const AdminDNSZoneDrawer = ({ open, onClose }: AdminDNSZoneDrawerProps) => {
+  const [form] = Form.useForm<AdminDNSZoneInput>();
+  const { data: caps } = useServerCapabilities();
+  const screens = Grid.useBreakpoint();
+  const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
+
+  const createMutation = useCreateMutation<DomainCreated, Record<string, unknown>>({
+    resource: "domains",
+  });
+
+  const usersQ = useQuery({
+    queryKey: ["admin-users-for-dns-zone-create"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{
+        data?: { id: string; email: string; username?: string }[];
+      }>("/users?page_size=500&is_admin=false");
+      return data.data ?? [];
+    },
+    enabled: open,
+  });
+
+  const handleFinish = async (values: AdminDNSZoneInput) => {
+    try {
+      // A DNS-only zone: web off, DNS on, no TLS. The apex IP and the mail
+      // provider (from the Template select) go straight to POST /domains, which
+      // validates the IP (bare IPv4, web-off) and seeds the apex A in the
+      // reconciler. mail_provider defaults to "none" (Default template).
+      await createMutation.mutateAsync({
+        name: values.name,
+        user_id: values.user_id,
+        web_enabled: false,
+        manage_dns: true,
+        ssl_mode: "none",
+        ip_address: values.ip_address,
+        mail_provider: values.mail_provider ?? "none",
+        m365_onmicrosoft: values.m365_onmicrosoft,
+        google_dkim: values.google_dkim,
+      });
+      feedback.message.success("DNS zone added");
+      onClose();
+    } catch (err) {
+      feedback.message.error(err instanceof Error ? err.message : "Failed to add DNS zone");
+    }
+  };
+
+  return (
+    <Drawer
+      title="Add DNS Zone"
+      open={open}
+      onClose={onClose}
+      width={isDesktop ? 480 : undefined}
+      placement="right"
+      destroyOnClose
+    >
+      <Form<AdminDNSZoneInput> form={form} layout="vertical" onFinish={handleFinish}>
+        <Form.Item
+          label="Owner"
+          name="user_id"
+          rules={[{ required: true, message: "Owner is required" }]}
+        >
+          <Select
+            showSearch
+            placeholder="Select a user"
+            optionFilterProp="label"
+            loading={usersQ.isLoading}
+            options={(usersQ.data ?? []).map((u) => ({
+              value: u.id,
+              label: u.username ? `${u.email} (${u.username})` : u.email,
+            }))}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Domain Name"
+          name="name"
+          // GH #884: stored lowercase; normalize live so an autocorrected capital
+          // can't slip through.
+          normalize={(v) => (typeof v === "string" ? v.toLowerCase() : v)}
+          rules={[
+            { required: true, message: "Domain name is required" },
+            { max: 253, message: "Domain name cannot exceed 253 characters" },
+            {
+              pattern: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/,
+              message: "Enter a valid domain name (e.g. example.com)",
+            },
+          ]}
+        >
+          <Input placeholder="e.g., example.com" />
+        </Form.Item>
+
+        <DnsZoneFields publicIP={caps?.public_ipv4} />
+
+        <Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit" loading={createMutation.isPending}>
+              Add
+            </Button>
+            <Button onClick={onClose}>Cancel</Button>
+          </Space>
+        </Form.Item>
+      </Form>
+    </Drawer>
+  );
+};

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.test.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.test.tsx
@@ -1,0 +1,52 @@
+// GH #1540: the admin DNS Zones list gets an "Add DNS Zone" button that opens
+// the admin drawer (Owner picker + Domain Name + IP + Template).
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock("react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    data: { mail_enabled: true, dns_enabled: true, public_ipv4: "192.0.2.1" },
+  }),
+}));
+vi.mock("../../../hooks/useQueries", () => ({
+  useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+}));
+vi.mock("../../../lib/feedback", () => ({
+  feedback: {
+    message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+    modal: { success: vi.fn() },
+  },
+}));
+vi.mock("../../../components/EmptyWithCTA", () => ({ EmptyWithCTA: () => <div /> }));
+// Stub the inventory — this adapter test only cares that the header action
+// (Add DNS Zone) is rendered and wired to the admin drawer.
+vi.mock("../../../components/dns/DNSZoneInventory", () => ({
+  DnsZoneInventory: ({ audience }: { audience: { header: { extra?: ReactNode } } }) => (
+    <div>{audience.header.extra}</div>
+  ),
+}));
+
+import { DNSZonesOverviewPage } from "./DNSZonesOverviewPage";
+
+describe("admin DNSZonesOverviewPage Add DNS Zone (GH #1540)", () => {
+  it("opens the admin Add DNS Zone drawer with owner, domain and prefilled IP", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <DNSZonesOverviewPage />
+      </QueryClientProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /add dns zone/i }));
+    expect(await screen.findByText("Owner")).toBeInTheDocument();
+    expect(await screen.findByPlaceholderText("e.g., example.com")).toBeInTheDocument();
+    const ip = (await screen.findByPlaceholderText("e.g., 203.0.113.10")) as HTMLInputElement;
+    expect(ip.value).toBe("192.0.2.1");
+  });
+});

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
@@ -3,19 +3,25 @@
 // visible, admin domain routes, a create-domain empty-state CTA, and the
 // owner-visible DNSSEC tab. All list/query/column behavior lives in
 // components/dns/DNSZoneInventory.
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
-import { ServerOutlined } from "@icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "antd";
+import { ServerOutlined, PlusOutlined } from "@icons";
 
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
 import {
   DnsZoneInventory,
   type DnsZoneInventoryAudience,
 } from "../../../components/dns/DNSZoneInventory";
+import { AdminDNSZoneDrawer } from "./AdminDNSZoneDrawer";
 
 export const DNSZonesOverviewPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
 
   const audience: DnsZoneInventoryAudience = {
     showOwner: true,
@@ -33,8 +39,32 @@ export const DNSZonesOverviewPage = () => {
       description:
         "Signing is best-effort NSEC3 with ECDSAP256SHA256 (RFC 8624). Keys are managed by PowerDNS via pdnsutil.",
     },
-    header: { icon: <ServerOutlined />, title: "DNS Zones" },
+    header: {
+      icon: <ServerOutlined />,
+      title: "DNS Zones",
+      // GH #1540: Add DNS Zone on the admin list too — opens the admin drawer
+      // (Owner picker + Domain Name + IP + Template).
+      extra: (
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>
+          Add DNS Zone
+        </Button>
+      ),
+    },
   };
 
-  return <DnsZoneInventory audience={audience} />;
+  return (
+    <>
+      <DnsZoneInventory audience={audience} />
+      <AdminDNSZoneDrawer
+        open={createOpen}
+        onClose={() => {
+          setCreateOpen(false);
+          // The drawer creates via the "domains" resource (invalidates
+          // ["list","domains"]); this page lists ["list","dns/zones"], so refresh
+          // that list explicitly to show the newly added zone.
+          void qc.invalidateQueries({ queryKey: ["list", "dns/zones"] });
+        }}
+      />
+    </>
+  );
 };

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
@@ -6,10 +6,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const caps = vi.hoisted(() => ({ mail: false, dns: true }));
+const caps = vi.hoisted(() => ({ mail: false, dns: true, ipv4: "192.0.2.1" }));
 const mutate = vi.hoisted(() => vi.fn());
 vi.mock("../../../hooks/useServerCapabilities", () => ({
-  useServerCapabilities: () => ({ data: { mail_enabled: caps.mail, dns_enabled: caps.dns } }),
+  useServerCapabilities: () => ({
+    data: { mail_enabled: caps.mail, dns_enabled: caps.dns, public_ipv4: caps.ipv4 },
+  }),
 }));
 vi.mock("../../../hooks/useQueries", () => ({
   useCreateMutation: () => ({ mutateAsync: mutate, isPending: false }),
@@ -43,6 +45,7 @@ const typeName = async (name: string) => {
 beforeEach(() => {
   caps.mail = false;
   caps.dns = true;
+  caps.ipv4 = "192.0.2.1";
   mutate.mockReset();
   mutate.mockResolvedValue({ id: "d1" });
 });
@@ -134,5 +137,72 @@ describe("UserDomainDrawer web create payload (GH #1541)", () => {
     submit();
     await waitFor(() => expect(mutate).toHaveBeenCalled());
     expect(mutate.mock.calls[0][0].manage_dns).toBe(false);
+  });
+});
+
+describe("UserDomainDrawer dns mode — Add DNS Zone (GH #1540)", () => {
+  it("prefills the apex IP with the panel IP and sends a web-off DNS-only payload", async () => {
+    renderDrawer("dns");
+    // IP Address is prefilled with the panel's public IPv4.
+    const ip = (await screen.findByPlaceholderText("e.g., 203.0.113.10")) as HTMLInputElement;
+    expect(ip.value).toBe("192.0.2.1");
+    await typeName("zone.example.com");
+    submit();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const body = mutate.mock.calls[0][0];
+    expect(body.web_enabled).toBe(false);
+    expect(body.manage_dns).toBe(true);
+    expect(body.ssl_mode).toBe("none");
+    expect(body.ip_address).toBe("192.0.2.1");
+    // Default template ⇒ no mail records.
+    expect(body.mail_provider).toBe("none");
+  });
+
+  it("Template Microsoft 365 maps to mail_provider m365 with the tenant helper", async () => {
+    renderDrawer("dns");
+    await typeName("zone.example.com");
+    // Open the Template select and pick Microsoft 365.
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByText("Microsoft 365"));
+    fireEvent.change(await screen.findByPlaceholderText("contoso.onmicrosoft.com (optional)"), {
+      target: { value: "contoso.onmicrosoft.com" },
+    });
+    submit();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const body = mutate.mock.calls[0][0];
+    expect(body.mail_provider).toBe("m365");
+    expect(body.m365_onmicrosoft).toBe("contoso.onmicrosoft.com");
+    expect(body.web_enabled).toBe(false);
+    expect(body.ip_address).toBe("192.0.2.1");
+  });
+
+  it("prefills the apex IP on reopen (survives the drawer's resetFields)", async () => {
+    // The real "add a second zone" flow: open → close → open. destroyOnClose
+    // remounts the form body in the same commit as the open flip, so the child
+    // prefill effect must not lose to the drawer's resetFields effect.
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrap = (open: boolean) => (
+      <QueryClientProvider client={qc}>
+        <UserDomainDrawer open={open} mode="dns" onClose={() => {}} />
+      </QueryClientProvider>
+    );
+    const { rerender } = render(wrap(false));
+    rerender(wrap(true));
+    await screen.findByPlaceholderText("e.g., 203.0.113.10");
+    rerender(wrap(false));
+    rerender(wrap(true));
+    const ip = (await screen.findByPlaceholderText("e.g., 203.0.113.10")) as HTMLInputElement;
+    expect(ip.value).toBe("192.0.2.1");
+  });
+
+  it("blocks submit on an invalid apex IP", async () => {
+    renderDrawer("dns");
+    const ip = await screen.findByPlaceholderText("e.g., 203.0.113.10");
+    fireEvent.change(ip, { target: { value: "not-an-ip" } });
+    await typeName("zone.example.com");
+    submit();
+    // Client-side IPv4 validation stops the create.
+    await screen.findByText("Enter a valid IPv4 address (e.g. 203.0.113.10)");
+    expect(mutate).not.toHaveBeenCalled();
   });
 });

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -19,6 +19,7 @@ import { useEffect } from "react";
 import { apiClient } from "../../../apiClient";
 import { useCreateMutation } from "../../../hooks/useQueries";
 import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
+import { DnsZoneFields } from "../../../components/dns/DnsZoneFields";
 
 type UserDomainCreateInput = {
   name: string;
@@ -30,6 +31,8 @@ type UserDomainCreateInput = {
   mail_provider?: string;
   m365_onmicrosoft?: string;
   google_dkim?: string;
+  // GH #1540: apex IP for a DNS-only zone (dns mode only) — the "pointed IP".
+  ip_address?: string;
   // GH #1541: create_www is no longer a checkbox — it's derived from the domain
   // (apex ⇒ true, subdomain ⇒ false) and sent as a plain flag.
   create_www?: boolean;
@@ -145,11 +148,20 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           name: values.name,
           web_enabled: false,
           manage_dns: isDNS ? true : values.manage_dns,
-          // GH #1479: the non-web branch is either a DNS-only zone (no mail) or a
-          // mail domain (always Jabali mail — the provider select is hidden in
-          // mail mode, so values.mail_provider isn't registered).
-          mail_provider: isDNS ? "none" : "jabali",
+          // GH #1479/#1540: mail mode is always Jabali mail (the provider select
+          // is hidden there, so values.mail_provider isn't registered). A DNS-only
+          // zone takes its provider from the DNS Template select (Default → none,
+          // or external m365/google).
+          mail_provider: isDNS ? (values.mail_provider ?? "none") : "jabali",
           ssl_mode: isDNS ? "none" : values.ssl_mode,
+          // GH #1540: the DNS-only zone's apex IP + the template's helper inputs.
+          ...(isDNS
+            ? {
+                ip_address: values.ip_address,
+                m365_onmicrosoft: values.m365_onmicrosoft,
+                google_dkim: values.google_dkim,
+              }
+            : {}),
         };
       }
       const created = await createMutation.mutateAsync(payload);
@@ -211,6 +223,11 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
         >
           <Input placeholder="e.g., example.com" />
         </Form.Item>
+
+        {/* GH #1540: DNS-only zone — the apex IP (prefilled with this server's
+            IP) and a DNS Template (Default / Microsoft 365 / Google Workspace).
+            Shared with the admin Add DNS Zone drawer. */}
+        {isDNS && <DnsZoneFields publicIP={caps?.public_ipv4} />}
 
         {(isWeb || isMail) && (
           <Form.Item
@@ -280,7 +297,10 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           </Form.Item>
         )}
 
-        {mailProvider === "m365" && (
+        {/* Web/mail Template helper inputs. In dns mode these live inside
+            DnsZoneFields instead, so gate them out here to avoid a duplicate
+            registration of the same field name. */}
+        {!isDNS && mailProvider === "m365" && (
           <Form.Item
             label={t("userdomaindrawer.microsoft_365_tenant")}
             name="m365_onmicrosoft"
@@ -290,7 +310,7 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           </Form.Item>
         )}
 
-        {mailProvider === "google" && (
+        {!isDNS && mailProvider === "google" && (
           <Form.Item
             label={t("userdomaindrawer.google_dkim_value")}
             name="google_dkim"


### PR DESCRIPTION
## What & why

GH #1540 (johnnyq): add an **Add DNS Zone** button to the DNS Zone list on
**both the tenant and admin** sides, with a simple form.

> Add DNS Zone Button in DNS Zone List (For Both Tenant and Admin) …
> Domain Name / IP Address (With Panel's IP Pre-inputted) / Template:
> (Default, Microsoft 365, Google Workspaces) … Default is basically no
> records created just domain and pointed IP. Didn't add Jabali Mail here
> as a DNS Template because mail records are overridden when you add mail
> domain.

This **extends the dns mode of the shared Add-domain drawer** shipped in
#1554. The tenant DNS Zones page already had the Add DNS Zone button, but
the drawer only sent an empty DNS-only zone (apex left for the tenant to
add by hand). It now collects the **apex IP** (the "pointed IP") and a
**Template**, and the admin DNS Zones list gets the same button + a drawer
with an Owner picker.

## The form

- **Domain Name**
- **IP Address** — prefilled with the panel's public IPv4 (`caps.public_ipv4`),
  editable, validated as IPv4.
- **Template** — **Default** (just the domain + its pointed apex IP, no mail
  records), **Microsoft 365**, or **Google Workspace** (each adds that
  provider's mail DNS). Jabali Mail is intentionally absent — as johnnyq
  noted, those records are set by adding a mail domain, which overrides them.
- **Admin only:** an **Owner (user)** picker, since an admin creates a zone
  on behalf of a tenant.

Both drawers create a web-off, DNS-managed domain via `POST /domains`
(resource `domains`) — the same backend path as the tenant dns-mode drawer.

## Backend

- **Migration 000291** adds a nullable `domains.dns_apex_ipv4 VARCHAR(45)`.
  A web-off zone's apex A is deliberately not seeded by `BootstrapRecords`
  (`includeApex=false`) and not re-asserted by `convergeApexAddrRecords`
  (both web-gated, GH #1449), so there is no managed apex row to carry the
  address. It is persisted on the domain row and read **once** by the
  reconciler at zone bootstrap to seed the `@ A <ip>` record, then never
  written again. NULL for every web/mail domain and every legacy row (DDL
  only, no DML — safe for a rolling deploy).
- **`createDomainOp`** validates `ip_address` as a **bare IPv4** and only for
  a DNS-only zone the panel hosts (web off, DNS on): a web domain's apex is
  panel-managed, and an external-DNS domain publishes nothing here. Rejects
  with `web_enabled_apex_ip` / `dns_disabled_apex_ip` / `invalid_apex_ip`.
- **Reconciler** seeds the apex A as a **tenant-owned** record
  (`Managed=false`). The panel does not reconcile a web-off apex, and the
  DNS-records API only hard-blocks editing/deleting managed **SOA/NS** rows —
  an A row is tenant-editable regardless — so `Managed=false` is the honest
  flag and avoids a misleading "managed by jabali" badge on a record the
  panel doesn't own.

## Frontend

- New shared **`DnsZoneFields`** (IP Address + Template + the M365/Google
  helper inputs), driven off the surrounding `Form` so both drawers reuse it.
  The IP field is prefilled via `initialValue` + a late-caps-load effect
  (so it survives the tenant drawer's `resetFields` on reopen).
- **`UserDomainDrawer`** (dns mode) renders `DnsZoneFields` and sends
  `ip_address` + the template's `mail_provider` (Default ⇒ `"none"`, because
  an empty `mail_provider` means Jabali server-side) + the M365/Google inputs.
  The web/mail Template helper inputs are gated to non-dns mode so the shared
  field names aren't registered twice.
- New **`AdminDNSZoneDrawer`** + the admin DNS Zones page header action.

## Deliberate choices / notes

- **IPv4 only** — the apex A row is IPv4.
- **`Managed=false`** for the seeded apex (see Backend) — the record is the
  tenant's to manage, exactly like johnnyq's "just domain and pointed IP".
- **Template label** is "Google Workspace" (johnnyq wrote "Workspaces").
- **openapi** is unchanged: the domain create body (mail_provider, web_enabled,
  manage_dns, …) is not modeled there today, so `ip_address` isn't either —
  not starting a new convention in this PR.

## Tests

- Go: `createDomainOp` apex-IP validation (persist / web-on reject /
  external-DNS reject / non-IP / IPv6 reject / trim); the reconciler
  `dnsOnlyApexSeed` helper (web-off seeds `Managed=false`; web-on / nil /
  empty / nil-domain do not; TTL follows the server default).
- Vitest: tenant dns payload (prefilled IP, Default and Microsoft 365
  templates, **reopen prefill**, invalid-IP block); admin drawer (owner
  required, web-off DNS-only payload); admin page (button opens the drawer).
- `go build`/`vet`, `tsc -b`, `eslint`, and the affected Go + vitest suites
  are green post-rebase onto `origin/main`.

GH #1540
