### PR TITLE
feat(domains): tenant Web Domain page with tabbed per-domain actions (GH #1543)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -86,6 +86,7 @@ const UserDashboard = lazy(() => import("./shells/user/UserDashboard").then((m) 
 const FileManagerPage = lazy(() => import("./shells/user/files/FileManagerPage").then((m) => ({ default: m.FileManagerPage })));
 const AdminFileManagerPage = lazy(() => import("./shells/admin/files/AdminFileManagerPage").then((m) => ({ default: m.AdminFileManagerPage })));
 const UserDomainList = lazy(() => import("./shells/user/domains/UserDomainList").then((m) => ({ default: m.UserDomainList })));
+const WebDomainPage = lazy(() => import("./shells/user/domains/WebDomainPage").then((m) => ({ default: m.WebDomainPage })));
 const UserDatabasesPage = lazy(() => import("./shells/user/databases/UserDatabasesPage").then((m) => ({ default: m.UserDatabasesPage })));
 const DNSRecordsPage = lazy(() => import("./shells/dns/DNSRecordsPage").then((m) => ({ default: m.DNSRecordsPage })));
 const DNSZonesOverviewPage = lazy(() => import("./shells/admin/dns/DNSZonesOverviewPage").then((m) => ({ default: m.DNSZonesOverviewPage })));
@@ -363,7 +364,12 @@ const ThemedApp = () => {
             <Route path="domains">
               <Route index element={<UserDomainList />} />
               <Route path="create" element={<Navigate to="../domains" replace />} />
+              {/* Static :id/dns outranks the dynamic :id/:tab (GH #1543 folds DNS
+                  into a tab in a follow-up); the tabbed Web Domain page owns the
+                  rest. */}
               <Route path=":id/dns" element={<DNSRecordsPage />} />
+              <Route path=":id" element={<WebDomainPage />} />
+              <Route path=":id/:tab" element={<WebDomainPage />} />
             </Route>
             <Route path="databases">
               <Route index element={<UserDatabasesPage />} />

--- a/panel-ui/src/components/domains/domainColumns.tsx
+++ b/panel-ui/src/components/domains/domainColumns.tsx
@@ -8,7 +8,7 @@
 import { Link } from "react-router";
 import { Tag, Tooltip, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { GlobalOutlined } from "@icons";
+import { GlobalOutlined, ExportOutlined } from "@icons";
 import { columnSearchProps } from "../columnSearch";
 import { humanBytes } from "../../utils/bytes";
 import { getSSLTag } from "../../utils/sslState";
@@ -31,18 +31,37 @@ const stripHomePrefix = (path: string): string => {
 
 // The name/docroot cell. The unified docroot line uses the admin list's
 // ellipsis + maxWidth so a long path can't stretch the column on either screen.
+// GH #1543: on the tenant list the name opens the domain's own Web Domain page
+// (an internal Link), with a separate launch icon still opening the live site;
+// the admin name keeps opening the live site directly, since admin edits a
+// domain from its own Edit page via the row menu.
 const renderDomainCell = (record: Domain, audience: DomainInventoryAudience) => (
   <div>
     <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
       <GlobalOutlined />
-      <Typography.Link
-        href={`https://${record.name}/`}
-        target="_blank"
-        rel="noopener noreferrer"
-        title={`Open https://${record.name}/ in a new tab`}
-      >
-        {record.name}
-      </Typography.Link>
+      {audience.kind === "tenant" ? (
+        <>
+          <Link to={`/jabali-panel/domains/${record.id}`}>{record.name}</Link>
+          <Typography.Link
+            href={`https://${record.name}/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`Open https://${record.name}/ in a new tab`}
+            aria-label={`Open https://${record.name}/ in a new tab`}
+          >
+            <ExportOutlined />
+          </Typography.Link>
+        </>
+      ) : (
+        <Typography.Link
+          href={`https://${record.name}/`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`Open https://${record.name}/ in a new tab`}
+        >
+          {record.name}
+        </Typography.Link>
+      )}
       {audience.kind === "admin" && record.is_panel_primary && <Tag color="purple">System</Tag>}
       {audience.kind === "admin" && record.is_quota_suspended && (
         <Tag color="orange">Suspended (quota)</Tag>

--- a/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
@@ -94,6 +94,22 @@ describe("UserDomainList DNS action gating (GH #1419)", () => {
   });
 });
 
+// GH #1543: on the tenant list the domain name links to its own Web Domain
+// page (not the live site); a separate launch icon still opens the live site.
+describe("UserDomainList domain name link (GH #1543)", () => {
+  it("links the domain name to its Web Domain page", async () => {
+    render(
+      <MemoryRouter>
+        <App>
+          <UserDomainList />
+        </App>
+      </MemoryRouter>,
+    );
+    const nameLink = await screen.findByRole("link", { name: "site.tld" });
+    expect(nameLink).toHaveAttribute("href", "/jabali-panel/domains/d1");
+  });
+});
+
 // GH #1541: the old "Add" split (Web / DNS / Mail) is replaced by a single
 // "Add Web Domain" button that opens the drawer in web mode.
 describe("UserDomainList Add Web Domain button (GH #1541)", () => {

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -1,0 +1,142 @@
+// WebDomainPage.test — GH #1543. The tenant Web Domain page: the URL :tab picks
+// the active pane, an unknown/absent tab falls back to Overview, the breadcrumb
+// trail ends at the domain name, a tab click navigates to that tab's URL, and a
+// domain the caller can't load surfaces an error (never a blank scoped view).
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigate = vi.hoisted(() => vi.fn());
+const setBreadcrumbs = vi.hoisted(() => vi.fn());
+const domainQ = vi.hoisted(() => ({
+  value: {
+    data: {
+      id: "d1",
+      name: "site.tld",
+      doc_root: "/home/alice/site.tld/public_html",
+      ssl_state: "active",
+      is_enabled: true,
+      temp_url_enabled: false,
+      temp_url: "",
+      bot_challenge_include: false,
+      reverse_proxy_port: null,
+    } as Record<string, unknown> | undefined,
+    isLoading: false,
+    isError: false,
+  },
+}));
+const patch = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return { ...actual, useNavigate: () => navigate };
+});
+vi.mock("../../../components/admin/BreadcrumbContext", () => ({
+  useSetBreadcrumbs: (c: unknown) => setBreadcrumbs(c),
+}));
+vi.mock("../../../hooks/useQueries", () => ({
+  useOneQuery: () => domainQ.value,
+}));
+vi.mock("../../../components/DomainCacheSection", () => ({
+  DomainCacheSection: ({ domainId }: { domainId: string }) => <div>caching-pane:{domainId}</div>,
+}));
+vi.mock("../../admin/domains/DomainDirectoryPrivacySection", () => ({
+  DomainDirectoryPrivacySection: ({ domainId }: { domainId: string }) => (
+    <div>dirpriv-pane:{domainId}</div>
+  ),
+}));
+vi.mock("../../../apiClient", () => ({ apiClient: { patch } }));
+vi.mock("../../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+
+import { WebDomainPage } from "./WebDomainPage";
+
+function renderAt(path: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/jabali-panel/domains/:id" element={<WebDomainPage />} />
+          <Route path="/jabali-panel/domains/:id/:tab" element={<WebDomainPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  navigate.mockReset();
+  setBreadcrumbs.mockReset();
+  patch.mockReset();
+  patch.mockResolvedValue({});
+  domainQ.value = {
+    data: {
+      id: "d1",
+      name: "site.tld",
+      doc_root: "/home/alice/site.tld/public_html",
+      ssl_state: "active",
+      is_enabled: true,
+      temp_url_enabled: false,
+      temp_url: "",
+      bot_challenge_include: false,
+      reverse_proxy_port: null,
+    },
+    isLoading: false,
+    isError: false,
+  };
+});
+
+describe("WebDomainPage (GH #1543)", () => {
+  it("defaults to the Overview pane with the domain facts and the two toggles", async () => {
+    renderAt("/jabali-panel/domains/d1");
+    expect(await screen.findByText("Preview URL")).toBeInTheDocument();
+    expect(screen.getByText("Bot-detection challenge")).toBeInTheDocument();
+    // Facts: the docroot is shown home-stripped.
+    expect(screen.getByText("site.tld/public_html")).toBeInTheDocument();
+  });
+
+  it("falls back to Overview for an unknown tab", async () => {
+    renderAt("/jabali-panel/domains/d1/bogus");
+    expect(await screen.findByText("Preview URL")).toBeInTheDocument();
+  });
+
+  it("renders the Caching pane when :tab=caching", async () => {
+    renderAt("/jabali-panel/domains/d1/caching");
+    expect(await screen.findByText("caching-pane:d1")).toBeInTheDocument();
+  });
+
+  it("renders the Directory Privacy pane when :tab=directory-privacy", async () => {
+    renderAt("/jabali-panel/domains/d1/directory-privacy");
+    expect(await screen.findByText("dirpriv-pane:d1")).toBeInTheDocument();
+  });
+
+  it("sets the breadcrumb trail ending at the domain name", async () => {
+    renderAt("/jabali-panel/domains/d1");
+    await screen.findByText("Preview URL");
+    const crumbs = setBreadcrumbs.mock.calls.at(-1)?.[0] as { title: string }[];
+    expect(crumbs.map((c) => c.title)).toEqual(["Dashboard", "Web Domains", "site.tld"]);
+  });
+
+  it("navigates to the tab URL when a tab is clicked", async () => {
+    renderAt("/jabali-panel/domains/d1");
+    fireEvent.click(await screen.findByText("Caching"));
+    expect(navigate).toHaveBeenCalledWith("/jabali-panel/domains/d1/caching");
+  });
+
+  it("toggling Preview URL PATCHes the domain", async () => {
+    renderAt("/jabali-panel/domains/d1");
+    fireEvent.click(await screen.findByLabelText("Preview URL"));
+    await vi.waitFor(() =>
+      expect(patch).toHaveBeenCalledWith("/domains/d1", { temp_url_enabled: true }),
+    );
+  });
+
+  it("surfaces an error when the domain can't be loaded", async () => {
+    domainQ.value = { data: undefined, isLoading: false, isError: true };
+    renderAt("/jabali-panel/domains/d1");
+    expect(await screen.findByText("Domain not available")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -1,0 +1,117 @@
+// WebDomainPage — GH #1543 (johnnyq): clicking a domain in the tenant Web
+// Domains list opens this dedicated page. Its per-domain actions are organised
+// as navigable tabs (like the admin Edit Domain page) rather than a row of
+// modal launchers. The tab lives in the URL (:tab), so a tab is linkable and
+// the browser Back button walks the tabs.
+//
+// Slice A (this PR) lands the shell + row-click navigation + breadcrumbs and
+// three panes that need no extraction: Overview (facts + the preview-URL /
+// bot-challenge toggles), Caching and Directory Privacy (both already shared
+// Section components). The remaining actions (Redirects, Index, Domain options,
+// Rewrite rules, Document root) and folding DNS in move here in a follow-up,
+// which also strips the row menu down to Disable/Delete.
+import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
+import { GlobalOutlined } from "@icons";
+import { useNavigate, useParams } from "react-router";
+
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
+import { useOneQuery } from "../../../hooks/useQueries";
+import type { Domain } from "../../../components/domains/types";
+import { DomainCacheSection } from "../../../components/DomainCacheSection";
+import { DomainDirectoryPrivacySection } from "../../admin/domains/DomainDirectoryPrivacySection";
+import { OverviewTab } from "./tabs/OverviewTab";
+
+const TAB_KEYS = ["overview", "caching", "directory-privacy"] as const;
+type TabKey = (typeof TAB_KEYS)[number];
+const DEFAULT_TAB: TabKey = "overview";
+
+const TAB_LABELS: Record<TabKey, string> = {
+  overview: "Overview",
+  caching: "Caching",
+  "directory-privacy": "Directory Privacy",
+};
+
+const LIST_PATH = "/jabali-panel/domains";
+
+export const WebDomainPage = () => {
+  const { id, tab } = useParams<{ id: string; tab?: string }>();
+  const navigate = useNavigate();
+
+  const domainQ = useOneQuery<Domain>({ resource: "domains", id });
+  const activeKey: TabKey = (TAB_KEYS as readonly string[]).includes(tab ?? "")
+    ? (tab as TabKey)
+    : DEFAULT_TAB;
+
+  // The shell already renders ONE breadcrumb (RouteBreadcrumb, GH #455). Override
+  // it with the entity trail so the last crumb is the domain name, not the raw
+  // :id — same approach as MailDomainPage (GH #1387).
+  const domainName = domainQ.data?.name;
+  useSetBreadcrumbs(
+    domainName
+      ? [
+          { title: "Dashboard", href: "/jabali-panel/dashboard" },
+          { title: "Web Domains", href: LIST_PATH },
+          { title: domainName },
+        ]
+      : null,
+  );
+
+  const back = () => navigate(LIST_PATH);
+
+  if (domainQ.isLoading) {
+    return (
+      <div style={{ padding: 20 }}>
+        <Skeleton active />
+      </div>
+    );
+  }
+  if (domainQ.isError || !domainQ.data) {
+    // Owner-scoped GET /domains/:id returns 403/404 for a domain the caller does
+    // not own — surface it as an error, never a blank scoped view.
+    return (
+      <div style={{ padding: 20 }}>
+        <Alert
+          type="error"
+          showIcon
+          message="Domain not available"
+          description="This domain doesn't exist or you don't have access to it."
+          action={<Button onClick={back}>Back to Web Domains</Button>}
+        />
+      </div>
+    );
+  }
+  const domain = domainQ.data;
+
+  const renderTab = () => {
+    switch (activeKey) {
+      case "overview":
+        return <OverviewTab domain={domain} />;
+      case "caching":
+        return <DomainCacheSection domainId={domain.id} />;
+      case "directory-privacy":
+        return <DomainDirectoryPrivacySection domainId={domain.id} domainName={domain.name} />;
+    }
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <Space
+        wrap
+        align="center"
+        style={{ marginBottom: 16, width: "100%", justifyContent: "space-between" }}
+      >
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          <GlobalOutlined /> {domain.name}
+        </Typography.Title>
+      </Space>
+
+      <Card
+        tabList={TAB_KEYS.map((k) => ({ key: k, tab: TAB_LABELS[k] }))}
+        activeTabKey={activeKey}
+        onTabChange={(k) => navigate(`${LIST_PATH}/${domain.id}/${k}`)}
+      >
+        {renderTab()}
+      </Card>
+    </div>
+  );
+};

--- a/panel-ui/src/shells/user/domains/tabs/OverviewTab.tsx
+++ b/panel-ui/src/shells/user/domains/tabs/OverviewTab.tsx
@@ -1,0 +1,132 @@
+// OverviewTab — the landing pane of the tenant Web Domain page (GH #1543).
+// Shows the domain's key facts and the two instant per-domain toggles that
+// were previously buried in the row's "Actions" menu (preview URL, bot
+// challenge). Both PATCH /domains/:id and invalidate the single-row + list
+// caches so the badge and the list stay in step, mirroring the DomainInventory
+// row handlers.
+import { useState } from "react";
+import { Descriptions, Space, Switch, Tag, Typography } from "antd";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../../../apiClient";
+import { feedback } from "../../../../lib/feedback";
+import { getSSLTag } from "../../../../utils/sslState";
+import type { Domain } from "../../../../components/domains/types";
+
+const stripHomePrefix = (path: string): string => {
+  if (path.startsWith("/home/")) {
+    const match = path.match(/^\/home\/[^/]+\/(.*)/);
+    return match ? match[1] : path;
+  }
+  return path;
+};
+
+export const OverviewTab = ({ domain }: { domain: Domain }) => {
+  const qc = useQueryClient();
+  const [busy, setBusy] = useState<null | "preview" | "bot">(null);
+
+  const patch = async (
+    field: "preview" | "bot",
+    body: Record<string, unknown>,
+    success: string,
+    errorPrefix: string,
+  ) => {
+    setBusy(field);
+    try {
+      await apiClient.patch(`/domains/${domain.id}`, body);
+      feedback.message.success(success);
+      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      feedback.message.error(
+        `${errorPrefix}: ${e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message}`,
+      );
+      // A long agent call can apply the change and still return 5xx; refetch so
+      // the toggle reflects the server, not the optimistic local value.
+      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const togglePreview = (next: boolean) =>
+    patch(
+      "preview",
+      { temp_url_enabled: next },
+      next ? "Preview URL enabled — live within a minute" : "Preview URL disabled",
+      "Failed to toggle preview URL",
+    );
+
+  const toggleBot = (next: boolean) =>
+    patch(
+      "bot",
+      { bot_challenge_include: next },
+      next
+        ? "Bot-detection challenge enabled — active within a minute if the server is in Selected-domains mode"
+        : "Bot-detection challenge disabled for this site",
+      "Failed to toggle bot challenge",
+    );
+
+  const ssl = getSSLTag(domain.ssl_state);
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: "100%" }}>
+      <Descriptions column={1} size="small" bordered>
+        <Descriptions.Item label="Status">
+          {domain.is_enabled ? <Tag color="green">Enabled</Tag> : <Tag color="red">Disabled</Tag>}
+        </Descriptions.Item>
+        <Descriptions.Item label="SSL">
+          <Tag color={ssl.color}>{ssl.label}</Tag>
+        </Descriptions.Item>
+        <Descriptions.Item label="Document root">
+          <Typography.Text code>{stripHomePrefix(domain.doc_root)}</Typography.Text>
+        </Descriptions.Item>
+        {domain.reverse_proxy_port ? (
+          <Descriptions.Item label="Reverse proxy">
+            <Typography.Text>Port {domain.reverse_proxy_port}</Typography.Text>
+          </Descriptions.Item>
+        ) : null}
+        {domain.temp_url_enabled && domain.temp_url ? (
+          <Descriptions.Item label="Preview URL">
+            <Typography.Link href={domain.temp_url} target="_blank" rel="noopener noreferrer">
+              {domain.temp_url}
+            </Typography.Link>
+          </Descriptions.Item>
+        ) : null}
+      </Descriptions>
+
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Space align="center">
+          <Switch
+            checked={!!domain.temp_url_enabled}
+            loading={busy === "preview"}
+            onChange={togglePreview}
+            aria-label="Preview URL"
+          />
+          <div>
+            <Typography.Text strong>Preview URL</Typography.Text>
+            <Typography.Paragraph type="secondary" style={{ margin: 0, fontSize: 13 }}>
+              A temporary hostname to preview the site before DNS points at the server.
+            </Typography.Paragraph>
+          </div>
+        </Space>
+
+        <Space align="center">
+          <Switch
+            checked={!!domain.bot_challenge_include}
+            loading={busy === "bot"}
+            onChange={toggleBot}
+            aria-label="Bot-detection challenge"
+          />
+          <div>
+            <Typography.Text strong>Bot-detection challenge</Typography.Text>
+            <Typography.Paragraph type="secondary" style={{ margin: 0, fontSize: 13 }}>
+              Challenge suspicious visitors when the server runs in Selected-domains mode.
+            </Typography.Paragraph>
+          </div>
+        </Space>
+      </Space>
+    </Space>
+  );
+};


### PR DESCRIPTION
## What & why

GH #1543 (johnnyq): clicking a domain in the tenant **Web Domains** list now
opens a dedicated **Web Domain page** whose per-domain actions live as
navigable tabs — modeled on the admin Edit Domain page and the tenant Mail
Domain page — instead of a row of modal launchers. The active tab lives in the
URL (`:tab`), so a tab is linkable and the browser Back button walks the tabs.

## Scope — first slice (of the #1543 epic)

#1543 is a 5-part restructure. This PR is the **foundation slice**, agreed to
ship on its own so the shape can be confirmed before the rest pours in:

**Here now**
- `WebDomainPage` at `/jabali-panel/domains/:id/:tab?` (owner-scoped
  `GET /domains/:id`; a foreign id renders an error, never a blank scoped view).
- Row-click: on the tenant list the domain **name** links to its Web Domain
  page; a separate launch icon still opens the live site. The admin name is
  unchanged (admin edits via its own Edit page).
- Breadcrumb trail Dashboard → Web Domains → *domain*.
- Three tabs that need no extraction: **Overview** (domain facts + the
  preview-URL / bot-challenge toggles), **Caching** and **Directory Privacy**
  (both already shared `Section` components, rendered inline).

**Deferred to follow-up slices** (called out so a reviewer opening the page
knows why Redirects isn't there yet)
- Extract Redirects / Index / Domain options / Rewrite rules / Document root
  into inline panes, and fold DNS in as a tab (the static `:id/dns` route
  currently outranks the dynamic `:id/:tab`, so today's DNS menu target is
  unchanged).
- **Strip the row "Actions" menu down to Disable/Delete** — until every action
  has a pane, the menu keeps its full item set, so nothing regresses. The two
  toggles and Caching/Directory-Privacy are reachable both ways during the
  transition.
- Then: move Logs/Statistics + PHP Settings in, and merge One-Click PHP Apps
  into the list.

## Notes

- The Overview toggles `PATCH /domains/:id` and invalidate the single-row +
  list caches, matching the `DomainInventory` row handlers. They also refetch
  on error, since a long agent call can apply the change and still return 5xx.
- The inlined `DomainCacheSection` / `DomainDirectoryPrivacySection` render no
  heading of their own, so there's no double header under the tab strip.

## Tests

- `WebDomainPage.test.tsx`: `:tab` selects the pane, an unknown/absent tab
  falls back to Overview, the breadcrumb trail ends at the domain name, a tab
  click navigates to that tab's URL, the Preview-URL toggle PATCHes, and an
  unloadable domain surfaces an error.
- `UserDomainList.test.tsx`: the tenant domain name links to its Web Domain page.
- `tsc -b`, `eslint`, and the two vitest suites are green post-rebase onto
  `origin/main`.

GH #1543