### PR TITLE
feat(domains): Redirects as a Web Domain tab (GH #1543)

### DIFF
--- a/panel-ui/src/shells/DomainRedirectsButton.tsx
+++ b/panel-ui/src/shells/DomainRedirectsButton.tsx
@@ -1,197 +1,19 @@
-// Redirects modal for per-domain and per-page redirects.
-// Opens a modal with two sections:
-// 1. Whole-domain redirect toggle + URL + type selector
-// 2. Page-level redirects list with add/delete controls (v2: drag-reorder, active toggle, wildcard)
-import { useEffect, useState } from "react";
+// DomainRedirectsButton — the row-menu launcher for per-domain and per-page
+// redirects (GH #717). The form body now lives in DomainRedirectsPanel
+// (GH #1543); this wrapper owns only the Button + Modal chrome and delegates
+// with footer={null}.
+import { useState } from "react";
+import { SwapOutlined } from "@icons";
+import { Button, Modal } from "antd";
+
 import {
-  SwapOutlined,
-  CheckOutlined,
-  CloseOutlined,
-  DeleteOutlined,
-  PlusOutlined,
-  DragOutlined,
-} from "@icons";
-import { Button, Modal, Switch, Row, Col, Input, Select, Card, Typography } from "antd";
-import { feedback } from "../lib/feedback"; // GH #970: themed toasts
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-  useSortable,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+  DomainRedirectsPanel,
+  type DomainRedirectsTarget,
+  type PageRedirect,
+} from "./DomainRedirectsPanel";
 
