### PR TITLE
feat(domains): per-domain settings as Web Domain tabs — Index, Document root, Domain options, Rewrite rules (GH #1543)

### DIFF
--- a/panel-ui/src/components/DomainNginxOptionsModal.tsx
+++ b/panel-ui/src/components/DomainNginxOptionsModal.tsx
@@ -1,134 +1,27 @@
+// DomainNginxOptionsModal — the row-menu launcher for the curated nginx options
+// (GH #307). The form body now lives in DomainNginxOptionsPanel (GH #1543); this
+// wrapper owns only the Modal chrome and delegates with footer={null}.
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
-import { Checkbox, Form, InputNumber, Modal, Select, Typography } from "antd";
-import { feedback } from "../lib/feedback"; // GH #970: themed toasts
+import { Modal } from "antd";
 
-import { apiClient } from "../apiClient";
-
-interface SafeOptions {
-  max_body_mb?: number;
-  hsts?: boolean;
-  security_headers?: boolean;
-  gzip?: boolean;
-  // GH #879 tri-state: absent/null = inherit the server-wide default
-  // (Server Settings → Page Templates), true/false = force per-domain.
-  intercept_errors?: boolean | null;
-  // GH #962: PATH_INFO support for front-controller PHP apps (osTicket, …).
-  path_info?: boolean;
-}
-
-// The form's Select uses string values; map to the wire tri-state.
-type InterceptChoice = "inherit" | "on" | "off";
-const interceptToChoice = (v: boolean | null | undefined): InterceptChoice =>
-  v === true ? "on" : v === false ? "off" : "inherit";
-const choiceToIntercept = (c: InterceptChoice | undefined): boolean | null =>
-  c === "on" ? true : c === "off" ? false : null;
+import { DomainNginxOptionsPanel } from "./DomainNginxOptionsPanel";
 
 export interface DomainNginxOptionsModalProps {
   domainId: string;
   onClose: () => void;
 }
 
-// DomainNginxOptionsModal — tenant-facing curated nginx options (GH #307).
-// Only mounted when the admin has enabled tenant_domain_options_enabled. The
-// panel renders these to fixed, vetted directives; no raw config.
 export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOptionsModalProps) => {
   const { t } = useTranslation();
-  const [form] = Form.useForm<SafeOptions & { intercept_choice?: InterceptChoice }>();
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const resp = await apiClient.get<{ nginx_safe_options?: SafeOptions }>(`/domains/${domainId}`);
-        if (!cancelled) {
-          const opts = resp.data.nginx_safe_options ?? {};
-          form.setFieldsValue({
-            ...opts,
-            intercept_choice: interceptToChoice(opts.intercept_errors),
-          });
-        }
-      } catch {
-        if (!cancelled) feedback.message.error("Failed to load domain options");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [domainId, form]);
-
-  const onOk = async () => {
-    const values = await form.validateFields();
-    setSaving(true);
-    try {
-      await apiClient.patch(`/domains/${domainId}`, {
-        nginx_safe_options: {
-          max_body_mb: values.max_body_mb ?? 0,
-          hsts: !!values.hsts,
-          security_headers: !!values.security_headers,
-          gzip: !!values.gzip,
-          intercept_errors: choiceToIntercept(values.intercept_choice),
-          path_info: !!values.path_info,
-        },
-      });
-      feedback.message.success("Domain options saved — applied on the next reconcile");
-      onClose();
-    } catch {
-      feedback.message.error("Failed to save domain options");
-    } finally {
-      setSaving(false);
-    }
-  };
-
   return (
-    <Modal open title={t("domainnginxoptionsmodal.domain_options")} onCancel={onClose} onOk={onOk} confirmLoading={saving} okText={t("domainnginxoptionsmodal.save")}>
-      <Typography.Paragraph type="secondary">
-        Safe nginx options for this domain. The panel renders fixed directives —
-        no raw config.
-      </Typography.Paragraph>
-      <Form<SafeOptions> form={form} layout="vertical" disabled={loading}>
-        <Form.Item
-          name="max_body_mb"
-          label={t("domainnginxoptionsmodal.max_upload_size_mb")}
-          tooltip="client_max_body_size. 0 = use the default."
-        >
-          <InputNumber min={0} max={10240} style={{ width: "100%" }} placeholder="0" />
-        </Form.Item>
-        <Form.Item name="hsts" valuePropName="checked">
-          <Checkbox>Enable HSTS (Strict-Transport-Security)</Checkbox>
-        </Form.Item>
-        <Form.Item name="security_headers" valuePropName="checked">
-          <Checkbox>Add security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy)</Checkbox>
-        </Form.Item>
-        <Form.Item name="gzip" valuePropName="checked">
-          <Checkbox>Enable gzip compression for text content</Checkbox>
-        </Form.Item>
-        <Form.Item
-          name="path_info"
-          valuePropName="checked"
-          tooltip="Some PHP apps route requests through /script.php/extra/path URLs (osTicket's /scp/ajax.php/…, and similar front-controller apps). The default nginx config only serves URLs ending in .php, so those requests fail. Turn this on for apps that need PATH_INFO. Leave off otherwise — plain PHP sites (WordPress, etc.) don't need it."
-        >
-          <Checkbox>Enable PATH_INFO for front-controller apps (osTicket, etc.)</Checkbox>
-        </Form.Item>
-        <Form.Item
-          name="intercept_choice"
-          label="Branded error page when the application fails (500-class errors)"
-          tooltip="A crashed PHP script normally returns an empty 500, so visitors see the browser's raw error screen. When on, nginx serves the branded 500 page instead (editable under Server Settings → Page Templates); the site keeps its own 404/403 pages. Apps that render their own error screens (e.g. WordPress's recovery notice) or return JSON errors will show the branded page instead — turn it off for those. 'Server default' follows the switch under Server Settings → Page Templates."
-          initialValue="inherit"
-        >
-          <Select
-            options={[
-              { value: "inherit", label: "Server default" },
-              { value: "on", label: "On" },
-              { value: "off", label: "Off" },
-            ]}
-          />
-        </Form.Item>
-      </Form>
+    <Modal
+      open
+      title={t("domainnginxoptionsmodal.domain_options")}
+      onCancel={onClose}
+      footer={null}
+      destroyOnClose
+    >
+      <DomainNginxOptionsPanel domainId={domainId} onSaved={onClose} />
     </Modal>
   );
 };

