### PR TITLE
refactor(mail): one-click mailbox password rotate + shared delete confirm (JAB-333)

### DIFF
--- a/panel-ui/src/components/mail/mailboxInventory.tsx
+++ b/panel-ui/src/components/mail/mailboxInventory.tsx
@@ -5,14 +5,14 @@
 //   - user/mail/tabs/MailboxesTab.tsx       (tenant, cross-domain)
 //   - admin/domains/DomainMailboxesSection.tsx (per-domain)
 //
-// Adapters still own their data source and their role-specific columns and the
-// SHAPE of the trigger (admin owner filter, tenant groups + autoresponders,
-// domain enable-email + create wizard; a one-click rotate button vs a form
-// modal with an optional custom password). This module owns what MUST stay
-// identical: the quota / status presentation, the safe webmail launcher
-// (JAB-354), and the password reset → reveal-once → toast/error core
-// (useMailboxPasswordReset), so a one-shot generated password is surfaced
-// through a single tested path no matter which surface produced it.
+// Adapters still own their data source and their role-specific columns (admin
+// owner filter, tenant groups + autoresponders, domain enable-email + create
+// wizard). This module owns what MUST stay identical: the quota / status
+// presentation, the safe webmail launcher (JAB-354), and the password rotate →
+// reveal-once → toast/error core (useMailboxPasswordReset). All three surfaces
+// now trigger a rotate the same way — a one-click action that auto-generates
+// and reveals the new password exactly once — so a one-shot generated password
+// is surfaced through a single tested path no matter which surface produced it.
 
 import { useCallback, useState } from "react";
 import { Progress, Tag, Tooltip } from "antd";
@@ -146,17 +146,18 @@ export function useMailboxWebmail() {
   };
 }
 
-// ---- password reset action (JAB-333) ------------------------------------
+// ---- password rotate action (JAB-333) -----------------------------------
 //
 // The three inventories each copied the same rotate flow: call the rotate
