### PR TITLE
feat(domains): per-domain PHP Settings tab on the Web Domain page

### DIFF
--- a/panel-ui/src/components/domains/DomainPHPSettingsPanel.test.tsx
+++ b/panel-ui/src/components/domains/DomainPHPSettingsPanel.test.tsx
@@ -1,0 +1,84 @@
+// DomainPHPSettingsPanel.test — GH #1543 / GH #1332. The per-domain PHP panel
+// binds every request to the domain it is given. This pins that at the extracted
+// call site: it loads THIS domain's settings on mount, and changing the version
+// to "Server default" DELETEs THIS domain's pool (never a stale/other domain).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), delete: vi.fn(), patch: vi.fn() },
+}));
+vi.mock("../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+import { apiClient } from "../../apiClient";
+import { DomainPHPSettingsPanel } from "./DomainPHPSettingsPanel";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+};
+
+const SETTINGS = {
+  php_version: "8.3",
+  php_memory_limit: null,
+  php_upload_max_filesize: null,
+  php_post_max_size: null,
+  php_max_input_vars: null,
+  php_max_execution_time: null,
+  php_max_input_time: null,
+  php_display_errors: null,
+  php_error_reporting: null,
+  php_timezone: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.get.mockImplementation((url: string) => {
+    if (url === "/php/versions") return Promise.resolve({ data: { versions: ["8.3", "8.4"] } });
+    if (url === "/domains/d1/php-settings") return Promise.resolve({ data: SETTINGS });
+    return Promise.resolve({ data: {} });
+  });
+  mocked.delete.mockResolvedValue({});
+  mocked.post.mockResolvedValue({});
+});
+
+function renderPanel() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <DomainPHPSettingsPanel domainId="d1" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DomainPHPSettingsPanel (GH #1543)", () => {
+  it("loads THIS domain's PHP settings on mount", async () => {
+    renderPanel();
+    await vi.waitFor(() =>
+      expect(mocked.get).toHaveBeenCalledWith("/domains/d1/php-settings"),
+    );
+  });
+
+  it("reverting the version to Server default DELETEs this domain's pool", async () => {
+    renderPanel();
+    // Wait for the form to appear (phpSettings loaded).
+    await screen.findByText("userphpsettingspage.php_version");
+    // The version Select is the first combobox; open it and pick Server default.
+    fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+    fireEvent.click(await screen.findByText("Server default"));
+    await vi.waitFor(() =>
+      expect(mocked.delete).toHaveBeenCalledWith("/domains/d1/php-pool"),
+    );
+  });
+});

