### PR TITLE
fix(agent): fail closed when the main-socket UID gate is unset or mangled (JAB-357)

### DIFF
--- a/install/tests/test_agent_socket_uid_gate.sh
+++ b/install/tests/test_agent_socket_uid_gate.sh
@@ -47,5 +47,14 @@ if ! grep -qE '\[\[ -n "\$panel_uid" \]\] \|\| _die' install.sh; then
   fail=1
 fi
 
+# JAB-357 fail-open hardening: the production agent unit must NEVER carry the
+# -insecure-allow-any-uid opt-out. That flag disables the SO_PEERCRED gate; it
+# exists only for out-of-systemd test runs. Its presence in install.sh would
+# reopen the exact root trust-boundary hole the gate closes.
+if grep -qE 'insecure-allow-any-uid' install.sh; then
+  echo "FAIL: install.sh passes -insecure-allow-any-uid — this disables the agent SO_PEERCRED gate (JAB-357)"
+  fail=1
+fi
+
 if [[ "$fail" -ne 0 ]]; then exit 1; fi
 echo "PASS: agent socket SO_PEERCRED UID gate is wired to panel_uid,0 (JAB-366/357)"

--- a/panel-agent/cmd/jabali-agent/main.go
+++ b/panel-agent/cmd/jabali-agent/main.go
@@ -4,15 +4,21 @@
 // connection, dispatches to a handler from the commands registry, and
 // writes a single NDJSON response.
 //
-// Access control is enforced entirely via socket permissions — agent never
-// parses credentials. Production install places the socket in a directory
-// owned root:jabali 0750 with the socket itself root:jabali 0660, so only
-// root and the jabali group (i.e. the panel-api process) can connect.
+// Access control has two layers. First, socket permissions: production
+// install places the socket in a directory owned root:jabali 0750 with the
+// socket itself root:jabali 0660, so only root and the jabali group (i.e.
+// the panel-api process) can connect. Second, an SO_PEERCRED UID allow-list
+// (JAB-366/357): the connecting peer's UID must be on the -allowed-uids list
+// (panel user + root), and the binary refuses to start without that gate
+// unless -insecure-allow-any-uid is passed. The agent never parses
+// credentials carried in the request itself.
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -63,12 +69,21 @@ func main() {
 		// webmail) could connect and drive every privileged command. Gate by the
 		// CONNECTING UID too: only the panel-api user (jabali) + root (operator
 		// CLI) are authorised, so a group regression can never silently re-grant
-		// agent root. Empty = allow any (kept for out-of-systemd test runs);
-		// install.sh always passes the real list.
-		allowedUIDs = flag.String("allowed-uids", envOr("JABALI_AGENT_ALLOWED_UIDS", ""), "comma-separated UIDs allowed to connect to the main socket (SO_PEERCRED gate); empty = allow any (testing only)")
-		timeout     = flag.Duration("timeout", defaultTimeout, "per-request wall-clock timeout (when caller sets no deadline)")
-		logFormat   = flag.String("log-format", envOr("JABALI_AGENT_LOG_FORMAT", "json"), "json|text")
-		logLevel    = flag.String("log-level", envOr("JABALI_AGENT_LOG_LEVEL", "info"), "debug|info|warn|error")
+		// agent root. install.sh always passes the real list (panel_uid,0).
+		//
+		// JAB-357 (fail-open hardening): an empty or wholly-malformed list must
+		// NOT silently disable the gate — that is the same "config regression
+		// silently grants root" hole the gate exists to close. decideUIDGate makes
+		// it fatal at startup unless -insecure-allow-any-uid is passed explicitly.
+		allowedUIDs = flag.String("allowed-uids", envOr("JABALI_AGENT_ALLOWED_UIDS", ""), "comma-separated UIDs allowed to connect to the main socket (SO_PEERCRED gate); empty is fatal unless -insecure-allow-any-uid")
+		// insecureAllowAny is the ONLY way to run the main socket without a
+		// SO_PEERCRED allow-list. It is a CLI flag with no env fallback on purpose:
+		// an Environment= drop-in would be exactly the silent channel this hardening
+		// closes. The "insecure-" name is the documentation — no prod unit carries it.
+		insecureAllowAny = flag.Bool("insecure-allow-any-uid", false, "disable the main socket SO_PEERCRED gate (out-of-systemd test runs only; never in production)")
+		timeout          = flag.Duration("timeout", defaultTimeout, "per-request wall-clock timeout (when caller sets no deadline)")
+		logFormat        = flag.String("log-format", envOr("JABALI_AGENT_LOG_FORMAT", "json"), "json|text")
+		logLevel         = flag.String("log-level", envOr("JABALI_AGENT_LOG_LEVEL", "info"), "debug|info|warn|error")
 	)
 	flag.Parse()
 
