### PR TITLE
feat(domains): per-domain Logs tab on the Web Domain page

### DIFF
--- a/panel-ui/src/components/logs/DomainLogsPanel.test.tsx
+++ b/panel-ui/src/components/logs/DomainLogsPanel.test.tsx
@@ -1,0 +1,62 @@
+// DomainLogsPanel.test — GH #1543 / JAB-296. The single-domain Logs pane offers
+// the three streams as buttons and, crucially, binds the domain id into every
+// open. This pins AC2 (a per-domain request always carries domain_id) at the
+// new call site: clicking "Error Log" must POST /logs/access with the domain
+// id, never the admin aggregate (no domain_id).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { post: vi.fn(), delete: vi.fn() },
+}));
+vi.mock("../../lib/feedback", () => ({
+  feedback: { message: { error: vi.fn() } },
+}));
+// Stub the modal so the WebSocket connection it would open is irrelevant here.
+vi.mock("../LogStreamModal", () => ({
+  LogStreamModal: () => null,
+}));
+
+import { apiClient } from "../../apiClient";
+import { DomainLogsPanel } from "./DomainLogsPanel";
+
+const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.post.mockResolvedValue({
+    data: { stream_key: "sk1", websocket_url: "wss://host/api/v1/logs/stream/sk1" },
+  });
+});
+
+describe("DomainLogsPanel (GH #1543)", () => {
+  it("opens each stream for THIS domain (domain_id always present, AC2)", async () => {
+    render(<DomainLogsPanel domainId="d1" />);
+
+    // antd folds each icon's aria-label into the button's accessible name, so
+    // match the label as a substring rather than exactly.
+    fireEvent.click(screen.getByRole("button", { name: /Error Log/ }));
+    await vi.waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/logs/access", {
+        log_type: "error",
+        domain_id: "d1",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Access Log/ }));
+    await vi.waitFor(() =>
+      expect(mocked.post).toHaveBeenLastCalledWith("/logs/access", {
+        log_type: "access",
+        domain_id: "d1",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Real Time/ }));
+    await vi.waitFor(() =>
+      expect(mocked.post).toHaveBeenLastCalledWith("/logs/access", {
+        log_type: "goaccess",
+        domain_id: "d1",
+      }),
+    );
+  });
+});

