### PR TITLE
fix(malware): CLI YARA delete removes the DB row, agent-first (JAB-325)

### DIFF
--- a/panel-api/cmd/server/malware_cmd.go
+++ b/panel-api/cmd/server/malware_cmd.go
@@ -317,6 +317,24 @@ func newMalwareYaraToggleCmd() *cobra.Command {
 	return cmd
 }
 
+// deleteYARAArtifact removes a custom YARA rule with agent-first ordering, the
+// same order the HTTP deleteYARA handler uses: the host artifact is removed
+// before the database row. A failed agent delete returns immediately and never
+// advances DB truth to "gone" while the file is still on disk. Unlike the HTTP
+// handler, a failed row delete is surfaced rather than swallowed — the host
+// artifact is already gone, so a lingering row is a real inconsistency the
+// operator must see (the old CLI omitted the row delete entirely, leaving
+// exactly such stale rows).
+func deleteYARAArtifact(ctx context.Context, filename string, agentDelete, dbDelete func(context.Context) error) error {
+	if err := agentDelete(ctx); err != nil {
+		return err
+	}
+	if err := dbDelete(ctx); err != nil {
+		return fmt.Errorf("yara rule %q removed from host but its database row could not be deleted: %w", filename, err)
+	}
+	return nil
+}
+
 func newMalwareYaraDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "delete <filename>",
@@ -326,11 +344,18 @@ func newMalwareYaraDeleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
-			err := csCall(ctx, "security.malware.yara.delete", map[string]any{"filename": args[0]})
-			if err == nil {
-				cliAuditOK(ctx, "malware.yara_delete", "yara_rule", args[0], nil)
+			name := args[0]
+			repo := repository.NewYARACustomRuleRepository(sharedDB)
+			if err := deleteYARAArtifact(ctx, name,
+				func(c context.Context) error {
+					return csCall(c, "security.malware.yara.delete", map[string]any{"filename": name})
+				},
+				func(c context.Context) error { return repo.Delete(c, name) },
+			); err != nil {
+				return err
 			}
-			return err
+			cliAuditOK(ctx, "malware.yara_delete", "yara_rule", name, nil)
+			return nil
 		},
 	}
 }