-// mutation, and if the server GENERATED the password (no custom one supplied)
-// reveal it exactly once via DatabaseUserPasswordModal, otherwise a success
-// toast. The trigger differs by surface and STAYS adapter-owned — a one-click
-// button (per-domain) or a form modal collecting an optional custom password
-// (admin, tenant) — but the reveal/toast/error core must stay identical: a
-// one-shot generated password dropped silently is a real support incident, and
-// that's exactly the kind of invariant that drifts across hand-copied screens.
-// Each surface calls `rotate(...)` and renders <MailboxPasswordRevealModal>.
+// mutation and, since no UI supplies a custom password, reveal the
+// server-generated one exactly once via DatabaseUserPasswordModal. All three
+// surfaces trigger it the same way now — a one-click action, no form — but the
+// reveal/toast/error core must stay identical: a one-shot generated password
+// dropped silently is a real support incident, and that's exactly the kind of
+// invariant that drifts across hand-copied screens. Each surface calls
+// `rotate(...)` and renders <MailboxPasswordRevealModal>. `newPassword` stays
+// on rotate() for API/CLI parity (the endpoint still accepts a custom password)
+// even though no surface passes it today.
 
 export interface MailboxReveal {
   email: string;

--- a/panel-ui/src/components/mail/mailboxInventorySurfaces.wiring.test.tsx
+++ b/panel-ui/src/components/mail/mailboxInventorySurfaces.wiring.test.tsx
@@ -1,0 +1,55 @@
+// mailboxInventorySurfaces.wiring.test.tsx (JAB-333) — pins the surface wiring
+// this slice retired: the admin + tenant mailbox inventories now trigger a
+// password rotate with ONE click (auto-generate + reveal-once, no form modal),
+// and the tenant delete uses the shared declarative RowActions `confirm:` prop
+// instead of a hand-rolled feedback.modal.confirm. The rotate/reveal/delete CORE
+// is behavior-tested in mailboxInventory.test.tsx + useMailboxes.test.tsx; this
+// guards that the two adapters keep routing through it and do not grow a fourth
+// copy (a form, or an inline modal) back.
+//
+// The negative pins are non-vacuous: each removed string was present in these
+// files before this slice (a `<Modal>` reset form with `<PasswordInput>`, a
+// tenant `feedback.modal.confirm` delete), so re-introducing either reddens.
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+// vitest runs with cwd = the panel-ui package root.
+const adminSrc = readFileSync(
+  resolve(process.cwd(), "src/shells/admin/mail/AdminMailPage.tsx"),
+  "utf8",
+);
+const tenantSrc = readFileSync(
+  resolve(process.cwd(), "src/shells/user/mail/tabs/MailboxesTab.tsx"),
+  "utf8",
+);
+
+describe("AdminMailPage password rotate wiring", () => {
+  it("rotates on one click via the shared hook (no reset form modal)", () => {
+    expect(adminSrc).toContain('label: "Rotate password"');
+    expect(adminSrc).toContain("rotatePassword({ id: row.id, email: row.email");
+  });
+
+  it("no longer renders the custom-password reset form", () => {
+    // The form's state, its PasswordInput, and the antd Form import are gone.
+    expect(adminSrc).not.toContain("setResetTarget");
+    expect(adminSrc).not.toContain("PasswordInput");
+  });
+});
+
+describe("MailboxesTab (tenant) rotate + delete wiring", () => {
+  it("rotates on one click via the shared hook (no reset form modal)", () => {
+    expect(tenantSrc).toContain('label: "Rotate password"');
+    expect(tenantSrc).toContain("rotatePassword({ id: row.id, email: row.email");
+    expect(tenantSrc).not.toContain("PasswordInput");
+  });
+
+  it("delete uses the shared declarative RowActions confirm, not a hand-rolled modal", () => {
+    // Retired: the copied `feedback.modal.confirm({ ... onOk })` delete flow.
+    expect(tenantSrc).not.toContain("feedback.modal.confirm");
+    // Present: the same declarative `confirm:` prop the other two surfaces use.
+    expect(tenantSrc).toContain('okText: "Delete" }');
+    expect(tenantSrc).toContain("confirm: {");
+  });
+});

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -14,8 +14,6 @@ import {
   App,
   Button,
   Empty,
-  Form,
-  Modal,
   Card,
   Space,
   Table,
@@ -44,7 +42,6 @@ import {
 import { AdminGroupsTab } from "./AdminGroupsTab";
 import { MailStatsTab } from "./MailStatsTab";
 import { CreateMailboxWizardModal } from "../../user/mail/CreateMailboxWizardModal";
-import { PasswordInput } from "../../../components/PasswordInput";
 import { RowActions } from "../../../components/RowActions";
 
 export function AdminMailPage() {
@@ -84,29 +81,13 @@ export function AdminMailPage() {
   );
 
   const deleteMutation = useDeleteMailbox();
-  const { rotate: rotatePassword, rotateMutation, reveal, clearReveal, revealPassword } =
+  const { rotate: rotatePassword, rotatingId, reveal, clearReveal, revealPassword } =
     useMailboxPasswordReset();
   const webmail = useMailboxWebmail();
 
   const [tab, setTab] = useTabParam<string>("mailboxes");
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<AdminMailbox | null>(null);
-  const [resetTarget, setResetTarget] = useState<AdminMailbox | null>(null);
-  const [resetForm] = Form.useForm<{ password?: string }>();
-
-  // Server-wide admin: a form modal collecting an OPTIONAL custom password. The
-  // rotate → reveal-once → error core is the shared hook.
-  const submitReset = async () => {
-    if (!resetTarget) return;
-    const v = await resetForm.validateFields();
-    const ok = await rotatePassword({
-      id: resetTarget.id,
-      email: resetTarget.email,
-      newPassword: v.password,
-      title: t("adminmailpage.mailbox_password"),
-    });
-    if (ok) setResetTarget(null);
-  };
 
   useSetBreadcrumbs(
     ownerId
@@ -262,7 +243,7 @@ export function AdminMailPage() {
                 actions={[
                   { key: "webmail", label: "Open webmail", icon: <MailOutlined />, loading: webmail.isLaunching(row.id), onClick: () => webmail.launch(row.id) },
                   { key: "edit", label: "Edit mailbox", icon: <EditOutlined />, onClick: () => setEditTarget(row) },
-                  { key: "reset", label: "Reset password", icon: <KeyOutlined />, onClick: () => { resetForm.resetFields(); setResetTarget(row); } },
+                  { key: "rotate", label: "Rotate password", icon: <KeyOutlined />, loading: rotatingId === row.id, onClick: () => rotatePassword({ id: row.id, email: row.email, title: t("adminmailpage.mailbox_password") }) },
                   {
                     key: "delete",
                     label: "Delete",
@@ -309,26 +290,6 @@ export function AdminMailPage() {
         mailbox={editTarget}
         onClose={() => setEditTarget(null)}
       />
-
-      <Modal
-        open={resetTarget !== null}
-        title={resetTarget ? `Reset password — ${resetTarget.email}` : "Reset password"}
-        okText={t("adminmailpage.set_password")}
-        confirmLoading={rotateMutation.isPending}
-        onOk={submitReset}
-        onCancel={() => setResetTarget(null)}
-        destroyOnClose
-      >
-        <Form form={resetForm} layout="vertical" requiredMark={false}>
-          <Form.Item
-            label={t("adminmailpage.new_password")}
-            name="password"
-            tooltip={t("adminmailpage.leave_blank_to_auto_generate_auto_generated")}
-          >
-            <PasswordInput autoComplete="new-password" placeholder="(leave blank to auto-generate)" />
-          </Form.Item>
-        </Form>
-      </Modal>
 
       <MailboxPasswordRevealModal reveal={reveal} onClose={clearReveal} />
     </>

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -5,7 +5,7 @@
 // client-side and provides password rotation, SSO mint, and delete actions.
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import { Button, Empty, Form, Modal, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
+import { Button, Empty, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
 import type { TableProps } from "antd";
 import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../../components/RowActions";
@@ -39,7 +39,6 @@ import {
 import { useListQuery } from "../../../../hooks/useQueries";
 import { useTableURL } from "../../../../hooks/useTableURL";
 import type { Domain } from "../../../../components/domains/types";
-import { PasswordInput } from "../../../../components/PasswordInput";
 import { EditMailboxModal } from "../../../../components/mail/EditMailboxModal";
 import { MailSyncInfoModal } from "../../../../components/mail/MailSyncInfoModal";
 
@@ -167,35 +166,13 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   }, [forwarders]);
 
 
-  const [resetTarget, setResetTarget] = useState<MailboxRow | null>(null);
   const [editTarget, setEditTarget] = useState<MailboxRow | null>(null);
   const [arTarget, setArTarget] = useState<MailboxRow | null>(null);
   const [syncTarget, setSyncTarget] = useState<MailboxRow | null>(null);
-  const [resetForm] = Form.useForm<{ password?: string }>();
 
   const deleteMutation = useDeleteMailbox();
   const { rotate: rotatePassword, rotatingId, reveal, clearReveal } = useMailboxPasswordReset();
   const webmail = useMailboxWebmail();
-
-  const openReset = (row: MailboxRow) => {
-    resetForm.resetFields();
-    setResetTarget(row);
-  };
-
-  // Tenant cross-domain: a form modal collecting an OPTIONAL custom password.
-  // The rotate → reveal-once (when the server generates one) → error handling is
-  // the shared hook; this adapter only owns the form trigger.
-  const submitReset = async () => {
-    if (!resetTarget) return;
-    const values = await resetForm.validateFields();
-    const ok = await rotatePassword({
-      id: resetTarget.id,
-      email: resetTarget.email,
-      newPassword: values.password,
-      title: "New mailbox password (auto-generated)",
-    });
-    if (ok) setResetTarget(null);
-  };
 
   const loading = query.isLoading;
 
@@ -416,32 +393,27 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
                         },
                       ]
                     : []),
-                  { key: "resetpw", label: "Reset password", icon: <KeyOutlined />, onClick: () => openReset(row) },
+                  { key: "resetpw", label: "Rotate password", icon: <KeyOutlined />, loading: rotatingId === row.id, onClick: () => rotatePassword({ id: row.id, email: row.email, title: "New mailbox password" }) },
                   { key: "autoreply", label: "Automatic replies", icon: <ClockCircleOutlined />, onClick: () => setArTarget(row) },
                   {
                     key: "remove",
                     label: "Remove",
                     icon: <DeleteOutlined />,
                     danger: true,
-                    onClick: () => {
-                      feedback.modal.confirm({
-                        title: `Delete ${row.email}?`,
-                        content: "All mail in this mailbox will be removed. This cannot be undone.",
-                        okText: "Delete",
-                        okType: "danger",
-                        onOk: async () => {
-                          try {
-                            await deleteMutation.mutateAsync({ id: row.id, domainId: row.domain_id });
-                            feedback.message.success("Mailbox deleted");
-                          } catch (err) {
-                            const msg =
-                              (err as { response?: { data?: { detail?: string } } })?.response?.data
-                                ?.detail ?? "Failed to delete";
-                            feedback.message.error(msg);
-                          }
-                        },
-                      });
+                    // Shared RowActions confirm modal (the other two inventories
+                    // use the same declarative prop) — no hand-rolled modal here.
+                    onClick: async () => {
+                      try {
+                        await deleteMutation.mutateAsync({ id: row.id, domainId: row.domain_id });
+                        feedback.message.success("Mailbox deleted");
+                      } catch (err) {
+                        const msg =
+                          (err as { response?: { data?: { detail?: string } } })?.response?.data
+                            ?.detail ?? "Failed to delete";
+                        feedback.message.error(msg);
+                      }
                     },
+                    confirm: { title: `Delete ${row.email}?`, description: "All mail in this mailbox will be removed. This cannot be undone.", okText: "Delete" },
                   },
                 ]}
               />
@@ -470,32 +442,6 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
         domain={syncTarget?.domain_name ?? ""}
         onClose={() => setSyncTarget(null)}
       />
-
-      <Modal
-        open={resetTarget !== null}
-        title={resetTarget ? `Reset password — ${resetTarget.email}` : "Reset password"}
-        okText={t("mailboxestab.set_password")}
-        confirmLoading={resetTarget ? rotatingId === resetTarget.id : false}
-        onOk={submitReset}
-        onCancel={() => setResetTarget(null)}
-        destroyOnClose
-      >
-        <Form form={resetForm} layout="vertical" requiredMark={false}>
-          <Form.Item
-            label={t("mailboxestab.new_password")}
-            name="password"
-            tooltip={t("mailboxestab.leave_blank_to_auto_generate_auto_generated")}
-          >
-            <PasswordInput
-              autoComplete="new-password"
-              placeholder="(leave blank to auto-generate)"
-            />
-          </Form.Item>
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            Use the dice button to generate a strong password, or type your own.
-          </Typography.Text>
-        </Form>
-      </Modal>
 
       <MailboxPasswordRevealModal reveal={reveal} onClose={clearReveal} />
     </>


### PR DESCRIPTION
## Decision this implements

Per the product call on JAB-333: mailbox password rotation is **one-click reveal**, not a form; the tenant delete confirm stays a **modal**. This PR makes both true across all three inventories. (My earlier hand-off mislabeled the carried question as "SSH-key management" — it was always the mailbox inventories; the two answers only fit here. Flagging in case a different surface was meant.)

## What

The Mailbox Inventory module (`components/mail/mailboxInventory.tsx`) already shares the quota/status presentation, the safe webmail launcher (JAB-354), the password rotate → reveal-once core, and the delete mutation across the three surfaces — `admin/mail/AdminMailPage`, `user/mail/tabs/MailboxesTab`, `admin/domains/DomainMailboxesSection`. Two behavior copies were still hand-written per surface:

- **Rotate trigger**: admin + tenant opened a form modal collecting an optional custom password; the per-domain admin surface already rotated in one click. The form was the last copy of the trigger.
- **Tenant delete**: hand-rolled `feedback.modal.confirm` inside the action's `onClick`, instead of the declarative `RowActions` `confirm:` prop the other two surfaces pass.

## How

- **One-click rotate** on admin + tenant: the "Rotate password" action calls the shared `rotate()` directly — auto-generate on the server, reveal exactly once through `MailboxPasswordRevealModal`. Removed the per-surface reset `<Modal>` + `<Form>` + `<PasswordInput>` and their state.
- **Tenant delete de-dup**: the "Remove" action now passes the same declarative `confirm: { title, description, okText }` prop the admin + per-domain surfaces use (RowActions renders it via `feedback.modal.confirm`, a modal). Kept the tenant's richer `detail` error extraction in `onClick`.
- Rewrote the module comment that documented the form-vs-one-click split as *deliberate* — it no longer is.

**Not a capability removal**: the rotate endpoint still accepts a custom password — `new_password` stays on the shared `rotate()` and on the API/CLI, and the create wizard keeps its password field. This drops a UI affordance and removes the last place a human-typed weak password could enter on rotate (security-positive, consistent with the standing hardening rule).

## Scope / residual

- `useUpdateMailboxQuota` invalidates only the per-domain list key, unlike the other mutations which bust all three (`admin/mailboxes`, `me/mailboxes`, per-domain). It has **no callers** on these surfaces today, so it changes nothing here — noted as a harmless cleanup, not fixed in this PR.
- `AdminMailPage`'s generic "Failed to delete" (vs the tenant/per-domain `detail` extraction) is pre-existing and left as-is.

## Tests

- `mailboxInventorySurfaces.wiring.test.tsx` (new): pins that both surfaces rotate on one click through the shared hook (no reset form) and that the tenant delete routes through the shared declarative confirm (no hand-rolled modal). The removed strings (`feedback.modal.confirm`, `PasswordInput`, `setResetTarget`) all existed on `main`, so the guards are non-vacuous — verified by reintroducing one and watching the pin redden.
- The rotate / reveal / delete behavior itself stays covered by `mailboxInventory.test.tsx` and `useMailboxes.test.tsx`.
- Full panel-ui vitest (113 files, 651 tests) and `tsc -b` pass. No E2E coupling (no Playwright test references the reset form). No box — pure frontend; `dist` is CI-built, not committed.

## JAB-333 acceptance criteria — all four now hold

1. **Shared quota/status/action semantics** — quota/status renderers, webmail launcher, one-click rotate, and declarative delete confirm are now identical across all three. ✓
2. **Every webmail launch uses opener isolation** — shipped (JAB-330/354); all three route through `useMailboxWebmail`. ✓
3. **Mutations invalidate the correct shared keys** — create/delete/update bust all three list keys (centralized in `hooks/useMailboxes.ts`); the one narrow mutation is unused. ✓
4. **Admin owner filter / tenant groups + autoresponders / domain enable-email remain explicit** — all adapter-owned, unchanged. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