--- a/panel-ui/src/components/DomainNginxOptionsPanel.tsx
+++ b/panel-ui/src/components/DomainNginxOptionsPanel.tsx
@@ -1,0 +1,144 @@
+// DomainNginxOptionsPanel — tenant-facing curated nginx options (GH #307),
+// extracted from DomainNginxOptionsModal (GH #1543) so it renders both inline
+// (a tab on the tenant Web Domain page) and inside the row-menu Modal, which
+// now delegates here. Only surfaced when the admin has enabled
+// tenant_domain_options_enabled; the panel renders fixed, vetted directives —
+// no raw config — and the backend re-enforces the safe subset regardless.
+import { useTranslation } from "react-i18next";
+import { useEffect, useState } from "react";
+import { Button, Checkbox, Form, InputNumber, Select, Typography } from "antd";
+import { feedback } from "../lib/feedback";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../apiClient";
+
+interface SafeOptions {
+  max_body_mb?: number;
+  hsts?: boolean;
+  security_headers?: boolean;
+  gzip?: boolean;
+  // GH #879 tri-state: absent/null = inherit the server-wide default
+  // (Server Settings → Page Templates), true/false = force per-domain.
+  intercept_errors?: boolean | null;
+  // GH #962: PATH_INFO support for front-controller PHP apps (osTicket, …).
+  path_info?: boolean;
+}
+
+// The form's Select uses string values; map to the wire tri-state.
+type InterceptChoice = "inherit" | "on" | "off";
+const interceptToChoice = (v: boolean | null | undefined): InterceptChoice =>
+  v === true ? "on" : v === false ? "off" : "inherit";
+const choiceToIntercept = (c: InterceptChoice | undefined): boolean | null =>
+  c === "on" ? true : c === "off" ? false : null;
+
+export interface DomainNginxOptionsPanelProps {
+  domainId: string;
+  onSaved?: () => void;
+}
+
+export const DomainNginxOptionsPanel = ({ domainId, onSaved }: DomainNginxOptionsPanelProps) => {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const [form] = Form.useForm<SafeOptions & { intercept_choice?: InterceptChoice }>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ nginx_safe_options?: SafeOptions }>(`/domains/${domainId}`);
+        if (!cancelled) {
+          const opts = resp.data.nginx_safe_options ?? {};
+          form.setFieldsValue({
+            ...opts,
+            intercept_choice: interceptToChoice(opts.intercept_errors),
+          });
+        }
+      } catch {
+        if (!cancelled) feedback.message.error("Failed to load domain options");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [domainId, form]);
+
+  const onSave = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      await apiClient.patch(`/domains/${domainId}`, {
+        nginx_safe_options: {
+          max_body_mb: values.max_body_mb ?? 0,
+          hsts: !!values.hsts,
+          security_headers: !!values.security_headers,
+          gzip: !!values.gzip,
+          intercept_errors: choiceToIntercept(values.intercept_choice),
+          path_info: !!values.path_info,
+        },
+      });
+      feedback.message.success("Domain options saved — applied on the next reconcile");
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
+      onSaved?.();
+    } catch {
+      feedback.message.error("Failed to save domain options");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Typography.Paragraph type="secondary">
+        Safe nginx options for this domain. The panel renders fixed directives —
+        no raw config.
+      </Typography.Paragraph>
+      <Form<SafeOptions> form={form} layout="vertical" disabled={loading}>
+        <Form.Item
+          name="max_body_mb"
+          label={t("domainnginxoptionsmodal.max_upload_size_mb")}
+          tooltip="client_max_body_size. 0 = use the default."
+        >
+          <InputNumber min={0} max={10240} style={{ width: "100%" }} placeholder="0" />
+        </Form.Item>
+        <Form.Item name="hsts" valuePropName="checked">
+          <Checkbox>Enable HSTS (Strict-Transport-Security)</Checkbox>
+        </Form.Item>
+        <Form.Item name="security_headers" valuePropName="checked">
+          <Checkbox>Add security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy)</Checkbox>
+        </Form.Item>
+        <Form.Item name="gzip" valuePropName="checked">
+          <Checkbox>Enable gzip compression for text content</Checkbox>
+        </Form.Item>
+        <Form.Item
+          name="path_info"
+          valuePropName="checked"
+          tooltip="Some PHP apps route requests through /script.php/extra/path URLs (osTicket's /scp/ajax.php/…, and similar front-controller apps). The default nginx config only serves URLs ending in .php, so those requests fail. Turn this on for apps that need PATH_INFO. Leave off otherwise — plain PHP sites (WordPress, etc.) don't need it."
+        >
+          <Checkbox>Enable PATH_INFO for front-controller apps (osTicket, etc.)</Checkbox>
+        </Form.Item>
+        <Form.Item
+          name="intercept_choice"
+          label="Branded error page when the application fails (500-class errors)"
+          tooltip="A crashed PHP script normally returns an empty 500, so visitors see the browser's raw error screen. When on, nginx serves the branded 500 page instead (editable under Server Settings → Page Templates); the site keeps its own 404/403 pages. Apps that render their own error screens (e.g. WordPress's recovery notice) or return JSON errors will show the branded page instead — turn it off for those. 'Server default' follows the switch under Server Settings → Page Templates."
+          initialValue="inherit"
+        >
+          <Select
+            options={[
+              { value: "inherit", label: "Server default" },
+              { value: "on", label: "On" },
+              { value: "off", label: "Off" },
+            ]}
+          />
+        </Form.Item>
+        <Button type="primary" loading={saving} disabled={loading} onClick={onSave}>
+          {t("domainnginxoptionsmodal.save")}
+        </Button>
+      </Form>
+    </div>
+  );
+};

