### PR TITLE
fix(domains): validate the CLI `domain set` advanced fields at HTTP parity (JAB-318)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -2279,7 +2279,7 @@ jabali domain set <domain-name|domain-id> [flags]
 - `--index-priority` — directory index priority (e.g. html_first, php_first)
 - `--nginx-directives` — raw custom nginx directives for the server block
 - `--redirect-all-to` — redirect the whole domain to this URL ('' clears)
-- `--redirect-type` — permanent|temporary
+- `--redirect-type` — 301|302|307|308 (permanent=301, temporary=302)
 - `--ssl-mode` — le|self|none (custom = install a cert)
 
 #### `jabali domain show`

--- a/panel-api/cmd/server/domain_advanced_cmd.go
+++ b/panel-api/cmd/server/domain_advanced_cmd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -160,6 +161,68 @@ func newDomainIPACLDeleteCmd() *cobra.Command {
 // (nginx re-render/reload, SSL re-issue, mta-sts DNS publish) within ~60s — same
 // end-state as the GUI (feedback_cli_reconcile_apply).
 
+// validateDomainSetInput enforces on the CLI `domain set` path the SAME field
+// validation the HTTP PATCH handler applies (JAB-318 parity): the admin nginx
+// directive allowlist (api.ValidateNginxDirectives), the redirect destination
+// scheme/host check (api.ValidateRedirectURL) and the index-priority enum
+// (api.IsValidIndexPriority). It also normalises the redirect type to the
+// numeric nginx return code the renderer emits — redirects.Compile writes
+// `return <type> <url>;` verbatim, so only 301|302|307|308 (or the friendly
+// aliases permanent=301 / temporary=302) produce valid nginx. Each pointer is
+// nil when its flag was not set, so an unchanged field is never validated.
+// Pure (no DB, no cobra) so it is unit-testable directly.
+func validateDomainSetInput(nginxDirs, redirectTo, redirectType, indexPriority *string) (normRedirectType string, err error) {
+	if nginxDirs != nil {
+		if msg := api.ValidateNginxDirectives(*nginxDirs); msg != "" {
+			return "", fmt.Errorf("--nginx-directives: %s", msg)
+		}
+	}
+	if redirectTo != nil {
+		// Empty clears the redirect (mirrors the HTTP handler); only a
+		// non-empty destination is scheme/host-validated.
+		if trimmed := strings.TrimSpace(*redirectTo); trimmed != "" {
+			if verr := api.ValidateRedirectURL(trimmed); verr != nil {
+				return "", fmt.Errorf("--redirect-all-to: %w", verr)
+			}
+		}
+	}
+	if indexPriority != nil {
+		if p := strings.TrimSpace(*indexPriority); !api.IsValidIndexPriority(p) {
+			return "", fmt.Errorf("--index-priority: invalid value %q", p)
+		}
+	}
+	if redirectType != nil {
+		norm, ok := normalizeRedirectType(*redirectType)
+		if !ok {
+			return "", fmt.Errorf("--redirect-type must be one of 301|302|307|308 (or permanent|temporary)")
+		}
+		normRedirectType = norm
+	}
+	return normRedirectType, nil
+}
+
+// normalizeRedirectType maps the redirect-type flag to the numeric nginx return
+// code redirects.Compile emits. The friendly aliases permanent/temporary (the
+// only values the CLI historically accepted — and which the renderer then
+// rejected as invalid nginx) map to their canonical codes; a numeric code is
+// accepted as-is when it is one the HTTP handler allows.
+func normalizeRedirectType(s string) (string, bool) {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return "", true // empty clears the redirect type (mirrors HTTP → nil)
+	}
+	switch strings.ToLower(t) {
+	case "permanent":
+		return "301", true
+	case "temporary":
+		return "302", true
+	}
+	if api.IsValidRedirectType(t) {
+		return t, true
+	}
+	return "", false
+}
+
 func newDomainSetCmd() *cobra.Command {
 	var (
 		redirectTo    string
@@ -181,21 +244,56 @@ func newDomainSetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// JAB-318: apply the SAME field validation the HTTP PATCH handler
+			// enforces (parity) BEFORE persisting. The general Update allowlist
+			// carries nginx_custom_directives / redirect_all_to / redirect_all_type /
+			// index_priority, so an unsafe value set here is written verbatim: an
+			// unbalanced brace or a directive outside the admin allowlist bricks
+			// nginx reload for every vhost on the box, and a non-numeric redirect
+			// type makes redirects.Compile emit `return permanent <url>;` — invalid
+			// nginx. The old CLI validated none of these (it only checked
+			// permanent|temporary, which the renderer then rejected anyway).
+			var nginxPtr, redirToPtr, redirTypePtr, indexPtr *string
+			if cmd.Flags().Changed("nginx-directives") {
+				nginxPtr = &nginxDirs
+			}
+			if cmd.Flags().Changed("redirect-all-to") {
+				redirToPtr = &redirectTo
+			}
+			if cmd.Flags().Changed("redirect-type") {
+				redirTypePtr = &redirectType
+			}
+			if cmd.Flags().Changed("index-priority") {
+				indexPtr = &indexPriority
+			}
+			normRedirectType, verr := validateDomainSetInput(nginxPtr, redirToPtr, redirTypePtr, indexPtr)
+			if verr != nil {
+				return verr
+			}
+
 			changed := false
 			if cmd.Flags().Changed("redirect-all-to") {
-				v := strings.TrimSpace(redirectTo)
-				d.RedirectAllTo = &v
+				// Mirror the HTTP handler: an empty destination clears the redirect
+				// (nil), it is not stored as an empty string.
+				if trimmed := strings.TrimSpace(redirectTo); trimmed == "" {
+					d.RedirectAllTo = nil
+				} else {
+					d.RedirectAllTo = &trimmed
+				}
 				changed = true
 			}
 			if cmd.Flags().Changed("redirect-type") {
-				if redirectType != "permanent" && redirectType != "temporary" {
-					return fmt.Errorf("--redirect-type must be permanent|temporary")
+				// Empty clears the type (mirrors the HTTP handler → nil); a set
+				// value is the normalised numeric nginx code.
+				if normRedirectType == "" {
+					d.RedirectAllType = nil
+				} else {
+					d.RedirectAllType = &normRedirectType
 				}
-				d.RedirectAllType = &redirectType
 				changed = true
 			}
 			if cmd.Flags().Changed("index-priority") {
-				d.IndexPriority = indexPriority
+				d.IndexPriority = strings.TrimSpace(indexPriority)
 				changed = true
 			}
 			if cmd.Flags().Changed("nginx-directives") {
@@ -255,7 +353,7 @@ func newDomainSetCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&redirectTo, "redirect-all-to", "", "redirect the whole domain to this URL ('' clears)")
-	cmd.Flags().StringVar(&redirectType, "redirect-type", "", "permanent|temporary")
+	cmd.Flags().StringVar(&redirectType, "redirect-type", "", "301|302|307|308 (permanent=301, temporary=302)")
 	cmd.Flags().StringVar(&indexPriority, "index-priority", "", "directory index priority (e.g. html_first, php_first)")
 	cmd.Flags().StringVar(&nginxDirs, "nginx-directives", "", "raw custom nginx directives for the server block")
 	cmd.Flags().StringVar(&sslMode, "ssl-mode", "", "le|self|none (custom = install a cert)")

--- a/panel-api/cmd/server/domain_advanced_cmd_validation_test.go
+++ b/panel-api/cmd/server/domain_advanced_cmd_validation_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestValidateDomainSetInput guards the JAB-318 parity fix: the CLI `domain set`
+// path must apply the SAME field validation the HTTP PATCH handler enforces
+// before the general Update persists the value verbatim. Each case exercises one
+// field; falsify by deleting that field's check in validateDomainSetInput and
+// the matching row reddens (the unsafe value would then be accepted and written).
+func TestValidateDomainSetInput(t *testing.T) {
+	sp := func(s string) *string { return &s }
+
+	cases := []struct {
+		name        string
+		nginx       *string
+		redirectTo  *string
+		redirectTyp *string
+		index       *string
+		wantErr     bool
+		errSub      string // substring the error must contain (when wantErr)
+		wantNormTyp string // expected normalised redirect type (when no error)
+	}{
+		// nginx directives — the admin allowlist / brace / null-byte checks.
+		{name: "nginx disallowed directive", nginx: sp("root /etc/jabali-panel;"), wantErr: true, errSub: "--nginx-directives"},
+		{name: "nginx access_log off forbidden", nginx: sp("access_log off;"), wantErr: true, errSub: "--nginx-directives"},
+		{name: "nginx unbalanced brace", nginx: sp("location / {"), wantErr: true, errSub: "--nginx-directives"},
+		{name: "nginx null byte", nginx: sp("add_header X \x00;"), wantErr: true, errSub: "--nginx-directives"},
+		{name: "nginx allowed directive ok", nginx: sp("proxy_set_header X-Test 1;")},
+		{name: "nginx empty ok", nginx: sp("")},
+
+		// redirect destination — scheme + host.
+		{name: "redirect ftp scheme rejected", redirectTo: sp("ftp://example.com"), wantErr: true, errSub: "--redirect-all-to"},
+		{name: "redirect no host rejected", redirectTo: sp("https://"), wantErr: true, errSub: "--redirect-all-to"},
+		{name: "redirect https ok", redirectTo: sp("https://example.com/new")},
+		{name: "redirect empty clears (ok)", redirectTo: sp("   ")},
+
+		// index priority — enum.
+		{name: "index invalid rejected", index: sp("sideways_first"), wantErr: true, errSub: "--index-priority"},
+		{name: "index empty rejected (parity)", index: sp(""), wantErr: true, errSub: "--index-priority"},
+		{name: "index php_first ok", index: sp("php_first")},
+
+		// redirect type — normalised to the numeric nginx return code.
+		{name: "type permanent -> 301", redirectTyp: sp("permanent"), wantNormTyp: "301"},
+		{name: "type temporary -> 302", redirectTyp: sp("temporary"), wantNormTyp: "302"},
+		{name: "type numeric 308 passes", redirectTyp: sp("308"), wantNormTyp: "308"},
+		{name: "type empty clears (ok)", redirectTyp: sp(""), wantNormTyp: ""},
+		{name: "type 303 rejected (not an allowed code)", redirectTyp: sp("303"), wantErr: true, errSub: "--redirect-type"},
+		{name: "type garbage rejected", redirectTyp: sp("forever"), wantErr: true, errSub: "--redirect-type"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			norm, err := validateDomainSetInput(tc.nginx, tc.redirectTo, tc.redirectTyp, tc.index)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errSub != "" && !strings.Contains(err.Error(), tc.errSub) {
+					t.Fatalf("error %q must contain %q", err.Error(), tc.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if norm != tc.wantNormTyp {
+				t.Fatalf("normalised redirect type = %q, want %q", norm, tc.wantNormTyp)
+			}
+		})
+	}
+}
+
+// TestValidateDomainSetInput_OnlyChecksSetFlags: a nil pointer means the flag was
+// not set, so an absent field must never be validated (else `domain set --cache`
+// alone would wrongly reject the empty index/redirect). All-nil is a no-op.
+func TestValidateDomainSetInput_OnlyChecksSetFlags(t *testing.T) {
+	norm, err := validateDomainSetInput(nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("all-nil input must not error, got %v", err)
+	}
+	if norm != "" {
+		t.Fatalf("no redirect-type set must yield empty norm, got %q", norm)
+	}
+}
+
+// TestDomainSet_RunEWiresValidation source-pins that the RunE actually calls the
+// pure validator before persisting — a behaviour test on the helper alone can't
+// prove the command invokes it, and cmd/server's advanced command runs on the
+// global repo with no injection seam (matches the JAB-313 test's precedent).
+func TestDomainSet_RunEWiresValidation(t *testing.T) {
+	src, err := os.ReadFile("domain_advanced_cmd.go")
+	if err != nil {
+		t.Fatalf("read domain_advanced_cmd.go: %v", err)
+	}
+	s := string(src)
+	// Pin the CALL expression, not the identifier — the definition line
+	// `func validateDomainSetInput(nginxDirs, ...` would satisfy a bare-name
+	// match while the RunE call was deleted, leaving the hole this test closes.
+	if !strings.Contains(s, "validateDomainSetInput(nginxPtr, redirToPtr, redirTypePtr, indexPtr)") {
+		t.Fatal("RunE must CALL validateDomainSetInput before Update, or the CLI persists nginx/redirect/index values the HTTP path would reject (JAB-318)")
+	}
+	if !strings.Contains(s, "d.RedirectAllType = &normRedirectType") {
+		t.Fatal("RunE must store the NORMALISED redirect type, not the raw flag — redirects.Compile emits it verbatim as the nginx return code (JAB-318)")
+	}
+}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -869,7 +869,7 @@ func (h *domainHandler) update(c *gin.Context) {
 	// is_enabled. Admin role bypasses the gate.
 	if claims.IsAdmin {
 		if req.NginxCustomDirectives != nil {
-			if msg := validateNginxDirectives(*req.NginxCustomDirectives); msg != "" {
+			if msg := ValidateNginxDirectives(*req.NginxCustomDirectives); msg != "" {
 				c.JSON(http.StatusBadRequest, gin.H{"error": msg})
 				return
 			}
@@ -967,7 +967,7 @@ func (h *domainHandler) update(c *gin.Context) {
 		if trimmed == "" {
 			domain.RedirectAllTo = nil
 		} else {
-			if err := validateRedirectURL(trimmed); err != nil {
+			if err := ValidateRedirectURL(trimmed); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
@@ -1009,7 +1009,7 @@ func (h *domainHandler) update(c *gin.Context) {
 		trimmed := strings.TrimSpace(*req.RedirectAllType)
 		if trimmed == "" {
 			domain.RedirectAllType = nil
-		} else if !isValidRedirectType(trimmed) {
+		} else if !IsValidRedirectType(trimmed) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid redirect type"})
 			return
 		} else {
@@ -1030,7 +1030,7 @@ func (h *domainHandler) update(c *gin.Context) {
 	}
 	if req.IndexPriority != nil {
 		p := strings.TrimSpace(*req.IndexPriority)
-		if !isValidIndexPriority(p) {
+		if !IsValidIndexPriority(p) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_index_priority"})
 			return
 		}
@@ -1429,7 +1429,7 @@ var allowedNginxDirectives = map[string]struct{}{
 	"open_file_cache_errors":   {},
 }
 
-func validateNginxDirectives(directives string) string {
+func ValidateNginxDirectives(directives string) string {
 	// Reject if input contains null bytes (binary/injection attempt).
 	if strings.ContainsRune(directives, '\x00') {
 		return "forbidden directive: null byte detected"
@@ -1560,7 +1560,7 @@ func extractDirective(line string) string {
 	return fields[0]
 }
 
-func validateRedirectURL(s string) error {
+func ValidateRedirectURL(s string) error {
 	u, err := url.Parse(s)
 	if err != nil {
 		return fmt.Errorf("invalid destination URL: %w", err)
@@ -1574,7 +1574,7 @@ func validateRedirectURL(s string) error {
 	return nil
 }
 
-func isValidRedirectType(s string) bool {
+func IsValidRedirectType(s string) bool {
 	switch s {
 	case "301", "302", "307", "308":
 		return true
@@ -1594,10 +1594,10 @@ func validatePageRedirects(prs models.PageRedirects) error {
 		if strings.ContainsAny(pr.Source, "\n\x00") {
 			return fmt.Errorf("entry %d: source contains invalid chars", i)
 		}
-		if err := validateRedirectURL(pr.Destination); err != nil {
+		if err := ValidateRedirectURL(pr.Destination); err != nil {
 			return fmt.Errorf("entry %d: invalid page redirect destination: %w", i, err)
 		}
-		if !isValidRedirectType(pr.Type) {
+		if !IsValidRedirectType(pr.Type) {
 			return fmt.Errorf("entry %d: invalid type for page redirect: %s", i, pr.Type)
 		}
 		// Wildcard only supports 301 and 302
@@ -1819,7 +1819,7 @@ func validateTenantNginxRules(rules models.NginxRules) error {
 	return validateNginxRules(rules)
 }
 
-func isValidIndexPriority(s string) bool {
+func IsValidIndexPriority(s string) bool {
 	switch s {
 	case "html_first", "php_first", "html_only", "php_only", "full":
 		return true

--- a/panel-api/internal/api/domains_directive_allowlist_test.go
+++ b/panel-api/internal/api/domains_directive_allowlist_test.go
@@ -17,13 +17,13 @@ func TestValidateNginxDirectives_UnsafeRemoved(t *testing.T) {
 		"proxy_pass":           "proxy_pass http://127.0.0.1:3306;",
 	}
 	for name, line := range forbidden {
-		if msg := validateNginxDirectives(line); msg == "" || !strings.Contains(msg, "forbidden directive") {
+		if msg := ValidateNginxDirectives(line); msg == "" || !strings.Contains(msg, "forbidden directive") {
 			t.Errorf("directive %s should be forbidden, got %q", name, msg)
 		}
 	}
 
 	// Sanity: a still-allowed directive passes.
-	if msg := validateNginxDirectives("proxy_set_header X-Test 1;"); msg != "" {
+	if msg := ValidateNginxDirectives("proxy_set_header X-Test 1;"); msg != "" {
 		t.Errorf("proxy_set_header should still be allowed, got %q", msg)
 	}
 }

--- a/panel-api/internal/api/domains_test.go
+++ b/panel-api/internal/api/domains_test.go
@@ -275,15 +275,15 @@ func TestValidateNginxDirectives(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateNginxDirectives(tt.input)
+			err := ValidateNginxDirectives(tt.input)
 			if (err != "") != tt.wantError {
-				t.Errorf("validateNginxDirectives() error = %q, wantError %v", err, tt.wantError)
+				t.Errorf("ValidateNginxDirectives() error = %q, wantError %v", err, tt.wantError)
 				return
 			}
 			if tt.wantError && tt.errMsg != "" && err != tt.errMsg {
 				// Check if the expected message is a substring (for some error messages)
 				if !contains(err, tt.errMsg) {
-					t.Errorf("validateNginxDirectives() error = %q, want substring %q", err, tt.errMsg)
+					t.Errorf("ValidateNginxDirectives() error = %q, want substring %q", err, tt.errMsg)
 				}
 			}
 		})

--- a/panel-api/internal/redirects/compile.go
+++ b/panel-api/internal/redirects/compile.go
@@ -27,6 +27,25 @@ func isActive(pr models.PageRedirect) bool {
 	return pr.Active == nil || *pr.Active
 }
 
+// redirectAllCode maps a stored redirect_all_type to the numeric nginx return
+// code emitted in `return <code> <url>;`. The value should already be numeric
+// (the HTTP handler and, since JAB-318, the CLI store 301|302|307|308), but the
+// old `jabali domain set` CLI persisted the literals "permanent"/"temporary" —
+// neither a valid nginx code — so `return permanent …;` failed nginx -t and
+// broke reload. Heal those existing rows (and any restored from a backup that
+// carried the bad value) at render time rather than with a data migration; an
+// already-numeric or unknown value passes through unchanged (unknown still fails
+// nginx -t, but that is a value neither writer can produce).
+func redirectAllCode(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "permanent":
+		return "301"
+	case "temporary":
+		return "302"
+	}
+	return t
+}
+
 func Compile(d *models.Domain) string {
 	if d == nil {
 		return ""
@@ -35,7 +54,7 @@ func Compile(d *models.Domain) string {
 	if d.RedirectAllTo != nil && *d.RedirectAllTo != "" {
 		code := "301"
 		if d.RedirectAllType != nil {
-			code = *d.RedirectAllType
+			code = redirectAllCode(*d.RedirectAllType)
 		}
 		fmt.Fprintf(&b, "    return %s %s;\n", code, quoteNginxURL(*d.RedirectAllTo))
 		return b.String()

--- a/panel-api/internal/redirects/compile_test.go
+++ b/panel-api/internal/redirects/compile_test.go
@@ -6,6 +6,35 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
+// TestCompile_HealsLegacyRedirectType guards the JAB-318 render-time heal: the
+// old `jabali domain set` CLI persisted redirect_all_type="permanent"/"temporary"
+// (invalid nginx return codes), which this file rendered verbatim as
+// `return permanent …;` — breaking nginx -t and the reload. Compile must now map
+// them to their numeric codes so existing rows and restored backups converge
+// without a data migration. Falsify by removing the redirectAllCode switch → the
+// first two cases render `return permanent/temporary …;`.
+func TestCompile_HealsLegacyRedirectType(t *testing.T) {
+	cases := []struct{ stored, wantCode string }{
+		{"permanent", "301"},
+		{"temporary", "302"},
+		{"Permanent", "301"}, // case-insensitive
+		{"301", "301"},       // already-numeric passes through
+		{"308", "308"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.stored, func(t *testing.T) {
+			got := Compile(&models.Domain{
+				RedirectAllTo:   str("https://new.com"),
+				RedirectAllType: str(tc.stored),
+			})
+			want := "    return " + tc.wantCode + " \"https://new.com\";\n"
+			if got != want {
+				t.Errorf("Compile() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestCompile(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What & why (JAB-318 — validated Domain Configuration, CLI slice)

The HTTP domain PATCH handler validates the advanced domain fields before
persisting: the raw nginx directive block (admin allowlist + brace/nesting/
null-byte checks), the redirect destination (http/https scheme + host), and the
index-priority enum. The `jabali domain set` CLI set the same fields on the
domain struct and called the general repository `Update` — whose column
allowlist **does** carry `nginx_custom_directives` / `redirect_all_to` /
`redirect_all_type` / `index_priority` — so an unsafe value was written verbatim
with **no validation**:

- An unbalanced brace, or a directive outside the allowlist (`root`,
  `access_log off;`), is not something `nginx -t` rejects on its own terms but
  breaks the rendered server block, so the next reconcile's nginx reload fails
  **for every vhost on the box**.
- `redirects.Compile` emits `return <redirect_all_type> <url>;` verbatim, but the
  CLI accepted only `permanent|temporary` — neither is a valid nginx return code.
  So `domain set --redirect-type permanent` produced invalid nginx. **The two
  values the flag accepted were exactly the two the renderer could not use.**

## The fix

- **Export the four field validators** from the api package
  (`ValidateNginxDirectives`, `ValidateRedirectURL`, `IsValidIndexPriority`,
  `IsValidRedirectType`) — `cmd/server` already imports `internal/api` and these
  are pure functions. Rename only; in-package callers + their tests updated,
  behaviour unchanged. (Unexported → the whole call graph is those files.)
- **Pure `validateDomainSetInput` helper** in the CLI runs them on only the flags
  the caller set, failing **before** the persisting `Update`.
- **Redirect type normalised** to the numeric nginx code: friendly aliases
  `permanent=301` / `temporary=302` keep working (now valid), and `301|302|307|308`
  are accepted directly at parity with HTTP. Empty `--redirect-type` clears the
  type (`nil`), and empty `--redirect-all-to` now clears the redirect (`nil`)
  instead of storing `""`, both mirroring the handler.
- **Render-time heal for existing rows:** any domain an operator already set to
  `permanent`/`temporary` carries that value today, and a restored backup
  re-persists it, so a write-time reject alone leaves them broken.
  `redirects.Compile` now maps `permanent→301` / `temporary→302` at render
  (numeric passes through), so those rows and restored backups converge with **no
  data migration**. Reject-at-write **plus** tolerate-at-render.

## Threat framing (honest payoff)

This is **admin↔admin parity**: the HTTP nginx-directive validation is gated
`if claims.IsAdmin`, and the CLI runs as the operator, so both privileged paths
now enforce the identical allowlist. **No tenant surface changes** — an operator
typo can no longer break nginx reload for the whole box.

## Scope

One slice of the JAB-318 parent. The full "Domain Configuration Apply" Module
(`Apply(domainID, patch, capability)`, ordered compensation, one convergence
schedule, TLS Mode Module hand-off) **remains — parent stays Backlog**. The
ticket's third evidence bullet (`ssl_mode`/`cache_enabled` silently dropped) was
already fixed by **JAB-313 (#1194)** via dedicated writers; unchanged here.

## Test plan

- [x] `go test ./panel-api/cmd/server/ ./panel-api/internal/api/ ./panel-api/internal/redirects/` — pass
- [x] Table-driven behaviour test on `validateDomainSetInput` (disallowed
      directive, `access_log off;`, unbalanced brace, null byte, `ftp://`,
      hostless redirect, bad index, `303`/garbage type; valid cases pass;
      permanent→301, temporary→302, numeric passthrough, empty clears) — **falsified**
      (neuter the nginx check → the nginx rows redden).
- [x] `redirects.Compile` heal test (permanent/temporary/case/numeric) — **falsified**.
- [x] Wiring source-pin matches the **call expression** (`nginxPtr, …`), which
      appears only at the call site, not the definition — closes the "helper
      exists, never called" hole.
- [x] `go vet` clean; `-race` clean; cli-reference golden regenerated (one line).
- [ ] **No live box needed** (pure CLI + validation + renderer, unit-covered).
      A human sanity-check of `jabali domain set --nginx-directives '…'` on a box
      is welcome but not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
