### PR TITLE
fix(notifications): CLI channel test refuses a disabled channel (JAB-308)

### DIFF
--- a/panel-api/cmd/server/notification_send_cmd.go
+++ b/panel-api/cmd/server/notification_send_cmd.go
@@ -132,6 +132,14 @@ func newNotificationChannelTestCmd() *cobra.Command {
 			if err != nil || ch == nil {
 				return fmt.Errorf("no channel with id %q", args[0])
 			}
+			// Refuse a disabled channel at the adapter, mirroring the HTTP
+			// testChannel 409. The dispatcher already skips disabled targets
+			// (resolveTargets drops !ch.Enabled), so testing one only queued an
+			// envelope that was silently dropped while the CLI reported success.
+			if !ch.Enabled {
+				cliAuditErr(ctx, "notification_channel.test", "notification_channel", ch.ID, nil)
+				return fmt.Errorf("channel %q is disabled — enable it before testing", ch.Name)
+			}
 			env := notifications.Envelope{
 				EventKind:  "notifications.channel.test",
 				Severity:   models.NotificationSeverityInfo,

--- a/panel-api/cmd/server/notification_send_cmd_test.go
+++ b/panel-api/cmd/server/notification_send_cmd_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNotificationChannelTestCmd_RefusesDisabled pins that the operator CLI
+// `notification channels test <id>` refuses a disabled channel BEFORE it
+// publishes a test envelope — the JAB-308 fix. The HTTP testChannel handler
+// already returns 409 for a disabled channel; the dispatcher's resolveTargets
+// drops !ch.Enabled targets, so testing a disabled channel from the CLI only
+// queued an envelope that was silently dropped while the command printed
+// success. This is a source-pin (the direct-DB command has no seam to exercise
+// without a live MariaDB + Redis); it is non-vacuous because the test command
+// referenced ch.Enabled nowhere on main. Falsify by deleting the guard.
+func TestNotificationChannelTestCmd_RefusesDisabled(t *testing.T) {
+	src, err := os.ReadFile("notification_send_cmd.go")
+	if err != nil {
+		t.Fatalf("read notification_send_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	// Scope the assertions to the test command's function body so the create
+	// command's own Enabled field (Enabled: !disabled) cannot satisfy them.
+	start := strings.Index(s, "func newNotificationChannelTestCmd()")
+	if start < 0 {
+		t.Fatalf("newNotificationChannelTestCmd not found")
+	}
+	body := s[start:]
+	if next := strings.Index(body[1:], "\nfunc "); next >= 0 {
+		body = body[:next+1]
+	}
+
+	findByID := strings.Index(body, "FindByID(ctx, args[0])")
+	// Pin the guard statement itself ("if !ch.Enabled {"), not a bare
+	// "!ch.Enabled" substring, so the mention of !ch.Enabled in this function's
+	// own comment cannot satisfy the assertion once the guard is deleted.
+	guard := strings.Index(body, "if !ch.Enabled {")
+	publish := strings.Index(body, "notifications.Envelope{")
+
+	if findByID < 0 || guard < 0 || publish < 0 {
+		t.Fatalf("expected FindByID + `if !ch.Enabled {` guard + Envelope construction in the test command; got findByID=%d guard=%d envelope=%d", findByID, guard, publish)
+	}
+	// The disabled guard must sit after the channel is loaded and before the
+	// envelope that would be published is built.
+	if !(findByID < guard && guard < publish) {
+		t.Errorf("!ch.Enabled guard (idx %d) must sit between FindByID (idx %d) and the Envelope construction (idx %d)", guard, findByID, publish)
+	}
+}


### PR DESCRIPTION
## What

Both HTTP "test this channel" endpoints refuse a disabled channel with `409 "channel is disabled — enable it before testing"`:

- the tenant handler (`me_notifications.go` `testChannel`), and
- the admin handler (`notifications_channels.go` `test`), whose primary path sends synchronously (GH #322 `sender.Send`) — so there the guard is a real *delivery* guard: without it a disabled channel actually fires from the request.

The operator CLI `jabali notification channels test <id>` had no such guard. It loaded the channel, published a test envelope with `ChannelIDs=[id]`, and printed `"published test envelope to … the dispatcher will deliver"`. But the CLI is queue-only, and the dispatcher's `resolveTargets` drops any target whose row is not `Enabled` — so the envelope was silently skipped while the operator saw a success line for a test that never delivered. That's the "disabled channels cannot be tested" criterion (JAB-308 AC4) enforced on every HTTP surface's primary path but missing on the CLI.

## How

Refuse a disabled channel at the CLI adapter, before publishing — failing closed rather than leaning on the dispatcher to drop the envelope — and mirror the HTTP 409 wording. The refusal is audited (`cliAuditErr`) like the command's other failure path.

```go
if !ch.Enabled {
    cliAuditErr(ctx, "notification_channel.test", "notification_channel", ch.ID, nil)
    return fmt.Errorf("channel %q is disabled — enable it before testing", ch.Name)
}
```

## Tests

- `TestNotificationChannelTestCmd_RefusesDisabled` — a source-pin on `notification_send_cmd.go` asserting the `if !ch.Enabled {` guard sits between the `FindByID` load and the `Envelope` construction in the test command. It pins the guard **statement** (`if !ch.Enabled {`), not a bare `!ch.Enabled` substring, so the mention of `!ch.Enabled` in the command's own explanatory comment cannot satisfy it. Non-vacuous — the test command referenced `ch.Enabled` nowhere on `main`; falsified by deleting the guard (the guard index goes to `-1` and the test fails). A source-pin rather than a behaviour test because the command is direct-DB and needs a live MariaDB + Redis to run end to end; the assertion is the ordering of the guard relative to the load and the publish.
- `gofmt`, `go build ./cmd/server/`, `go vet ./cmd/server/`, and `go test ./cmd/server/` all clean, rebased on latest `main`.

## Scope

One slice of JAB-308 (Deepen Notification Channel Lifecycle behind owner policy). The rest stays on the parent:

- **AC1/AC2** — CLI `channels create --user <id>` makes a tenant-owned channel but runs only the admin validators (`ValidateChannelName` / `ValidateChannelKindConfig`); it bypasses the tenant policy the HTTP `createChannel` applies — the kind allowlist (`TenantNotificationKinds`), the own-address / local-submission forcing in `forceOwnEmailConfig` (anti-SSRF / open-relay), and the per-user channel quota. Closing it is a transport-neutral extraction of that policy (a larger slice — `forceOwnEmailConfig` is currently gin-bound). **Not met.**
- **AC3** (masked secrets preserved on edit) — **N/A for the CLI**: there is no `channels edit`/`update` subcommand; masked-placeholder handling only applies to the HTTP PATCH edit path.
- **AC5** (delete cleans up dependents) — CLI `channels delete` is a bare repo `Delete`, while HTTP `deleteChannel` also calls `Routes.DeleteByChannel`. The routes still drop via the `ON DELETE CASCADE` FK (HTTP itself calls the explicit delete "belt-and-suspenders"), so this is a redundancy gap, not a correctness gap; a candidate follow-up.

The parent stays in Backlog. No fleet / agent / reconciler surface; `stable` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
