### PR TITLE
feat(domains): fold DNS into a Web Domain tab; tenant menu is now Enable/Delete (GH #1543)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -364,10 +364,9 @@ const ThemedApp = () => {
             <Route path="domains">
               <Route index element={<UserDomainList />} />
               <Route path="create" element={<Navigate to="../domains" replace />} />
-              {/* Static :id/dns outranks the dynamic :id/:tab (GH #1543 folds DNS
-                  into a tab in a follow-up); the tabbed Web Domain page owns the
-                  rest. */}
-              <Route path=":id/dns" element={<DNSRecordsPage />} />
+              {/* GH #1543: DNS is now a tab on the Web Domain page — :id/:tab
+                  catches "dns" and WebDomainPage renders DNSRecordsPanel embedded.
+                  Admin keeps its standalone /jabali-admin/domains/:id/dns route. */}
               <Route path=":id" element={<WebDomainPage />} />
               <Route path=":id/:tab" element={<WebDomainPage />} />
             </Route>

--- a/panel-ui/src/components/domains/domainActions.test.tsx
+++ b/panel-ui/src/components/domains/domainActions.test.tsx
@@ -78,14 +78,14 @@ describe("buildDomainMenuItems — admin audience", () => {
 });
 
 describe("buildDomainMenuItems — tenant audience", () => {
-  it("is stripped to DNS + Enable/Delete — the per-domain editors moved to the Web Domain page (GH #1543)", () => {
+  it("is stripped to Enable/Delete — every per-domain surface (incl. DNS) moved to the Web Domain page (GH #1543)", () => {
     const k = keys(buildDomainMenuItems(row(), ctx({ caps: { dns_enabled: true } })));
-    expect(k).toEqual(["dns", "toggle", "delete"]);
-    // Everything that used to open a row modal (or toggle from the row) now
-    // lives on the page reached by clicking the domain name.
+    expect(k).toEqual(["toggle", "delete"]);
+    // Everything that used to open a row modal, toggle from the row, or navigate
+    // to DNS now lives on the page reached by clicking the domain name.
     for (const gone of [
       "edit", "info", "settings",
-      "redirects", "index", "directory-privacy", "caching",
+      "dns", "redirects", "index", "directory-privacy", "caching",
       "nginx-options", "rewrite-rules", "document-root",
       "preview-url", "bot-challenge",
     ]) {
@@ -100,14 +100,7 @@ describe("buildDomainMenuItems — tenant audience", () => {
         ctx({ caps: { dns_enabled: true, tenant_domain_options_enabled: true, tenant_docroot_editable: true } }),
       ),
     );
-    expect(k).toEqual(["dns", "toggle", "delete"]);
-  });
-
-  it("DNS navigates to the tenant route prefix", () => {
-    const navigate = vi.fn();
-    const items = buildDomainMenuItems(row(), ctx({ caps: { dns_enabled: true }, navigate }));
-    byKey(items, "dns")?.onClick?.();
-    expect(navigate).toHaveBeenCalledWith("/jabali-panel/domains/d1/dns");
+    expect(k).toEqual(["toggle", "delete"]);
   });
 });
 
@@ -135,7 +128,7 @@ describe("buildDomainMenuItems — shared lifecycle wiring", () => {
     ]);
 
     // The tenant menu no longer opens any modal — clicking every item it offers
-    // (dns / toggle / delete) never calls onOpenModal.
+    // (toggle / delete) never calls onOpenModal.
     const onOpenTenant = vi.fn();
     const tenant = buildDomainMenuItems(
       row({ id: "d2" }),

--- a/panel-ui/src/components/domains/domainActions.tsx
+++ b/panel-ui/src/components/domains/domainActions.tsx
@@ -6,10 +6,10 @@
 // callback DomainInventory supplies, so the builder stays a pure list producer
 // that unit tests can exercise per audience.
 //
-// GH #1543: the tenant per-domain actions moved onto the dedicated Web Domain
-// page (row-click → tabs). The tenant menu is now just DNS + Disable/Delete —
-// DNS stays until it too is folded into a tab. The admin list is unchanged; it
-// keeps its full modal-driven menu (admin has no per-domain page).
+// GH #1543: the tenant per-domain actions (DNS and every editor) moved onto the
+// dedicated Web Domain page (row-click → tabs). The tenant menu is now just
+// Enable/Disable + Delete. The admin list is unchanged; it keeps its full
+// modal-driven menu, including DNS (admin has no per-domain page).
 import {
   DeleteOutlined,
   EditOutlined,
@@ -151,10 +151,10 @@ export function buildDomainMenuItems(r: Domain, ctx: DomainMenuCtx): MenuProps["
     ];
   }
 
-  // Tenant. Every per-domain editor (Redirects, Index, Caching, Directory
-  // Privacy, Domain options, Rewrite rules, Document root) and the preview-URL /
-  // bot-challenge toggles now live on the dedicated Web Domain page, reached by
-  // clicking the domain name. The row menu keeps only DNS (until it too becomes
-  // a tab) and the Enable/Disable + Delete lifecycle. GH #1543.
-  return [...dnsItem, toggleItem, ...deleteItems];
+  // Tenant. Every per-domain surface — the editors (Redirects, Index, Caching,
+  // Directory Privacy, Domain options, Rewrite rules, Document root), the
+  // preview-URL / bot-challenge toggles, and now DNS — lives on the dedicated
+  // Web Domain page, reached by clicking the domain name. The row menu keeps
+  // only the Enable/Disable + Delete lifecycle. GH #1543.
+  return [toggleItem, ...deleteItems];
 }

--- a/panel-ui/src/shells/dns/DNSRecordsPage.tsx
+++ b/panel-ui/src/shells/dns/DNSRecordsPage.tsx
@@ -163,9 +163,20 @@ const getPlaceholders = (
   }
 };
 
-export const DNSRecordsPage = () => {
+interface DNSRecordsPanelProps {
+  domainId: string;
+  // embedded → rendered inside the tenant Web Domain page's DNS tab, which
+  // already frames the domain name and provides navigation; suppress this
+  // component's own Back link + title. Standalone (admin route, DNS-zones
+  // drill-in) keeps them.
+  embedded?: boolean;
+}
+
+// GH #1543: the DNS records manager. Renders standalone (the admin
+// /jabali-admin/domains/:id/dns route and the tenant DNS-zones drill-in) and
+// embedded as the DNS tab on the tenant Web Domain page.
+export const DNSRecordsPanel = ({ domainId, embedded = false }: DNSRecordsPanelProps) => {
   const { t } = useTranslation();
-  const { id: domainId } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const { open } = useNotification();
@@ -498,14 +509,16 @@ export const DNSRecordsPage = () => {
   if (zoneNotProvisioned) {
     return (
       <div >
-        <Button
-          type="text"
-          icon={<ArrowLeftOutlined />}
-          onClick={() => navigate(dnsListPath)}
-          style={{ marginBottom: 16 }}
-        >
-          Back to DNS
-        </Button>
+        {!embedded && (
+          <Button
+            type="text"
+            icon={<ArrowLeftOutlined />}
+            onClick={() => navigate(dnsListPath)}
+            style={{ marginBottom: 16 }}
+          >
+            Back to DNS
+          </Button>
+        )}
 
         <Card
           style={{
@@ -532,25 +545,29 @@ export const DNSRecordsPage = () => {
   return (
     <div >
       {/* Header */}
-      <Button
-        type="text"
-        icon={<ArrowLeftOutlined />}
-        onClick={() => navigate(dnsListPath)}
-        style={{ marginBottom: 16 }}
-      >
-        Back to DNS
-      </Button>
+      {!embedded && (
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate(dnsListPath)}
+          style={{ marginBottom: 16 }}
+        >
+          Back to DNS
+        </Button>
+      )}
 
       <Flex
         wrap
         gap="middle"
-        justify="space-between"
+        justify={embedded ? "flex-end" : "space-between"}
         align="center"
         style={{ marginBottom: 16 }}
       >
-        <Typography.Title level={3} style={{ margin: 0, wordBreak: "break-word" }}>
-          DNS Records for {domain?.name}
-        </Typography.Title>
+        {!embedded && (
+          <Typography.Title level={3} style={{ margin: 0, wordBreak: "break-word" }}>
+            DNS Records for {domain?.name}
+          </Typography.Title>
+        )}
         <Tooltip title={creatableTypeOptions.length === 0 ? "Your administrator does not allow creating any DNS record types." : ""}>
           <Button
             type="primary"
@@ -959,4 +976,12 @@ export const DNSRecordsPage = () => {
       </Drawer>
     </div>
   );
+};
+
+// Standalone page wrapper: the admin /jabali-admin/domains/:id/dns route (and
+// the tenant DNS-zones drill-in, which now lands on the tenant Web Domain page's
+// DNS tab instead) read the domain id from the URL. Embedded callers pass it in.
+export const DNSRecordsPage = () => {
+  const { id } = useParams<{ id: string }>();
+  return <DNSRecordsPanel domainId={id ?? ""} />;
 };

--- a/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.test.tsx
@@ -1,11 +1,12 @@
-// UserDomainList.test.tsx — GH #1419. The Domains list Actions menu showed a
-// "DNS" entry even when the DNS module is off, leading to a page that only
-// redirects + 403s. It must be hidden, gated on the shared server-capabilities
-// dns flag (the same signal the sidebar uses). Real AntD table + dropdown run.
+// UserDomainList.test.tsx — GH #1543 + #1541. The tenant Domains list: the
+// domain name links to its own Web Domain page, and a single "Add Web Domain"
+// button opens the create drawer. DNS gating moved off the row menu (which is
+// now just Enable/Delete) onto the Web Domain page's DNS tab — see
+// WebDomainPage.test for the relocated GH #1419 coverage.
 import { App } from "antd";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { UserDomainList } from "./UserDomainList";
 
@@ -51,49 +52,9 @@ vi.mock("../../../hooks/useTableURL", () => ({
   }),
 }));
 
-let dnsEnabled = true;
 vi.mock("../../../hooks/useServerCapabilities", () => ({
-  useServerCapabilities: () => ({ data: { dns_enabled: dnsEnabled } }),
+  useServerCapabilities: () => ({ data: { dns_enabled: true } }),
 }));
-
-const openRowMenu = async () => {
-  const moreBtn = await screen.findByRole("button", { name: /more/i }, { timeout: 5000 });
-  fireEvent.click(moreBtn);
-};
-
-beforeEach(() => {
-  dnsEnabled = true;
-});
-
-describe("UserDomainList DNS action gating (GH #1419)", () => {
-  it("shows the DNS action when the DNS module is enabled", async () => {
-    render(
-      <MemoryRouter>
-        <App>
-          <UserDomainList />
-        </App>
-      </MemoryRouter>,
-    );
-    await openRowMenu();
-    expect(await screen.findByText("DNS")).toBeInTheDocument();
-  });
-
-  it("hides the DNS action when the DNS module is disabled", async () => {
-    dnsEnabled = false;
-    render(
-      <MemoryRouter>
-        <App>
-          <UserDomainList />
-        </App>
-      </MemoryRouter>,
-    );
-    await openRowMenu();
-    // Another always-present action confirms the menu opened. GH #1543 stripped
-    // the tenant menu to DNS + Enable/Delete, so Delete is the stable anchor.
-    expect(await screen.findByText("Delete")).toBeInTheDocument();
-    expect(screen.queryByText("DNS")).not.toBeInTheDocument();
-  });
-});
 
 // GH #1543: on the tenant list the domain name links to its own Web Domain
 // page (not the live site); a separate launch icon still opens the live site.

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -27,7 +27,9 @@ const domainQ = vi.hoisted(() => ({
   },
 }));
 const patch = vi.hoisted(() => vi.fn());
-const caps = vi.hoisted(() => ({ value: { tenant_domain_options_enabled: false, tenant_docroot_editable: false } }));
+const caps = vi.hoisted(() => ({
+  value: { dns_enabled: true, tenant_domain_options_enabled: false, tenant_docroot_editable: false } as Record<string, boolean>,
+}));
 
 vi.mock("react-router", async () => {
   const actual = await vi.importActual<typeof import("react-router")>("react-router");
@@ -50,6 +52,9 @@ vi.mock("../../DomainSettingsButton", () => ({
 }));
 vi.mock("../../../components/domains/DomainDocRootPanel", () => ({
   DomainDocRootPanel: ({ domainId }: { domainId: string }) => <div>docroot-pane:{domainId}</div>,
+}));
+vi.mock("../../dns/DNSRecordsPage", () => ({
+  DNSRecordsPanel: ({ domainId }: { domainId: string }) => <div>dns-pane:{domainId}</div>,
 }));
 vi.mock("../../../components/DomainCacheSection", () => ({
   DomainCacheSection: ({ domainId }: { domainId: string }) => <div>caching-pane:{domainId}</div>,
@@ -85,7 +90,7 @@ beforeEach(() => {
   setBreadcrumbs.mockReset();
   patch.mockReset();
   patch.mockResolvedValue({});
-  caps.value = { tenant_domain_options_enabled: false, tenant_docroot_editable: false };
+  caps.value = { dns_enabled: true, tenant_domain_options_enabled: false, tenant_docroot_editable: false };
   domainQ.value = {
     data: {
       id: "d1",
@@ -140,6 +145,18 @@ describe("WebDomainPage (GH #1543)", () => {
         page_redirects: [],
       }),
     );
+  });
+
+  it("shows the DNS tab and renders the DNS panel when the DNS module is on (GH #1419 gating relocated from the row menu)", async () => {
+    renderAt("/jabali-panel/domains/d1/dns");
+    expect(await screen.findByText("dns-pane:d1")).toBeInTheDocument();
+  });
+
+  it("hides the DNS tab and falls back to Overview when the DNS module is off (GH #1419)", async () => {
+    caps.value = { dns_enabled: false, tenant_domain_options_enabled: false, tenant_docroot_editable: false };
+    renderAt("/jabali-panel/domains/d1/dns");
+    expect(await screen.findByText("Preview URL")).toBeInTheDocument();
+    expect(screen.queryByText("dns-pane:d1")).not.toBeInTheDocument();
   });
 
   it("renders the Caching pane when :tab=caching", async () => {

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -4,12 +4,13 @@
 // modal launchers. The tab lives in the URL (:tab), so a tab is linkable and
 // the browser Back button walks the tabs.
 //
-// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles),
-// Redirects, Index Files, Caching and Directory Privacy, plus three tabs gated
-// on the same caps as the row menu — Domain options and Rewrite rules
-// (tenant_domain_options_enabled) and Document root (tenant_docroot_editable).
-// Folding DNS in and stripping the row menu down to Disable/Delete move here in
-// follow-up slices.
+// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles), DNS
+// (gated on dns_enabled), Redirects, Index Files, Caching and Directory
+// Privacy, plus three tabs gated on the same caps as the old row menu — Domain
+// options and Rewrite rules (tenant_domain_options_enabled) and Document root
+// (tenant_docroot_editable). The tenant row menu is now just Enable/Delete; the
+// DNS records manager (DNSRecordsPanel) renders here embedded and standalone on
+// the admin route.
 import type { ReactNode } from "react";
 import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
 import { GlobalOutlined } from "@icons";
@@ -23,6 +24,7 @@ import { DomainCacheSection } from "../../../components/DomainCacheSection";
 import { DomainDirectoryPrivacySection } from "../../admin/domains/DomainDirectoryPrivacySection";
 import { DomainIndexPanel } from "../../DomainIndexPanel";
 import { DomainRedirectsPanel } from "../../DomainRedirectsPanel";
+import { DNSRecordsPanel } from "../../dns/DNSRecordsPage";
 import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsPanel";
 import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
 import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
@@ -82,9 +84,15 @@ export const WebDomainPage = () => {
   // sees neither the menu item nor the tab (never a disabled stub).
   const optionsOn = caps?.tenant_domain_options_enabled === true;
   const docrootOn = caps?.tenant_docroot_editable === true;
+  // DNS folds in here as a tab (GH #1543). Gate on the same dns_enabled signal
+  // the sidebar and the old row-menu item used — default-on while caps load.
+  const dnsOn = caps?.dns_enabled !== false;
 
   const tabs: { key: string; label: string; node: ReactNode }[] = [
     { key: "overview", label: "Overview", node: <OverviewTab domain={domain} /> },
+    ...(dnsOn
+      ? [{ key: "dns", label: "DNS", node: <DNSRecordsPanel domainId={domain.id} embedded /> }]
+      : []),
     { key: "redirects", label: "Redirects", node: <DomainRedirectsPanel domain={domain} /> },
     { key: "index", label: "Index Files", node: <DomainIndexPanel domain={domain} /> },
     { key: "caching", label: "Caching", node: <DomainCacheSection domainId={domain.id} /> },

--- a/panel-ui/tests/e2e/dns-record-permissions.spec.ts
+++ b/panel-ui/tests/e2e/dns-record-permissions.spec.ts
@@ -1,5 +1,6 @@
-// Wave D E2E for GH #466: the tenant DNS Records page must honor the admin's
-// per-type permission matrix returned by GET /dns/policy. With a locked-down
+// Wave D E2E for GH #466: the tenant DNS records manager (now the DNS tab of the
+// Web Domain page, GH #1543) must honor the admin's per-type permission matrix
+// returned by GET /dns/policy. With a locked-down
 // policy (A/AAAA/CNAME only), an MX record is read-only ("Restricted") while an
 // A record keeps its Edit/Delete actions, and the Add Record type picker offers
 // only creatable types.
@@ -104,8 +105,10 @@ test("tenant DNS page honors a locked-down record-type policy (#466)", async ({ 
   await signIn(page, user);
   await page.goto(`/jabali-panel/domains/${DOMAIN_ID}/dns`);
 
-  // Page loaded.
-  await expect(page.getByText("DNS Records for example.com")).toBeVisible();
+  // GH #1543: this URL now renders the Web Domain page with DNS as an embedded
+  // tab, so the standalone "DNS Records for …" title is suppressed. The panel's
+  // own Add Record control is the stable "records manager loaded" anchor.
+  await expect(page.getByRole("button", { name: "Add Record" }).first()).toBeVisible();
 
   // The MX row is restricted (no Edit/Delete) under locked-down policy.
   const mxRow = page.getByRole("row").filter({ hasText: "mail.example.com" });
@@ -160,6 +163,7 @@ test("tenant DNS Add button is disabled when no type is creatable (#466)", async
 
   await signIn(page, user);
   await page.goto(`/jabali-panel/domains/${DOMAIN_ID}/dns`);
-  await expect(page.getByText("DNS Records for example.com")).toBeVisible();
+  // GH #1543: DNS renders embedded in the Web Domain page's DNS tab; the
+  // Add Record button is the load anchor (and here must be disabled).
   await expect(page.getByRole("button", { name: "Add Record" }).first()).toBeDisabled();
 });


### PR DESCRIPTION
## What

Fifth slice of the tenant Web Domains restructure (#1543). The DNS records manager becomes a tab on the tenant Web Domain page, and with it the **tenant row Actions menu is now just Enable/Disable + Delete** — every per-domain surface lives on the page reached by clicking the domain name.

## How

**Extract `DNSRecordsPanel({ domainId, embedded })`** from `DNSRecordsPage`. The panel holds all the DNS logic (zone, records table, system records, zone settings, the add/edit drawer). `embedded` toggles the framing:

- **standalone** (`embedded={false}`, the default): keeps its "Back to DNS" link + `DNS Records for …` title. Used by the admin `/jabali-admin/domains/:id/dns` route and the DNS-zones drill-in path.
- **embedded** (the tenant DNS tab): suppresses the back link + title (the page already shows the domain name and tab strip) and right-aligns the Add Record button.

`DNSRecordsPage` is now a thin wrapper that reads `:id` from the URL and renders the panel standalone — so the admin route and its import are unchanged.

**Routing:** remove the tenant static `:id/dns` route so the dynamic `:id/:tab` owns `dns` and `WebDomainPage` renders the panel embedded. The tenant DNS-zones overview drill-in (`/jabali-panel/domains/:id/dns`) now lands on the tabbed page with DNS active — same URL, nicer destination. The admin standalone route is untouched.

**Menu:** drop the last `dns` item from the tenant branch of `buildDomainMenuItems`; it is now `[toggle, delete]`. Admin keeps DNS (no per-domain page).

**#1419 gating relocated:** the "don't surface DNS when the module is off" rule moves from the row menu to the tab — the DNS tab is gated on `dns_enabled` (default-on while caps load, matching the sidebar), and a `/:id/dns` URL falls back to Overview when off. Its coverage moves from `UserDomainList.test` (the row-menu form is now impossible) to `WebDomainPage.test`, keeping the #1419 reference.

## This completes the page

The tenant Web Domain page now carries Overview, DNS, Redirects, Index, Caching, Directory Privacy, and the cap-gated Domain options / Rewrite rules / Document root. Remaining #1543 slices are independent of the page: B (Logs/Statistics + side-nav rename), C (PHP Settings), D (One-Click Apps into the list), E (remove the Applications menu).

## Test plan

- [x] `tsc -b` clean (whole-project — validates the extraction, the new export, and the route removal)
- [x] `eslint` clean on changed files (one pre-existing unused-`err` warning in `DNSRecordsPage`'s untouched `loadDomain`, left as-is)
- [x] `WebDomainPage.test`: DNS tab renders the panel when `dns_enabled`; hidden + `/dns` → Overview when off (relocated #1419)
- [x] `domainActions.test`: tenant set is now `["toggle","delete"]`; `dns` in the gone-list; admin menu + DNS nav unchanged
- [x] `UserDomainList.test`: name-link + Add-Web-Domain tests pass; obsolete row-menu DNS-gating block removed
- [x] `DNSZoneInventory.test`: drill-in still targets `/jabali-panel/domains/d1/dns` (unchanged) — passes
- [x] Full domain-area suite green (48 tests)

GH #1543
