### PR TITLE
refactor(packages): shared package-row validation for REST and CLI (JAB-306)

### DIFF
--- a/panel-api/cmd/server/package_cmd.go
+++ b/panel-api/cmd/server/package_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/packageops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -120,6 +121,14 @@ func newPackageCreateCmd() *cobra.Command {
 				CGIEnabled:       cgiEnabled,
 				CreatedAt:        now,
 				UpdatedAt:        now,
+			}
+			// JAB-306: the operator CLI persists direct-to-DB, so it must run
+			// the same invariant check the REST handler does — otherwise an
+			// out-of-range limit the API rejects with 422 (e.g. --cpu 999999)
+			// would silently land in the row. Unset FPM/backup fields fall to
+			// their GORM column defaults at INSERT and pass.
+			if err := packageops.Validate(p); err != nil {
+				return fmt.Errorf("invalid package: %w", err)
 			}
 			if err := packageRepoFromDB().Create(ctx, p); err != nil {
 				if errors.Is(err, repository.ErrConflict) {
@@ -253,6 +262,14 @@ func newPackageEditCmd() *cobra.Command {
 				return fmt.Errorf("no changes specified")
 			}
 			p.UpdatedAt = time.Now().UTC()
+			// JAB-306: same invariant gate as create + the REST handler, so an
+			// edit can't drive a limit out of the bounds the API enforces. The
+			// loaded row already carries valid FPM/backup values, so this only
+			// rejects an operator's out-of-range edit — never "heals" untouched
+			// fields.
+			if err := packageops.Validate(p); err != nil {
+				return fmt.Errorf("invalid package: %w", err)
+			}
 			if err := repo.Update(ctx, p); err != nil {
 				return fmt.Errorf("update package: %w", err)
 			}

--- a/panel-api/cmd/server/package_cmd_validate_test.go
+++ b/panel-api/cmd/server/package_cmd_validate_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPackageCLI_ValidatesBeforePersisting pins that both direct-DB write paths
+// (`package create` and `package edit`) run packageops.Validate on the row
+// BEFORE handing it to the repository — the JAB-306 fix. Without the ordering
+// the CLI would persist a limit the REST API rejects with 422. This is a
+// source-pin (the transport-neutral validator has no HTTP/agent seam to unit
+// test through the CLI without a live DB); it is non-vacuous because the
+// packageops.Validate call did not exist on main. Falsify by deleting either
+// call.
+func TestPackageCLI_ValidatesBeforePersisting(t *testing.T) {
+	src, err := os.ReadFile("package_cmd.go")
+	if err != nil {
+		t.Fatalf("read package_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	firstValidate := strings.Index(s, "packageops.Validate(p)")
+	lastValidate := strings.LastIndex(s, "packageops.Validate(p)")
+	createCall := strings.Index(s, "Create(ctx, p)")
+	updateCall := strings.Index(s, "repo.Update(ctx, p)")
+
+	if firstValidate < 0 || createCall < 0 || updateCall < 0 {
+		t.Fatalf("expected packageops.Validate(p) + Create(ctx, p) + repo.Update(ctx, p) to all be present; got validate=%d create=%d update=%d", firstValidate, createCall, updateCall)
+	}
+	if firstValidate == lastValidate {
+		t.Fatalf("expected packageops.Validate(p) on BOTH the create and edit paths, found only one occurrence")
+	}
+	// create path: the first Validate must precede the repository Create.
+	if !(firstValidate < createCall) {
+		t.Errorf("create path: packageops.Validate(p) (idx %d) must come before Create(ctx, p) (idx %d)", firstValidate, createCall)
+	}
+	// edit path: the second Validate sits after the create call and before the
+	// repository Update.
+	if !(createCall < lastValidate && lastValidate < updateCall) {
+		t.Errorf("edit path: packageops.Validate(p) (idx %d) must sit between the create call (idx %d) and repo.Update(ctx, p) (idx %d)", lastValidate, createCall, updateCall)
+	}
+}

--- a/panel-api/internal/api/packages.go
+++ b/panel-api/internal/api/packages.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/limits"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/packageops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -241,7 +241,7 @@ func (h *packageHandler) create(c *gin.Context) {
 		pkg.NspawnImageVersion = &v
 	}
 
-	if err := validatePackageLimits(pkg); err != nil {
+	if err := packageops.Validate(pkg); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
 		return
 	}
@@ -255,22 +255,6 @@ func (h *packageHandler) create(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, pkg)
-}
-
-// validatePackageLimits enforces the bounds from internal/limits on the
-// M18 resource-limit fields before write. Runs at both create and
-// update — the agent validates again as defense-in-depth, but returning
-// a clean 422 here is much better UX than a 502-agent-error later.
-func validatePackageLimits(pkg *models.HostingPackage) error {
-	e := limits.EffectiveLimits{
-		DiskQuotaMB:     pkg.DiskQuotaMB,
-		CPUQuotaPercent: pkg.CPUQuotaPercent,
-		MemoryLimitMB:   pkg.MemoryLimitMB,
-		IOReadMbps:      pkg.IOReadMbps,
-		IOWriteMbps:     pkg.IOWriteMbps,
-		MaxTasks:        pkg.MaxTasks,
-	}
-	return e.Validate()
 }
 
 func (h *packageHandler) get(c *gin.Context) {
@@ -435,7 +419,7 @@ func (h *packageHandler) update(c *gin.Context) {
 	}
 	pkg.UpdatedAt = time.Now().UTC()
 
-	if err := validatePackageLimits(pkg); err != nil {
+	if err := packageops.Validate(pkg); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
 		return
 	}

--- a/panel-api/internal/packageops/packageops.go
+++ b/panel-api/internal/packageops/packageops.go
@@ -1,0 +1,109 @@
+// Package packageops holds the transport-neutral Hosting Package invariants
+// shared by every write adapter (the REST handler and the operator CLI).
+//
+// JAB-306: HTTP package create/update validated resource limits, the FPM
+// children cap, backup retention/kinds and the nspawn image name before
+// persisting, but the direct-DB CLI (`jabali package create|edit`) persisted
+// its field subset with no validation at all — so `package create --cpu 999999`
+// or `--memory-mb 2000000` stored a row the REST API rejects with 422. This
+// package owns the one predicate both adapters run before Create/Update, so a
+// value one adapter refuses can never be smuggled in through the other. It
+// mirrors the existing REST+CLI-shared limits.ValidateOverrideBounds (JAB-309).
+//
+// Only VALIDATION lives here, not defaulting: create relies on the GORM
+// `default:` column tags (FPM cap 20, worker mem 64, retention "reject",
+// version-defaults "{}") to fill unset fields at INSERT, and update PATCHes a
+// row that is already valid — so there is no shared defaulting step to extract,
+// and applying create-defaults on an update would wrongly "heal" fields the
+// caller never touched.
+package packageops
+
+import (
+	"errors"
+	"fmt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/limits"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
+)
+
+// Sentinel errors let a caller that wants adapter-specific reporting map a
+// failure to its own code; the CLI just fails closed on any non-nil error.
+var (
+	// ErrFpmCapTooHigh is returned when fpm_max_children_cap exceeds the
+	// admin ceiling (phppoolops.AdminMaxChildrenCap).
+	ErrFpmCapTooHigh = errors.New("fpm_max_children_cap exceeds the admin cap")
+	// ErrInvalidBackupRetentionPolicy is returned for a retention policy that
+	// is neither "reject", "prune", nor the empty string.
+	ErrInvalidBackupRetentionPolicy = errors.New("invalid backup retention policy")
+	// ErrInvalidNspawnImage is returned when nspawn_image_version is set but is
+	// not the [a-z0-9-]+ shape.
+	ErrInvalidNspawnImage = errors.New("invalid nspawn image version")
+)
+
+// Validate reports the first invariant a hosting package row violates, or nil
+// when every adapter may safely persist it. It is the single authority for
+// "what is a legal hosting_packages row" and MUST be called by every write
+// path (REST create/update and CLI create/edit) immediately before the
+// repository Create/Update.
+//
+// The bounded resource limits (cpu/memory/io/tasks) are the fields the CLI can
+// actually set today, so they are the ones this closes in practice; the FPM
+// cap, retention, backup-kinds and nspawn checks make the module the complete
+// invariant set for when the CLI grows flags for those fields (and as
+// defense-in-depth for the REST path, which already rejects them inline).
+func Validate(p *models.HostingPackage) error {
+	// Resource-limit bounds — identical to the REST handler's former
+	// validatePackageLimits. Zero is always legal (unlimited); DiskQuotaMB is
+	// intentionally unbounded (a filesystem-layer concern), matching
+	// limits.EffectiveLimits.Validate.
+	e := limits.EffectiveLimits{
+		DiskQuotaMB:     p.DiskQuotaMB,
+		CPUQuotaPercent: p.CPUQuotaPercent,
+		MemoryLimitMB:   p.MemoryLimitMB,
+		IOReadMbps:      p.IOReadMbps,
+		IOWriteMbps:     p.IOWriteMbps,
+		MaxTasks:        p.MaxTasks,
+	}
+	if err := e.Validate(); err != nil {
+		return err
+	}
+	if p.FpmMaxChildrenCap > phppoolops.AdminMaxChildrenCap {
+		return fmt.Errorf("%w: must be <= %d", ErrFpmCapTooHigh, phppoolops.AdminMaxChildrenCap)
+	}
+	if !models.IsValidBackupRetentionPolicy(p.BackupRetentionPolicy) {
+		return fmt.Errorf("%w: %q (must be reject or prune)", ErrInvalidBackupRetentionPolicy, p.BackupRetentionPolicy)
+	}
+	// NormalizeBackupKindsCSV rejects any unknown kind. It is idempotent on its
+	// own output — a stored, already-normalised value re-normalises to itself
+	// with no error — so running it here on a persisted row is a pure validity
+	// check.
+	if _, err := models.NormalizeBackupKindsCSV(p.AllowedBackupDestinationKinds); err != nil {
+		return err
+	}
+	if p.NspawnImageVersion != nil && !isImageNamePattern(*p.NspawnImageVersion) {
+		return fmt.Errorf("%w: %q (must match [a-z0-9-]+)", ErrInvalidNspawnImage, *p.NspawnImageVersion)
+	}
+	return nil
+}
+
+// isImageNamePattern matches the [a-z0-9-]+ shape. A private copy of the
+// identical helper in internal/api and internal/settingsops — duplicated
+// rather than cross-imported, matching the precedent those packages set (api
+// imports settingsops, so settingsops can't import api; packageops is a leaf
+// both import, so it keeps its own copy too).
+func isImageNamePattern(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/panel-api/internal/packageops/packageops_test.go
+++ b/panel-api/internal/packageops/packageops_test.go
@@ -1,0 +1,88 @@
+package packageops
+
+import (
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/limits"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
+)
+
+func strptr(s string) *string { return &s }
+
+// TestValidate exercises every invariant Validate guards. The limit-bound rows
+// mirror internal/limits/resolve_test.go so the two stay in lockstep; the FPM /
+// retention / kinds / nspawn rows prove those checks are actually reachable
+// (not dead branches) — the point the reviewer flagged, since the CLI can't set
+// those fields yet.
+func TestValidate(t *testing.T) {
+	valid := func() *models.HostingPackage {
+		// A row that passes every check: zero limits (unlimited), and the
+		// FPM/backup fields at the values a fresh INSERT gets from the column
+		// defaults.
+		return &models.HostingPackage{
+			Name:                  "ok",
+			FpmMaxChildrenCap:     20,
+			FpmWorkerMemMb:        64,
+			FpmVersionDefaults:    "{}",
+			BackupRetentionPolicy: models.BackupRetentionReject,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(p *models.HostingPackage)
+		wantErr bool
+		is      error // when set, the returned error must errors.Is this
+	}{
+		{"all zero limits pass (unlimited is legal)", func(p *models.HostingPackage) {}, false, nil},
+		{"sane limits pass", func(p *models.HostingPackage) {
+			p.DiskQuotaMB, p.CPUQuotaPercent, p.MemoryLimitMB, p.MaxTasks = 5120, 200, 4096, 500
+		}, false, nil},
+
+		// Resource-limit bounds — mirror limits/resolve_test.go:128-132.
+		{"cpu at max passes", func(p *models.HostingPackage) { p.CPUQuotaPercent = limits.MaxCPUQuotaPercent }, false, nil},
+		{"cpu over max fails", func(p *models.HostingPackage) { p.CPUQuotaPercent = limits.MaxCPUQuotaPercent + 1 }, true, nil},
+		{"memory over max fails", func(p *models.HostingPackage) { p.MemoryLimitMB = limits.MaxMemoryLimitMB + 1 }, true, nil},
+		{"io_read over max fails", func(p *models.HostingPackage) { p.IOReadMbps = limits.MaxIOMbps + 1 }, true, nil},
+		{"io_write over max fails", func(p *models.HostingPackage) { p.IOWriteMbps = limits.MaxIOMbps + 1 }, true, nil},
+		{"tasks over max fails", func(p *models.HostingPackage) { p.MaxTasks = limits.MaxTasks + 1 }, true, nil},
+		// Disk is intentionally unbounded — pins the "not our job" boundary.
+		{"huge disk passes (unbounded)", func(p *models.HostingPackage) { p.DiskQuotaMB = 1 << 31 }, false, nil},
+
+		// FPM children cap — reachable only through this check today.
+		{"fpm cap at admin max passes", func(p *models.HostingPackage) { p.FpmMaxChildrenCap = phppoolops.AdminMaxChildrenCap }, false, nil},
+		{"fpm cap over admin max fails", func(p *models.HostingPackage) { p.FpmMaxChildrenCap = phppoolops.AdminMaxChildrenCap + 1 }, true, ErrFpmCapTooHigh},
+
+		// Backup retention policy.
+		{"empty retention passes (treated as reject)", func(p *models.HostingPackage) { p.BackupRetentionPolicy = "" }, false, nil},
+		{"prune retention passes", func(p *models.HostingPackage) { p.BackupRetentionPolicy = models.BackupRetentionPrune }, false, nil},
+		{"bogus retention fails", func(p *models.HostingPackage) { p.BackupRetentionPolicy = "delete-everything" }, true, ErrInvalidBackupRetentionPolicy},
+
+		// Backup destination kinds CSV.
+		{"unknown backup kind fails", func(p *models.HostingPackage) { p.AllowedBackupDestinationKinds = "s3,not-a-kind" }, true, nil},
+
+		// Nspawn image name.
+		{"nil nspawn image passes", func(p *models.HostingPackage) { p.NspawnImageVersion = nil }, false, nil},
+		{"valid nspawn image passes", func(p *models.HostingPackage) { p.NspawnImageVersion = strptr("bookworm-2026-01") }, false, nil},
+		{"bad nspawn image fails", func(p *models.HostingPackage) { p.NspawnImageVersion = strptr("Bad/Image!") }, true, ErrInvalidNspawnImage},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := valid()
+			tc.mutate(p)
+			err := Validate(p)
+			if tc.wantErr && err == nil {
+				t.Fatalf("Validate() = nil, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+			if tc.is != nil && !errors.Is(err, tc.is) {
+				t.Fatalf("Validate() error = %v, want errors.Is %v", err, tc.is)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The REST hosting-package create/update handlers validate resource limits, the FPM children cap, backup retention/kinds, and the nspawn image name before persisting. The direct-DB operator CLI (`jabali package create|edit`) persisted its field subset with **no validation at all**, so a value the API rejects with a 422 landed silently in the row — for example `jabali package create --name x --cpu 999999`, or an edit that pushes `memory-mb` / `io-read-mbps` / `max-tasks` past the `internal/limits` bounds. This is the core "equivalent inputs, different rows / invalid values persist" gap called out in JAB-306.

## How

New leaf package **`panel-api/internal/packageops`** owns `Validate(*models.HostingPackage) error` — the single "what is a legal `hosting_packages` row" predicate. All four write paths call it immediately before the repository `Create`/`Update`:

- REST create + update: `packageops.Validate` replaces the former `validatePackageLimits` (its only two callers) as the final gate, after the handlers' own specific 400 checks.
- CLI create + edit: now call `packageops.Validate(p)` and fail closed on any error.

**On the REST side:** create is unchanged. Update already re-validated the loaded resource-limit fields (the old `validatePackageLimits` ran on the loaded row); it now also re-validates the loaded FPM-cap / retention / backup-kinds / nspawn fields, because those inline 400 checks are gated on the request field being present. So a legacy row that violates a rule tightened *after* it was written now returns 422 on any PATCH (e.g. a rename or quota bump) instead of being silently re-persisted — the fail-closed direction, deliberate, and consistent with AC2. Rows written under the current rules are unaffected.

This mirrors the existing REST+CLI-shared `limits.ValidateOverrideBounds` (JAB-309): a value one adapter refuses can no longer be smuggled in through the other.

## A stale piece of the ticket's evidence

The ticket says the CLI "can store … zero FPM defaults." **That does not reproduce on current `main`.** The model carries GORM `default:` column tags (`fpm_max_children_cap` 20, `fpm_worker_mem_mb` 64, `backup_retention_policy` `'reject'`, `fpm_version_defaults` `'{}'`), and GORM omits a zero-valued field that has a default tag on INSERT, so the DB supplies those values on a CLI create. Update PATCHes an already-valid loaded row. So there is no shared *defaulting* step to extract, and applying create-defaults on an update would wrongly "heal" fields the caller never touched. Only **validation** is shared here; the confirmed, closed gap is the missing bounds check.

The shared validator still carries the FPM-cap / retention / backup-kinds / nspawn checks so it is the complete invariant authority for when the CLI grows flags for those fields; those branches are reachable and unit-tested even though the CLI cannot set them today.

## Tests

- `packageops.TestValidate` table: each limit bound at `Max+1` (cpu/memory/io/tasks, mirroring `internal/limits/resolve_test.go`), FPM cap at `AdminMaxChildrenCap+1`, bad retention, unknown backup kind, bad nspawn image, plus the passing rows (zero = unlimited, huge unbounded disk, empty retention, `prune`). Falsified by stubbing `Validate` to `return nil` → all nine error rows go red.
- `package_cmd_validate_test.go` source-pin: asserts both the create and edit paths call `packageops.Validate(p)` before persisting (ordering). Falsified by deleting either call. Non-vacuous — the call did not exist on `main`. (Source-pin rather than a behaviour test because the CLI is direct-DB and needs a live MariaDB to exercise end to end; the predicate itself is unit-tested.)
- `go build ./...`, `go vet`, `gofmt`, and `go test -race ./internal/packageops/ ./cmd/server/ ./internal/api/` all clean, rebased on latest `main`.

## Scope

One slice of JAB-306.

- **AC1** equivalent HTTP/CLI inputs → identical rows: met for the fields the CLI exposes; DB column defaults make the rest identical today.
- **AC2** invalid values never persist: met on all four paths for the bounded limits.
- **AC3** no adapter may omit entitlement fields: **not met** — the CLI still has no flags for the docker/python/ftp/backup/FPM entitlement fields; follow-up slice.
- **AC4/AC5** fan-out once / repo-failure no fan-out: untouched.

The parent stays in Backlog. No fleet/agent/reconciler surface; `stable` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