--- a/panel-ui/src/components/logs/DomainLogsPanel.tsx
+++ b/panel-ui/src/components/logs/DomainLogsPanel.tsx
@@ -1,0 +1,60 @@
+// DomainLogsPanel — the single-domain web-log viewer (JAB-296 / GH #1543). The
+// admin DomainLogsTab and the tenant UserLogsPage both render a TABLE of
+// domains whose rows open a stream; this is the one-domain counterpart, used by
+// the tenant Web Domain page's Logs tab where the domain is already fixed by the
+// route. It offers the three streams (Access / Error / Real Time) as direct
+// buttons rather than a one-row table, and reuses the neutral stream lifecycle
+// (useDomainLogStreams) and modal so the create/close contract — and its AC2
+// guarantee that a per-domain request always carries the domain id — is shared,
+// not re-implemented.
+//
+// Audience-neutral by design (props are just { domainId }): the admin Edit
+// Domain page has no per-domain Logs tab either and would render exactly this.
+import type { ReactNode } from "react";
+import { Button, Space, Typography } from "antd";
+import {
+  DashboardOutlined,
+  FileTextOutlined,
+  WarningOutlined,
+} from "@ant-design/icons";
+import { LogStreamModal } from "../LogStreamModal";
+import { LOG_STREAM_LABELS, type LogType } from "./domainLogStreams";
+import { useDomainLogStreams } from "./useDomainLogStreams";
+
+// The three streams, in the order the domain tables present them. Each opens
+// with the domain id bound, so the request is always per-domain (never the
+// admin aggregate).
+const STREAMS: { logType: LogType; icon: ReactNode }[] = [
+  { logType: "access", icon: <FileTextOutlined /> },
+  { logType: "error", icon: <WarningOutlined /> },
+  { logType: "goaccess", icon: <DashboardOutlined /> },
+];
+
+export interface DomainLogsPanelProps {
+  domainId: string;
+}
+
+export const DomainLogsPanel = ({ domainId }: DomainLogsPanelProps) => {
+  const streams = useDomainLogStreams();
+
+  return (
+    <>
+      <Typography.Paragraph type="secondary">
+        Live tail of this domain's web logs. Access and Error stream the raw nginx
+        logs; Real Time opens the GoAccess dashboard.
+      </Typography.Paragraph>
+      <Space wrap>
+        {STREAMS.map(({ logType, icon }) => (
+          <Button
+            key={logType}
+            icon={icon}
+            onClick={() => streams.openStream(logType, domainId)}
+          >
+            {LOG_STREAM_LABELS[logType]}
+          </Button>
+        ))}
+      </Space>
+      <LogStreamModal {...streams.modalProps} />
+    </>
+  );
+};

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -56,6 +56,9 @@ vi.mock("../../../components/domains/DomainDocRootPanel", () => ({
 vi.mock("../../dns/DNSRecordsPage", () => ({
   DNSRecordsPanel: ({ domainId }: { domainId: string }) => <div>dns-pane:{domainId}</div>,
 }));
+vi.mock("../../../components/logs/DomainLogsPanel", () => ({
+  DomainLogsPanel: ({ domainId }: { domainId: string }) => <div>logs-pane:{domainId}</div>,
+}));
 vi.mock("../../../components/DomainCacheSection", () => ({
   DomainCacheSection: ({ domainId }: { domainId: string }) => <div>caching-pane:{domainId}</div>,
 }));
@@ -157,6 +160,11 @@ describe("WebDomainPage (GH #1543)", () => {
     renderAt("/jabali-panel/domains/d1/dns");
     expect(await screen.findByText("Preview URL")).toBeInTheDocument();
     expect(screen.queryByText("dns-pane:d1")).not.toBeInTheDocument();
+  });
+
+  it("renders the Logs pane when :tab=logs (GH #1543)", async () => {
+    renderAt("/jabali-panel/domains/d1/logs");
+    expect(await screen.findByText("logs-pane:d1")).toBeInTheDocument();
   });
 
   it("renders the Caching pane when :tab=caching", async () => {

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -25,6 +25,7 @@ import { DomainDirectoryPrivacySection } from "../../admin/domains/DomainDirecto
 import { DomainIndexPanel } from "../../DomainIndexPanel";
 import { DomainRedirectsPanel } from "../../DomainRedirectsPanel";
 import { DNSRecordsPanel } from "../../dns/DNSRecordsPage";
+import { DomainLogsPanel } from "../../../components/logs/DomainLogsPanel";
 import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsPanel";
 import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
 import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
@@ -90,6 +91,10 @@ export const WebDomainPage = () => {
 
   const tabs: { key: string; label: string; node: ReactNode }[] = [
     { key: "overview", label: "Overview", node: <OverviewTab domain={domain} /> },
+    // Logs is a read-only diagnostic view — the most-checked thing after
+    // "is the site up" — so it sits second, before the editors. It exists for
+    // every web domain, so it is not cap-gated.
+    { key: "logs", label: "Logs", node: <DomainLogsPanel domainId={domain.id} /> },
     ...(dnsOn
       ? [{ key: "dns", label: "DNS", node: <DNSRecordsPanel domainId={domain.id} embedded /> }]
       : []),


### PR DESCRIPTION
## What

Adds a **Logs** tab to the tenant Web Domain page (GH #1543, johnnyq). Clicking a domain in the Web Domains list opens the dedicated page; this tab now offers that domain's web log streams — **Access Log / Error Log / Real Time (GoAccess)** — in place, instead of only from the standalone *Logs & Statistics* page's domain-list table.

## How

- **New `components/logs/DomainLogsPanel.tsx`** — the single-domain counterpart to the admin `DomainLogsTab` and the tenant `UserLogsPage`, both of which render a *table* of domains whose rows open a stream. Here the domain is fixed by the route, so the three streams are direct buttons.
- It reuses the neutral **JAB-296** stream lifecycle (`useDomainLogStreams`) and `LogStreamModal`, so the create/close contract — including **AC2**, that a per-domain request always carries `domain_id` and can never emit the admin aggregate — is shared, not re-implemented.
- The panel takes only `{ domainId }` and lives in `components/logs/`, so it is **audience-neutral**: the admin Edit Domain page has no per-domain Logs tab either and could render exactly this. **Not wired into admin in this PR** — that would be scope creep; placing it in `components/logs/` means the next person who wants it there just imports it.
- Tab placement: **second, right after Overview and before the editors** — Logs is a read-only diagnostic view (the most-checked thing after "is the site up"). It is **not cap-gated**; web logs exist for every web domain.

## Deferred (separate decision)

The side-nav **"Logs" → "Account Activity"** rename is left out on purpose. It implies demoting the cross-domain `Domain logs` list on the standalone page — a judgment call about whether that list is still worth a nav slot now that every domain page has its own Logs tab. That's the operator's call and is independent of this panel existing.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean on all changed files
- [x] `DomainLogsPanel.test.tsx` — clicking Access/Error/Real Time POSTs `/logs/access` with `{ log_type, domain_id: "d1" }` (pins AC2 at the new call site)
- [x] `WebDomainPage.test.tsx` — `:tab=logs` renders the panel; existing 16 tests still pass
- [ ] Manual: open a tenant domain → Logs tab → each stream opens its modal

GH #1543