--- a/panel-ui/src/components/domains/DomainPHPSettingsPanel.tsx
+++ b/panel-ui/src/components/domains/DomainPHPSettingsPanel.tsx
@@ -1,0 +1,536 @@
+// DomainPHPSettingsPanel — the per-domain PHP surface (GH #1543 / GH #1332),
+// extracted from UserPHPSettingsPage's "Version & Domains" tab so it can render
+// two ways: on the tenant Web Domain page as a tab (domain fixed by the route),
+// and inside the standalone PHP Settings page behind a domain picker. It owns
+// only the DOMAIN-scoped controls — the PHP version for this domain
+// (POST/DELETE /domains/:id/php-pool) and the php.ini limit overrides
+// (GET/PATCH /domains/:id/php-settings). The account/pool-level tabs on the
+// standalone page (CLI/Composer, Performance, OPcache, Extensions, Xdebug) are
+// per-version-pool — shared by every domain on that version — so they stay put.
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Col, Form, Row, Select, Space, Spin, Tag, Typography } from "antd";
+import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import { apiClient } from "../../apiClient";
+import { isPHPEOL } from "../../utils/phpEol";
+import { IANA_TIMEZONES } from "../../data/timezones";
+
+type DomainPHPSettings = {
+  php_pool_id?: string | null;
+  php_version?: string | null;
+  php_memory_limit?: string | null;
+  php_upload_max_filesize?: string | null;
+  php_post_max_size?: string | null;
+  php_max_input_vars?: number | null;
+  php_max_execution_time?: number | null;
+  php_max_input_time?: number | null;
+  // GH #1332 per-domain runtime directives.
+  php_display_errors?: boolean | null;
+  php_error_reporting?: number | null;
+  php_timezone?: string | null;
+};
+
+type PHPSettingsFormData = {
+  php_memory_limit?: string | null;
+  php_upload_max_filesize?: string | null;
+  php_post_max_size?: string | null;
+  php_max_input_vars?: number | null;
+  php_max_execution_time?: number | null;
+  php_max_input_time?: number | null;
+  php_display_errors?: boolean | null;
+  php_error_reporting?: number | null;
+  php_timezone?: string | null;
+};
+
+const MEMORY_LIMIT_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "32M", value: "32M" },
+  { label: "64M", value: "64M" },
+  { label: "128M", value: "128M" },
+  { label: "256M", value: "256M" },
+  { label: "512M", value: "512M" },
+  { label: "1G", value: "1G" },
+];
+
+const UPLOAD_MAX_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "1M", value: "1M" },
+  { label: "10M", value: "10M" },
+  { label: "50M", value: "50M" },
+  { label: "100M", value: "100M" },
+  { label: "256M", value: "256M" },
+  { label: "512M", value: "512M" },
+];
+
+const POST_MAX_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "1M", value: "1M" },
+  { label: "10M", value: "10M" },
+  { label: "50M", value: "50M" },
+  { label: "100M", value: "100M" },
+  { label: "256M", value: "256M" },
+  { label: "512M", value: "512M" },
+];
+
+const MAX_INPUT_VARS_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "100", value: 100 },
+  { label: "500", value: 500 },
+  { label: "1000", value: 1000 },
+  { label: "2000", value: 2000 },
+  { label: "5000", value: 5000 },
+  { label: "10000", value: 10000 },
+];
+
+const MAX_EXECUTION_TIME_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "10s", value: 10 },
+  { label: "30s", value: 30 },
+  { label: "60s", value: 60 },
+  { label: "120s", value: 120 },
+  { label: "300s", value: 300 },
+  { label: "600s", value: 600 },
+];
+
+const MAX_INPUT_TIME_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "10s", value: 10 },
+  { label: "30s", value: 30 },
+  { label: "60s", value: 60 },
+  { label: "120s", value: 120 },
+  { label: "300s", value: 300 },
+];
+
+// GH #1332 per-domain runtime directives. display_errors is pinned Off on every
+// PHP vhost by the agent, so "Use pool default" and "Off" are the same effect —
+// both keep errors hidden; "On" surfaces them for this domain only.
+const DISPLAY_ERRORS_OPTIONS = [
+  { label: "On (show errors)", value: true },
+  { label: "Off", value: false },
+];
+
+// error_reporting bitmask presets. Production (22527) = E_ALL minus notices,
+// deprecations and strict; matches the php.ini-production default. All (32767)
+// = E_ALL (php.ini-development).
+const ERROR_REPORTING_OPTIONS = [
+  { label: "Use pool default", value: null },
+  { label: "None (report nothing)", value: 0 },
+  { label: "Production (errors + warnings)", value: 22527 },
+  { label: "All (development)", value: 32767 },
+];
+
+// The full IANA/PHP timezone list, shared with admin Server Settings so both
+// selectors offer the same zones (GH #1332). Searchable in the Select below.
+const TIMEZONE_OPTIONS = [
+  { label: "Use pool default", value: null as string | null },
+  ...IANA_TIMEZONES.map((z) => ({ label: z, value: z as string | null })),
+];
+
+export interface DomainPHPSettingsPanelProps {
+  domainId: string;
+}
+
+export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [phpSettings, setPhpSettings] = useState<DomainPHPSettings | null>(null);
+  const [availableVersions, setAvailableVersions] = useState<string[]>([]);
+  const [versionSaving, setVersionSaving] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form] = Form.useForm<PHPSettingsFormData>();
+
+  // Installed PHP versions for the version selector. Non-fatal: the selector
+  // falls back to "Server default" only.
+  useEffect(() => {
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ versions: string[] }>("/php/versions");
+        setAvailableVersions(resp.data?.versions ?? []);
+      } catch {
+        /* selector falls back to Default only */
+      }
+    })();
+  }, []);
+
+  const onChangePHPVersion = async (version: string | null) => {
+    setVersionSaving(true);
+    try {
+      if (version === null) {
+        await apiClient.delete(`/domains/${domainId}/php-pool`);
+      } else {
+        await apiClient.post(`/domains/${domainId}/php-pool`, {
+          php_version: version,
+        });
+      }
+      feedback.message.success(
+        version
+          ? `Switched to PHP ${version}`
+          : "Reverted to server default PHP version",
+      );
+      const resp = await apiClient.get<DomainPHPSettings>(
+        `/domains/${domainId}/php-settings`,
+      );
+      setPhpSettings(resp.data);
+      // GH #1332: switching a domain's version may have created a new
+      // per-version pool — refresh the Performance card so its version list +
+      // per-version values reflect it.
+      qc.invalidateQueries({ queryKey: ["me-php-pool-tuning"] });
+    } catch (err) {
+      const e = err as {
+        response?: { data?: { error?: string } };
+        message?: string;
+      };
+      feedback.message.error(
+        e.response?.data?.error ?? e.message ?? "Failed to change PHP version",
+      );
+    } finally {
+      setVersionSaving(false);
+    }
+  };
+
+  // Load this domain's PHP settings on mount and whenever the domain changes
+  // (the standalone page reuses one instance behind its picker).
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const resp = await apiClient.get<DomainPHPSettings>(
+          `/domains/${domainId}/php-settings`,
+        );
+        setPhpSettings(resp.data);
+        // resetFields BEFORE setFieldsValue: setFieldsValue does not clear the
+        // touched flags, so without the reset a domain switch would leave Save
+        // enabled on a stale dirty state (latent bug in the original page).
+        form.resetFields();
+        form.setFieldsValue({
+          php_memory_limit: resp.data.php_memory_limit,
+          php_upload_max_filesize: resp.data.php_upload_max_filesize,
+          php_post_max_size: resp.data.php_post_max_size,
+          php_max_input_vars: resp.data.php_max_input_vars,
+          php_max_execution_time: resp.data.php_max_execution_time,
+          php_max_input_time: resp.data.php_max_input_time,
+          php_display_errors: resp.data.php_display_errors,
+          php_error_reporting: resp.data.php_error_reporting,
+          php_timezone: resp.data.php_timezone,
+        });
+      } catch {
+        feedback.message.error("Failed to load PHP settings");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [domainId, form]);
+
+  const onSave = async (values: PHPSettingsFormData) => {
+    setSubmitting(true);
+    try {
+      await apiClient.patch(`/domains/${domainId}/php-settings`, {
+        php_memory_limit: values.php_memory_limit,
+        php_upload_max_filesize: values.php_upload_max_filesize,
+        php_post_max_size: values.php_post_max_size,
+        php_max_input_vars: values.php_max_input_vars,
+        php_max_execution_time: values.php_max_execution_time,
+        php_max_input_time: values.php_max_input_time,
+        // undefined (never set / cleared) -> null so the API clears the override.
+        php_display_errors: values.php_display_errors ?? null,
+        php_error_reporting: values.php_error_reporting ?? null,
+        php_timezone: values.php_timezone ?? null,
+      });
+      feedback.message.success("PHP settings updated successfully");
+      // Reload settings to confirm.
+      const resp = await apiClient.get<DomainPHPSettings>(
+        `/domains/${domainId}/php-settings`,
+      );
+      setPhpSettings(resp.data);
+    } catch {
+      feedback.message.error("Failed to update PHP settings");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Fields the Save button cares about. AntD's form state changes don't
+  // trigger parent re-renders, so we can't compute `hasChanges` inline —
+  // we have to evaluate it inside a Form.Item shouldUpdate wrapper so it
+  // re-runs on every form mutation. Typed literal-tuple so
+  // form.isFieldsTouched's keyof-narrowed overload accepts it.
+  const dirtyFields: (keyof PHPSettingsFormData)[] = [
+    "php_memory_limit",
+    "php_upload_max_filesize",
+    "php_post_max_size",
+    "php_max_input_vars",
+    "php_max_execution_time",
+    "php_max_input_time",
+    "php_display_errors",
+    "php_error_reporting",
+    "php_timezone",
+  ];
+
+  // GH #1332 item 6: a small tag on each field showing whether it is a custom
+  // override or falls back to the pool default. Reflects the last-saved state
+  // (phpSettings), refreshed after every save.
+  const fieldSet = (v: unknown) => v !== null && v !== undefined;
+  const overrideLabel = (text: string, overridden: boolean) => (
+    <Space size={6}>
+      {text}
+      {overridden ? (
+        <Tag color="blue" style={{ marginInlineEnd: 0 }}>
+          Custom
+        </Tag>
+      ) : (
+        <Tag style={{ marginInlineEnd: 0 }}>Pool default</Tag>
+      )}
+    </Space>
+  );
+
+  return (
+    <Form<PHPSettingsFormData> form={form} layout="vertical" onFinish={onSave}>
+      <Spin spinning={loading}>
+          {phpSettings && (
+            <>
+              <Form.Item
+                label={t("userphpsettingspage.php_version")}
+                extra="Applies to this domain only — each domain can run its own PHP version. EOL versions have no security patches; avoid them on public sites."
+              >
+                <Select
+                  value={phpSettings.php_version ?? null}
+                  loading={versionSaving}
+                  disabled={versionSaving}
+                  onChange={(v) => onChangePHPVersion(v)}
+                  style={{ width: 220 }}
+                  options={[
+                    { label: "Server default", value: null },
+                    ...availableVersions.map((v) => ({
+                      label: isPHPEOL(v) ? (
+                        <span>
+                          PHP {v}{" "}
+                          <Typography.Text type="danger">(EOL)</Typography.Text>
+                        </span>
+                      ) : (
+                        `PHP ${v}`
+                      ),
+                      value: v,
+                    })),
+                  ]}
+                />
+              </Form.Item>
+
+              {/* GH #1332 items 7, 15: quick actions for this domain. Reset
+                  OPcache lives on the OPcache & JIT tab (per-version / shared-
+                  pool, not per-domain), so it is not duplicated here. */}
+              <Space wrap style={{ marginBottom: 8 }}>
+                <Button
+                  type="link"
+                  style={{ paddingInline: 0 }}
+                  onClick={() => navigate(`/jabali-panel/logs?domain=${domainId}`)}
+                >
+                  View error log
+                </Button>
+                <Button
+                  type="link"
+                  style={{ paddingInline: 0 }}
+                  onClick={() => navigate("/jabali-panel/cron")}
+                >
+                  Scheduled tasks (Cron)
+                </Button>
+              </Space>
+
+              <Typography.Title level={5} style={{ marginBottom: 0 }}>
+                Resource Limits
+              </Typography.Title>
+              {/* GH #1332 item 3: these are DOMAIN-level php.ini overrides,
+                  applied to this domain regardless of which PHP version it
+                  runs — not per-version. Label it so that's clear. */}
+              <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+                Applied to this domain across all PHP versions. Per-version
+                worker tuning lives under Performance.
+              </Typography.Paragraph>
+              <Row gutter={[16, 16]}>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      t("userphpsettingspage.memory_limit"),
+                      fieldSet(phpSettings?.php_memory_limit),
+                    )}
+                    name="php_memory_limit"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={MEMORY_LIMIT_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      t("userphpsettingspage.upload_max_file_size"),
+                      fieldSet(phpSettings?.php_upload_max_filesize),
+                    )}
+                    name="php_upload_max_filesize"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={UPLOAD_MAX_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      t("userphpsettingspage.post_max_size"),
+                      fieldSet(phpSettings?.php_post_max_size),
+                    )}
+                    name="php_post_max_size"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={POST_MAX_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      t("userphpsettingspage.max_input_variables"),
+                      fieldSet(phpSettings?.php_max_input_vars),
+                    )}
+                    name="php_max_input_vars"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={MAX_INPUT_VARS_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+              </Row>
+
+              <Typography.Title level={5}>Execution Limits</Typography.Title>
+              <Row gutter={[16, 16]}>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      t("userphpsettingspage.max_execution_time"),
+                      fieldSet(phpSettings?.php_max_execution_time),
+                    )}
+                    name="php_max_execution_time"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={MAX_EXECUTION_TIME_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      t("userphpsettingspage.max_input_time"),
+                      fieldSet(phpSettings?.php_max_input_time),
+                    )}
+                    name="php_max_input_time"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={MAX_INPUT_TIME_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+              </Row>
+
+              <Typography.Title level={5}>
+                Error Handling &amp; Runtime
+              </Typography.Title>
+              <Typography.Paragraph type="secondary" style={{ marginTop: -4 }}>
+                These apply to this domain across all its PHP versions. Turn{" "}
+                <strong>Display errors</strong> on only for development — it
+                prints PHP errors to visitors.
+              </Typography.Paragraph>
+              <Row gutter={[16, 16]}>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      "Display errors",
+                      fieldSet(phpSettings?.php_display_errors),
+                    )}
+                    name="php_display_errors"
+                    extra="Shows PHP errors in the page output. Keep off on public/production sites."
+                  >
+                    <Select
+                      placeholder="Use pool default (off)"
+                      allowClear
+                      options={DISPLAY_ERRORS_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      "Error reporting",
+                      fieldSet(phpSettings?.php_error_reporting),
+                    )}
+                    name="php_error_reporting"
+                  >
+                    <Select
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      options={ERROR_REPORTING_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Form.Item
+                    label={overrideLabel(
+                      "Timezone",
+                      fieldSet(phpSettings?.php_timezone),
+                    )}
+                    name="php_timezone"
+                    extra="date.timezone for this domain's PHP."
+                  >
+                    <Select
+                      showSearch
+                      placeholder={t("userphpsettingspage.use_pool_default")}
+                      allowClear
+                      optionFilterProp="label"
+                      options={TIMEZONE_OPTIONS}
+                    />
+                  </Form.Item>
+                </Col>
+              </Row>
+
+              <Form.Item
+                noStyle
+                shouldUpdate={(prev, cur) =>
+                  dirtyFields.some((f) => prev[f] !== cur[f])
+                }
+              >
+                {() => {
+                  const hasChanges = form.isFieldsTouched(dirtyFields);
+                  return (
+                    <Form.Item style={{ marginBottom: 0, marginTop: 24 }}>
+                      <Button
+                        type="primary"
+                        htmlType="submit"
+                        loading={submitting}
+                        disabled={!hasChanges}
+                      >
+                        Save Changes
+                      </Button>
+                    </Form.Item>
+                  );
+                }}
+              </Form.Item>
+            </>
+          )}
+      </Spin>
+    </Form>
+  );
+}

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -59,6 +59,12 @@ vi.mock("../../dns/DNSRecordsPage", () => ({
 vi.mock("../../../components/logs/DomainLogsPanel", () => ({
   DomainLogsPanel: ({ domainId }: { domainId: string }) => <div>logs-pane:{domainId}</div>,
 }));
+vi.mock("../../../components/domains/DomainPHPSettingsPanel", () => ({
+  DomainPHPSettingsPanel: ({ domainId }: { domainId: string }) => <div>php-pane:{domainId}</div>,
+}));
+vi.mock("../php-settings/DomainEnvVarsCard", () => ({
+  DomainEnvVarsCard: ({ domainId }: { domainId?: string }) => <div>env-pane:{domainId}</div>,
+}));
 vi.mock("../../../components/DomainCacheSection", () => ({
   DomainCacheSection: ({ domainId }: { domainId: string }) => <div>caching-pane:{domainId}</div>,
 }));
@@ -165,6 +171,12 @@ describe("WebDomainPage (GH #1543)", () => {
   it("renders the Logs pane when :tab=logs (GH #1543)", async () => {
     renderAt("/jabali-panel/domains/d1/logs");
     expect(await screen.findByText("logs-pane:d1")).toBeInTheDocument();
+  });
+
+  it("renders the PHP Settings pane (panel + env card) when :tab=php-settings (GH #1543)", async () => {
+    renderAt("/jabali-panel/domains/d1/php-settings");
+    expect(await screen.findByText("php-pane:d1")).toBeInTheDocument();
+    expect(screen.getByText("env-pane:d1")).toBeInTheDocument();
   });
 
   it("renders the Caching pane when :tab=caching", async () => {

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -29,6 +29,8 @@ import { DomainLogsPanel } from "../../../components/logs/DomainLogsPanel";
 import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsPanel";
 import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
 import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
+import { DomainPHPSettingsPanel } from "../../../components/domains/DomainPHPSettingsPanel";
+import { DomainEnvVarsCard } from "../php-settings/DomainEnvVarsCard";
 import { OverviewTab } from "./tabs/OverviewTab";
 
 const DEFAULT_TAB = "overview";
@@ -98,6 +100,20 @@ export const WebDomainPage = () => {
     ...(dnsOn
       ? [{ key: "dns", label: "DNS", node: <DNSRecordsPanel domainId={domain.id} embedded /> }]
       : []),
+    // PHP Settings — this domain's PHP version + php.ini limit overrides and its
+    // env vars. The account/pool-level PHP tabs (Performance, OPcache,
+    // Extensions, Xdebug, CLI/Composer) are per-version-pool and stay on the
+    // standalone PHP Settings page. GH #1543.
+    {
+      key: "php-settings",
+      label: "PHP Settings",
+      node: (
+        <Space direction="vertical" size="large" style={{ width: "100%" }}>
+          <DomainPHPSettingsPanel domainId={domain.id} />
+          <DomainEnvVarsCard domainId={domain.id} />
+        </Space>
+      ),
+    },
     { key: "redirects", label: "Redirects", node: <DomainRedirectsPanel domain={domain} /> },
     { key: "index", label: "Index Files", node: <DomainIndexPanel domain={domain} /> },
     { key: "caching", label: "Caching", node: <DomainCacheSection domainId={domain.id} /> },

--- a/panel-ui/src/shells/user/php-settings/DomainEnvVarsCard.test.tsx
+++ b/panel-ui/src/shells/user/php-settings/DomainEnvVarsCard.test.tsx
@@ -1,0 +1,38 @@
+// DomainEnvVarsCard.test — GH #1543. In domain-fixed mode (a `domainId` prop,
+// used by the Web Domain page), the card must bind to that domain: it loads
+// THAT domain's env vars, issues no /domains list fetch, and renders no domain
+// picker. This is the tenant-scope guarantee at the fixed call site.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), put: vi.fn() },
+}));
+vi.mock("../../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+
+import { apiClient } from "../../../apiClient";
+import { DomainEnvVarsCard } from "./DomainEnvVarsCard";
+
+const mocked = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.get.mockResolvedValue({ data: { env_vars: [{ key: "APP_ENV", value: "prod" }] } });
+});
+
+describe("DomainEnvVarsCard domain-fixed mode (GH #1543)", () => {
+  it("loads the given domain's env vars and never lists /domains", async () => {
+    render(<DomainEnvVarsCard domainId="d1" />);
+    await vi.waitFor(() =>
+      expect(mocked.get).toHaveBeenCalledWith("/domains/d1/env-vars"),
+    );
+    // No domain-list fetch in fixed mode.
+    expect(mocked.get).not.toHaveBeenCalledWith("/domains");
+    // No picker rendered.
+    expect(screen.queryByText("Select a domain")).not.toBeInTheDocument();
+    // The loaded var is shown.
+    expect(await screen.findByDisplayValue("APP_ENV")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/php-settings/DomainEnvVarsCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/DomainEnvVarsCard.tsx
@@ -1,6 +1,8 @@
 // DomainEnvVarsCard — GH #1332 item 14. Per-domain environment variables,
-// delivered to PHP as fastcgi_param (reach getenv() + $_SERVER). Self-contained
-// (its own domain picker) so it drops into the PHP Settings tabs cleanly.
+// delivered to PHP as fastcgi_param (reach getenv() + $_SERVER). On the
+// standalone PHP Settings page it self-selects a domain (its own picker); on
+// the Web Domain page (GH #1543) the domain is fixed by the route, so passing
+// `domainId` binds it and hides the picker.
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -43,14 +45,20 @@ function keyError(key: string): string | null {
   return null;
 }
 
-export function DomainEnvVarsCard() {
+export function DomainEnvVarsCard({ domainId }: { domainId?: string } = {}) {
   const [domains, setDomains] = useState<Domain[]>([]);
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
   const [rows, setRows] = useState<EnvVar[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
 
+  // When a domainId is supplied (GH #1543 Web Domain page) the domain is fixed:
+  // use it directly and skip the picker and its domain-list fetch.
+  const fixedDomain = domainId !== undefined;
+  const activeDomain = domainId ?? selectedDomain;
+
   useEffect(() => {
+    if (fixedDomain) return;
     (async () => {
       try {
         const resp = await apiClient.get<{ data: Domain[] }>("/domains");
@@ -59,20 +67,20 @@ export function DomainEnvVarsCard() {
         feedback.message.error("Failed to load domains");
       }
     })();
-  }, []);
+  }, [fixedDomain]);
 
   useEffect(() => {
-    if (!selectedDomain) {
+    if (!activeDomain) {
       setRows([]);
       return;
     }
     setLoading(true);
     apiClient
-      .get<{ env_vars: EnvVar[] }>(`/domains/${selectedDomain}/env-vars`)
+      .get<{ env_vars: EnvVar[] }>(`/domains/${activeDomain}/env-vars`)
       .then((resp) => setRows(resp.data.env_vars ?? []))
       .catch(() => feedback.message.error("Failed to load environment variables"))
       .finally(() => setLoading(false));
-  }, [selectedDomain]);
+  }, [activeDomain]);
 
   const setRow = (i: number, patch: Partial<EnvVar>) =>
     setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
@@ -95,10 +103,10 @@ export function DomainEnvVarsCard() {
     dupKeys.size > 0;
 
   const save = async () => {
-    if (!selectedDomain) return;
+    if (!activeDomain) return;
     setSaving(true);
     try {
-      await apiClient.put(`/domains/${selectedDomain}/env-vars`, {
+      await apiClient.put(`/domains/${activeDomain}/env-vars`, {
         env_vars: rows.map((r) => ({ key: r.key, value: r.value })),
       });
       feedback.message.success("Environment variables saved");
@@ -122,15 +130,17 @@ export function DomainEnvVarsCard() {
           domain&apos;s PHP requests.
         </Typography.Paragraph>
 
-        <Select
-          style={{ minWidth: 280 }}
-          placeholder="Select a domain"
-          value={selectedDomain}
-          onChange={setSelectedDomain}
-          options={domains.map((d) => ({ label: d.name, value: d.id }))}
-        />
+        {!fixedDomain && (
+          <Select
+            style={{ minWidth: 280 }}
+            placeholder="Select a domain"
+            value={selectedDomain}
+            onChange={setSelectedDomain}
+            options={domains.map((d) => ({ label: d.name, value: d.id }))}
+          />
+        )}
 
-        {selectedDomain && (
+        {activeDomain && (
           <Spin spinning={loading}>
             <Space direction="vertical" size="small" style={{ width: "100%" }}>
               {rows.length === 0 && (

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -1,9 +1,7 @@
 import { useTranslation } from "react-i18next";
-import { Tabs, Alert, Button, Card, Form, Row, Col, Select, Space, Spin, Tag, Typography } from "antd";
+import { Tabs, Alert, Card, Select, Space, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
-import { useQueryClient } from "@tanstack/react-query";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
 import { UserPHPOpcacheCard } from "./UserPHPOpcacheCard";
@@ -12,8 +10,7 @@ import { PHPExtensionsCard } from "./PHPExtensionsCard";
 import { PHPXdebugCard } from "./PHPXdebugCard";
 import { apiClient } from "../../../apiClient";
 import { getIdentity, type Identity } from "../../../identity";
-import { isPHPEOL } from "../../../utils/phpEol";
-import { IANA_TIMEZONES } from "../../../data/timezones";
+import { DomainPHPSettingsPanel } from "../../../components/domains/DomainPHPSettingsPanel";
 
 type Domain = {
   id: string;
@@ -21,135 +18,16 @@ type Domain = {
   user_id: string;
 };
 
-type DomainPHPSettings = {
-  php_pool_id?: string | null;
-  php_version?: string | null;
-  php_memory_limit?: string | null;
-  php_upload_max_filesize?: string | null;
-  php_post_max_size?: string | null;
-  php_max_input_vars?: number | null;
-  php_max_execution_time?: number | null;
-  php_max_input_time?: number | null;
-  // GH #1332 per-domain runtime directives.
-  php_display_errors?: boolean | null;
-  php_error_reporting?: number | null;
-  php_timezone?: string | null;
-};
-
-type PHPSettingsFormData = {
-  domain_id: string;
-  php_memory_limit?: string | null;
-  php_upload_max_filesize?: string | null;
-  php_post_max_size?: string | null;
-  php_max_input_vars?: number | null;
-  php_max_execution_time?: number | null;
-  php_max_input_time?: number | null;
-  php_display_errors?: boolean | null;
-  php_error_reporting?: number | null;
-  php_timezone?: string | null;
-};
-
-const MEMORY_LIMIT_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "32M", value: "32M" },
-  { label: "64M", value: "64M" },
-  { label: "128M", value: "128M" },
-  { label: "256M", value: "256M" },
-  { label: "512M", value: "512M" },
-  { label: "1G", value: "1G" },
-];
-
-const UPLOAD_MAX_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "1M", value: "1M" },
-  { label: "10M", value: "10M" },
-  { label: "50M", value: "50M" },
-  { label: "100M", value: "100M" },
-  { label: "256M", value: "256M" },
-  { label: "512M", value: "512M" },
-];
-
-const POST_MAX_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "1M", value: "1M" },
-  { label: "10M", value: "10M" },
-  { label: "50M", value: "50M" },
-  { label: "100M", value: "100M" },
-  { label: "256M", value: "256M" },
-  { label: "512M", value: "512M" },
-];
-
-const MAX_INPUT_VARS_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "100", value: 100 },
-  { label: "500", value: 500 },
-  { label: "1000", value: 1000 },
-  { label: "2000", value: 2000 },
-  { label: "5000", value: 5000 },
-  { label: "10000", value: 10000 },
-];
-
-const MAX_EXECUTION_TIME_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "10s", value: 10 },
-  { label: "30s", value: 30 },
-  { label: "60s", value: 60 },
-  { label: "120s", value: 120 },
-  { label: "300s", value: 300 },
-  { label: "600s", value: 600 },
-];
-
-const MAX_INPUT_TIME_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "10s", value: 10 },
-  { label: "30s", value: 30 },
-  { label: "60s", value: 60 },
-  { label: "120s", value: 120 },
-  { label: "300s", value: 300 },
-];
-
-// GH #1332 per-domain runtime directives. display_errors is pinned Off on every
-// PHP vhost by the agent, so "Use pool default" and "Off" are the same effect —
-// both keep errors hidden; "On" surfaces them for this domain only.
-const DISPLAY_ERRORS_OPTIONS = [
-  { label: "On (show errors)", value: true },
-  { label: "Off", value: false },
-];
-
-// error_reporting bitmask presets. Production (22527) = E_ALL minus notices,
-// deprecations and strict; matches the php.ini-production default. All (32767)
-// = E_ALL (php.ini-development).
-const ERROR_REPORTING_OPTIONS = [
-  { label: "Use pool default", value: null },
-  { label: "None (report nothing)", value: 0 },
-  { label: "Production (errors + warnings)", value: 22527 },
-  { label: "All (development)", value: 32767 },
-];
-
-// The full IANA/PHP timezone list, shared with admin Server Settings so both
-// selectors offer the same zones (GH #1332). Searchable in the Select below.
-const TIMEZONE_OPTIONS = [
-  { label: "Use pool default", value: null as string | null },
-  ...IANA_TIMEZONES.map((z) => ({ label: z, value: z as string | null })),
-];
-
 export function UserPHPSettingsPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const qc = useQueryClient();
   const [, setMe] = useState<Identity | null>(null);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
-  const [phpSettings, setPhpSettings] = useState<DomainPHPSettings | null>(null);
   const [availableVersions, setAvailableVersions] = useState<string[]>([]);
-  const [versionSaving, setVersionSaving] = useState(false);
   const [cliVersion, setCliVersion] = useState<string>(""); // "" = auto
   const [cliSaving, setCliSaving] = useState(false);
   const [composerChannel, setComposerChannel] = useState<string>("latest");
   const [composerSaving, setComposerSaving] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [form] = Form.useForm<PHPSettingsFormData>();
 
   // Load identity, domains, and installed PHP versions on mount
   useEffect(() => {
@@ -162,7 +40,7 @@ export function UserPHPSettingsPage() {
           "/domains",
         );
         setDomains(resp.data?.data ?? []);
-      } catch (err) {
+      } catch {
         feedback.message.error("Failed to load domains");
       }
 
@@ -171,8 +49,8 @@ export function UserPHPSettingsPage() {
           "/php/versions",
         );
         setAvailableVersions(resp.data?.versions ?? []);
-      } catch (err) {
-        // Non-fatal: PHP version selector falls back to "Default only".
+      } catch {
+        // Non-fatal: CLI version selector falls back to "Automatic" only.
       }
 
       try {
@@ -235,145 +113,6 @@ export function UserPHPSettingsPage() {
     }
   };
 
-  const onChangePHPVersion = async (version: string | null) => {
-    if (!selectedDomain) return;
-    setVersionSaving(true);
-    try {
-      if (version === null) {
-        await apiClient.delete(`/domains/${selectedDomain}/php-pool`);
-      } else {
-        await apiClient.post(`/domains/${selectedDomain}/php-pool`, {
-          php_version: version,
-        });
-      }
-      feedback.message.success(
-        version
-          ? `Switched to PHP ${version}`
-          : "Reverted to server default PHP version",
-      );
-      const resp = await apiClient.get<DomainPHPSettings>(
-        `/domains/${selectedDomain}/php-settings`,
-      );
-      setPhpSettings(resp.data);
-      // GH #1332: switching a domain's version may have created a new
-      // per-version pool — refresh the Performance card so its version list +
-      // per-version values reflect it.
-      qc.invalidateQueries({ queryKey: ["me-php-pool-tuning"] });
-    } catch (err) {
-      const e = err as {
-        response?: { data?: { error?: string } };
-        message?: string;
-      };
-      feedback.message.error(
-        e.response?.data?.error ?? e.message ?? "Failed to change PHP version",
-      );
-    } finally {
-      setVersionSaving(false);
-    }
-  };
-
-  // Load PHP settings when domain is selected
-  useEffect(() => {
-    if (!selectedDomain) {
-      setPhpSettings(null);
-      form.resetFields();
-      return;
-    }
-
-    (async () => {
-      setLoading(true);
-      try {
-        const resp = await apiClient.get<DomainPHPSettings>(
-          `/domains/${selectedDomain}/php-settings`,
-        );
-        setPhpSettings(resp.data);
-        form.setFieldsValue({
-          domain_id: selectedDomain,
-          php_memory_limit: resp.data.php_memory_limit,
-          php_upload_max_filesize: resp.data.php_upload_max_filesize,
-          php_post_max_size: resp.data.php_post_max_size,
-          php_max_input_vars: resp.data.php_max_input_vars,
-          php_max_execution_time: resp.data.php_max_execution_time,
-          php_max_input_time: resp.data.php_max_input_time,
-          php_display_errors: resp.data.php_display_errors,
-          php_error_reporting: resp.data.php_error_reporting,
-          php_timezone: resp.data.php_timezone,
-        });
-      } catch (err) {
-        feedback.message.error("Failed to load PHP settings");
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [selectedDomain, form]);
-
-  const onSave = async (values: PHPSettingsFormData) => {
-    if (!selectedDomain) return;
-
-    setSubmitting(true);
-    try {
-      await apiClient.patch(`/domains/${selectedDomain}/php-settings`, {
-        php_memory_limit: values.php_memory_limit,
-        php_upload_max_filesize: values.php_upload_max_filesize,
-        php_post_max_size: values.php_post_max_size,
-        php_max_input_vars: values.php_max_input_vars,
-        php_max_execution_time: values.php_max_execution_time,
-        php_max_input_time: values.php_max_input_time,
-        // undefined (never set / cleared) -> null so the API clears the override.
-        php_display_errors: values.php_display_errors ?? null,
-        php_error_reporting: values.php_error_reporting ?? null,
-        php_timezone: values.php_timezone ?? null,
-      });
-      feedback.message.success("PHP settings updated successfully");
-      // Reload settings to confirm
-      if (selectedDomain) {
-        const resp = await apiClient.get<DomainPHPSettings>(
-          `/domains/${selectedDomain}/php-settings`,
-        );
-        setPhpSettings(resp.data);
-      }
-    } catch (err) {
-      feedback.message.error("Failed to update PHP settings");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  // Fields the Save button cares about. AntD's form state changes don't
-  // trigger parent re-renders, so we can't compute `hasChanges` inline —
-  // we have to evaluate it inside a Form.Item shouldUpdate wrapper so it
-  // re-runs on every form mutation. Typed literal-tuple so
-  // form.isFieldsTouched's keyof-narrowed overload accepts it.
-  const dirtyFields: (keyof PHPSettingsFormData)[] = [
-    "php_memory_limit",
-    "php_upload_max_filesize",
-    "php_post_max_size",
-    "php_max_input_vars",
-    "php_max_execution_time",
-    "php_max_input_time",
-    "php_display_errors",
-    "php_error_reporting",
-    "php_timezone",
-  ];
-
-  // GH #1332 item 6: a small tag on each field showing whether it is a custom
-  // override or falls back to the pool default. Reflects the last-saved state
-  // (phpSettings), refreshed after every save.
-  const fieldSet = (v: unknown) => v !== null && v !== undefined;
-  const overrideLabel = (text: string, overridden: boolean) => (
-    <Space size={6}>
-      {text}
-      {overridden ? (
-        <Tag color="blue" style={{ marginInlineEnd: 0 }}>
-          Custom
-        </Tag>
-      ) : (
-        <Tag style={{ marginInlineEnd: 0 }}>Pool default</Tag>
-      )}
-    </Space>
-  );
-
-
   return (
     // GH #1332 item 1: the page was clamped to 800px and centred, unlike every
     // other settings page. Use the shell's full responsive width like its peers.
@@ -398,319 +137,61 @@ export function UserPHPSettingsPage() {
               label: "Version & Domains",
               children: (
                 <Space direction="vertical" size="large" style={{ width: "100%" }}>
-        <Card title={t("userphpsettingspage.cli_terminal_default_php_version")} size="small">
-          <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
-            Sets which PHP version a bare <code>php</code> (and composer / wp-cli)
-            uses in your SSH/terminal sessions. This is separate from each
-            domain&apos;s web PHP version. You can always pick a specific version
-            per command with <code>php8.3</code>, <code>php8.4</code>, etc.
-          </Typography.Paragraph>
-          <Select
-            style={{ minWidth: 280 }}
-            value={cliVersion}
-            loading={cliSaving}
-            onChange={onChangeCliVersion}
-            options={[
-              { value: "", label: "Automatic (follow domain pool)" },
-              ...availableVersions.map((v) => ({ value: v, label: `PHP ${v}` })),
-            ]}
-          />
-          {/* GH #1332 item 13: Composer version channel. */}
-          <Typography.Paragraph
-            type="secondary"
-            style={{ marginTop: 16, marginBottom: 4 }}
-          >
-            Composer version for your shell <code>composer</code>.
-          </Typography.Paragraph>
-          <Select
-            style={{ minWidth: 280 }}
-            value={composerChannel}
-            loading={composerSaving}
-            onChange={onChangeComposer}
-            options={[
-              { value: "latest", label: "Composer (latest)" },
-              { value: "lts", label: "Composer 2.2 LTS (older PHP compatibility)" },
-            ]}
-          />
-        </Card>
-
-        <Card>
-          <Form<PHPSettingsFormData>
-            form={form}
-            layout="vertical"
-            onFinish={onSave}
-          >
-            <Form.Item
-              label={t("userphpsettingspage.domain")}
-              name="domain_id"
-              rules={[{ required: true, message: "Please select a domain" }]}
-            >
-              <Select
-                placeholder={t("userphpsettingspage.select_a_domain")}
-                onChange={setSelectedDomain}
-                options={domains.map((d) => ({
-                  label: d.name,
-                  value: d.id,
-                }))}
-              />
-            </Form.Item>
-
-            <Spin spinning={loading}>
-              {selectedDomain && phpSettings && (
-                <>
-                  <Form.Item
-                    label={t("userphpsettingspage.php_version")}
-                    extra="Applies to this domain only — each domain can run its own PHP version. EOL versions have no security patches; avoid them on public sites."
-                  >
+                  <Card title={t("userphpsettingspage.cli_terminal_default_php_version")} size="small">
+                    <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+                      Sets which PHP version a bare <code>php</code> (and composer / wp-cli)
+                      uses in your SSH/terminal sessions. This is separate from each
+                      domain&apos;s web PHP version. You can always pick a specific version
+                      per command with <code>php8.3</code>, <code>php8.4</code>, etc.
+                    </Typography.Paragraph>
                     <Select
-                      value={phpSettings.php_version ?? null}
-                      loading={versionSaving}
-                      disabled={versionSaving}
-                      onChange={(v) => onChangePHPVersion(v)}
-                      style={{ width: 220 }}
+                      style={{ minWidth: 280 }}
+                      value={cliVersion}
+                      loading={cliSaving}
+                      onChange={onChangeCliVersion}
                       options={[
-                        { label: "Server default", value: null },
-                        ...availableVersions.map((v) => ({
-                          label: isPHPEOL(v) ? (
-                            <span>
-                              PHP {v}{" "}
-                              <Typography.Text type="danger">
-                                (EOL)
-                              </Typography.Text>
-                            </span>
-                          ) : (
-                            `PHP ${v}`
-                          ),
-                          value: v,
-                        })),
+                        { value: "", label: "Automatic (follow domain pool)" },
+                        ...availableVersions.map((v) => ({ value: v, label: `PHP ${v}` })),
                       ]}
                     />
-                  </Form.Item>
-
-                  {/* GH #1332 items 7, 15: quick actions for the selected domain.
-                      Reset OPcache lives on the OPcache & JIT tab now (it is
-                      per-version / shared-pool, not per-domain) — removed here to
-                      avoid the same control in two places (lxsdevcode). */}
-                  <Space wrap style={{ marginBottom: 8 }}>
-                    <Button
-                      type="link"
-                      style={{ paddingInline: 0 }}
-                      onClick={() =>
-                        navigate(`/jabali-panel/logs?domain=${selectedDomain}`)
-                      }
+                    {/* GH #1332 item 13: Composer version channel. */}
+                    <Typography.Paragraph
+                      type="secondary"
+                      style={{ marginTop: 16, marginBottom: 4 }}
                     >
-                      View error log
-                    </Button>
-                    <Button
-                      type="link"
-                      style={{ paddingInline: 0 }}
-                      onClick={() => navigate("/jabali-panel/cron")}
-                    >
-                      Scheduled tasks (Cron)
-                    </Button>
-                  </Space>
+                      Composer version for your shell <code>composer</code>.
+                    </Typography.Paragraph>
+                    <Select
+                      style={{ minWidth: 280 }}
+                      value={composerChannel}
+                      loading={composerSaving}
+                      onChange={onChangeComposer}
+                      options={[
+                        { value: "latest", label: "Composer (latest)" },
+                        { value: "lts", label: "Composer 2.2 LTS (older PHP compatibility)" },
+                      ]}
+                    />
+                  </Card>
 
-                  <Typography.Title level={5} style={{ marginBottom: 0 }}>
-                    Resource Limits
-                  </Typography.Title>
-                  {/* GH #1332 item 3: these are DOMAIN-level php.ini overrides,
-                      applied to this domain regardless of which PHP version it
-                      runs — not per-version. Label it so that's clear. */}
-                  <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
-                    Applied to this domain across all PHP versions. Per-version
-                    worker tuning lives under Performance.
-                  </Typography.Paragraph>
-                  <Row gutter={[16, 16]}>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          t("userphpsettingspage.memory_limit"),
-                          fieldSet(phpSettings?.php_memory_limit),
-                        )}
-                        name="php_memory_limit"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={MEMORY_LIMIT_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          t("userphpsettingspage.upload_max_file_size"),
-                          fieldSet(phpSettings?.php_upload_max_filesize),
-                        )}
-                        name="php_upload_max_filesize"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={UPLOAD_MAX_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          t("userphpsettingspage.post_max_size"),
-                          fieldSet(phpSettings?.php_post_max_size),
-                        )}
-                        name="php_post_max_size"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={POST_MAX_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          t("userphpsettingspage.max_input_variables"),
-                          fieldSet(phpSettings?.php_max_input_vars),
-                        )}
-                        name="php_max_input_vars"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={MAX_INPUT_VARS_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                  </Row>
-
-                  <Typography.Title level={5}>Execution Limits</Typography.Title>
-                  <Row gutter={[16, 16]}>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          t("userphpsettingspage.max_execution_time"),
-                          fieldSet(phpSettings?.php_max_execution_time),
-                        )}
-                        name="php_max_execution_time"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={MAX_EXECUTION_TIME_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          t("userphpsettingspage.max_input_time"),
-                          fieldSet(phpSettings?.php_max_input_time),
-                        )}
-                        name="php_max_input_time"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={MAX_INPUT_TIME_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                  </Row>
-
-                  <Typography.Title level={5}>
-                    Error Handling &amp; Runtime
-                  </Typography.Title>
-                  <Typography.Paragraph
-                    type="secondary"
-                    style={{ marginTop: -4 }}
-                  >
-                    These apply to this domain across all its PHP versions.
-                    Turn <strong>Display errors</strong> on only for
-                    development — it prints PHP errors to visitors.
-                  </Typography.Paragraph>
-                  <Row gutter={[16, 16]}>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          "Display errors",
-                          fieldSet(phpSettings?.php_display_errors),
-                        )}
-                        name="php_display_errors"
-                        extra="Shows PHP errors in the page output. Keep off on public/production sites."
-                      >
-                        <Select
-                          placeholder="Use pool default (off)"
-                          allowClear
-                          options={DISPLAY_ERRORS_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          "Error reporting",
-                          fieldSet(phpSettings?.php_error_reporting),
-                        )}
-                        name="php_error_reporting"
-                      >
-                        <Select
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          options={ERROR_REPORTING_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col xs={24} sm={12}>
-                      <Form.Item
-                        label={overrideLabel(
-                          "Timezone",
-                          fieldSet(phpSettings?.php_timezone),
-                        )}
-                        name="php_timezone"
-                        extra="date.timezone for this domain's PHP."
-                      >
-                        <Select
-                          showSearch
-                          placeholder={t("userphpsettingspage.use_pool_default")}
-                          allowClear
-                          optionFilterProp="label"
-                          options={TIMEZONE_OPTIONS}
-                        />
-                      </Form.Item>
-                    </Col>
-                  </Row>
-
-                  <Form.Item
-                    noStyle
-                    shouldUpdate={(prev, cur) =>
-                      dirtyFields.some((f) => prev[f] !== cur[f])
-                    }
-                  >
-                    {() => {
-                      const hasChanges =
-                        !!selectedDomain &&
-                        form.isFieldsTouched(dirtyFields);
-                      return (
-                        <Form.Item
-                          style={{ marginBottom: 0, marginTop: 24 }}
-                        >
-                          <Button
-                            type="primary"
-                            htmlType="submit"
-                            loading={submitting}
-                            disabled={!hasChanges}
-                          >
-                            Save Changes
-                          </Button>
-                        </Form.Item>
-                      );
-                    }}
-                  </Form.Item>
-                </>
-              )}
-            </Spin>
-          </Form>
-        </Card>
+                  {/* GH #1543: the per-domain PHP controls (version + php.ini
+                      limit overrides) live in DomainPHPSettingsPanel, shared
+                      with the Web Domain page's PHP Settings tab. Here a picker
+                      selects the domain; on the domain page the domain is fixed
+                      by the route. */}
+                  <Card>
+                    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+                      <Select
+                        style={{ minWidth: 280 }}
+                        placeholder={t("userphpsettingspage.select_a_domain")}
+                        value={selectedDomain}
+                        onChange={setSelectedDomain}
+                        options={domains.map((d) => ({ label: d.name, value: d.id }))}
+                      />
+                      {selectedDomain && (
+                        <DomainPHPSettingsPanel key={selectedDomain} domainId={selectedDomain} />
+                      )}
+                    </Space>
+                  </Card>
                 </Space>
               ),
             },


### PR DESCRIPTION
## What

Adds a **PHP Settings** tab to the tenant Web Domain page (GH #1543, johnnyq). It holds the **domain-scoped** PHP controls for that domain:

- **PHP version** for this domain (`POST`/`DELETE /domains/:id/php-pool`)
- **php.ini limit overrides** — memory / upload / post / input-vars / execution & input time / display_errors / error_reporting / timezone (`GET`/`PATCH /domains/:id/php-settings`)
- **Environment variables** (`/domains/:id/env-vars`)

## Why the standalone PHP Settings page stays

The other PHP tabs — **CLI & Composer, Performance, OPcache & JIT, Extensions, Xdebug** — are all `/me/...` and **per-version-pool**: a pool is shared by every domain running that PHP version, so they are *not* per-domain and can't live on a single-domain page. They remain on the standalone PHP Settings page. Whether that page's domain-selector *Version & Domains* tab is still worth keeping now that every domain page carries its own PHP Settings is a **separate decision** (same shape as the Logs nav-rename deferred in #1569).

## How — extraction, not duplication (A3/A5 pattern)

- **New `components/domains/DomainPHPSettingsPanel.tsx`** (`{ domainId }`, audience-neutral) — the version + limits form, its option lists, and its save logic, lifted out of `UserPHPSettingsPage`. The standalone page's *Version & Domains* tab now renders it **behind its domain picker**, so there is one copy of the form. (Page net **−591** lines.)
- **`DomainEnvVarsCard`** gains an optional `domainId` prop that binds the domain and hides its own picker; the Web Domain tab passes it, the standalone Environment tab keeps calling it bare.

## Latent-bug fix carried in the extraction

The load effect now `resetFields()` **before** `setFieldsValue()`. `setFieldsValue` doesn't clear touched state, so without it, switching the selected domain on the standalone page left **Save enabled on a stale dirty flag**. Not a behavior change to the happy path — a fix.

## Test plan

- [x] `tsc -b` clean, `eslint` clean on all changed files
- [x] `DomainPHPSettingsPanel.test.tsx` — loads THIS domain's settings on mount; reverting version to *Server default* DELETEs `/domains/d1/php-pool` (pins domain binding)
- [x] `DomainEnvVarsCard.test.tsx` — `domainId="d1"` loads `/domains/d1/env-vars`, never lists `/domains`, renders no picker
- [x] `WebDomainPage.test.tsx` — `:tab=php-settings` renders panel + env card; existing tests still green (23 tests total across the 4 files)
- [ ] Manual: tenant domain → PHP Settings tab → change version, save a limit, add an env var; standalone PHP Settings page still works behind its picker

GH #1543