### PR TITLE
feat(dns): optional IPv6 (AAAA) apex on the Add DNS Zone flow (GH #1540)

### DIFF
--- a/panel-api/internal/api/domain_create_apex_ip_test.go
+++ b/panel-api/internal/api/domain_create_apex_ip_test.go
@@ -131,4 +131,89 @@ func TestCreateDomainOp_ApexIP(t *testing.T) {
 			t.Fatalf("want invalid_apex_ip, got %v", oerr)
 		}
 	})
+
+	// GH #1540 follow-up: optional apex IPv6 (AAAA).
+	t.Run("DNS-only with an IPv4 and IPv6 apex persists both (v6 canonicalised)", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "dual.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv4:  "203.0.113.10",
+			DNSApexIPv6:  "2001:DB8:0:0::1",
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.DNSApexIPv4 == nil || *d.DNSApexIPv4 != "203.0.113.10" {
+			t.Fatalf("DNSApexIPv4 should be 203.0.113.10, got %v", d.DNSApexIPv4)
+		}
+		// net.IP.String() canonicalises the v6 (lowercase, :: collapse).
+		if d.DNSApexIPv6 == nil || *d.DNSApexIPv6 != "2001:db8::1" {
+			t.Fatalf("DNSApexIPv6 should canonicalise to 2001:db8::1, got %v", d.DNSApexIPv6)
+		}
+	})
+
+	t.Run("IPv6-only on a web domain is rejected (shared web-off gate)", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "webv6.example.com",
+			MailProvider: models.MailProviderNone,
+			SSLMode:      models.SSLModeNone,
+			DNSApexIPv6:  "2001:db8::1",
+		})
+		if oerr == nil || oerr.Code != "web_enabled_apex_ip" {
+			t.Fatalf("want web_enabled_apex_ip, got %v", oerr)
+		}
+	})
+
+	t.Run("an IPv4 value in the IPv6 field is rejected", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "v4inv6.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv6:  "1.2.3.4",
+		})
+		if oerr == nil || oerr.Code != "invalid_apex_ipv6" {
+			t.Fatalf("want invalid_apex_ipv6, got %v", oerr)
+		}
+	})
+
+	t.Run("an IPv4-mapped IPv6 in the IPv6 field is rejected", func(t *testing.T) {
+		h, _ := newH()
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "mapped.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv6:  "::ffff:203.0.113.10",
+		})
+		if oerr == nil || oerr.Code != "invalid_apex_ipv6" {
+			t.Fatalf("want invalid_apex_ipv6, got %v", oerr)
+		}
+	})
+
+	t.Run("IPv6-only DNS-only zone persists just the AAAA apex", func(t *testing.T) {
+		h, _ := newH()
+		d, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "v6only.example.com",
+			MailProvider: models.MailProviderNone,
+			WebDisabled:  true,
+			DNSApexIPv6:  "2001:db8::1",
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v", oerr)
+		}
+		if d.DNSApexIPv4 != nil {
+			t.Fatalf("DNSApexIPv4 should be nil, got %q", *d.DNSApexIPv4)
+		}
+		if d.DNSApexIPv6 == nil || *d.DNSApexIPv6 != "2001:db8::1" {
+			t.Fatalf("DNSApexIPv6 should be 2001:db8::1, got %v", d.DNSApexIPv6)
+		}
+	})
 }

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -85,6 +85,10 @@ type createDomainInput struct {
 	// panel-managed). Validated in createDomainOp (must be a bare IPv4, web off,
 	// DNS on).
 	DNSApexIPv4 string
+	// DNSApexIPv6 (GH #1540 follow-up) is the optional apex IPv6 (AAAA) for a
+	// DNS-only zone. Same web-off/DNS-on gate as DNSApexIPv4; must be a bare IPv6
+	// (not an IPv4 or IPv4-mapped address). Empty when the zone has no v6 apex.
+	DNSApexIPv6 string
 }
 
 // createDomainError carries the exact HTTP shape the inline create() used, so
@@ -142,23 +146,40 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 	}
 
 	// GH #1540: a DNS-only zone may carry a tenant-chosen apex IP (the "pointed
