### PR TITLE
feat(domains): show installed apps in the Web Domains list (GH #1543 D1)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -385,6 +385,26 @@ type domainListRow struct {
 	// TempURL is the full preview URL, populated when the domain has
 	// temp_url_enabled and a panel hostname is configured.
 	TempURL *string `json:"temp_url,omitempty"`
+	// Applications denormalizes this domain's One-Click app installs onto the
+	// row so the tenant Web Domains list can show an Application column without
+	// an N+1 (GH #1543). Ordered docroot-first; a domain may host several
+	// (/, /blog). omitempty drops both nil and an empty slice, so a domain with
+	// no apps ships no key (never a JSON null the SPA would trip on). Populated
+	// only when AppInstalls is wired; admin and tenant share this list handler,
+	// admin simply doesn't render the column.
+	Applications []domainAppSummary `json:"applications,omitempty"`
+}
+
+// domainAppSummary is the per-row app view (GH #1543): just what the Web
+// Domains Application column needs — enough to show the badge, version, live
+// status, and mint a login. The full install record stays on GET /applications.
+type domainAppSummary struct {
+	ID           string  `json:"id"`
+	AppType      string  `json:"app_type"`
+	Version      *string `json:"version"`
+	Status       string  `json:"status"`
+	LastError    string  `json:"last_error,omitempty"`
+	Subdirectory string  `json:"subdirectory"`
 }
 
 // ipSummary is the denormalized {id, address} blob the UI consumes for
@@ -573,6 +593,35 @@ func (h *domainHandler) list(c *gin.Context) {
 						}
 					}
 				}
+			}
+		}
+	}
+
+	// GH #1543: denormalize each domain's One-Click app installs onto its row
+	// so the tenant Web Domains list can render an Application column without an
+	// N+1 fetch. Single batch lookup, grouped in memory (docroot-first, as the
+	// repo orders by subdirectory); on error we drop the field rather than
+	// 500ing — the standalone Applications page is the recovery path.
+	if h.cfg.AppInstalls != nil && len(domains) > 0 {
+		domainIDs := make([]string, len(domains))
+		for i := range domains {
+			domainIDs[i] = domains[i].ID
+		}
+		if installs, appErr := h.cfg.AppInstalls.ListByDomainIDs(c.Request.Context(), domainIDs); appErr == nil {
+			appsByDomain := make(map[string][]domainAppSummary, len(installs))
+			for i := range installs {
+				a := &installs[i]
+				appsByDomain[a.DomainID] = append(appsByDomain[a.DomainID], domainAppSummary{
+					ID:           a.ID,
+					AppType:      a.AppType,
+					Version:      a.Version,
+					Status:       a.Status,
+					LastError:    a.LastError,
+					Subdirectory: a.Subdirectory,
+				})
+			}
+			for i := range rows {
+				rows[i].Applications = appsByDomain[rows[i].ID]
 			}
 		}
 	}

