### PR TITLE
fix(files): fail closed when the CLI stat reply is malformed (JAB-340)

### DIFF
--- a/panel-api/cmd/server/files_cmd.go
+++ b/panel-api/cmd/server/files_cmd.go
@@ -259,6 +259,13 @@ func newFilesStatCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Validate the reply fails-closed before printing it: a malformed or
+			// empty stat body must be an error, not an exit-0 pass-through of the
+			// raw bytes. On success we print the original raw JSON so operator
+			// output stays byte-for-byte stable.
+			if _, err := filesops.DecodeStat(raw); err != nil {
+				return err
+			}
 			os.Stdout.Write(raw)
 			fmt.Println()
 			return nil

--- a/panel-api/cmd/server/files_cmd_stat_test.go
+++ b/panel-api/cmd/server/files_cmd_stat_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// JAB-340 / AC2: the CLI `files stat` command used to print the raw agent reply
+// straight to stdout and exit 0, so a malformed or empty stat body looked like a
+// success. It must now validate the reply through the shared fail-closed decoder
+// before printing. Source-pin the wiring: DecodeStat(raw) is called, and it runs
+// BEFORE the raw bytes are written, so a decode failure short-circuits the print.
+func TestFilesStat_DecodesReplyBeforePrinting(t *testing.T) {
+	src, err := os.ReadFile("files_cmd.go")
+	if err != nil {
+		t.Fatalf("read files_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	decodeIdx := strings.Index(s, "filesops.DecodeStat(raw)")
+	if decodeIdx < 0 {
+		t.Fatal("files stat must validate the agent reply via filesops.DecodeStat(raw) before printing (JAB-340 AC2)")
+	}
+	printIdx := strings.Index(s, "os.Stdout.Write(raw)")
+	if printIdx < 0 {
+		t.Fatal("expected stat to print the raw reply on success")
+	}
+	if decodeIdx > printIdx {
+		t.Fatal("filesops.DecodeStat(raw) must run BEFORE os.Stdout.Write(raw); a malformed reply must not be printed as an exit-0 success")
+	}
+}

--- a/panel-api/internal/filesops/decode.go
+++ b/panel-api/internal/filesops/decode.go
@@ -47,6 +47,16 @@ type ArchiveResult struct {
 	Size        int64  `json:"size"`
 }
 
+// StatResult is a decoded files.stat reply. Mirrors the agent's stat output.
+type StatResult struct {
+	Path      string `json:"path"`
+	Size      int64  `json:"size"`
+	Mode      string `json:"mode"`
+	IsDir     bool   `json:"is_dir"`
+	ModTime   string `json:"mod_time"`
+	IsSymlink bool   `json:"is_symlink"`
+}
+
 // ErrTruncated reports that a full-content read came back truncated because the
 // file exceeds the agent's read cap. Callers that need the whole file (download,
 // CLI read/download) turn this into a failure so a partial file is never written
@@ -57,6 +67,15 @@ var ErrTruncated = errors.New("file exceeds the read limit and was truncated by 
 // ErrNoArchivePath reports that a files.archive reply decoded cleanly but named
 // no archive — an empty archive_path, which cannot be streamed back.
 var ErrNoArchivePath = errors.New("agent did not return an archive path")
+
+// ErrNoStatMode reports that a files.stat reply decoded cleanly but carried no
+// file mode. Mode is the field a successful stat can never omit: the agent sets
+// it from FileInfo.Mode().String(), which is never the empty string for a real
+// file. An empty mode therefore means the body was not a stat result at all — an
+// agent error blob, or a JSON null, decoding into a zero-valued struct. (Path is
+// only a normalized echo of the caller's input, so it is the weaker identity
+// field to hang this check on.)
+var ErrNoStatMode = errors.New("agent did not return a file mode for the stat")
 
 // DecodeList decodes a files.list reply, failing closed on a malformed body.
 func DecodeList(raw []byte) (ListResult, error) {
@@ -87,6 +106,19 @@ func DecodeArchive(raw []byte) (ArchiveResult, error) {
 	}
 	if r.ArchivePath == "" {
 		return ArchiveResult{}, ErrNoArchivePath
+	}
+	return r, nil
+}
+
+// DecodeStat decodes a files.stat reply, failing closed on a malformed body or a
+// reply that carries no file mode (see ErrNoStatMode).
+func DecodeStat(raw []byte) (StatResult, error) {
+	var r StatResult
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return StatResult{}, fmt.Errorf("decode files.stat reply: %w", err)
+	}
+	if r.Mode == "" {
+		return StatResult{}, ErrNoStatMode
 	}
 	return r, nil
 }

--- a/panel-api/internal/filesops/decode_test.go
+++ b/panel-api/internal/filesops/decode_test.go
@@ -80,3 +80,29 @@ func TestDecodeArchive(t *testing.T) {
 		t.Fatalf("DecodeArchive decoded wrong: %+v", got)
 	}
 }
+
+func TestDecodeStat(t *testing.T) {
+	// Malformed body fails closed with a decode error, never a zero success.
+	if _, err := DecodeStat([]byte(`{`)); err == nil {
+		t.Fatal("DecodeStat(malformed) = nil error, want a decode error")
+	}
+	// AC2, load-bearing: an agent error blob is valid JSON but not a stat — it
+	// decodes to a zero-valued struct with an empty mode and must fail closed.
+	if _, err := DecodeStat([]byte(`{"error":"boom"}`)); !errors.Is(err, ErrNoStatMode) {
+		t.Fatalf("DecodeStat(error blob) = %v, want ErrNoStatMode", err)
+	}
+	// JSON null Unmarshals into a struct without error, leaving a zero value.
+	// The mode guard — not Unmarshal — is what rejects it, so this row proves
+	// the guard is load-bearing.
+	if _, err := DecodeStat([]byte(`null`)); !errors.Is(err, ErrNoStatMode) {
+		t.Fatalf("DecodeStat(null) = %v, want ErrNoStatMode", err)
+	}
+	got, err := DecodeStat([]byte(`{"path":"/home/shuki/f.txt","size":7,"mode":"-rw-r--r--","is_dir":false,"mod_time":"2026-01-02T03:04:05Z","is_symlink":true}`))
+	if err != nil {
+		t.Fatalf("DecodeStat(valid): %v", err)
+	}
+	if got.Path != "/home/shuki/f.txt" || got.Size != 7 || got.Mode != "-rw-r--r--" ||
+		got.IsDir || got.ModTime != "2026-01-02T03:04:05Z" || !got.IsSymlink {
+		t.Fatalf("DecodeStat decoded wrong: %+v", got)
+	}
+}


### PR DESCRIPTION
## What

The `files stat` CLI command wrote the raw agent reply straight to stdout and exited 0. A malformed or empty stat reply — an agent error blob, a JSON `null`, truncated JSON — therefore looked like a successful stat. This was the **last raw pass-through success path** among the CLI file verbs: `list`, `read`/`download`, and `archive` already decode through the shared `filesops` fail-closed decoders; `stat` was the one that didn't.

This closes that gap for JAB-340 AC #2 ("malformed Agent replies never become success").

## How

- **`filesops.DecodeStat` + `StatResult`** (`panel-api/internal/filesops/decode.go`): mirrors the existing `DecodeList` / `DecodeRead` / `DecodeArchive` shape and the agent's stat output (`path`, `size`, `mode`, `is_dir`, `mod_time`, `is_symlink`). Fails closed on a malformed body and on a reply that carries no file **mode**.
  - Mode is the reply's required identity field: the agent always sets it from `FileInfo.Mode().String()` for a real stat, so an empty mode means the body was not a stat result at all (error blob / `null` → zero-valued struct). Guarding on **mode rather than path** avoids a false failure on the jail root, whose normalized path can legitimately decode to empty.
- **CLI wiring** (`panel-api/cmd/server/files_cmd.go`): `stat` now calls `DecodeStat(raw)` before printing. On success it still writes the **original raw JSON** so operator output stays byte-for-byte stable; on a decode failure it returns the error instead of a silent exit 0.

## Scope

- Panel/CLI-side only. The agent `files.stat` verb and its reply shape are unchanged — no box. `files.stat` has no HTTP endpoint (CLI-only verb), so this is a CLI-adapter fix.
- No new subcommand or flag → `cli-reference.md` golden is unchanged (`TestCLIReferenceGolden` still passes).
- Additive: new `StatResult` / `DecodeStat` / `ErrNoStatMode` plus one call site. No existing symbol changed.

## Tests

- `TestDecodeStat`: valid round-trip (all six fields), malformed body → decode error, agent error blob → `ErrNoStatMode`, JSON `null` → `ErrNoStatMode`. The last two prove the mode guard is load-bearing — both decode cleanly into a zero-valued struct, so only the guard rejects them. Falsified by removing the guard (both rows red).
- `TestFilesStat_DecodesReplyBeforePrinting`: source-pins that the CLI calls `filesops.DecodeStat(raw)` **before** `os.Stdout.Write(raw)`. Non-vacuous — neither the call nor the ordering existed on `main`; falsified by removing the call (pin red).
- `go test ./internal/filesops/ ./cmd/server/` and `go vet` pass; server binary builds.

## JAB-340 acceptance criteria

This ships **AC #2** (fail-closed replies) for the `stat` verb — the remaining raw pass-through. The other ACs (parity table, shared rename/move/copy validation, truncated-read consistency, adapter separation) are separate slices; the ticket stays open as the multi-slice parent. AC status walk is in the Plane comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