-import { apiClient } from "../apiClient";
-
-export type PageRedirect = {
-  source: string;
-  destination: string;
-  type: "301" | "302" | "307" | "308";
-  active?: boolean;
-  wildcard?: boolean;
-};
-
-export type DomainRedirectsTarget = {
-  id: string;
-  name: string;
-  redirect_all_to?: string | null;
-  redirect_all_type?: string | null;
-  page_redirects?: PageRedirect[] | null;
-};
-
-const REDIRECT_TYPE_OPTIONS = [
-  { value: "301", label: "Permanent (301) - SEO friendly" },
-  { value: "302", label: "Temporary (302)" },
-  { value: "307", label: "Temporary (307) - preserves method" },
-  { value: "308", label: "Permanent (308) - preserves method" },
-];
-
-// Sortable card item for drag-reorder
-interface SortableCardProps {
-  idx: number;
-  pr: PageRedirect;
-  onRemove: (idx: number) => void;
-  onUpdate: (idx: number, key: keyof PageRedirect, value: string | boolean) => void;
-}
-
-const SortableCard = ({
-  idx,
-  pr,
-  onRemove,
-  onUpdate,
-}: SortableCardProps) => {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: idx,
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style}>
-      <Card
-        style={{ marginBottom: 12 }}
-        bodyStyle={{ padding: 12 }}
-      >
-        <div style={{ display: "flex", alignItems: "center", marginBottom: 12, gap: 8 }}>
-          <button
-            {...attributes}
-            {...listeners}
-            style={{
-              cursor: "grab",
-              background: "none",
-              border: "none",
-              padding: 4,
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
-            <DragOutlined />
-          </button>
-
-          <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />}
-            checked={pr.active ?? true}
-            onChange={(checked) => onUpdate(idx, "active", checked)}
-            style={{ marginRight: 4 }}
-          />
-          <Typography.Text type="secondary">
-            Active
-          </Typography.Text>
-
-          <div style={{ flex: 1 }} />
-
-          <Typography.Text type="secondary">
-            → {pr.type}
-          </Typography.Text>
-          <Button
-            danger
-            icon={<DeleteOutlined />}
-            type="text"
-            onClick={() => onRemove(idx)}
-          />
-        </div>
-
-        <>
-          <Row gutter={16} style={{ marginBottom: 12 }}>
-              <Col span={12}>
-                <div style={{ marginBottom: 8 }}>
-                  <Typography.Text>
-                    Source Path <Typography.Text type="danger">*</Typography.Text>
-                  </Typography.Text>
-                </div>
-                <Input
-                  placeholder="/old-page"
-                  value={pr.source}
-                  onChange={(e) => onUpdate(idx, "source", e.target.value)}
-                />
-                <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
-                  Path to redirect from (e.g., /old-page)
-                </Typography.Text>
-              </Col>
-              <Col span={12}>
-                <div style={{ marginBottom: 8 }}>
-                  <Typography.Text>
-                    Destination URL <Typography.Text type="danger">*</Typography.Text>
-                  </Typography.Text>
-                </div>
-                <Input
-                  placeholder="https://example.com/new-page"
-                  value={pr.destination}
-                  onChange={(e) => onUpdate(idx, "destination", e.target.value)}
-                />
-                <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
-                  Full URL to redirect to
-                </Typography.Text>
-              </Col>
-            </Row>
-
-            <Row gutter={16} style={{ marginBottom: 12 }}>
-              <Col span={12}>
-                <div style={{ marginBottom: 8 }}>
-                  <Typography.Text>
-                    Type <Typography.Text type="danger">*</Typography.Text>
-                  </Typography.Text>
-                </div>
-                <Select
-                  value={pr.type}
-                  onChange={(value) => onUpdate(idx, "type", value)}
-                  options={REDIRECT_TYPE_OPTIONS}
-                  style={{ width: "100%" }}
-                />
-              </Col>
-              <Col span={12}>
-                <div style={{ marginBottom: 8 }}>
-                  <Typography.Text>Wildcard Matching</Typography.Text>
-                </div>
-                <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />}
-                  checked={pr.wildcard ?? false}
-                  onChange={(checked) => onUpdate(idx, "wildcard", checked)}
-                  style={{ marginRight: 8 }}
-                />
-                <Typography.Text type="secondary">
-                  Prefix match + capture path (301/302 only)
-                </Typography.Text>
-              </Col>
-            </Row>
-        </>
-      </Card>
-    </div>
-  );
-};
+// Re-export the types so existing importers keep resolving them here.
+export type { DomainRedirectsTarget, PageRedirect };
 
 export const DomainRedirectsButton = ({
   domain,
@@ -204,50 +26,6 @@ export const DomainRedirectsButton = ({
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const effectiveOpen = controlledOpen ?? isModalOpen;
-  const [wholeToggle, setWholeToggle] = useState(!!domain.redirect_all_to);
-  const [wholeUrl, setWholeUrl] = useState(domain.redirect_all_to ?? "");
-  const [wholeType, setWholeType] = useState(domain.redirect_all_type ?? "301");
-  const [pageRedirects, setPageRedirects] = useState<PageRedirect[]>(
-    domain.page_redirects ?? []
-  );
-  const [isSaving, setIsSaving] = useState(false);
-  const qc = useQueryClient();
-
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
-
-  useEffect(() => {
-    if (controlledOpen) {
-      setWholeToggle(!!domain.redirect_all_to);
-      setWholeUrl(domain.redirect_all_to ?? "");
-      setWholeType(domain.redirect_all_type ?? "301");
-      setPageRedirects(domain.page_redirects ?? []);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [controlledOpen]);
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-
-    if (over && active.id !== over.id) {
-      const oldIndex = Number(active.id);
-      const newIndex = Number(over.id);
-      setPageRedirects(arrayMove(pageRedirects, oldIndex, newIndex));
-    }
-  };
-
-  const handleOpenModal = () => {
-    // Re-sync from prop in case the value was updated elsewhere
-    setWholeToggle(!!domain.redirect_all_to);
-    setWholeUrl(domain.redirect_all_to ?? "");
-    setWholeType(domain.redirect_all_type ?? "301");
-    setPageRedirects(domain.page_redirects ?? []);
-    setIsModalOpen(true);
-  };
 
   const handleCloseModal = () => {
     if (onClose) {
@@ -257,84 +35,13 @@ export const DomainRedirectsButton = ({
     }
   };
 
-  const addPageRedirect = () => {
-    setPageRedirects([
-      ...pageRedirects,
-      { source: "", destination: "", type: "301", active: true, wildcard: false },
-    ]);
-  };
-
-  const removePageRedirect = (idx: number) => {
-    setPageRedirects(pageRedirects.filter((_, i) => i !== idx));
-  };
-
-  const updatePageRedirect = (
-    idx: number,
-    key: keyof PageRedirect,
-    value: string | boolean
-  ) => {
-    const updated = [...pageRedirects];
-    updated[idx] = { ...updated[idx], [key]: value };
-    setPageRedirects(updated);
-  };
-
-  const handleSave = async () => {
-    setIsSaving(true);
-    try {
-      const body: Record<string, unknown> = {};
-
-      if (wholeToggle) {
-        const url = wholeUrl.trim();
-        if (!url) {
-          feedback.message.error("Enter a redirect URL");
-          setIsSaving(false);
-          return;
-        }
-        body.redirect_all_to = url;
-        body.redirect_all_type = wholeType;
-      } else {
-        // GH #717: send an empty string, NOT null, to CLEAR the whole-domain
-        // redirect. The API's *string field can't tell a JSON `null` apart from
-        // an omitted field — both unmarshal to a nil pointer, which the handler
-        // treats as "no change", so the redirect never got removed. An empty
-        // string is a non-nil pointer the handler clears on.
-        body.redirect_all_to = "";
-        body.redirect_all_type = "";
-      }
-
-      const clean = pageRedirects.map((pr) => ({
-        source: pr.source.trim(),
-        destination: pr.destination.trim(),
-        type: pr.type,
-        active: pr.active ?? true,
-        wildcard: pr.wildcard ?? false,
-      }));
-      // Don't send half-filled rows — drop blank ones silently
-      body.page_redirects = clean.filter((pr) => pr.source && pr.destination);
-
-      await apiClient.patch(`/domains/${domain.id}`, body);
-      feedback.message.success("Redirects saved");
-      qc.invalidateQueries({ queryKey: ["list", "domains"] });
-      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
-      handleCloseModal();
-    } catch (err) {
-      const e = err as {
-        response?: { data?: { detail?: string } };
-        message?: string;
-      };
-      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
   return (
     <>
       {controlledOpen === undefined && (
         <Button
           type="text"
           icon={<SwapOutlined />}
-          onClick={handleOpenModal}
+          onClick={() => setIsModalOpen(true)}
         >
           Redirects
         </Button>
@@ -345,121 +52,10 @@ export const DomainRedirectsButton = ({
         open={effectiveOpen}
         onCancel={handleCloseModal}
         width={720}
-        footer={[
-          <Button key="cancel" onClick={handleCloseModal}>
-            Cancel
-          </Button>,
-          <Button
-            key="save"
-            type="primary"
-            icon={<CheckOutlined />}
-            onClick={handleSave}
-            loading={isSaving}
-          >
-            Save Redirects
-          </Button>,
-        ]}
+        footer={null}
+        destroyOnHidden
       >
-        <Typography.Paragraph type="secondary" style={{ marginBottom: 24 }}>
-          Redirect this domain to another domain or set up page redirects.
-        </Typography.Paragraph>
-
-        {/* Section 1: Redirect Entire Domain */}
-        <div style={{ marginBottom: 32 }}>
-          <div style={{ marginBottom: 12 }}>
-            <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />}
-              checked={wholeToggle}
-              onChange={setWholeToggle}
-              style={{ marginRight: 8 }}
-            />
-            <Typography.Text strong>Redirect Entire Domain</Typography.Text>
-          </div>
-          <Typography.Text type="secondary" style={{ marginBottom: 12, display: "block" }}>
-            Redirect all traffic from this domain to another domain
-          </Typography.Text>
-
-          {wholeToggle && (
-            <>
-              <Row gutter={16} style={{ marginBottom: 12 }}>
-                <Col span={12}>
-                  <div style={{ marginBottom: 8 }}>
-                    <Typography.Text>
-                      Redirect To <Typography.Text type="danger">*</Typography.Text>
-                    </Typography.Text>
-                  </div>
-                  <Input
-                    placeholder="https://newdomain.com"
-                    value={wholeUrl}
-                    onChange={(e) => setWholeUrl(e.target.value)}
-                  />
-                </Col>
-                <Col span={12}>
-                  <div style={{ marginBottom: 8 }}>
-                    <Typography.Text>
-                      Redirect Type <Typography.Text type="danger">*</Typography.Text>
-                    </Typography.Text>
-                  </div>
-                  <Select
-                    value={wholeType}
-                    onChange={setWholeType}
-                    options={REDIRECT_TYPE_OPTIONS}
-                    style={{ width: "100%" }}
-                  />
-                </Col>
-              </Row>
-              <Typography.Text type="secondary">
-                All requests to this domain will be redirected to this URL
-              </Typography.Text>
-            </>
-          )}
-        </div>
-
-        {/* Section 2: Page Redirects */}
-        <div
-          style={{
-            opacity: wholeToggle ? 0.5 : 1,
-            pointerEvents: wholeToggle ? "none" : "auto",
-          }}
-        >
-          <div style={{ marginBottom: 12 }}>
-            <Typography.Text strong>Page Redirects</Typography.Text>
-          </div>
-
-          <div style={{ marginBottom: 16 }}>
-            {pageRedirects.length > 0 && (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={pageRedirects.map((_, idx) => idx)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  {pageRedirects.map((pr, idx) => (
-                    <SortableCard
-                      key={idx}
-                      idx={idx}
-                      pr={pr}
-                      onRemove={removePageRedirect}
-                      onUpdate={updatePageRedirect}
-                    />
-                  ))}
-                </SortableContext>
-              </DndContext>
-            )}
-          </div>
-
-          <div style={{ textAlign: "center", marginBottom: 16 }}>
-            <Button icon={<PlusOutlined />} onClick={addPageRedirect}>
-              Add Page Redirect
-            </Button>
-          </div>
-
-          <Typography.Text type="secondary">
-            Redirect specific paths to other URLs. Drag to reorder, toggle active status, or enable wildcard matching.
-          </Typography.Text>
-        </div>
+        <DomainRedirectsPanel domain={domain} onSaved={handleCloseModal} />
       </Modal>
     </>
   );

--- a/panel-ui/src/shells/DomainRedirectsPanel.tsx
+++ b/panel-ui/src/shells/DomainRedirectsPanel.tsx
@@ -1,0 +1,430 @@
+// DomainRedirectsPanel — whole-domain + per-page redirects (GH #717), extracted
+// from DomainRedirectsButton (GH #1543) so it renders both inline (a tab on the
+// tenant Web Domain page) and inside the row-menu Modal, which now delegates
+// here with footer={null}.
+//
+// Two sections:
+// 1. Whole-domain redirect toggle + URL + type selector
+// 2. Page-level redirects list with add/delete, drag-reorder, active toggle,
+//    wildcard matching.
+import { useEffect, useState } from "react";
+import {
+  CheckOutlined,
+  CloseOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  DragOutlined,
+} from "@icons";
+import { Button, Switch, Row, Col, Input, Select, Card, Typography } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+import { apiClient } from "../apiClient";
+
+export type PageRedirect = {
+  source: string;
+  destination: string;
+  type: "301" | "302" | "307" | "308";
+  active?: boolean;
+  wildcard?: boolean;
+};
+
+export type DomainRedirectsTarget = {
+  id: string;
+  name: string;
+  redirect_all_to?: string | null;
+  redirect_all_type?: string | null;
+  page_redirects?: PageRedirect[] | null;
+};
+
+const REDIRECT_TYPE_OPTIONS = [
+  { value: "301", label: "Permanent (301) - SEO friendly" },
+  { value: "302", label: "Temporary (302)" },
+  { value: "307", label: "Temporary (307) - preserves method" },
+  { value: "308", label: "Permanent (308) - preserves method" },
+];
+
+// Sortable card item for drag-reorder
+interface SortableCardProps {
+  idx: number;
+  pr: PageRedirect;
+  onRemove: (idx: number) => void;
+  onUpdate: (idx: number, key: keyof PageRedirect, value: string | boolean) => void;
+}
+
+const SortableCard = ({
+  idx,
+  pr,
+  onRemove,
+  onUpdate,
+}: SortableCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: idx,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <Card
+        style={{ marginBottom: 12 }}
+        bodyStyle={{ padding: 12 }}
+      >
+        <div style={{ display: "flex", alignItems: "center", marginBottom: 12, gap: 8 }}>
+          <button
+            {...attributes}
+            {...listeners}
+            style={{
+              cursor: "grab",
+              background: "none",
+              border: "none",
+              padding: 4,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <DragOutlined />
+          </button>
+
+          <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />}
+            checked={pr.active ?? true}
+            onChange={(checked) => onUpdate(idx, "active", checked)}
+            style={{ marginRight: 4 }}
+          />
+          <Typography.Text type="secondary">
+            Active
+          </Typography.Text>
+
+          <div style={{ flex: 1 }} />
+
+          <Typography.Text type="secondary">
+            → {pr.type}
+          </Typography.Text>
+          <Button
+            danger
+            icon={<DeleteOutlined />}
+            type="text"
+            onClick={() => onRemove(idx)}
+          />
+        </div>
+
+        <>
+          <Row gutter={16} style={{ marginBottom: 12 }}>
+              <Col span={12}>
+                <div style={{ marginBottom: 8 }}>
+                  <Typography.Text>
+                    Source Path <Typography.Text type="danger">*</Typography.Text>
+                  </Typography.Text>
+                </div>
+                <Input
+                  placeholder="/old-page"
+                  value={pr.source}
+                  onChange={(e) => onUpdate(idx, "source", e.target.value)}
+                />
+                <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
+                  Path to redirect from (e.g., /old-page)
+                </Typography.Text>
+              </Col>
+              <Col span={12}>
+                <div style={{ marginBottom: 8 }}>
+                  <Typography.Text>
+                    Destination URL <Typography.Text type="danger">*</Typography.Text>
+                  </Typography.Text>
+                </div>
+                <Input
+                  placeholder="https://example.com/new-page"
+                  value={pr.destination}
+                  onChange={(e) => onUpdate(idx, "destination", e.target.value)}
+                />
+                <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
+                  Full URL to redirect to
+                </Typography.Text>
+              </Col>
+            </Row>
+
+            <Row gutter={16} style={{ marginBottom: 12 }}>
+              <Col span={12}>
+                <div style={{ marginBottom: 8 }}>
+                  <Typography.Text>
+                    Type <Typography.Text type="danger">*</Typography.Text>
+                  </Typography.Text>
+                </div>
+                <Select
+                  value={pr.type}
+                  onChange={(value) => onUpdate(idx, "type", value)}
+                  options={REDIRECT_TYPE_OPTIONS}
+                  style={{ width: "100%" }}
+                />
+              </Col>
+              <Col span={12}>
+                <div style={{ marginBottom: 8 }}>
+                  <Typography.Text>Wildcard Matching</Typography.Text>
+                </div>
+                <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />}
+                  checked={pr.wildcard ?? false}
+                  onChange={(checked) => onUpdate(idx, "wildcard", checked)}
+                  style={{ marginRight: 8 }}
+                />
+                <Typography.Text type="secondary">
+                  Prefix match + capture path (301/302 only)
+                </Typography.Text>
+              </Col>
+            </Row>
+        </>
+      </Card>
+    </div>
+  );
+};
+
+export interface DomainRedirectsPanelProps {
+  domain: DomainRedirectsTarget;
+  onSaved?: () => void;
+}
+
+export const DomainRedirectsPanel = ({ domain, onSaved }: DomainRedirectsPanelProps) => {
+  const [wholeToggle, setWholeToggle] = useState(!!domain.redirect_all_to);
+  const [wholeUrl, setWholeUrl] = useState(domain.redirect_all_to ?? "");
+  const [wholeType, setWholeType] = useState(domain.redirect_all_type ?? "301");
+  const [pageRedirects, setPageRedirects] = useState<PageRedirect[]>(
+    domain.page_redirects ?? []
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const qc = useQueryClient();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // Re-sync from the source domain when it changes (e.g. the single-domain
+  // query refetches after a save elsewhere). page_redirects is an array, so
+  // JSON.stringify keys the effect — same load-bearing pattern as nginx_rules;
+  // a fresh array ref every render would otherwise re-fire and clobber edits.
+  useEffect(() => {
+    setWholeToggle(!!domain.redirect_all_to);
+    setWholeUrl(domain.redirect_all_to ?? "");
+    setWholeType(domain.redirect_all_type ?? "301");
+    setPageRedirects(domain.page_redirects ?? []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [domain.id, domain.redirect_all_to, domain.redirect_all_type, JSON.stringify(domain.page_redirects)]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = Number(active.id);
+      const newIndex = Number(over.id);
+      setPageRedirects(arrayMove(pageRedirects, oldIndex, newIndex));
+    }
+  };
+
+  const addPageRedirect = () => {
+    setPageRedirects([
+      ...pageRedirects,
+      { source: "", destination: "", type: "301", active: true, wildcard: false },
+    ]);
+  };
+
+  const removePageRedirect = (idx: number) => {
+    setPageRedirects(pageRedirects.filter((_, i) => i !== idx));
+  };
+
+  const updatePageRedirect = (
+    idx: number,
+    key: keyof PageRedirect,
+    value: string | boolean
+  ) => {
+    const updated = [...pageRedirects];
+    updated[idx] = { ...updated[idx], [key]: value };
+    setPageRedirects(updated);
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const body: Record<string, unknown> = {};
+
+      if (wholeToggle) {
+        const url = wholeUrl.trim();
+        if (!url) {
+          feedback.message.error("Enter a redirect URL");
+          setIsSaving(false);
+          return;
+        }
+        body.redirect_all_to = url;
+        body.redirect_all_type = wholeType;
+      } else {
+        // GH #717: send an empty string, NOT null, to CLEAR the whole-domain
+        // redirect. The API's *string field can't tell a JSON `null` apart from
+        // an omitted field — both unmarshal to a nil pointer, which the handler
+        // treats as "no change", so the redirect never got removed. An empty
+        // string is a non-nil pointer the handler clears on.
+        body.redirect_all_to = "";
+        body.redirect_all_type = "";
+      }
+
+      const clean = pageRedirects.map((pr) => ({
+        source: pr.source.trim(),
+        destination: pr.destination.trim(),
+        type: pr.type,
+        active: pr.active ?? true,
+        wildcard: pr.wildcard ?? false,
+      }));
+      // Don't send half-filled rows — drop blank ones silently
+      body.page_redirects = clean.filter((pr) => pr.source && pr.destination);
+
+      await apiClient.patch(`/domains/${domain.id}`, body);
+      feedback.message.success("Redirects saved");
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
+      onSaved?.();
+    } catch (err) {
+      const e = err as {
+        response?: { data?: { detail?: string } };
+        message?: string;
+      };
+      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 24 }}>
+        Redirect this domain to another domain or set up page redirects.
+      </Typography.Paragraph>
+
+      {/* Section 1: Redirect Entire Domain */}
+      <div style={{ marginBottom: 32 }}>
+        <div style={{ marginBottom: 12 }}>
+          <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />}
+            checked={wholeToggle}
+            onChange={setWholeToggle}
+            style={{ marginRight: 8 }}
+          />
+          <Typography.Text strong>Redirect Entire Domain</Typography.Text>
+        </div>
+        <Typography.Text type="secondary" style={{ marginBottom: 12, display: "block" }}>
+          Redirect all traffic from this domain to another domain
+        </Typography.Text>
+
+        {wholeToggle && (
+          <>
+            <Row gutter={16} style={{ marginBottom: 12 }}>
+              <Col span={12}>
+                <div style={{ marginBottom: 8 }}>
+                  <Typography.Text>
+                    Redirect To <Typography.Text type="danger">*</Typography.Text>
+                  </Typography.Text>
+                </div>
+                <Input
+                  placeholder="https://newdomain.com"
+                  value={wholeUrl}
+                  onChange={(e) => setWholeUrl(e.target.value)}
+                />
+              </Col>
+              <Col span={12}>
+                <div style={{ marginBottom: 8 }}>
+                  <Typography.Text>
+                    Redirect Type <Typography.Text type="danger">*</Typography.Text>
+                  </Typography.Text>
+                </div>
+                <Select
+                  value={wholeType}
+                  onChange={setWholeType}
+                  options={REDIRECT_TYPE_OPTIONS}
+                  style={{ width: "100%" }}
+                />
+              </Col>
+            </Row>
+            <Typography.Text type="secondary">
+              All requests to this domain will be redirected to this URL
+            </Typography.Text>
+          </>
+        )}
+      </div>
+
+      {/* Section 2: Page Redirects */}
+      <div
+        style={{
+          opacity: wholeToggle ? 0.5 : 1,
+          pointerEvents: wholeToggle ? "none" : "auto",
+        }}
+      >
+        <div style={{ marginBottom: 12 }}>
+          <Typography.Text strong>Page Redirects</Typography.Text>
+        </div>
+
+        <div style={{ marginBottom: 16 }}>
+          {pageRedirects.length > 0 && (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={pageRedirects.map((_, idx) => idx)}
+                strategy={verticalListSortingStrategy}
+              >
+                {pageRedirects.map((pr, idx) => (
+                  <SortableCard
+                    key={idx}
+                    idx={idx}
+                    pr={pr}
+                    onRemove={removePageRedirect}
+                    onUpdate={updatePageRedirect}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+          )}
+        </div>
+
+        <div style={{ textAlign: "center", marginBottom: 16 }}>
+          <Button icon={<PlusOutlined />} onClick={addPageRedirect}>
+            Add Page Redirect
+          </Button>
+        </div>
+
+        <Typography.Text type="secondary">
+          Redirect specific paths to other URLs. Drag to reorder, toggle active status, or enable wildcard matching.
+        </Typography.Text>
+      </div>
+
+      <div style={{ marginTop: 24 }}>
+        <Button
+          type="primary"
+          icon={<CheckOutlined />}
+          onClick={handleSave}
+          loading={isSaving}
+        >
+          Save Redirects
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -127,6 +127,21 @@ describe("WebDomainPage (GH #1543)", () => {
     );
   });
 
+  it("renders the Redirects pane when :tab=redirects and saves", async () => {
+    renderAt("/jabali-panel/domains/d1/redirects");
+    expect(await screen.findByText("Redirect Entire Domain")).toBeInTheDocument();
+    // Whole-domain toggle starts OFF (fixture has no redirect_all_to). Saving
+    // sends empty strings, not null — the GH #717 clear semantics.
+    fireEvent.click(screen.getByRole("button", { name: "Save Redirects" }));
+    await vi.waitFor(() =>
+      expect(patch).toHaveBeenCalledWith("/domains/d1", {
+        redirect_all_to: "",
+        redirect_all_type: "",
+        page_redirects: [],
+      }),
+    );
+  });
+
   it("renders the Caching pane when :tab=caching", async () => {
     renderAt("/jabali-panel/domains/d1/caching");
     expect(await screen.findByText("caching-pane:d1")).toBeInTheDocument();

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -4,12 +4,12 @@
 // modal launchers. The tab lives in the URL (:tab), so a tab is linkable and
 // the browser Back button walks the tabs.
 //
-// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles), Index
-// Files, Caching and Directory Privacy, plus three tabs gated on the same caps
-// as the row menu — Domain options and Rewrite rules (tenant_domain_options_
-// enabled) and Document root (tenant_docroot_editable). Redirects and folding
-// DNS in move here in a follow-up, which also strips the row menu down to
-// Disable/Delete.
+// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles),
+// Redirects, Index Files, Caching and Directory Privacy, plus three tabs gated
+// on the same caps as the row menu — Domain options and Rewrite rules
+// (tenant_domain_options_enabled) and Document root (tenant_docroot_editable).
+// Folding DNS in and stripping the row menu down to Disable/Delete move here in
+// follow-up slices.
 import type { ReactNode } from "react";
 import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
 import { GlobalOutlined } from "@icons";
@@ -22,6 +22,7 @@ import type { Domain } from "../../../components/domains/types";
 import { DomainCacheSection } from "../../../components/DomainCacheSection";
 import { DomainDirectoryPrivacySection } from "../../admin/domains/DomainDirectoryPrivacySection";
 import { DomainIndexPanel } from "../../DomainIndexPanel";
+import { DomainRedirectsPanel } from "../../DomainRedirectsPanel";
 import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsPanel";
 import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
 import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
@@ -84,6 +85,7 @@ export const WebDomainPage = () => {
 
   const tabs: { key: string; label: string; node: ReactNode }[] = [
     { key: "overview", label: "Overview", node: <OverviewTab domain={domain} /> },
+    { key: "redirects", label: "Redirects", node: <DomainRedirectsPanel domain={domain} /> },
     { key: "index", label: "Index Files", node: <DomainIndexPanel domain={domain} /> },
     { key: "caching", label: "Caching", node: <DomainCacheSection domainId={domain.id} /> },
     {


### PR DESCRIPTION
## What

Third slice of the tenant Web Domains restructure (#1543). Slice A shipped the tabbed Web Domain page; A2 (#1563) moved the per-domain **settings** actions onto it as tabs. This slice adds **Redirects** as a tab on the same page.

## How

Same pane-extraction pattern as A2: the redirects form body — whole-domain redirect + the per-page redirects list (dnd-kit drag-reorder, active toggle, wildcard) — moves from `DomainRedirectsButton` into a standalone `DomainRedirectsPanel`. It renders both inline (the Redirects tab) and back inside the row-menu Modal, which now delegates with `footer={null}`.

The panel preserves the GH #717 clear semantics verbatim — turning the whole-domain redirect off sends an empty string, not `null`, so the API actually clears it — and re-syncs from the source domain on change, keyed on `JSON.stringify(page_redirects)` so an unsaved edit survives a background refetch. Saving invalidates both the domain list and the single-domain query.

`Domain` is assignable to `DomainRedirectsTarget` (all redirect fields optional), so no type change was needed; the Redirects tab sits right after Overview, matching the row menu's redirects-then-index order.

## Scope / what is deferred

- The tenant row menu is **unchanged** this slice.
- Next two slices: strip the tenant row menu down to Disable/Delete and remove the now-dead tenant-only modal wrappers (Domain options, Document root, Rewrite rules, Directory Privacy — admin never opens those); and fold the DNS records view into a tab (extracting a shared panel out of `DNSRecordsPage`, which admin still uses as a standalone page).

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on all changed files
- [x] `WebDomainPage` suite: renders the Redirects tab and saving sends the #717 empty-string clear (`{redirect_all_to: "", redirect_all_type: "", page_redirects: []}`)
- [x] `DomainRedirectsButton.clear.test` (GH #717) still passes through the delegate — the regression stays covered
- [x] Full domain-area suite green (46 tests, no regression from the button rewrite)

GH #1543