--- a/panel-api/cmd/server/malware_cmd_test.go
+++ b/panel-api/cmd/server/malware_cmd_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDeleteYARAArtifact locks the agent-first ordering that keeps DB truth
+// consistent with the host: the artifact is removed before the row, a failed
+// agent delete must not advance DB truth, and a failed row delete is surfaced
+// rather than swallowed.
+func TestDeleteYARAArtifact(t *testing.T) {
+	errAgent := errors.New("agent boom")
+	errDB := errors.New("db boom")
+
+	t.Run("both succeed in agent-then-db order", func(t *testing.T) {
+		var order []string
+		err := deleteYARAArtifact(context.Background(), "evil.yar",
+			func(context.Context) error { order = append(order, "agent"); return nil },
+			func(context.Context) error { order = append(order, "db"); return nil },
+		)
+		if err != nil {
+			t.Fatalf("want nil error, got %v", err)
+		}
+		if len(order) != 2 || order[0] != "agent" || order[1] != "db" {
+			t.Fatalf("want [agent db], got %v", order)
+		}
+	})
+
+	// Load-bearing: agent failure must not advance DB truth. If the helper is
+	// ever reordered to delete the row first, dbCalled flips true and this
+	// reddens.
+	t.Run("agent fails: db row is not touched", func(t *testing.T) {
+		dbCalled := false
+		err := deleteYARAArtifact(context.Background(), "evil.yar",
+			func(context.Context) error { return errAgent },
+			func(context.Context) error { dbCalled = true; return nil },
+		)
+		if !errors.Is(err, errAgent) {
+			t.Fatalf("want agent error surfaced, got %v", err)
+		}
+		if dbCalled {
+			t.Fatal("db delete ran after the agent delete failed — stale-artifact ordering broken")
+		}
+	})
+
+	t.Run("db fails: error wraps cause and names the rule", func(t *testing.T) {
+		err := deleteYARAArtifact(context.Background(), "evil.yar",
+			func(context.Context) error { return nil },
+			func(context.Context) error { return errDB },
+		)
+		if !errors.Is(err, errDB) {
+			t.Fatalf("want db error wrapped, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "evil.yar") {
+			t.Fatalf("want rule name in error, got %q", err.Error())
+		}
+		// It must not falsely tell the operator a re-run will clear it: the
+		// agent os.Remove ENOENTs on the second call, so it would not.
+		if strings.Contains(err.Error(), "re-run") {
+			t.Fatalf("error promises a re-run remedy the agent does not honor: %q", err.Error())
+		}
+	})
+}
+
+// TestMalwareYaraDelete_RunEWiresAgentFirstThenDBRow source-pins that the
+// delete RunE actually routes the agent verb and the repository row delete
+// through deleteYARAArtifact. The pins are the call expression (call-site arg
+// names ctx/name differ from the definition's filename param, so the string
+// appears only at the call site — not the func header) and each wired op.
+func TestMalwareYaraDelete_RunEWiresAgentFirstThenDBRow(t *testing.T) {
+	src, err := os.ReadFile("malware_cmd.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	s := string(src)
+	for _, pin := range []string{
+		"deleteYARAArtifact(ctx, name,",
+		`csCall(c, "security.malware.yara.delete", map[string]any{"filename": name})`,
+		"repo.Delete(c, name)",
+	} {
+		if !strings.Contains(s, pin) {
+			t.Errorf("delete RunE no longer wires: %s", pin)
+		}
+	}
+}


### PR DESCRIPTION
## What

`jabali malware yara delete <filename>` called the agent verb
`security.malware.yara.delete` and, on success, only wrote a CLI audit entry —
it **never deleted the `yara_custom_rules` row**. The host artifact was removed
but the DB row stayed, so the rule kept appearing in the list and toggle
surfaces with no file behind it. The HTTP `deleteYARA` handler already deletes
the row after the agent call; this brings the CLI to parity (JAB-325).

## How

The delete now routes through a small `deleteYARAArtifact` helper that enforces
the same **agent-first ordering** the handler uses:

1. Remove the host artifact via the agent verb.
2. Only on agent success, delete the `yara_custom_rules` row.
3. Only on full success, write the audit entry.

A failed agent delete returns immediately and never advances DB truth to "gone"
while the file is still on disk. Unlike the handler (which swallows the row
delete with `_ =`), a failed row delete here is **surfaced** — the artifact is
already gone, so a lingering row is a real inconsistency the operator should
see. The error names the rule and makes no false "re-run to clear it" promise:
the agent's `os.Remove` returns ENOENT on a second call, so a re-run would not
clear it.

## Scope

This is the **CLI↔HTTP delete-parity slice** of JAB-325 (parent stays Backlog).

Out of scope, called out honestly:

- **Healing rows left by the old CLI**, and re-running delete against an
  already-removed artifact, is a *shared* gap on **both** surfaces (HTTP has the
  same non-heal because the agent errors on a missing file rather than treating
  a delete as idempotent). The clean fix is to make the agent's
  `security.malware.yara.delete` treat ENOENT as success — an agent-verb change
  that warrants a box run — so it is a separate follow-up.
- The YARA **toggle**'s `_ = SetEnabled` swallow and the HTTP handler's
  `_ = YARARules.Delete` swallow are pre-existing and unchanged here.

## Tests

- `TestDeleteYARAArtifact` — table over the helper: both-succeed asserts
  agent-then-db order; **agent-fails asserts the DB row is not touched**
  (load-bearing — reversing the helper's order reddens it, verified); db-fails
  asserts the error wraps the cause, names the rule, and carries no false
  "re-run" remedy.
- `TestMalwareYaraDelete_RunEWiresAgentFirstThenDBRow` — non-vacuous source-pin
  that the RunE routes `csCall(...yara.delete)` and `repo.Delete` through
  `deleteYARAArtifact` (pins the call expression, whose call-site arg names
  differ from the definition's params, so it appears only at the call site).

`go build`, `go vet`, and the full `cmd/server` package pass; the cli-reference
golden is untouched (no flag or help change). No box: the agent verb is
unchanged — only the panel-side ordering.

Rebased on `origin/main` (d5f35ebb) and re-ran tests post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