--- a/panel-api/internal/api/domains_apps_summary_test.go
+++ b/panel-api/internal/api/domains_apps_summary_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// mockAppInstallsForSummary embeds the repo interface (auto-satisfying the
+// methods the list handler never calls) and implements only ListByDomainIDs,
+// the one the GH #1543 domains-list app summary uses.
+type mockAppInstallsForSummary struct {
+	repository.ApplicationInstallRepository
+	byDomain map[string][]models.ApplicationInstall
+}
+
+func (m *mockAppInstallsForSummary) ListByDomainIDs(_ context.Context, ids []string) ([]models.ApplicationInstall, error) {
+	var out []models.ApplicationInstall
+	for _, id := range ids {
+		out = append(out, m.byDomain[id]...)
+	}
+	return out, nil
+}
+
+// TestDomainList_EmbedsAppSummary asserts GET /domains denormalizes each
+// domain's One-Click installs onto the row: a domain with a docroot + subdir
+// install gets both (docroot first), and a domain with none ships no key.
+func TestDomainList_EmbedsAppSummary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: true})
+		c.Next()
+	})
+
+	base := newMockDomainRepo()
+	base.Create(context.Background(), &models.Domain{ID: "d1", UserID: "u1", Name: "a.com"})
+	base.Create(context.Background(), &models.Domain{ID: "d2", UserID: "u1", Name: "b.com"})
+	domains := &domainListWithSeedData{mockDomainRepo: base}
+
+	apps := &mockAppInstallsForSummary{byDomain: map[string][]models.ApplicationInstall{
+		"d1": {
+			{ID: "i_root", DomainID: "d1", AppType: "wordpress", Version: strptr("6.5.3"), Status: "ready", Subdirectory: ""},
+			{ID: "i_blog", DomainID: "d1", AppType: "wordpress", Version: strptr("6.5.3"), Status: "installing", Subdirectory: "blog"},
+		},
+		// d2 has no installs.
+	}}
+
+	RegisterDomainRoutes(v1, DomainHandlerConfig{Domains: domains, AppInstalls: apps})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/domains", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data []struct {
+			ID           string `json:"id"`
+			Applications []struct {
+				ID           string  `json:"id"`
+				AppType      string  `json:"app_type"`
+				Version      *string `json:"version"`
+				Status       string  `json:"status"`
+				Subdirectory string  `json:"subdirectory"`
+			} `json:"applications"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	byID := map[string]int{}
+	for i, row := range resp.Data {
+		byID[row.ID] = i
+	}
+	d1 := resp.Data[byID["d1"]]
+	if len(d1.Applications) != 2 {
+		t.Fatalf("d1 apps: got %d want 2", len(d1.Applications))
+	}
+	if d1.Applications[0].Subdirectory != "" {
+		t.Errorf("d1 docroot install must sort first, got subdir %q", d1.Applications[0].Subdirectory)
+	}
+	if d1.Applications[0].AppType != "wordpress" || d1.Applications[0].Version == nil || *d1.Applications[0].Version != "6.5.3" {
+		t.Errorf("d1 docroot summary wrong: %+v", d1.Applications[0])
+	}
+	if d1.Applications[1].Status != "installing" {
+		t.Errorf("d1 subdir status: got %q want installing", d1.Applications[1].Status)
+	}
+	if len(resp.Data[byID["d2"]].Applications) != 0 {
+		t.Errorf("d2 must ship no applications, got %+v", resp.Data[byID["d2"]].Applications)
+	}
+}
+
+// TestDomainList_AppSummaryAbsentWhenUnwired: with no AppInstalls repo wired,
+// the list still serves and simply omits the applications field (older clients
+// and installs-off deployments stay happy).
+func TestDomainList_AppSummaryAbsentWhenUnwired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: true})
+		c.Next()
+	})
+
+	base := newMockDomainRepo()
+	base.Create(context.Background(), &models.Domain{ID: "d1", UserID: "u1", Name: "a.com"})
+	domains := &domainListWithSeedData{mockDomainRepo: base}
+
+	RegisterDomainRoutes(v1, DomainHandlerConfig{Domains: domains})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/domains", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	// Raw body must not carry an "applications" key when unwired.
+	if body := w.Body.String(); contains(body, "\"applications\"") {
+		t.Errorf("applications key must be absent when AppInstalls unwired; body=%s", body)
+	}
+}

--- a/panel-api/internal/api/wordpress_helpers_test.go
+++ b/panel-api/internal/api/wordpress_helpers_test.go
@@ -65,6 +65,28 @@ func (m *mockWordPressInstallRepo) FindByDomainID(ctx context.Context, domainID 
 	return nil, repository.ErrNotFound
 }
 
+// ListByDomainIDs — GH #1543 domains-list app summary. Returns every seeded
+// install whose domain_id is in the set, docroot-first, mirroring the repo's
+// order so the api tests that assert the summary get a stable shape.
+func (m *mockWordPressInstallRepo) ListByDomainIDs(_ context.Context, domainIDs []string) ([]models.ApplicationInstall, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	want := make(map[string]struct{}, len(domainIDs))
+	for _, id := range domainIDs {
+		want[id] = struct{}{}
+	}
+	var out []models.ApplicationInstall
+	for _, inst := range m.byDomain {
+		if inst == nil {
+			continue
+		}
+		if _, ok := want[inst.DomainID]; ok {
+			out = append(out, *inst)
+		}
+	}
+	return out, nil
+}
+
 func (m *mockWordPressInstallRepo) FindByDomainAndSubdirectory(ctx context.Context, domainID, subdirectory string) (*models.WordPressInstall, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/panel-api/internal/reconciler/wordpress_reconcile_test.go
+++ b/panel-api/internal/reconciler/wordpress_reconcile_test.go
@@ -45,6 +45,12 @@ func (m *mockWordPressInstallRepo) FindByDomainID(ctx context.Context, domainID 
 	return nil, repository.ErrNotFound
 }
 
+// ListByDomainIDs — GH #1543 domains-list app summary. Reconciler tests don't
+// exercise it; return nothing.
+func (m *mockWordPressInstallRepo) ListByDomainIDs(_ context.Context, _ []string) ([]models.ApplicationInstall, error) {
+	return nil, nil
+}
+
 // FindByDomainAndSubdirectory — added for multi-install-per-domain
 // (migration 000045). Reconciler tests don't exercise subdir lookups;
 // return the same not-found signal as the other Find stubs.

--- a/panel-api/internal/repository/application_install_repository.go
+++ b/panel-api/internal/repository/application_install_repository.go
@@ -20,6 +20,12 @@ type ApplicationInstallRepository interface {
 	FindByID(ctx context.Context, id string) (*models.ApplicationInstall, error)
 	FindByIDAndUserID(ctx context.Context, id, userID string) (*models.ApplicationInstall, error)
 	FindByDomainID(ctx context.Context, domainID string) (*models.ApplicationInstall, error)
+	// ListByDomainIDs returns every install across the given domains, ordered
+	// by (domain_id, subdirectory, created_at) so a domain's docroot install
+	// (subdirectory "") sorts first. Used to denormalize a per-domain app
+	// summary onto the domains list (GH #1543) without an N+1 per row. An
+	// empty id slice returns no rows without touching the DB.
+	ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.ApplicationInstall, error)
 	// FindByDomainAndSubdirectory enforces install uniqueness at the
 	// (domain, subdirectory) granularity that matches the on-disk install
 	// path. Empty subdirectory = docroot install. PRE-M19 callers used
@@ -126,6 +132,20 @@ func (r *applicationInstallRepo) FindByDomainID(ctx context.Context, domainID st
 		return nil, err
 	}
 	return &install, nil
+}
+
+func (r *applicationInstallRepo) ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.ApplicationInstall, error) {
+	if len(domainIDs) == 0 {
+		return nil, nil
+	}
+	var installs []models.ApplicationInstall
+	if err := r.db.WithContext(ctx).
+		Where("domain_id IN ?", domainIDs).
+		Order("domain_id, subdirectory, created_at").
+		Find(&installs).Error; err != nil {
+		return nil, err
+	}
+	return installs, nil
 }
 
 func (r *applicationInstallRepo) FindByDomainAndSubdirectory(ctx context.Context, domainID, subdirectory string) (*models.ApplicationInstall, error) {

--- a/panel-api/internal/repository/application_install_repository_test.go
+++ b/panel-api/internal/repository/application_install_repository_test.go
@@ -139,6 +139,46 @@ func TestWordPressInstallFindByID_NotFound(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestApplicationInstallListByDomainIDs_GroupsDocrootFirst(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewApplicationInstallRepository(db)
+	now := time.Now()
+
+	// The repo orders by (domain_id, subdirectory, created_at) so the docroot
+	// install ("") sorts before a /blog subdir install on the same domain.
+	mock.ExpectQuery("SELECT .* FROM `application_installs` WHERE domain_id IN \\(\\?,\\?\\).*ORDER BY domain_id, subdirectory, created_at").
+		WithArgs("domain1", "domain2").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"id", "user_id", "domain_id", "db_id", "version", "admin_username", "admin_email", "locale", "use_www", "subdirectory", "status", "last_error", "created_at", "updated_at", "app_type"},
+		).AddRow(
+			"i_root", "u1", "domain1", "db1", "6.5.3", "admin", "a@e.com", "en_US", false, "", "ready", "", now, now, "wordpress",
+		).AddRow(
+			"i_blog", "u1", "domain1", "db2", "6.5.3", "admin", "a@e.com", "en_US", false, "blog", "ready", "", now, now, "wordpress",
+		))
+
+	installs, err := repo.ListByDomainIDs(context.Background(), []string{"domain1", "domain2"})
+	require.NoError(t, err)
+	require.Len(t, installs, 2)
+	require.Equal(t, "", installs[0].Subdirectory)
+	require.Equal(t, "blog", installs[1].Subdirectory)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplicationInstallListByDomainIDs_EmptyIDsNoQuery(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewApplicationInstallRepository(db)
+
+	// No ids => no DB round-trip at all; any ExpectQuery would go unmet.
+	installs, err := repo.ListByDomainIDs(context.Background(), nil)
+	require.NoError(t, err)
+	require.Nil(t, installs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestWordPressInstallFindByIDAndUserID_Found(t *testing.T) {
 	db, mock, raw := newMockDB(t)
 	defer raw.Close()

--- a/panel-ui/src/components/domains/DomainApplicationCell.test.tsx
+++ b/panel-ui/src/components/domains/DomainApplicationCell.test.tsx
@@ -1,0 +1,57 @@
+// DomainApplicationCell.test — GH #1543 (D1). The Application cell shows the
+// primary (docroot) install: badge + version for a ready app with a Login, the
+// live status instead of a version while it settles, an em dash when empty, and
+// a "+N more" link when a domain hosts several installs.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+vi.mock("../../hooks/useMagicLink", () => ({
+  useMagicLink: () => ({ mint: vi.fn(), loading: false, error: null }),
+}));
+
+import { DomainApplicationCell } from "./DomainApplicationCell";
+import type { DomainApplicationSummary } from "./types";
+
+const app = (over: Partial<DomainApplicationSummary> = {}): DomainApplicationSummary => ({
+  id: "i1",
+  app_type: "wordpress",
+  version: "6.5.3",
+  status: "ready",
+  subdirectory: "",
+  ...over,
+});
+
+const renderCell = (applications?: DomainApplicationSummary[]) =>
+  render(
+    <MemoryRouter>
+      <DomainApplicationCell applications={applications} />
+    </MemoryRouter>,
+  );
+
+describe("DomainApplicationCell (GH #1543)", () => {
+  it("shows an em dash when the domain has no apps", () => {
+    renderCell([]);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows badge, version and Login for a ready WordPress install", () => {
+    renderCell([app()]);
+    expect(screen.getByText("WordPress")).toBeInTheDocument();
+    expect(screen.getByText("6.5.3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+  });
+
+  it("shows the live status (not a version or Login) while installing", () => {
+    renderCell([app({ status: "installing", version: null })]);
+    expect(screen.queryByRole("button", { name: "Login" })).not.toBeInTheDocument();
+    // A version string must not stand in for an unsettled install.
+    expect(screen.queryByText("6.5.3")).not.toBeInTheDocument();
+  });
+
+  it("collapses extra installs into a +N more link", () => {
+    renderCell([app(), app({ id: "i2", subdirectory: "blog" })]);
+    const link = screen.getByRole("link", { name: "+1 more" });
+    expect(link).toHaveAttribute("href", "/jabali-panel/applications");
+  });
+});

--- a/panel-ui/src/components/domains/DomainApplicationCell.tsx
+++ b/panel-ui/src/components/domains/DomainApplicationCell.tsx
@@ -1,0 +1,72 @@
+// DomainApplicationCell — the tenant Web Domains "Application" column (GH
+// #1543, D1). Renders this domain's primary (docroot) One-Click install as a
+// badge + version (or live status while it settles), with a one-click Login for
+// ready apps that support SSO. A domain can host several installs (/, /blog);
+// the extras collapse to a "+N" link out to the Applications page. Install and
+// Delete are intentionally NOT here — they land in D2, which owns the mutations
+// and the transitional poll.
+//
+// It needs a per-row hook (useMagicLink), so it is a component, not a render fn.
+// appDisplayName lives under shells/user/applications; importing it here mirrors
+// DomainInventory already importing shells/DomainRedirectsButton — the domain
+// inventory module and the applications module are peers, not layered.
+import { Button, Space, Tag, Typography } from "antd";
+import { Link } from "react-router";
+import type { DomainApplicationSummary } from "./types";
+import { ApplicationStatusTag } from "../applications/ApplicationStatusTag";
+import {
+  canApplicationLogin,
+  openApplicationLogin,
+} from "../applications/applicationInventory";
+import { useMagicLink } from "../../hooks/useMagicLink";
+import { appDisplayName } from "../../shells/user/applications/CmsIcon";
+
+interface DomainApplicationCellProps {
+  applications?: DomainApplicationSummary[];
+}
+
+// The Login control is its own component so useMagicLink (one mint state per
+// install) is scoped to the row that renders it, not the whole table.
+const AppLoginButton = ({ app }: { app: DomainApplicationSummary }) => {
+  const { mint, loading, error } = useMagicLink(app.id);
+  return (
+    <Button
+      type="link"
+      size="small"
+      loading={loading}
+      style={{ paddingInline: 0 }}
+      onClick={() => openApplicationLogin(mint, error)}
+    >
+      Login
+    </Button>
+  );
+};
+
+export const DomainApplicationCell = ({ applications }: DomainApplicationCellProps) => {
+  const apps = applications ?? [];
+  if (apps.length === 0) {
+    return <span style={{ color: "#bbb" }}>—</span>;
+  }
+
+  const primary = apps[0];
+  const extra = apps.length - 1;
+
+  return (
+    <Space size={6} wrap>
+      <Tag style={{ marginInlineEnd: 0 }}>{appDisplayName(primary.app_type)}</Tag>
+      {primary.status === "ready" ? (
+        <Typography.Text>{primary.version || "-"}</Typography.Text>
+      ) : (
+        // Not ready: show the live status (installing / failed …) instead of a
+        // version, so a settling or broken install is visible in the grid.
+        <ApplicationStatusTag status={primary.status} lastError={primary.last_error} />
+      )}
+      {canApplicationLogin(primary) && <AppLoginButton app={primary} />}
+      {extra > 0 && (
+        <Link to="/jabali-panel/applications" style={{ fontSize: 12 }}>
+          +{extra} more
+        </Link>
+      )}
+    </Space>
+  );
+};

--- a/panel-ui/src/components/domains/domainColumns.test.tsx
+++ b/panel-ui/src/components/domains/domainColumns.test.tsx
@@ -1,0 +1,19 @@
+// domainColumns.test — GH #1543 (D1). The Application column is tenant-only:
+// the tenant Web Domains list gains it; the admin list (which edits from its
+// own Edit page and has a dedicated Applications list) must not.
+import { describe, it, expect, vi } from "vitest";
+import { buildDomainDataColumns, type DomainInventoryAudience } from "./domainColumns";
+
+const ctx = { t: (k: string) => k, query: { params: {}, setParams: vi.fn() } };
+const colKeys = (audience: DomainInventoryAudience) =>
+  buildDomainDataColumns(audience, ctx).map((c) => c.key ?? ("dataIndex" in c ? c.dataIndex : undefined));
+
+describe("buildDomainDataColumns Application column (GH #1543)", () => {
+  it("adds an Application column on the tenant list", () => {
+    expect(colKeys({ kind: "tenant" })).toContain("application");
+  });
+
+  it("omits the Application column on the admin list", () => {
+    expect(colKeys({ kind: "admin" })).not.toContain("application");
+  });
+});

--- a/panel-ui/src/components/domains/domainColumns.tsx
+++ b/panel-ui/src/components/domains/domainColumns.tsx
@@ -14,6 +14,7 @@ import { humanBytes } from "../../utils/bytes";
 import { getSSLTag } from "../../utils/sslState";
 import { adminLinks } from "../admin/entityLinks";
 import { serviceBadge, type Domain } from "./types";
+import { DomainApplicationCell } from "./DomainApplicationCell";
 
 // A discriminated union — audience policy stays internal to the module rather
 // than being rebuilt as caller-supplied column/callback bags (JAB-300 AC).
@@ -221,13 +222,30 @@ export const buildDomainDataColumns = (
       title: title("redirect"),
       render: (_: unknown, record: Domain) => renderRedirect(record),
     },
-    {
-      dataIndex: "bytes_30d",
-      title: title("bw_30d"),
-      key: "bytes_30d",
-      render: (v: number | undefined) => humanBytes(v ?? 0),
-    },
   );
+
+  // GH #1543: the tenant Web Domains list gains an Application column showing
+  // this domain's primary One-Click install (badge + version/status + Login).
+  // Tenant-only: admin edits a domain from its Edit page and has its own
+  // Applications list. The literal header avoids adding an i18n key (no unused-
+  // key gate; the tenant namespace has no "application" entry).
+  if (audience.kind === "tenant") {
+    columns.push({
+      key: "application",
+      title: "Application",
+      responsive: ["md"],
+      render: (_: unknown, record: Domain) => (
+        <DomainApplicationCell applications={record.applications} />
+      ),
+    });
+  }
+
+  columns.push({
+    dataIndex: "bytes_30d",
+    title: title("bw_30d"),
+    key: "bytes_30d",
+    render: (v: number | undefined) => humanBytes(v ?? 0),
+  });
 
   return columns;
 };

--- a/panel-ui/src/components/domains/types.ts
+++ b/panel-ui/src/components/domains/types.ts
@@ -6,6 +6,7 @@
 // screens' wire shapes: every field that only one audience sends is optional,
 // so a row from either endpoint satisfies the type and each screen reads the
 // subset it cares about.
+import type { ApplicationStatus } from "../../utils/applicationStatus";
 
 // The nested SSL badge the admin list/get handler denormalises onto each row.
 // The tenant list sends a flat `ssl_state` string instead; both fold through
@@ -16,6 +17,21 @@ export type SSLBadge = {
   issuer?: string | null;
   issued_at?: string | null;
   expires_at?: string | null;
+};
+
+// GH #1543: the per-domain One-Click app summary the domains list handler
+// denormalises onto each row (docroot-first). Just what the tenant Web Domains
+// Application column needs — badge, version, live status, and enough to mint a
+// login; the full install record stays on GET /applications. Reuses the shared
+// ApplicationStatus vocabulary so the column and the Applications page can't
+// drift on status meaning.
+export type DomainApplicationSummary = {
+  id: string;
+  app_type: string;
+  version: string | null;
+  status: ApplicationStatus;
+  last_error?: string;
+  subdirectory: string;
 };
 
 export type Domain = {
@@ -50,6 +66,10 @@ export type Domain = {
   // mail-only); dns_disabled = the panel doesn't host this domain's DNS.
   web_disabled?: boolean;
   dns_disabled?: boolean;
+  // GH #1543: this domain's One-Click app installs, denormalised onto the row
+  // for the tenant Web Domains Application column. Absent (never null) when the
+  // domain has none or the module is unwired; ordered docroot-first.
+  applications?: DomainApplicationSummary[];
   // Shared across both audiences.
   bytes_30d?: number;
   temp_url_enabled?: boolean;


### PR DESCRIPTION
## What

Part **D** of GH #1543 (johnnyq) merges One-Click Apps into the tenant **Web Domains** list. **Slice 1 of 2 (D1) = the read side**: an **Application column** showing each domain's install(s) with a one-click **Login**. Inline **Install** + **Delete** and the transitional poll are **D2** (next PR).

```
Web Domains list (tenant)
──────────────────────────────────────
Domain      Application            …
site.tld    [WordPress] 6.5.3  Login
shop.tld    [WordPress] installing
blog.tld    [WordPress] 6.5.3  Login  +1 more
empty.tld   —
```

## Backend

- **New `ApplicationInstallRepository.ListByDomainIDs`** — batch fetch installs across the page's domains, ordered `(domain_id, subdirectory, created_at)` so the **docroot** install sorts first; empty id set skips the DB.
- The **domains list handler** denormalises them onto each row (`applications`), mirroring the existing bandwidth / username / listen-IP enrichment blocks — **no N+1**. `omitempty` drops both nil and empty slice (never a JSON `null` the SPA trips on); populated only when `AppInstalls` is wired, so installs-off deploys and older clients stay happy.
- Admin + tenant share the handler; the field ships for both, only the **tenant** grid renders it.
- Two hand-mocks of the repo interface (`mockWordPressInstallRepo`, api + reconciler pkgs) gain a `ListByDomainIDs` stub.

## Frontend

- `buildDomainDataColumns` adds a **tenant-only** Application column (admin edits from its Edit page and has its own Applications list).
- New `DomainApplicationCell`: primary (docroot) install as **badge + version**, or its **live status** while it settles, with a **Login** for ready SSO apps; extra installs collapse to a **"+N more"** link out to the Applications page. Reuses the shared applications module (`useMagicLink`, `openApplicationLogin`, `canApplicationLogin`, `ApplicationStatusTag`, `appDisplayName`) so the column and the Applications page can't drift.

## Note on part E

E as originally planned ("remove the Applications side-nav") is **no longer viable**: after D the Applications page still owns Catalog, Scan, Migrate-from-remote, Clone, cache toggle/settings, and purge/warmup — D only surfaces Login/Install/Delete on the domains list and links out for the rest. **E becomes a rename/re-scope decision, not a removal** — flagging so it can be re-planned with correct information.

## Test plan

- [x] Go: `go build ./...`; `ListByDomainIDs` sqlmock test (IN-clause, docroot-first, empty-ids-no-query); handler test (docroot+subdir summary, no-apps domain ships no key, unwired → field absent); api + repository + reconciler packages green
- [x] UI: `tsc -b`, `eslint` clean; `domainColumns.test` (tenant has column, admin doesn't); `DomainApplicationCell.test` (empty / ready+Login / installing / +N); `UserDomainList.test` still green
- [x] Rebased onto latest origin/main, retested (Go + UI)
- [ ] Manual: tenant with a WP install → Application column shows badge+version+Login; a second install shows "+N more"; admin list unchanged

GH #1543