-	// IP"). It is only meaningful for a web-off zone whose DNS the panel hosts:
-	// a web domain's apex is panel-managed (convergeApexAddrRecords re-asserts
-	// it), and an external-DNS domain (dns off) publishes nothing here. Must be
-	// a bare IPv4 — no CIDR, no port, no IPv6 (the apex A row is IPv4).
-	var dnsApexIPv4 string
-	if raw := strings.TrimSpace(in.DNSApexIPv4); raw != "" {
+	// IP") — an IPv4 (A) and/or an optional IPv6 (AAAA). Only meaningful for a
+	// web-off zone whose DNS the panel hosts: a web domain's apex is
+	// panel-managed (convergeApexAddrRecords re-asserts it), and an external-DNS
+	// domain (dns off) publishes nothing here. The web-off / DNS-on gate is
+	// shared by both families; each is then parsed as a BARE address of its own
+	// family — an IPv4 or IPv4-mapped value in the v6 field is rejected (an AAAA
+	// holding a mapped-v4 is nonsense) and vice versa. ip.String() canonicalises
+	// so a zone stores one row shape per address.
+	var dnsApexIPv4, dnsApexIPv6 string
+	raw4 := strings.TrimSpace(in.DNSApexIPv4)
+	raw6 := strings.TrimSpace(in.DNSApexIPv6)
+	if raw4 != "" || raw6 != "" {
 		if webEnabled {
 			return nil, &createDomainError{http.StatusBadRequest, "web_enabled_apex_ip", "a web domain's apex IP is managed by the panel — set an apex IP only on a DNS-only zone"}
 		}
 		if !dnsEnabled {
 			return nil, &createDomainError{http.StatusBadRequest, "dns_disabled_apex_ip", "an apex IP requires the panel to host DNS for this domain"}
 		}
-		ip := net.ParseIP(raw)
-		if ip == nil || ip.To4() == nil {
-			return nil, &createDomainError{http.StatusBadRequest, "invalid_apex_ip", "apex IP must be a valid IPv4 address"}
+		if raw4 != "" {
+			ip := net.ParseIP(raw4)
+			if ip == nil || ip.To4() == nil {
+				return nil, &createDomainError{http.StatusBadRequest, "invalid_apex_ip", "apex IP must be a valid IPv4 address"}
+			}
+			dnsApexIPv4 = ip.String()
 		}
-		dnsApexIPv4 = ip.String()
+		if raw6 != "" {
+			ip := net.ParseIP(raw6)
+			// To4() != nil means it parsed as IPv4 (or IPv4-mapped) — not a bare
+			// IPv6, so reject it for the AAAA field.
+			if ip == nil || ip.To4() != nil {
+				return nil, &createDomainError{http.StatusBadRequest, "invalid_apex_ipv6", "apex IPv6 must be a valid IPv6 address"}
+			}
+			dnsApexIPv6 = ip.String()
+		}
 	}
 
 	user, err := h.cfg.Users.FindByID(ctx, in.OwnerID)
@@ -302,8 +323,9 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		// written) state, so a full-service create leaves both zero.
 		WebDisabled: in.WebDisabled,
 		DNSDisabled: in.DNSDisabled,
-		// GH #1540: apex IP for a DNS-only zone (nil for web/mail domains).
+		// GH #1540: apex IP(s) for a DNS-only zone (nil for web/mail domains).
 		DNSApexIPv4: strPtrOrNil(dnsApexIPv4),
+		DNSApexIPv6: strPtrOrNil(dnsApexIPv6),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -151,6 +151,9 @@ type createDomainRequest struct {
 	// (validated in createDomainOp as a bare IPv4). Empty/absent for web and
 	// mail domains, whose apex is panel-managed.
 	IPAddress string `json:"ip_address"`
+	// IPv6Address (GH #1540 follow-up) is the optional apex IPv6 (AAAA) of a
+	// DNS-only zone. Same gate as IPAddress; validated as a bare IPv6.
+	IPv6Address string `json:"ip6_address"`
 }
 
 // normalizeDomainName canonicalizes a domain for storage (GH #884): trim
@@ -776,8 +779,9 @@ func (h *domainHandler) create(c *gin.Context) {
 		// GH #1449: both default ON — only an explicit false opts out.
 		WebDisabled: req.WebEnabled != nil && !*req.WebEnabled,
 		DNSDisabled: req.ManageDNS != nil && !*req.ManageDNS,
-		// GH #1540: apex IP for a DNS-only zone (validated web-off + IPv4 in op).
+		// GH #1540: apex IP(s) for a DNS-only zone (validated web-off + family in op).
 		DNSApexIPv4: req.IPAddress,
+		DNSApexIPv6: req.IPv6Address,
 	})
 	if oerr != nil {
 		body := gin.H{"error": oerr.Code}

--- a/panel-api/internal/db/migrations/000292_domain_dns_apex_ipv6.down.sql
+++ b/panel-api/internal/db/migrations/000292_domain_dns_apex_ipv6.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE domains
+  DROP COLUMN dns_apex_ipv6;

--- a/panel-api/internal/db/migrations/000292_domain_dns_apex_ipv6.up.sql
+++ b/panel-api/internal/db/migrations/000292_domain_dns_apex_ipv6.up.sql
@@ -1,0 +1,7 @@
+-- GH #1540 follow-up: a DNS-only zone (web_disabled=1) may also carry an apex
+-- IPv6 (the AAAA record), alongside the IPv4 apex added in 000291. Same shape:
+-- read once by the reconciler at zone bootstrap to seed the "@ AAAA <ip>" row,
+-- then never written again. Nullable, no default — only DNS-only creates that
+-- pass an IPv6 set it; every other row stays NULL.
+ALTER TABLE domains
+  ADD COLUMN dns_apex_ipv6 VARCHAR(45) NULL;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -247,6 +247,12 @@ type Domain struct {
 	// domain (apex is panel-managed) and every legacy row.
 	DNSApexIPv4 *string `gorm:"column:dns_apex_ipv4;type:varchar(45)" json:"dns_apex_ipv4,omitempty"`
 
+	// DNSApexIPv6 (GH #1540 follow-up) is the optional apex IPv6 (AAAA) for a
+	// DNS-only zone, seeded alongside DNSApexIPv4 with the same read-once
+	// semantics. NULL when the zone has no IPv6 apex (the common case) and for
+	// every web/mail domain and legacy row.
+	DNSApexIPv6 *string `gorm:"column:dns_apex_ipv6;type:varchar(45)" json:"dns_apex_ipv6,omitempty"`
+
 	// IsQuotaSuspended marks domains the M13.1.1 bandwidth reconciler
 	// disabled because their owning user crossed BandwidthQuotaMB.
 	// Disambiguates panel-driven disables from manual operator

--- a/panel-api/internal/reconciler/dns_only_apex_seed_test.go
+++ b/panel-api/internal/reconciler/dns_only_apex_seed_test.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"fmt"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -8,76 +9,100 @@ import (
 
 func strptr(s string) *string { return &s }
 
-// GH #1540: dnsOnlyApexSeed builds the single "@ A <ip>" row for a web-off DNS
-// zone created with a tenant-chosen apex IP. BootstrapRecords skips the apex for
-// a web-off zone, and convergeApexAddrRecords is web-gated, so this seed is the
-// only writer — it must produce a tenant-owned (Managed=false) apex A only when
-// the domain is a web-off zone carrying a non-empty IP.
-func TestDNSOnlyApexSeed(t *testing.T) {
+// counterID returns a fresh id each call so a multi-record seed gets distinct
+// IDs (the reconciler passes ids.NewULID, which is likewise unique per call).
+func counterID() func() string {
+	n := 0
+	return func() string { n++; return fmt.Sprintf("rec-%d", n) }
+}
+
+// GH #1540 (+ IPv6 follow-up): dnsOnlyApexSeeds builds the "@ A <ipv4>" and/or
+// "@ AAAA <ipv6>" rows for a web-off DNS zone created with a tenant-chosen apex
+// IP. BootstrapRecords skips the apex for a web-off zone, and
+// convergeApexAddrRecords is web-gated, so these seeds are the only writer —
+// tenant-owned (Managed=false), each family independent.
+func TestDNSOnlyApexSeeds(t *testing.T) {
 	srv := &models.ServerSettings{PublicIPv4: "192.0.2.1"}
-	idNew := func() string { return "rec-1" }
 
-	t.Run("web-off zone with an apex IP seeds a tenant-owned @ A", func(t *testing.T) {
+	t.Run("IPv4 only → one tenant-owned @ A", func(t *testing.T) {
 		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("203.0.113.10")}
-		rec, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew)
-		if !ok {
-			t.Fatal("expected a seed record")
+		recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID())
+		if len(recs) != 1 {
+			t.Fatalf("want 1 record, got %d", len(recs))
 		}
-		if rec.Name != "@" || rec.Type != "A" {
-			t.Errorf("want @ A, got %s %s", rec.Name, rec.Type)
+		r := recs[0]
+		if r.Name != "@" || r.Type != "A" || r.Content != "203.0.113.10" {
+			t.Errorf("want @ A 203.0.113.10, got %s %s %s", r.Name, r.Type, r.Content)
 		}
-		if rec.Content != "203.0.113.10" {
-			t.Errorf("content should be the apex IP, got %q", rec.Content)
+		if r.Managed || r.ManagedBy != nil || !r.IsEnabled {
+			t.Error("apex seed must be tenant-owned (Managed=false, ManagedBy=nil) and enabled")
 		}
-		if rec.ZoneID != "zone-1" {
-			t.Errorf("zone id should be zone-1, got %q", rec.ZoneID)
-		}
-		if rec.Managed {
-			t.Error("a web-off apex is tenant-owned — Managed must be false")
-		}
-		if rec.ManagedBy != nil {
-			t.Error("ManagedBy must be nil")
-		}
-		if !rec.IsEnabled {
-			t.Error("seed must be enabled")
-		}
-		if rec.TTL != models.EffectiveDNSTTL(srv) {
-			t.Errorf("TTL should follow the server default, got %d", rec.TTL)
+		if r.TTL != models.EffectiveDNSTTL(srv) {
+			t.Errorf("TTL should follow the server default, got %d", r.TTL)
 		}
 	})
 
-	t.Run("trims surrounding whitespace on the IP", func(t *testing.T) {
+	t.Run("IPv6 only → one @ AAAA", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true, DNSApexIPv6: strptr("2001:db8::1")}
+		recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID())
+		if len(recs) != 1 {
+			t.Fatalf("want 1 record, got %d", len(recs))
+		}
+		if recs[0].Type != "AAAA" || recs[0].Content != "2001:db8::1" {
+			t.Errorf("want @ AAAA 2001:db8::1, got %s %s", recs[0].Type, recs[0].Content)
+		}
+	})
+
+	t.Run("both → an A and an AAAA with distinct IDs", func(t *testing.T) {
+		dom := &models.Domain{
+			WebDisabled: true,
+			DNSApexIPv4: strptr("203.0.113.10"),
+			DNSApexIPv6: strptr("2001:db8::1"),
+		}
+		recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID())
+		if len(recs) != 2 {
+			t.Fatalf("want 2 records, got %d", len(recs))
+		}
+		if recs[0].Type != "A" || recs[1].Type != "AAAA" {
+			t.Errorf("want [A, AAAA], got [%s, %s]", recs[0].Type, recs[1].Type)
+		}
+		if recs[0].ID == recs[1].ID {
+			t.Errorf("the two seeds must have distinct IDs, both %q", recs[0].ID)
+		}
+	})
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
 		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("  198.51.100.7 ")}
-		rec, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew)
-		if !ok || rec.Content != "198.51.100.7" {
-			t.Fatalf("want trimmed 198.51.100.7, got ok=%v content=%q", ok, rec.Content)
+		recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID())
+		if len(recs) != 1 || recs[0].Content != "198.51.100.7" {
+			t.Fatalf("want trimmed 198.51.100.7, got %+v", recs)
 		}
 	})
 
-	t.Run("web-enabled domain never seeds (apex is panel-managed)", func(t *testing.T) {
+	t.Run("web-enabled domain seeds nothing (apex is panel-managed)", func(t *testing.T) {
 		dom := &models.Domain{WebDisabled: false, DNSApexIPv4: strptr("203.0.113.10")}
-		if _, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew); ok {
-			t.Error("a web-enabled domain must not seed a custom apex")
+		if recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID()); len(recs) != 0 {
+			t.Errorf("a web-enabled domain must seed nothing, got %d", len(recs))
 		}
 	})
 
-	t.Run("nil apex IP does not seed", func(t *testing.T) {
-		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: nil}
-		if _, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew); ok {
-			t.Error("a web-off zone without a custom IP must not seed")
+	t.Run("no apex IP seeds nothing", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true}
+		if recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID()); len(recs) != 0 {
+			t.Errorf("a web-off zone without a custom IP must seed nothing, got %d", len(recs))
 		}
 	})
 
-	t.Run("empty apex IP does not seed", func(t *testing.T) {
-		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("   ")}
-		if _, ok := dnsOnlyApexSeed(dom, "zone-1", srv, idNew); ok {
-			t.Error("a blank custom IP must not seed")
+	t.Run("empty apex IPs seed nothing", func(t *testing.T) {
+		dom := &models.Domain{WebDisabled: true, DNSApexIPv4: strptr("  "), DNSApexIPv6: strptr("")}
+		if recs := dnsOnlyApexSeeds(dom, "zone-1", srv, counterID()); len(recs) != 0 {
+			t.Errorf("blank custom IPs must seed nothing, got %d", len(recs))
 		}
 	})
 
-	t.Run("nil domain does not seed", func(t *testing.T) {
-		if _, ok := dnsOnlyApexSeed(nil, "zone-1", srv, idNew); ok {
-			t.Error("nil domain must not seed")
+	t.Run("nil domain seeds nothing", func(t *testing.T) {
+		if recs := dnsOnlyApexSeeds(nil, "zone-1", srv, counterID()); len(recs) != 0 {
+			t.Errorf("nil domain must seed nothing, got %d", len(recs))
 		}
 	})
 }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2380,36 +2380,47 @@ func (r *Reconciler) resolveListenIPAddress(ctx context.Context, id *uint64, fam
 	return row.Address
 }
 
-// dnsOnlyApexSeed builds the single apex A record for a web-off DNS zone that
-// was created with a tenant-chosen apex IP (GH #1540). A web-off zone's apex is
+// dnsOnlyApexSeeds builds the apex records for a web-off DNS zone that was
+// created with a tenant-chosen apex IP (GH #1540): an A for DNSApexIPv4 and/or
+// an AAAA for DNSApexIPv6, each seeded independently. A web-off zone's apex is
 // deliberately left unseeded by dnscompile.BootstrapRecords (includeApex=false)
-// and is never re-asserted by convergeApexAddrRecords (web-gated), so this row
-// is seeded ONCE at zone bootstrap and then owned by the tenant. Managed=false
-// (the panel does not reconcile it — an honest flag, no false "managed" badge),
-// ManagedBy nil. Returns ok=false unless the domain is a web-off zone carrying a
-// non-empty apex IP, so callers can seed unconditionally.
-func dnsOnlyApexSeed(domain *models.Domain, zoneID string, srv *models.ServerSettings, idNew func() string) (models.DNSRecord, bool) {
-	if domain == nil || !domain.WebDisabled || domain.DNSApexIPv4 == nil {
-		return models.DNSRecord{}, false
-	}
-	ip := strings.TrimSpace(*domain.DNSApexIPv4)
-	if ip == "" {
-		return models.DNSRecord{}, false
+// and is never re-asserted by convergeApexAddrRecords (web-gated), so these rows
+// are seeded ONCE at zone bootstrap and then owned by the tenant. Managed=false
+// (the panel does not reconcile them — an honest flag, no false "managed"
+// badge), ManagedBy nil. Returns nil for a web-on domain or one with no apex IP.
+func dnsOnlyApexSeeds(domain *models.Domain, zoneID string, srv *models.ServerSettings, idNew func() string) []models.DNSRecord {
+	if domain == nil || !domain.WebDisabled {
+		return nil
 	}
 	now := time.Now().UTC()
-	return models.DNSRecord{
-		ID:        idNew(),
-		ZoneID:    zoneID,
-		Name:      "@",
-		Type:      "A",
-		Content:   ip,
-		TTL:       models.EffectiveDNSTTL(srv),
-		Priority:  0,
-		Managed:   false,
-		IsEnabled: true,
-		CreatedAt: now,
-		UpdatedAt: now,
-	}, true
+	ttl := models.EffectiveDNSTTL(srv)
+	mk := func(typ, content string) models.DNSRecord {
+		return models.DNSRecord{
+			ID:        idNew(),
+			ZoneID:    zoneID,
+			Name:      "@",
+			Type:      typ,
+			Content:   content,
+			TTL:       ttl,
+			Priority:  0,
+			Managed:   false,
+			IsEnabled: true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+	}
+	var out []models.DNSRecord
+	if domain.DNSApexIPv4 != nil {
+		if ip := strings.TrimSpace(*domain.DNSApexIPv4); ip != "" {
+			out = append(out, mk("A", ip))
+		}
+	}
+	if domain.DNSApexIPv6 != nil {
+		if ip := strings.TrimSpace(*domain.DNSApexIPv6); ip != "" {
+			out = append(out, mk("AAAA", ip))
+		}
+	}
+	return out
 }
 
 // reconcileDNSZone ensures a domain's DNS zone and records are provisioned
@@ -2468,10 +2479,12 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 				}
 			}
 			// GH #1540: a DNS-only zone created with a tenant-chosen apex IP
-			// seeds its single "@ A <ip>" here — BootstrapRecords skips the apex
-			// for a web-off zone. Tenant-owned (Managed=false), never re-asserted.
-			if seed, ok := dnsOnlyApexSeed(domain, zone.ID, srv, ids.NewULID); ok {
-				if err := r.dnsRecords.Create(ctx, &seed); err != nil {
+			// seeds its "@ A <ipv4>" and/or "@ AAAA <ipv6>" here —
+			// BootstrapRecords skips the apex for a web-off zone. Tenant-owned
+			// (Managed=false), never re-asserted.
+			seeds := dnsOnlyApexSeeds(domain, zone.ID, srv, ids.NewULID)
+			for i := range seeds {
+				if err := r.dnsRecords.Create(ctx, &seeds[i]); err != nil {
 					r.log.Error("dns-only apex seed failed", "zone", zone.Name, "err", err)
 					return
 				}

--- a/panel-ui/src/components/dns/DnsZoneFields.tsx
+++ b/panel-ui/src/components/dns/DnsZoneFields.tsx
@@ -5,9 +5,9 @@
 // so the two lists offer the same simple form johnnyq asked for.
 //
 // It reads the surrounding <Form> via Form.useFormInstance(), so a parent just
-// drops <DnsZoneFields publicIP={caps?.public_ipv4} /> inside its <Form> — the
-// field names (ip_address, mail_provider, m365_onmicrosoft, google_dkim) match
-// the POST /domains body verbatim.
+// drops <DnsZoneFields publicIP={caps?.public_ipv4} publicIPv6={caps?.public_ipv6} />
+// inside its <Form> — the field names (ip_address, ip6_address, mail_provider,
+// m365_onmicrosoft, google_dkim) match the POST /domains body verbatim.
 import { useEffect } from "react";
 import { Form, Input, Select } from "antd";
 
@@ -20,24 +20,40 @@ const isIPv4 = (value: string): boolean => {
   return parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
 };
 
+// isIPv6 is deliberately permissive (hex + colons, must contain a colon) and
+// rejects an IPv4 / IPv4-mapped value so the user puts those in the v4 field.
+// The backend (net.ParseIP + To4()==nil) is the authority.
+const isIPv6 = (value: string): boolean => {
+  const v = value.trim();
+  if (!v.includes(":")) return false;
+  if (/^::ffff:\d+\.\d+\.\d+\.\d+$/i.test(v)) return false; // IPv4-mapped → use the v4 field
+  return /^[0-9a-f:]+$/i.test(v);
+};
+
 export interface DnsZoneFieldsProps {
   // The panel's public IPv4, prefilled into the apex IP field so the common
   // case ("point it at this server") is one click. The user can overwrite it.
   publicIP?: string;
+  // The panel's public IPv6, prefilled into the optional AAAA field. Empty when
+  // the server has no IPv6 — the field then renders blank and stays optional.
+  publicIPv6?: string;
 }
 
-export const DnsZoneFields = ({ publicIP }: DnsZoneFieldsProps) => {
+export const DnsZoneFields = ({ publicIP, publicIPv6 }: DnsZoneFieldsProps) => {
   const form = Form.useFormInstance();
   const template = Form.useWatch("mail_provider", form) ?? "none";
 
-  // Prefill the apex IP with the panel's IP once, and never clobber a value the
-  // user already typed (or one restored on a remount). destroyOnClose remounts
-  // the drawer per open, so this re-runs with an empty field each open.
+  // Prefill the apex IPs with the panel's IPs once, and never clobber a value
+  // the user already typed (or one restored on a remount). destroyOnClose
+  // remounts the drawer per open, so this re-runs with an empty field each open.
   useEffect(() => {
     if (publicIP && !form.getFieldValue("ip_address")) {
       form.setFieldValue("ip_address", publicIP);
     }
-  }, [publicIP, form]);
+    if (publicIPv6 && !form.getFieldValue("ip6_address")) {
+      form.setFieldValue("ip6_address", publicIPv6);
+    }
+  }, [publicIP, publicIPv6, form]);
 
   return (
     <>
@@ -61,6 +77,25 @@ export const DnsZoneFields = ({ publicIP }: DnsZoneFieldsProps) => {
         ]}
       >
         <Input placeholder="e.g., 203.0.113.10" />
+      </Form.Item>
+
+      {/* GH #1540 follow-up: optional apex IPv6 (AAAA). Prefilled with the
+          server's IPv6 when it has one; left blank (and optional) otherwise. */}
+      <Form.Item
+        label="IPv6 Address (optional)"
+        name="ip6_address"
+        initialValue={publicIPv6}
+        tooltip="Optional — the IPv6 address for the apex AAAA record. Prefilled with this server's IPv6 if it has one. Leave blank for no AAAA."
+        rules={[
+          {
+            validator: (_, v) =>
+              !v || isIPv6(v)
+                ? Promise.resolve()
+                : Promise.reject(new Error("Enter a valid IPv6 address (e.g. 2001:db8::1)")),
+          },
+        ]}
+      >
+        <Input placeholder="e.g., 2001:db8::1" />
       </Form.Item>
 
       {/* GH #1540: "Template" — Default seeds no mail records (just the apex the

--- a/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.test.tsx
+++ b/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.test.tsx
@@ -7,7 +7,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mutate = vi.hoisted(() => vi.fn());
 vi.mock("../../../hooks/useServerCapabilities", () => ({
-  useServerCapabilities: () => ({ data: { public_ipv4: "192.0.2.1" } }),
+  useServerCapabilities: () => ({
+    data: { public_ipv4: "192.0.2.1", public_ipv6: "2001:db8::1" },
+  }),
 }));
 vi.mock("../../../hooks/useQueries", () => ({
   useCreateMutation: () => ({ mutateAsync: mutate, isPending: false }),
@@ -75,6 +77,7 @@ describe("AdminDNSZoneDrawer (GH #1540)", () => {
     expect(body.manage_dns).toBe(true);
     expect(body.ssl_mode).toBe("none");
     expect(body.ip_address).toBe("192.0.2.1");
+    expect(body.ip6_address).toBe("2001:db8::1");
     expect(body.mail_provider).toBe("none");
   });
 });

--- a/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.tsx
+++ b/panel-ui/src/shells/admin/dns/AdminDNSZoneDrawer.tsx
@@ -20,6 +20,7 @@ type AdminDNSZoneInput = {
   name: string;
   user_id: string;
   ip_address?: string;
+  ip6_address?: string;
   mail_provider?: string;
   m365_onmicrosoft?: string;
   google_dkim?: string;
@@ -66,6 +67,7 @@ export const AdminDNSZoneDrawer = ({ open, onClose }: AdminDNSZoneDrawerProps) =
         manage_dns: true,
         ssl_mode: "none",
         ip_address: values.ip_address,
+        ip6_address: values.ip6_address,
         mail_provider: values.mail_provider ?? "none",
         m365_onmicrosoft: values.m365_onmicrosoft,
         google_dkim: values.google_dkim,
@@ -122,7 +124,7 @@ export const AdminDNSZoneDrawer = ({ open, onClose }: AdminDNSZoneDrawerProps) =
           <Input placeholder="e.g., example.com" />
         </Form.Item>
 
-        <DnsZoneFields publicIP={caps?.public_ipv4} />
+        <DnsZoneFields publicIP={caps?.public_ipv4} publicIPv6={caps?.public_ipv6} />
 
         <Form.Item>
           <Space>

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
@@ -6,11 +6,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const caps = vi.hoisted(() => ({ mail: false, dns: true, ipv4: "192.0.2.1" }));
+const caps = vi.hoisted(() => ({ mail: false, dns: true, ipv4: "192.0.2.1", ipv6: "2001:db8::1" }));
 const mutate = vi.hoisted(() => vi.fn());
 vi.mock("../../../hooks/useServerCapabilities", () => ({
   useServerCapabilities: () => ({
-    data: { mail_enabled: caps.mail, dns_enabled: caps.dns, public_ipv4: caps.ipv4 },
+    data: {
+      mail_enabled: caps.mail,
+      dns_enabled: caps.dns,
+      public_ipv4: caps.ipv4,
+      public_ipv6: caps.ipv6,
+    },
   }),
 }));
 vi.mock("../../../hooks/useQueries", () => ({
@@ -46,6 +51,7 @@ beforeEach(() => {
   caps.mail = false;
   caps.dns = true;
   caps.ipv4 = "192.0.2.1";
+  caps.ipv6 = "2001:db8::1";
   mutate.mockReset();
   mutate.mockResolvedValue({ id: "d1" });
 });
@@ -141,11 +147,14 @@ describe("UserDomainDrawer web create payload (GH #1541)", () => {
 });
 
 describe("UserDomainDrawer dns mode — Add DNS Zone (GH #1540)", () => {
-  it("prefills the apex IP with the panel IP and sends a web-off DNS-only payload", async () => {
+  it("prefills the apex IPv4 + IPv6 with the panel IPs and sends a web-off DNS-only payload", async () => {
     renderDrawer("dns");
     // IP Address is prefilled with the panel's public IPv4.
     const ip = (await screen.findByPlaceholderText("e.g., 203.0.113.10")) as HTMLInputElement;
     expect(ip.value).toBe("192.0.2.1");
+    // The optional IPv6 field is prefilled with the panel's public IPv6.
+    const ip6 = (await screen.findByPlaceholderText("e.g., 2001:db8::1")) as HTMLInputElement;
+    expect(ip6.value).toBe("2001:db8::1");
     await typeName("zone.example.com");
     submit();
     await waitFor(() => expect(mutate).toHaveBeenCalled());
@@ -154,8 +163,32 @@ describe("UserDomainDrawer dns mode — Add DNS Zone (GH #1540)", () => {
     expect(body.manage_dns).toBe(true);
     expect(body.ssl_mode).toBe("none");
     expect(body.ip_address).toBe("192.0.2.1");
+    expect(body.ip6_address).toBe("2001:db8::1");
     // Default template ⇒ no mail records.
     expect(body.mail_provider).toBe("none");
+  });
+
+  it("leaves the AAAA out when the server has no IPv6 and the field is blank", async () => {
+    caps.ipv6 = "";
+    renderDrawer("dns");
+    const ip6 = (await screen.findByPlaceholderText("e.g., 2001:db8::1")) as HTMLInputElement;
+    expect(ip6.value).toBe("");
+    await typeName("zone.example.com");
+    submit();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const body = mutate.mock.calls[0][0];
+    expect(body.ip_address).toBe("192.0.2.1");
+    expect(body.ip6_address).toBeFalsy();
+  });
+
+  it("blocks submit on an invalid apex IPv6", async () => {
+    renderDrawer("dns");
+    const ip6 = await screen.findByPlaceholderText("e.g., 2001:db8::1");
+    fireEvent.change(ip6, { target: { value: "1.2.3.4" } });
+    await typeName("zone.example.com");
+    submit();
+    await screen.findByText("Enter a valid IPv6 address (e.g. 2001:db8::1)");
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   it("Template Microsoft 365 maps to mail_provider m365 with the tenant helper", async () => {
@@ -193,6 +226,8 @@ describe("UserDomainDrawer dns mode — Add DNS Zone (GH #1540)", () => {
     rerender(wrap(true));
     const ip = (await screen.findByPlaceholderText("e.g., 203.0.113.10")) as HTMLInputElement;
     expect(ip.value).toBe("192.0.2.1");
+    const ip6 = (await screen.findByPlaceholderText("e.g., 2001:db8::1")) as HTMLInputElement;
+    expect(ip6.value).toBe("2001:db8::1");
   });
 
   it("blocks submit on an invalid apex IP", async () => {

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -33,6 +33,8 @@ type UserDomainCreateInput = {
   google_dkim?: string;
   // GH #1540: apex IP for a DNS-only zone (dns mode only) — the "pointed IP".
   ip_address?: string;
+  // GH #1540 follow-up: optional apex IPv6 (AAAA) for a DNS-only zone.
+  ip6_address?: string;
   // GH #1541: create_www is no longer a checkbox — it's derived from the domain
   // (apex ⇒ true, subdomain ⇒ false) and sent as a plain flag.
   create_www?: boolean;
@@ -158,6 +160,7 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           ...(isDNS
             ? {
                 ip_address: values.ip_address,
+                ip6_address: values.ip6_address,
                 m365_onmicrosoft: values.m365_onmicrosoft,
                 google_dkim: values.google_dkim,
               }
@@ -227,7 +230,9 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
         {/* GH #1540: DNS-only zone — the apex IP (prefilled with this server's
             IP) and a DNS Template (Default / Microsoft 365 / Google Workspace).
             Shared with the admin Add DNS Zone drawer. */}
-        {isDNS && <DnsZoneFields publicIP={caps?.public_ipv4} />}
+        {isDNS && (
+          <DnsZoneFields publicIP={caps?.public_ipv4} publicIPv6={caps?.public_ipv6} />
+        )}
 
         {(isWeb || isMail) && (
           <Form.Item


### PR DESCRIPTION
## What & why

Follow-up to #1556 (GH #1540). In the #1540 thread I offered an IPv6 option
on the Add DNS Zone form and johnnyq accepted. This adds an **optional IPv6
Address** field next to the IPv4 one, so a DNS-only zone can be created with
an apex **A** and/or an apex **AAAA**.

IPv4 stays required (the primary "pointed IP"); IPv6 is optional and
prefilled with the panel's own IPv6 when it has one.

## Backend

- **Migration 000292**: nullable `domains.dns_apex_ipv6 VARCHAR(45)`, same
  read-once-at-bootstrap semantics as `dns_apex_ipv4` (000291). NULL for
  every web/mail domain and every legacy row (DDL only).
- **`createDomainOp`**: the web-off / DNS-on gate now covers both families in
  one block. `ip6_address` is parsed as a **bare IPv6** — `net.ParseIP` with
  `To4() == nil`, so an IPv4 or IPv4-mapped value in the v6 field is rejected
  as `invalid_apex_ipv6`. `ip.String()` canonicalises the stored value.
- The reconciler seed is now **`dnsOnlyApexSeeds`**, returning the apex A
  and/or AAAA (each family independent), tenant-owned (`Managed=false`) as
  before. The bootstrap block creates each returned record.

## Frontend

- `DnsZoneFields` gains an optional **IPv6 Address** field (`ip6_address`),
  prefilled from `caps.public_ipv6` (`initialValue` + effect, same
  `resetFields`-on-reopen reason as the v4 field) and validated as IPv6
  client-side. When the server has no IPv6 the field renders blank and stays
  optional.
- Both drawers pass `publicIPv6` and send `ip6_address`.

## Notes

- The wire field `ip_address` is deliberately **not** renamed — it shipped
  hours ago in #1556 and a rename would be pointless churn.
- IPv4-mapped IPv6 (`::ffff:1.2.3.4`) is rejected in the v6 field on purpose
  (an AAAA holding a mapped-v4 is nonsense; that value belongs in the v4
  field).

## Tests

- Go: `createDomainOp` v6 validation (persist + canonicalise
  `2001:DB8:0:0::1` → `2001:db8::1`; v6-only on a web domain hits the shared
  `web_enabled_apex_ip` gate; IPv4 and IPv4-mapped in the v6 field rejected;
  v6-only DNS-only zone); `dnsOnlyApexSeeds` (A only / AAAA only / both with
  distinct IDs / none).
- Vitest: tenant + admin drawer payloads carry `ip6_address`; the v6 field
  prefill; the no-IPv6 server case (AAAA omitted); an invalid-v6 block; the
  reopen test asserts both fields.
- `go build`/`vet`, `tsc -b`, `eslint`, and the affected Go + vitest suites
  are green post-rebase onto `origin/main`.

GH #1540