--- a/panel-ui/src/components/domains/DomainDocRootModal.tsx
+++ b/panel-ui/src/components/domains/DomainDocRootModal.tsx
@@ -1,14 +1,9 @@
-// DomainDocRootModal — GH #526. Lets a tenant repoint their own domain's
-// document root, confined server-side to the domain's own tree
-// (/home/<user>/domains/<domain>/...). Useful for framework apps whose real
-// entrypoint is a subdir (e.g. Laravel's public/). Surfaced only when the admin
-// has enabled tenant domain options; the backend re-validates regardless.
-import { useState } from "react";
-import { Modal, Form, Input, Typography } from "antd";
-import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+// DomainDocRootModal — GH #526. The row-menu launcher for the document-root
+// editor; the form body now lives in DomainDocRootPanel (GH #1543) and this
+// wrapper only owns the Modal chrome, delegating to the panel with footer={null}.
+import { Modal } from "antd";
 
-import { apiClient } from "../../apiClient";
+import { DomainDocRootPanel } from "./DomainDocRootPanel";
 
 interface DomainDocRootModalProps {
   domainId: string;
@@ -17,59 +12,15 @@ interface DomainDocRootModalProps {
   onClose: () => void;
 }
 
-// domainTreeBase derives /home/<user>/domains/<domain> from the current docroot
-// so the hint shows the exact folder the value must stay inside.
-function domainTreeBase(docRoot: string, domainName: string): string {
-  const marker = `/domains/${domainName}`;
-  const i = docRoot.indexOf(marker);
-  return i >= 0 ? docRoot.slice(0, i + marker.length) : `…/domains/${domainName}`;
-}
-
 export function DomainDocRootModal({ domainId, domainName, currentDocRoot, onClose }: DomainDocRootModalProps) {
-  const qc = useQueryClient();
-  const [form] = Form.useForm<{ doc_root: string }>();
-  const [value, setValue] = useState(currentDocRoot);
-  const base = domainTreeBase(currentDocRoot, domainName);
-
-  const mut = useMutation({
-    mutationFn: async (docRoot: string) => {
-      await apiClient.patch(`/domains/${domainId}`, { doc_root: docRoot });
-    },
-    onSuccess: () => {
-      feedback.message.success("Document root updated");
-      void qc.invalidateQueries({ queryKey: ["list", "domains"] });
-      onClose();
-    },
-    onError: (err: unknown) => {
-      const detail = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
-      feedback.message.error(detail?.detail ?? detail?.error ?? "Failed to update document root");
-    },
-  });
-
   return (
-    <Modal
-      title={`Document root — ${domainName}`}
-      open
-      onCancel={onClose}
-      onOk={() => form.submit()}
-      okText="Save"
-      confirmLoading={mut.isPending}
-    >
-      <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
-        Point this domain at a folder inside <Typography.Text code>{base}</Typography.Text>. Handy for apps whose
-        entrypoint is a subdirectory (e.g. a framework's <Typography.Text code>public/</Typography.Text>). Leave it
-        empty to reset to the default <Typography.Text code>public_html</Typography.Text>.
-      </Typography.Paragraph>
-      <Form form={form} layout="vertical" onFinish={(v) => void mut.mutateAsync((v.doc_root ?? "").trim())}>
-        <Form.Item name="doc_root" label="Document root" initialValue={currentDocRoot}>
-          <Input
-            placeholder={`${base}/public_html`}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            style={{ fontFamily: "monospace" }}
-          />
-        </Form.Item>
-      </Form>
+    <Modal title={`Document root — ${domainName}`} open onCancel={onClose} footer={null} destroyOnClose>
+      <DomainDocRootPanel
+        domainId={domainId}
+        domainName={domainName}
+        currentDocRoot={currentDocRoot}
+        onSaved={onClose}
+      />
     </Modal>
   );
 }

--- a/panel-ui/src/components/domains/DomainDocRootPanel.tsx
+++ b/panel-ui/src/components/domains/DomainDocRootPanel.tsx
@@ -1,0 +1,91 @@
+// DomainDocRootPanel — GH #1543 (extracted from DomainDocRootModal, GH #526).
+// The document-root form body, rendered both inline (a tab on the tenant Web
+// Domain page) and inside the row-menu Modal, which now delegates here. Lets a
+// tenant repoint their own domain's document root, confined server-side to the
+// domain's own tree (/home/<user>/domains/<domain>/...). Useful for framework
+// apps whose real entrypoint is a subdir (e.g. Laravel's public/). Surfaced
+// only when the admin has enabled tenant domain options; the backend
+// re-validates regardless.
+import { useEffect, useState } from "react";
+import { Button, Form, Input, Typography } from "antd";
+import { feedback } from "../../lib/feedback";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+
+// domainTreeBase derives /home/<user>/domains/<domain> from the current docroot
+// so the hint shows the exact folder the value must stay inside.
+function domainTreeBase(docRoot: string, domainName: string): string {
+  const marker = `/domains/${domainName}`;
+  const i = docRoot.indexOf(marker);
+  return i >= 0 ? docRoot.slice(0, i + marker.length) : `…/domains/${domainName}`;
+}
+
+interface DomainDocRootPanelProps {
+  domainId: string;
+  domainName: string;
+  currentDocRoot: string;
+  onSaved?: () => void;
+}
+
+export function DomainDocRootPanel({
+  domainId,
+  domainName,
+  currentDocRoot,
+  onSaved,
+}: DomainDocRootPanelProps) {
+  const qc = useQueryClient();
+  const [form] = Form.useForm<{ doc_root: string }>();
+  const [value, setValue] = useState(currentDocRoot);
+  const base = domainTreeBase(currentDocRoot, domainName);
+
+  // Re-sync when the source docroot changes underneath (another save, the
+  // reconciler) so an inline pane that stays mounted doesn't clobber it.
+  useEffect(() => {
+    setValue(currentDocRoot);
+    form.setFieldsValue({ doc_root: currentDocRoot });
+  }, [domainId, currentDocRoot, form]);
+
+  const mut = useMutation({
+    mutationFn: async (docRoot: string) => {
+      await apiClient.patch(`/domains/${domainId}`, { doc_root: docRoot });
+    },
+    onSuccess: () => {
+      feedback.message.success("Document root updated");
+      void qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      void qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
+      onSaved?.();
+    },
+    onError: (err: unknown) => {
+      const detail = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
+      feedback.message.error(detail?.detail ?? detail?.error ?? "Failed to update document root");
+    },
+  });
+
+  return (
+    <div>
+      <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
+        Point this domain at a folder inside <Typography.Text code>{base}</Typography.Text>. Handy for apps whose
+        entrypoint is a subdirectory (e.g. a framework's <Typography.Text code>public/</Typography.Text>). Leave it
+        empty to reset to the default <Typography.Text code>public_html</Typography.Text>.
+      </Typography.Paragraph>
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={(v) => void mut.mutateAsync((v.doc_root ?? "").trim())}
+      >
+        <Form.Item name="doc_root" label="Document root" initialValue={currentDocRoot}>
+          <Input
+            placeholder={`${base}/public_html`}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            style={{ fontFamily: "monospace" }}
+          />
+        </Form.Item>
+        <Button type="primary" htmlType="submit" loading={mut.isPending}>
+          Save
+        </Button>
+      </Form>
+    </div>
+  );
+}

--- a/panel-ui/src/shells/DomainIndexButton.tsx
+++ b/panel-ui/src/shells/DomainIndexButton.tsx
@@ -1,36 +1,14 @@
-// Index Manager — picks which file(s) nginx serves as the default
-// directory index. Values are an enum the agent maps to concrete
-// `index ...;` directives; see indexDirectiveFor() in the agent.
-import { useEffect, useState } from "react";
-import { FileTextOutlined, CheckOutlined } from "@icons";
-import { Button, Modal, Radio, Typography } from "antd";
-import { feedback } from "../lib/feedback"; // GH #970: themed toasts
-import { useQueryClient } from "@tanstack/react-query";
+// DomainIndexButton — the row-menu launcher for the Index Manager. The body
+// now lives in DomainIndexPanel (GH #1543) so it renders both as a tab on the
+// tenant Web Domain page and inside this Modal; this wrapper only owns the
+// open/close chrome and delegates the form + save to the panel.
+import { useState } from "react";
+import { FileTextOutlined } from "@icons";
+import { Button, Modal } from "antd";
 
-import { apiClient } from "../apiClient";
+import { DomainIndexPanel, type DomainIndexTarget } from "./DomainIndexPanel";
 
-export type IndexPriority =
-  | "html_first"
-  | "php_first"
-  | "html_only"
-  | "php_only"
-  | "full";
-
-export type DomainIndexTarget = {
-  id: string;
-  name: string;
-  index_priority?: IndexPriority | string | null;
-};
-
-// Options in the order they appear in the user-facing radio group.
-// The labels mirror the screenshots the user supplied.
-const options: { value: IndexPriority; label: string }[] = [
-  { value: "php_first", label: "PHP first (index.php, then index.html)" },
-  { value: "html_first", label: "HTML first (index.html, then index.php)" },
-  { value: "php_only", label: "PHP only (index.php)" },
-  { value: "html_only", label: "HTML only (index.html)" },
-  { value: "full", label: "PHP, HTML, HTM (full support)" },
-];
+export type { IndexPriority, DomainIndexTarget } from "./DomainIndexPanel";
 
 export const DomainIndexButton = ({
   domain,
@@ -43,11 +21,6 @@ export const DomainIndexButton = ({
 }) => {
   const [internalOpen, setInternalOpen] = useState(false);
   const effectiveOpen = controlledOpen ?? internalOpen;
-  const [saving, setSaving] = useState(false);
-  const [value, setValue] = useState<IndexPriority>(
-    (domain.index_priority as IndexPriority) || "html_first",
-  );
-  const qc = useQueryClient();
 
   const handleClose = () => {
     if (onClose) {
@@ -57,44 +30,10 @@ export const DomainIndexButton = ({
     }
   };
 
-  // Re-sync from prop each time the modal opens so another user's
-  // concurrent edit doesn't get silently clobbered.
-  useEffect(() => {
-    if (effectiveOpen) {
-      setValue((domain.index_priority as IndexPriority) || "html_first");
-    }
-
-  }, [effectiveOpen, domain.index_priority]);
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      await apiClient.patch(`/domains/${domain.id}`, {
-        index_priority: value,
-      });
-      feedback.message.success("Index priority saved");
-      qc.invalidateQueries({ queryKey: ["list", "domains"] });
-      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
-      handleClose();
-    } catch (err) {
-      const e = err as {
-        response?: { data?: { detail?: string } };
-        message?: string;
-      };
-      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
-    } finally {
-      setSaving(false);
-    }
-  };
-
   return (
     <>
       {controlledOpen === undefined && (
-        <Button
-          type="text"
-          icon={<FileTextOutlined />}
-          onClick={() => setInternalOpen(true)}
-        >
+        <Button type="text" icon={<FileTextOutlined />} onClick={() => setInternalOpen(true)}>
           Index
         </Button>
       )}
@@ -103,53 +42,10 @@ export const DomainIndexButton = ({
         open={effectiveOpen}
         onCancel={handleClose}
         width={560}
-        footer={[
-          <Button key="cancel" onClick={handleClose}>
-            Cancel
-          </Button>,
-          <Button
-            key="save"
-            type="primary"
-            icon={<CheckOutlined />}
-            loading={saving}
-            onClick={handleSave}
-          >
-            Submit
-          </Button>,
-        ]}
+        footer={null}
+        destroyOnClose
       >
-        <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
-          Set the default directory index files
-        </Typography.Paragraph>
-        <Typography.Text strong>
-          Directory Index Priority <Typography.Text type="danger">*</Typography.Text>
-        </Typography.Text>
-        <Radio.Group
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          style={{ display: "block", marginTop: 12 }}
-        >
-          {options.map((opt) => (
-            <Radio
-              key={opt.value}
-              value={opt.value}
-              style={{
-                display: "flex",
-                alignItems: "flex-start",
-                padding: "8px 0",
-                whiteSpace: "normal",
-              }}
-            >
-              <span style={{ display: "inline-block", lineHeight: 1.4 }}>{opt.label}</span>
-            </Radio>
-          ))}
-        </Radio.Group>
-        <Typography.Text
-          type="secondary"
-          style={{ display: "block", marginTop: 12 }}
-        >
-          Choose which file should be served as the default index
-        </Typography.Text>
+        <DomainIndexPanel domain={domain} onSaved={handleClose} />
       </Modal>
     </>
   );

--- a/panel-ui/src/shells/DomainIndexPanel.tsx
+++ b/panel-ui/src/shells/DomainIndexPanel.tsx
@@ -1,0 +1,104 @@
+// DomainIndexPanel — the body of the Index Manager (GH #1543). Extracted from
+// DomainIndexButton so it renders both inline (a tab on the tenant Web Domain
+// page) and inside the row-menu Modal, which now delegates to this panel. Picks
+// which file(s) nginx serves as the default directory index; the value is an
+// enum the agent maps to concrete `index ...;` directives.
+import { useEffect, useState } from "react";
+import { CheckOutlined } from "@icons";
+import { Button, Radio, Typography } from "antd";
+import { feedback } from "../lib/feedback";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../apiClient";
+
+export type IndexPriority =
+  | "html_first"
+  | "php_first"
+  | "html_only"
+  | "php_only"
+  | "full";
+
+export type DomainIndexTarget = {
+  id: string;
+  name: string;
+  index_priority?: IndexPriority | string | null;
+};
+
+// Options in the order they appear in the user-facing radio group.
+const options: { value: IndexPriority; label: string }[] = [
+  { value: "php_first", label: "PHP first (index.php, then index.html)" },
+  { value: "html_first", label: "HTML first (index.html, then index.php)" },
+  { value: "php_only", label: "PHP only (index.php)" },
+  { value: "html_only", label: "HTML only (index.html)" },
+  { value: "full", label: "PHP, HTML, HTM (full support)" },
+];
+
+export const DomainIndexPanel = ({
+  domain,
+  onSaved,
+}: {
+  domain: DomainIndexTarget;
+  onSaved?: () => void;
+}) => {
+  const qc = useQueryClient();
+  const [saving, setSaving] = useState(false);
+  const [value, setValue] = useState<IndexPriority>(
+    (domain.index_priority as IndexPriority) || "html_first",
+  );
+
+  // Re-sync from the source when it changes underneath (another user's save, a
+  // reconciler flip) so an inline pane that stays mounted doesn't clobber it.
+  useEffect(() => {
+    setValue((domain.index_priority as IndexPriority) || "html_first");
+  }, [domain.id, domain.index_priority]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await apiClient.patch(`/domains/${domain.id}`, { index_priority: value });
+      feedback.message.success("Index priority saved");
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
+      onSaved?.();
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string } }; message?: string };
+      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+        Set the default directory index files
+      </Typography.Paragraph>
+      <Typography.Text strong>
+        Directory Index Priority <Typography.Text type="danger">*</Typography.Text>
+      </Typography.Text>
+      <Radio.Group
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        style={{ display: "block", marginTop: 12 }}
+      >
+        {options.map((opt) => (
+          <Radio
+            key={opt.value}
+            value={opt.value}
+            style={{ display: "flex", alignItems: "flex-start", padding: "8px 0", whiteSpace: "normal" }}
+          >
+            <span style={{ display: "inline-block", lineHeight: 1.4 }}>{opt.label}</span>
+          </Radio>
+        ))}
+      </Radio.Group>
+      <Typography.Text type="secondary" style={{ display: "block", marginTop: 12 }}>
+        Choose which file should be served as the default index
+      </Typography.Text>
+      <div style={{ marginTop: 16 }}>
+        <Button type="primary" icon={<CheckOutlined />} loading={saving} onClick={handleSave}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/panel-ui/src/shells/DomainSettingsButton.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.tsx
@@ -1234,26 +1234,25 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
 // (caps.tenant_domain_options_enabled); the backend re-enforces the safe subset
 // (validateTenantNginxRules) so the type filter here is UX, not the security
 // boundary.
-export const TenantNginxRulesButton = ({
+// TenantNginxRulesPanel — GH #1543. The Rule Builder body, rendered both inline
+// (a tab on the tenant Web Domain page) and inside the row-menu Modal, which now
+// delegates here. Re-syncs from domain.nginx_rules when it changes underneath
+// so an inline pane that stays mounted doesn't clobber a concurrent save.
+export const TenantNginxRulesPanel = ({
   domain,
-  open: controlledOpen,
-  onClose,
+  onSaved,
 }: {
   domain: DomainSettingsTarget;
-  open?: boolean;
-  onClose?: () => void;
+  onSaved?: () => void;
 }) => {
-  const [internalOpen, setInternalOpen] = useState(false);
-  const open = controlledOpen ?? internalOpen;
-  const close = () => (onClose ? onClose() : setInternalOpen(false));
   const [rules, setRules] = useState<NginxRule[]>(domain.nginx_rules ?? []);
   const [saving, setSaving] = useState(false);
   const qc = useQueryClient();
 
   useEffect(() => {
-    if (open) setRules(domain.nginx_rules ?? []);
+    setRules(domain.nginx_rules ?? []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, domain.id, JSON.stringify(domain.nginx_rules)]);
+  }, [domain.id, JSON.stringify(domain.nginx_rules)]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -1263,7 +1262,7 @@ export const TenantNginxRulesButton = ({
       feedback.message.success("Rewrite rules saved — applied on the next reconcile");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
-      close();
+      onSaved?.();
     } catch (err) {
       const e = err as {
         response?: { data?: { detail?: string } };
@@ -1276,6 +1275,36 @@ export const TenantNginxRulesButton = ({
   };
 
   return (
+    <div>
+      <Typography.Paragraph type="secondary">
+        Add rewrite rules and custom response headers for this domain. Rewrites
+        must point to a local path on your own site (no external URLs or
+        proxying).
+      </Typography.Paragraph>
+      <RuleBuilder rules={rules} onRulesChange={setRules} allowedTypes={["rewrite", "custom_header"]} />
+      <div style={{ marginTop: 16 }}>
+        <Button type="primary" loading={saving} onClick={handleSave}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const TenantNginxRulesButton = ({
+  domain,
+  open: controlledOpen,
+  onClose,
+}: {
+  domain: DomainSettingsTarget;
+  open?: boolean;
+  onClose?: () => void;
+}) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const close = () => (onClose ? onClose() : setInternalOpen(false));
+
+  return (
     <>
       {controlledOpen === undefined && (
         <Button icon={<ToolOutlined />} onClick={() => setInternalOpen(true)}>
@@ -1286,22 +1315,11 @@ export const TenantNginxRulesButton = ({
         open={open}
         title="Rewrite & header rules"
         onCancel={close}
-        onOk={handleSave}
-        okText="Save"
-        confirmLoading={saving}
+        footer={null}
         width={720}
         destroyOnClose
       >
-        <Typography.Paragraph type="secondary">
-          Add rewrite rules and custom response headers for this domain. Rewrites
-          must point to a local path on your own site (no external URLs or
-          proxying).
-        </Typography.Paragraph>
-        <RuleBuilder
-          rules={rules}
-          onRulesChange={setRules}
-          allowedTypes={["rewrite", "custom_header"]}
-        />
+        <TenantNginxRulesPanel domain={domain} onSaved={close} />
       </Modal>
     </>
   );

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -103,6 +103,16 @@ describe("WebDomainPage (GH #1543)", () => {
     expect(await screen.findByText("Preview URL")).toBeInTheDocument();
   });
 
+  it("renders the Index pane when :tab=index and saves the chosen priority", async () => {
+    renderAt("/jabali-panel/domains/d1/index");
+    expect(await screen.findByText("Directory Index Priority")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("PHP first (index.php, then index.html)"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await vi.waitFor(() =>
+      expect(patch).toHaveBeenCalledWith("/domains/d1", { index_priority: "php_first" }),
+    );
+  });
+
   it("renders the Caching pane when :tab=caching", async () => {
     renderAt("/jabali-panel/domains/d1/caching");
     expect(await screen.findByText("caching-pane:d1")).toBeInTheDocument();

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -27,6 +27,7 @@ const domainQ = vi.hoisted(() => ({
   },
 }));
 const patch = vi.hoisted(() => vi.fn());
+const caps = vi.hoisted(() => ({ value: { tenant_domain_options_enabled: false, tenant_docroot_editable: false } }));
 
 vi.mock("react-router", async () => {
   const actual = await vi.importActual<typeof import("react-router")>("react-router");
@@ -37,6 +38,18 @@ vi.mock("../../../components/admin/BreadcrumbContext", () => ({
 }));
 vi.mock("../../../hooks/useQueries", () => ({
   useOneQuery: () => domainQ.value,
+}));
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: caps.value }),
+}));
+vi.mock("../../../components/DomainNginxOptionsPanel", () => ({
+  DomainNginxOptionsPanel: ({ domainId }: { domainId: string }) => <div>options-pane:{domainId}</div>,
+}));
+vi.mock("../../DomainSettingsButton", () => ({
+  TenantNginxRulesPanel: ({ domain }: { domain: { id: string } }) => <div>rewrite-pane:{domain.id}</div>,
+}));
+vi.mock("../../../components/domains/DomainDocRootPanel", () => ({
+  DomainDocRootPanel: ({ domainId }: { domainId: string }) => <div>docroot-pane:{domainId}</div>,
 }));
 vi.mock("../../../components/DomainCacheSection", () => ({
   DomainCacheSection: ({ domainId }: { domainId: string }) => <div>caching-pane:{domainId}</div>,
@@ -72,6 +85,7 @@ beforeEach(() => {
   setBreadcrumbs.mockReset();
   patch.mockReset();
   patch.mockResolvedValue({});
+  caps.value = { tenant_domain_options_enabled: false, tenant_docroot_editable: false };
   domainQ.value = {
     data: {
       id: "d1",
@@ -142,6 +156,33 @@ describe("WebDomainPage (GH #1543)", () => {
     await vi.waitFor(() =>
       expect(patch).toHaveBeenCalledWith("/domains/d1", { temp_url_enabled: true }),
     );
+  });
+
+  it("hides the cap-gated tabs when the caps are off", async () => {
+    renderAt("/jabali-panel/domains/d1");
+    await screen.findByText("Preview URL");
+    expect(screen.getByText("Index Files")).toBeInTheDocument();
+    expect(screen.queryByText("Domain options")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rewrite rules")).not.toBeInTheDocument();
+    // "Document root" also labels an Overview fact, so assert the pane itself
+    // (its stub marker) is absent rather than the ambiguous tab text.
+    expect(screen.queryByText("docroot-pane:d1")).not.toBeInTheDocument();
+  });
+
+  it("shows the cap-gated tabs and renders their panes when the caps are on", async () => {
+    caps.value = { tenant_domain_options_enabled: true, tenant_docroot_editable: true };
+    renderAt("/jabali-panel/domains/d1/domain-options");
+    expect(await screen.findByText("options-pane:d1")).toBeInTheDocument();
+    // The other gated tabs are present in the strip.
+    expect(screen.getByText("Rewrite rules")).toBeInTheDocument();
+    expect(screen.getByText("Document root")).toBeInTheDocument();
+  });
+
+  it("falls back to Overview when a URL targets a cap-gated tab that is off", async () => {
+    // options off (default) → /domain-options is not a visible tab.
+    renderAt("/jabali-panel/domains/d1/domain-options");
+    expect(await screen.findByText("Preview URL")).toBeInTheDocument();
+    expect(screen.queryByText("options-pane:d1")).not.toBeInTheDocument();
   });
 
   it("surfaces an error when the domain can't be loaded", async () => {

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -19,14 +19,16 @@ import { useOneQuery } from "../../../hooks/useQueries";
 import type { Domain } from "../../../components/domains/types";
 import { DomainCacheSection } from "../../../components/DomainCacheSection";
 import { DomainDirectoryPrivacySection } from "../../admin/domains/DomainDirectoryPrivacySection";
+import { DomainIndexPanel } from "../../DomainIndexPanel";
 import { OverviewTab } from "./tabs/OverviewTab";
 
-const TAB_KEYS = ["overview", "caching", "directory-privacy"] as const;
+const TAB_KEYS = ["overview", "index", "caching", "directory-privacy"] as const;
 type TabKey = (typeof TAB_KEYS)[number];
 const DEFAULT_TAB: TabKey = "overview";
 
 const TAB_LABELS: Record<TabKey, string> = {
   overview: "Overview",
+  index: "Index Files",
   caching: "Caching",
   "directory-privacy": "Directory Privacy",
 };
@@ -86,6 +88,8 @@ export const WebDomainPage = () => {
     switch (activeKey) {
       case "overview":
         return <OverviewTab domain={domain} />;
+      case "index":
+        return <DomainIndexPanel domain={domain} />;
       case "caching":
         return <DomainCacheSection domainId={domain.id} />;
       case "directory-privacy":

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -4,35 +4,30 @@
 // modal launchers. The tab lives in the URL (:tab), so a tab is linkable and
 // the browser Back button walks the tabs.
 //
-// Slice A (this PR) lands the shell + row-click navigation + breadcrumbs and
-// three panes that need no extraction: Overview (facts + the preview-URL /
-// bot-challenge toggles), Caching and Directory Privacy (both already shared
-// Section components). The remaining actions (Redirects, Index, Domain options,
-// Rewrite rules, Document root) and folding DNS in move here in a follow-up,
-// which also strips the row menu down to Disable/Delete.
+// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles), Index
+// Files, Caching and Directory Privacy, plus three tabs gated on the same caps
+// as the row menu — Domain options and Rewrite rules (tenant_domain_options_
+// enabled) and Document root (tenant_docroot_editable). Redirects and folding
+// DNS in move here in a follow-up, which also strips the row menu down to
+// Disable/Delete.
+import type { ReactNode } from "react";
 import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
 import { GlobalOutlined } from "@icons";
 import { useNavigate, useParams } from "react-router";
 
 import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { useOneQuery } from "../../../hooks/useQueries";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 import type { Domain } from "../../../components/domains/types";
 import { DomainCacheSection } from "../../../components/DomainCacheSection";
 import { DomainDirectoryPrivacySection } from "../../admin/domains/DomainDirectoryPrivacySection";
 import { DomainIndexPanel } from "../../DomainIndexPanel";
+import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsPanel";
+import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
+import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
 import { OverviewTab } from "./tabs/OverviewTab";
 
-const TAB_KEYS = ["overview", "index", "caching", "directory-privacy"] as const;
-type TabKey = (typeof TAB_KEYS)[number];
-const DEFAULT_TAB: TabKey = "overview";
-
-const TAB_LABELS: Record<TabKey, string> = {
-  overview: "Overview",
-  index: "Index Files",
-  caching: "Caching",
-  "directory-privacy": "Directory Privacy",
-};
-
+const DEFAULT_TAB = "overview";
 const LIST_PATH = "/jabali-panel/domains";
 
 export const WebDomainPage = () => {
@@ -40,9 +35,7 @@ export const WebDomainPage = () => {
   const navigate = useNavigate();
 
   const domainQ = useOneQuery<Domain>({ resource: "domains", id });
-  const activeKey: TabKey = (TAB_KEYS as readonly string[]).includes(tab ?? "")
-    ? (tab as TabKey)
-    : DEFAULT_TAB;
+  const { data: caps } = useServerCapabilities();
 
   // The shell already renders ONE breadcrumb (RouteBreadcrumb, GH #455). Override
   // it with the entity trail so the last crumb is the domain name, not the raw
@@ -84,18 +77,53 @@ export const WebDomainPage = () => {
   }
   const domain = domainQ.data;
 
-  const renderTab = () => {
-    switch (activeKey) {
-      case "overview":
-        return <OverviewTab domain={domain} />;
-      case "index":
-        return <DomainIndexPanel domain={domain} />;
-      case "caching":
-        return <DomainCacheSection domainId={domain.id} />;
-      case "directory-privacy":
-        return <DomainDirectoryPrivacySection domainId={domain.id} domainName={domain.name} />;
-    }
-  };
+  // The cap-gated tabs mirror the row menu exactly: a tenant without the cap
+  // sees neither the menu item nor the tab (never a disabled stub).
+  const optionsOn = caps?.tenant_domain_options_enabled === true;
+  const docrootOn = caps?.tenant_docroot_editable === true;
+
+  const tabs: { key: string; label: string; node: ReactNode }[] = [
+    { key: "overview", label: "Overview", node: <OverviewTab domain={domain} /> },
+    { key: "index", label: "Index Files", node: <DomainIndexPanel domain={domain} /> },
+    { key: "caching", label: "Caching", node: <DomainCacheSection domainId={domain.id} /> },
+    {
+      key: "directory-privacy",
+      label: "Directory Privacy",
+      node: <DomainDirectoryPrivacySection domainId={domain.id} domainName={domain.name} />,
+    },
+    ...(optionsOn
+      ? [
+          {
+            key: "domain-options",
+            label: "Domain options",
+            node: <DomainNginxOptionsPanel domainId={domain.id} />,
+          },
+          {
+            key: "rewrite-rules",
+            label: "Rewrite rules",
+            node: <TenantNginxRulesPanel domain={domain} />,
+          },
+        ]
+      : []),
+    ...(docrootOn
+      ? [
+          {
+            key: "document-root",
+            label: "Document root",
+            node: (
+              <DomainDocRootPanel
+                domainId={domain.id}
+                domainName={domain.name}
+                currentDocRoot={domain.doc_root}
+              />
+            ),
+          },
+        ]
+      : []),
+  ];
+
+  const activeKey = tabs.some((tdef) => tdef.key === tab) ? (tab as string) : DEFAULT_TAB;
+  const active = tabs.find((tdef) => tdef.key === activeKey) ?? tabs[0];
 
   return (
     <div style={{ padding: "20px" }}>
@@ -110,11 +138,11 @@ export const WebDomainPage = () => {
       </Space>
 
       <Card
-        tabList={TAB_KEYS.map((k) => ({ key: k, tab: TAB_LABELS[k] }))}
+        tabList={tabs.map((tdef) => ({ key: tdef.key, tab: tdef.label }))}
         activeTabKey={activeKey}
         onTabChange={(k) => navigate(`${LIST_PATH}/${domain.id}/${k}`)}
       >
-        {renderTab()}
+        {active.node}
       </Card>
     </div>
   );


### PR DESCRIPTION
## What

Second slice of the tenant Web Domains restructure (#1543). Slice A shipped the dedicated tabbed Web Domain page (row-click → page, breadcrumbs, Overview / Caching / Directory Privacy tabs). This slice moves the remaining per-domain **settings** actions onto that page as their own tabs, so a tenant edits a domain from one page instead of a row of modal launchers.

New tabs on the Web Domain page:

- **Index Files** — directory index priority.
- **Domain options** — the curated nginx options (gated on `tenant_domain_options_enabled`).
- **Rewrite rules** — the safe rewrite-rule builder (gated on `tenant_domain_options_enabled`).
- **Document root** — docroot editor (gated on `tenant_docroot_editable`).

The cap-gated tabs mirror the row menu exactly: a tenant without the capability sees neither the menu item nor the tab (never a disabled stub), and a URL pointed at a gated-off tab falls back to Overview.

## How

Each of these actions was a row-menu **Modal**. This slice extracts each Modal's body into a standalone **Panel** component that renders both inline (a tab) and inside the original Modal, which now delegates to the panel with `footer={null}`:

- `DomainIndexPanel` ← `DomainIndexButton` (shared modal — proves the delegate pattern keeps the admin list working)
- `DomainNginxOptionsPanel` ← `DomainNginxOptionsModal`
- `DomainDocRootPanel` ← `DomainDocRootModal`
- `TenantNginxRulesPanel` (exported from `DomainSettingsButton`) ← `TenantNginxRulesButton`

Each panel keeps its own load/save and re-syncs from the source domain on change (primitive key for Index/DocRoot, `JSON.stringify(nginx_rules)` for Rewrite so unsaved edits survive a background refetch). Saving invalidates both the domain list and the single-domain query so the page and the list stay consistent.

## Scope / what is deferred

- The tenant row menu is **not** stripped yet — it stays intact until Redirects also has a panel, so both the menu and the tabs keep working in the interim.
- Redirects (the dnd-kit builder), folding the DNS records view into a tab, stripping the row menu down to Disable/Delete, and the later slices (Logs/Statistics, PHP Settings, One-Click Apps into the list, remove the Applications menu) remain follow-ups.

Pre-existing parity note: `DomainNginxOptionsPanel` enables its form after a failed GET (same as the original modal); left as-is here.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on all changed files
- [x] `WebDomainPage` suite: renders each tab, cap-off hides gated tabs, gated-off URL → Overview, Index tab saves the chosen priority
- [x] Full domain-area suite green (no regression from rewriting the four shared modals)

GH #1543