@@ -102,11 +117,15 @@ func main() {
 		// Note: we hold the client for the process lifetime; no defer Close().
 	}
 
-	allowUID := parseUIDList(*allowedUIDs)
+	allowUID, err := decideUIDGate(*allowedUIDs, *insecureAllowAny)
+	if err != nil {
+		log.Error("agent main socket SO_PEERCRED gate misconfigured", "err", err)
+		os.Exit(2)
+	}
 	if len(allowUID) > 0 {
 		log.Info("agent main socket SO_PEERCRED gate active", "allowed_uids", allowUID)
 	} else {
-		log.Warn("agent main socket SO_PEERCRED gate DISABLED (no -allowed-uids) — any local UID with socket access may connect")
+		log.Warn("agent main socket SO_PEERCRED gate DISABLED via -insecure-allow-any-uid — any local UID with socket access may connect (test runs only)")
 	}
 
 	srv, err := server.New(server.Config{
@@ -189,10 +208,11 @@ func newLogger(format, level string) *slog.Logger {
 }
 
 // parseUIDList parses a comma-separated UID list ("1001,0") into []uint32,
-// skipping blanks and unparseable entries. An empty/blank input yields an
-// empty slice, which the server treats as "gate disabled" (allow any). Used
-// only at startup, so a bad entry logs nothing louder than being ignored —
-// install.sh builds the value from `id -u`, not user input.
+// skipping blanks and unparseable entries. Dropping a bad entry from an
+// otherwise-valid list only ever RESTRICTS who may connect (fail-closed
+// direction), so "1001,xyz" → [1001] is safe. Whether an EMPTY result is
+// tolerated is decided by decideUIDGate, not here — an all-malformed or unset
+// list must not silently open the socket.
 func parseUIDList(s string) []uint32 {
 	var out []uint32
 	for _, part := range strings.Split(s, ",") {
@@ -207,6 +227,40 @@ func parseUIDList(s string) []uint32 {
 		out = append(out, uint32(n))
 	}
 	return out
+}
+
+// decideUIDGate resolves the main socket's SO_PEERCRED policy at startup and
+// fails closed (JAB-357). It never returns an empty allow-list together with a
+// nil error unless the operator explicitly opted out with -insecure-allow-any-uid:
+//
+//   - a list that parses to one or more UIDs → gate active with those UIDs;
+//   - a NON-BLANK list that parses to zero UIDs (every entry malformed) → fatal,
+//     because the operator intended a gate and it wholly failed to parse; the
+//     opt-out does NOT rescue this, since garbage is never a deliberate "open";
+//   - a blank/unset list → fatal unless insecureAllowAny is set, in which case
+//     the gate is deliberately disabled (test runs only).
+//
+// This closes the fail-open where a mangled -allowed-uids used to silently serve
+// the root Agent socket to any local UID.
+func decideUIDGate(rawAllowed string, insecureAllowAny bool) ([]uint32, error) {
+	uids := parseUIDList(rawAllowed)
+	if len(uids) > 0 {
+		return uids, nil
+	}
+	hadToken := false
+	for _, part := range strings.Split(rawAllowed, ",") {
+		if strings.TrimSpace(part) != "" {
+			hadToken = true
+			break
+		}
+	}
+	if hadToken {
+		return nil, fmt.Errorf("-allowed-uids %q was set but no valid UID parsed; refusing to open the main socket without a SO_PEERCRED gate", rawAllowed)
+	}
+	if !insecureAllowAny {
+		return nil, errors.New("refusing to serve the main agent socket without a SO_PEERCRED allow-list; set -allowed-uids (install.sh does) or pass -insecure-allow-any-uid for out-of-systemd test runs only")
+	}
+	return nil, nil
 }
 
 // envOr returns the env var if set + non-empty, else fallback. Tiny helper

--- a/panel-agent/cmd/jabali-agent/main_test.go
+++ b/panel-agent/cmd/jabali-agent/main_test.go
@@ -6,8 +6,9 @@ import (
 )
 
 // JAB-366: parseUIDList feeds the main agent socket's SO_PEERCRED allow-list.
-// install.sh builds it as "<panel_uid>,0"; it must parse cleanly, skip blanks,
-// and ignore junk rather than fail the agent at startup.
+// install.sh builds it as "<panel_uid>,0". It skips blanks and junk WITHIN a
+// list (dropping a bad token only restricts the allow-list); whether an empty
+// result is tolerated is decided by decideUIDGate, tested below.
 func TestParseUIDList(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -25,6 +26,46 @@ func TestParseUIDList(t *testing.T) {
 		got := parseUIDList(c.in)
 		if !reflect.DeepEqual(got, c.want) {
 			t.Errorf("parseUIDList(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// JAB-357 fail-open hardening: decideUIDGate must never yield an empty allow-list
+// with a nil error unless the operator explicitly opted out. A mangled or unset
+// -allowed-uids used to silently disable the SO_PEERCRED gate and serve the root
+// Agent socket to any local UID (e.g. a regressed webmail service account).
+func TestDecideUIDGate(t *testing.T) {
+	cases := []struct {
+		name             string
+		raw              string
+		insecureAllowAny bool
+		want             []uint32
+		wantErr          bool
+	}{
+		// Prod path (install.sh passes panel_uid,0) — unchanged, gate active.
+		{"prod list", "1001,0", false, []uint32{1001, 0}, false},
+		{"root only", "0", false, []uint32{0}, false},
+		// A bad token inside a valid list only restricts the allow-list → kept.
+		{"partial junk stays active", "1001,xyz", false, []uint32{1001}, false},
+		// Unset/blank without the opt-out is fatal, not fail-open.
+		{"unset is fatal", "", false, nil, true},
+		{"blank is fatal", "   ", false, nil, true},
+		{"commas only is fatal", " , , ", false, nil, true},
+		// Explicit opt-out disables the gate (test runs only).
+		{"unset with opt-out ok", "", true, nil, false},
+		// All-malformed is fatal EVEN WITH the opt-out: garbage is never a
+		// deliberate "open", and the operator clearly intended a gate. (Load-bearing.)
+		{"all junk is fatal despite opt-out", "abc,xyz", true, nil, true},
+		{"all junk is fatal", "abc,xyz", false, nil, true},
+		{"lone bad uid is fatal", "-1", false, nil, true},
+	}
+	for _, c := range cases {
+		got, err := decideUIDGate(c.raw, c.insecureAllowAny)
+		if (err != nil) != c.wantErr {
+			t.Errorf("%s: decideUIDGate(%q, %v) err = %v; wantErr %v", c.name, c.raw, c.insecureAllowAny, err, c.wantErr)
+		}
+		if !c.wantErr && !reflect.DeepEqual(got, c.want) {
+			t.Errorf("%s: decideUIDGate(%q, %v) = %v; want %v", c.name, c.raw, c.insecureAllowAny, got, c.want)
 		}
 	}
 }

--- a/panel-agent/internal/server/server.go
+++ b/panel-agent/internal/server/server.go
@@ -43,8 +43,11 @@ type Config struct {
 	PerRequestTimeout time.Duration
 
 	// AllowedUIDs lists the Unix UIDs permitted to connect. If empty, any
-	// UID is allowed (for testing). Production should set this to the
-	// panel-api user's UID + root (0).
+	// UID is allowed — this tolerance is for the server package's own tests,
+	// which construct a socket without a gate. The PRODUCTION policy lives at
+	// the composition root (cmd/jabali-agent decideUIDGate, JAB-357): the
+	// binary refuses to start with an empty/mangled allow-list unless
+	// explicitly opted out, so an empty list never reaches here in production.
 	AllowedUIDs []uint32
 
 	// MaxRequestBytes caps a single NDJSON request line. A misbehaving or


### PR DESCRIPTION
## What

The main agent socket's `SO_PEERCRED` UID allow-list (JAB-366, #1217) is the trust boundary that stops a regressed non-panel service account — webmail was the reported case in JAB-357 — from reaching `/run/jabali/agent.sock` and driving every privileged Agent command as root. It resolved **fail-open**: `parseUIDList` silently drops unparseable entries, so an unset *or* wholly-malformed `-allowed-uids` yielded an empty slice, and both `main.go` and `server.go` treat an empty list as "gate disabled, allow any UID." A mangled flag therefore silently reopened the exact root trust-boundary hole the gate exists to close — precisely the "an accidental regression must not silently grant root" property the ticket's AC #3 demands, in configuration form. This was flagged as a residual on JAB-357 by the independent AI security review ("the Agent UID parser/config is fail-open when the list is empty or wholly malformed").

Production is correctly wired today (`install.sh` passes `-allowed-uids ${panel_uid},0`, and `install.sh` already `_die`s if `panel_uid` can't be resolved), so this closes the *config-regression* path, not a live prod exposure.

## How

New `decideUIDGate` at the composition root (`cmd/jabali-agent`) makes an empty allow-list fatal at startup:

- **list parses to ≥1 UID** → gate active with those UIDs. **Production path, unchanged.**
- **non-blank list parses to 0 UIDs** (every entry malformed) → **fatal**. The operator plainly intended a gate and it wholly failed to parse; the opt-out below does *not* rescue this — garbage is never a deliberate "open".
- **blank/unset list** → **fatal** unless the new `-insecure-allow-any-uid` flag is passed (the only way to run the socket ungated — out-of-systemd test runs only).

Dropping a bad token from an otherwise-valid list still only *restricts* the allow-list (`"1001,xyz"` → `[1001]`), which is the fail-closed direction, so that remains a warning-free skip. The opt-out is a **CLI flag with no environment fallback on purpose** — an `Environment=` drop-in would be exactly the silent channel this hardening closes, and the `insecure-` name keeps it out of prod units.

`server.go` keeps its empty-list tolerance (the server package's own tests construct a socket without a gate); the production policy now lives entirely at the binary, which never hands the server an empty list unless explicitly opted out. Comment-only change there to say so. The `cmd/jabali-agent` package doc comment is also corrected: it claimed access was "enforced entirely via socket permissions," which has been stale since the SO_PEERCRED gate landed in #1217 — it now describes both layers.

## Scope

- `panel-agent` only. No fleet action, `stable` untouched. The agent verb surface is unchanged.
- Production start is **unchanged** — the non-empty-list path behaves exactly as before; only empty/malformed config now fails closed instead of open.

## Tests

- `TestDecideUIDGate`: gate-active (`1001,0`, `0`), partial-junk-stays-active (`1001,xyz` → `[1001]`), and the fatal cases — unset, blank, commas-only, all-malformed **with and without** the opt-out (load-bearing: the opt-out must not rescue garbage), lone bad uid. Falsified by reverting `decideUIDGate` to the old fail-open → all six fatal rows red.
- `install/tests/test_agent_socket_uid_gate.sh`: new negative pin that `install.sh` never passes `-insecure-allow-any-uid` (AC #6 — guards the "someone adds the opt-out to the prod unit to fix a dev problem" regression). Script passes against current `install.sh`.
- Built the binary and verified end to end: `-socket … ` with **no** `-allowed-uids` → exit 2, error logged, **no socket bound**; `-allowed-uids "abc,xyz"` → exit 2; `-allowed-uids $(id -u),0` → gate active, proceeds to serve.
- `go test -race ./cmd/jabali-agent/ ./internal/server/`, `go vet`, `gofmt` all clean.

## Ticket

JAB-357 stays **In Progress** — its only remaining criterion is #7 (operator secret rotation), which is operational, not code. This hardens criterion #3's gate (shipped in JAB-366 / #1217) so a config regression can no longer silently disable it. Note for reviewers/operators: **out-of-systemd dev runs of the agent now require `-insecure-allow-any-uid`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
