### PR TITLE
refactor(notifications): shared tenant channel owner policy for HTTP and CLI (JAB-308)

### DIFF
--- a/panel-api/cmd/server/notification_send_cmd.go
+++ b/panel-api/cmd/server/notification_send_cmd.go
@@ -21,6 +21,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifchannelops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -55,11 +56,55 @@ func newNotificationChannelCreateCmd() *cobra.Command {
 			if err := api.ValidateChannelName(name); err != nil {
 				return err
 			}
+			ctx, cancel := context.WithTimeout(c.Context(), 15*time.Second)
+			defer cancel()
+			// --user makes the channel tenant-owned (JAB-171); omit for a
+			// server-wide admin channel. A tenant-owned channel is subject to the
+			// same owner policy the tenant HTTP handler enforces: master gate +
+			// kind allowlist, then own-address email forcing (anti-relay/SSRF),
+			// then the per-user quota — so the operator CLI can't create a tenant
+			// channel the API would refuse. Order mirrors the handler: allowlist
+			// before the owner-email lookup, forcing before per-kind config
+			// validation, quota last. For a custom SMTP host, create a server-wide
+			// channel (omit --user). The users FK still rejects an unknown id.
+			uid := strings.TrimSpace(userID)
+			if uid != "" {
+				st, serr := repository.NewServerSettingsRepository(sharedDB).Get(ctx)
+				if serr != nil {
+					return fmt.Errorf("load server settings: %w", serr)
+				}
+				if err := notifchannelops.CheckKindAllowed(st, kind); err != nil {
+					return fmt.Errorf("tenant channel policy: %w", err)
+				}
+				if kind == models.NotificationChannelKindEmail {
+					// Surface a real lookup failure instead of folding it into an
+					// empty owner email, which ForceOwnEmailConfig would misreport
+					// as "owner account has no email address".
+					u, uerr := repository.NewUserRepository(sharedDB).FindByID(ctx, uid)
+					if uerr != nil {
+						return fmt.Errorf("load owner %s: %w", uid, uerr)
+					}
+					ownerEmail := ""
+					if u != nil {
+						ownerEmail = u.Email
+					}
+					if err := notifchannelops.ForceOwnEmailConfig(ownerEmail, &cfg); err != nil {
+						return fmt.Errorf("tenant channel policy: %w", err)
+					}
+				}
+			}
 			if err := api.ValidateChannelKindConfig(kind, cfg); err != nil {
 				return err
 			}
-			ctx, cancel := context.WithTimeout(c.Context(), 15*time.Second)
-			defer cancel()
+			if uid != "" {
+				existing, lerr := notificationChannelRepoFromDB().ListByUser(ctx, uid)
+				if lerr != nil {
+					return fmt.Errorf("count owner channels: %w", lerr)
+				}
+				if err := notifchannelops.CheckQuota(len(existing)); err != nil {
+					return fmt.Errorf("tenant channel policy: %w", err)
+				}
+			}
 			row := &models.NotificationChannel{
 				ID:      ids.NewULID(),
 				Name:    name,
@@ -67,9 +112,7 @@ func newNotificationChannelCreateCmd() *cobra.Command {
 				Config:  cfg,
 				Enabled: !disabled,
 			}
-			// --user makes the channel tenant-owned (JAB-171); omit for a
-			// server-wide admin channel. The users FK rejects an unknown id.
-			if uid := strings.TrimSpace(userID); uid != "" {
+			if uid != "" {
 				row.UserID = &uid
 			}
 			if err := notificationChannelRepoFromDB().Create(ctx, row); err != nil {

--- a/panel-api/cmd/server/notification_send_cmd_test.go
+++ b/panel-api/cmd/server/notification_send_cmd_test.go
@@ -49,3 +49,44 @@ func TestNotificationChannelTestCmd_RefusesDisabled(t *testing.T) {
 		t.Errorf("!ch.Enabled guard (idx %d) must sit between FindByID (idx %d) and the Envelope construction (idx %d)", guard, findByID, publish)
 	}
 }
+
+// TestNotificationChannelCreateCmd_EnforcesTenantOwnerPolicy pins that the
+// operator CLI `notification channels create --user <id>` runs the shared
+// notifchannelops owner policy in the same order the tenant HTTP handler does —
+// the JAB-308 AC1/AC2 fix. Without it the CLI created a tenant-owned channel
+// that skipped the kind allowlist, the own-address email forcing (anti-relay /
+// SSRF) and the per-user quota the API enforces. Order matters and is pinned:
+// CheckKindAllowed → ForceOwnEmailConfig → ValidateChannelKindConfig →
+// CheckQuota (allowlist before the owner-email lookup; forcing before per-kind
+// config validation so the forced fields are validated; quota last). Source-pin
+// because the command is direct-DB with no seam to run without a live MariaDB;
+// non-vacuous because none of the notifchannelops calls existed on main.
+// Falsify by deleting any of the four calls.
+func TestNotificationChannelCreateCmd_EnforcesTenantOwnerPolicy(t *testing.T) {
+	src, err := os.ReadFile("notification_send_cmd.go")
+	if err != nil {
+		t.Fatalf("read notification_send_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	start := strings.Index(s, "func newNotificationChannelCreateCmd()")
+	if start < 0 {
+		t.Fatalf("newNotificationChannelCreateCmd not found")
+	}
+	body := s[start:]
+	if next := strings.Index(body[1:], "\nfunc "); next >= 0 {
+		body = body[:next+1]
+	}
+
+	allowlist := strings.Index(body, "notifchannelops.CheckKindAllowed(")
+	force := strings.Index(body, "notifchannelops.ForceOwnEmailConfig(")
+	kindConfig := strings.Index(body, "api.ValidateChannelKindConfig(")
+	quota := strings.Index(body, "notifchannelops.CheckQuota(")
+
+	if allowlist < 0 || force < 0 || kindConfig < 0 || quota < 0 {
+		t.Fatalf("expected CheckKindAllowed + ForceOwnEmailConfig + ValidateChannelKindConfig + CheckQuota in the create command; got allowlist=%d force=%d kindConfig=%d quota=%d", allowlist, force, kindConfig, quota)
+	}
+	if !(allowlist < force && force < kindConfig && kindConfig < quota) {
+		t.Errorf("owner-policy calls out of order: CheckKindAllowed(%d) < ForceOwnEmailConfig(%d) < ValidateChannelKindConfig(%d) < CheckQuota(%d) must hold", allowlist, force, kindConfig, quota)
+	}
+}

--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -38,6 +38,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifchannelops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -126,9 +127,10 @@ var tenantRelevantEventKinds = map[string]bool{
 // state; the test-send limit bounds tenant-triggerable outbound traffic (real
 // events fire from system actions, not on tenant demand, so the test endpoint is
 // the only tenant-controllable send).
+// The per-user channel quota lives in notifchannelops.MaxTenantChannelsPerUser
+// (shared with the operator CLI); this file references it there.
 const (
-	maxTenantChannelsPerUser = 10
-	tenantTestSendPerMinute  = 5
+	tenantTestSendPerMinute = 5
 )
 
 type meNotificationsHandler struct {
@@ -222,20 +224,37 @@ func (h *meNotificationsHandler) createChannel(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 		return
 	}
-	// Admin-configurable kind allowlist (empty settings → safe default set).
-	if !st.TenantNotificationKinds.OrDefault().Allows(req.Kind) {
-		c.JSON(http.StatusUnprocessableEntity, gin.H{
-			"error":   "kind_not_allowed_for_tenant",
-			"message": "channel kind " + req.Kind + " is not permitted for tenant channels on this server",
-		})
+	// Full tenant owner policy — master gate + kind allowlist, then own-address
+	// email forcing (email kinds only), then the per-kind config validation
+	// below, then the per-user quota — lives in notifchannelops so the operator
+	// CLI enforces the identical rules. Order matters: the allowlist is checked
+	// before the owner-email lookup so a disallowed kind is rejected without
+	// touching the user repo, and forcing runs before config validation so the
+	// forced destination fields are what gets validated and persisted.
+	if perr := notifchannelops.CheckKindAllowed(st, req.Kind); perr != nil {
+		if errors.Is(perr, notifchannelops.ErrTenantNotificationsDisabled) {
+			// Unreachable here: loadSettings already enforced the master gate
+			// above. Kept fail-closed for defence in depth (and because the CLI,
+			// which has no such pre-gate, relies on CheckKindAllowed for it).
+			c.JSON(http.StatusConflict, gin.H{"error": "tenant_notifications_disabled"})
+		} else {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{
+				"error":   "kind_not_allowed_for_tenant",
+				"message": "channel kind " + req.Kind + " is not permitted for tenant channels on this server",
+			})
+		}
 		return
 	}
-	// Tenant email channels are forced to deliver only to the caller's own
-	// account address over the local submission path — no arbitrary destination
-	// (open relay) and no custom SMTP host (SSRF). Applied before validation so
-	// the forced fields satisfy the email config rules.
 	if req.Kind == models.NotificationChannelKindEmail {
-		if !h.forceOwnEmailConfig(c, claims.UserID, &req.Config) {
+		ownerEmail, ok := h.resolveOwnerEmail(c, claims.UserID)
+		if !ok {
+			return
+		}
+		if err := notifchannelops.ForceOwnEmailConfig(ownerEmail, &req.Config); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{
+				"error":   "no_account_email",
+				"message": "your account has no email address to deliver to",
+			})
 			return
 		}
 	}
@@ -243,18 +262,17 @@ func (h *meNotificationsHandler) createChannel(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 		return
 	}
-	// Per-user channel quota — bound how many channels one tenant can create.
 	existing, err := h.cfg.Channels.ListByUser(c.Request.Context(), claims.UserID)
 	if err != nil {
 		h.cfg.Log.Error("count own channels failed", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_failed"})
 		return
 	}
-	if len(existing) >= maxTenantChannelsPerUser {
+	if perr := notifchannelops.CheckQuota(len(existing)); perr != nil {
 		c.JSON(http.StatusConflict, gin.H{
 			"error":   "too_many_channels",
-			"message": fmt.Sprintf("channel limit reached (%d per user)", maxTenantChannelsPerUser),
-			"max":     maxTenantChannelsPerUser,
+			"message": fmt.Sprintf("channel limit reached (%d per user)", notifchannelops.MaxTenantChannelsPerUser),
+			"max":     notifchannelops.MaxTenantChannelsPerUser,
 		})
 		return
 	}
@@ -319,7 +337,15 @@ func (h *meNotificationsHandler) updateChannel(c *gin.Context) {
 		// Re-force own-address + local mode on every email edit so a tenant can't
 		// PATCH to_email to an arbitrary destination after create (phase 4d).
 		if existing.Kind == models.NotificationChannelKindEmail {
-			if !h.forceOwnEmailConfig(c, claims.UserID, &merged) {
+			ownerEmail, ok := h.resolveOwnerEmail(c, claims.UserID)
+			if !ok {
+				return
+			}
+			if err := notifchannelops.ForceOwnEmailConfig(ownerEmail, &merged); err != nil {
+				c.JSON(http.StatusUnprocessableEntity, gin.H{
+					"error":   "no_account_email",
+					"message": "your account has no email address to deliver to",
+				})
 				return
 			}
 		}
@@ -570,36 +596,23 @@ func (h *meNotificationsHandler) eventCatalog(c *gin.Context) {
 
 // --- validation helpers ---
 
-// forceOwnEmailConfig rewrites a tenant email channel's config so it can only
-// deliver to the caller's OWN account address over the local submission path.
-// This is the phase-4d safety property: no arbitrary destination (open relay)
-// and no tenant-supplied SMTP host (SSRF). Returns false (and writes the
-// response) when the user can't be resolved. Any body-supplied to_email /
-// smtp_host / smtp_mode is discarded.
-func (h *meNotificationsHandler) forceOwnEmailConfig(c *gin.Context, userID string, cfg *models.NotificationChannelConfig) bool {
+// resolveOwnerEmail loads the owner's account email so an email channel's
+// destination can be forced to it (notifchannelops.ForceOwnEmailConfig / the
+// email branch of ValidateTenantCreate). It returns ok=false only when the
+// users repository is unavailable, having already written a 503; a missing user
+// or empty address returns ("", true) so the shared validator fails closed with
+// no_account_email. Keeping the repo/gin coupling here lets the forcing logic
+// itself stay transport-neutral in notifchannelops.
+func (h *meNotificationsHandler) resolveOwnerEmail(c *gin.Context, userID string) (string, bool) {
 	if h.cfg.Users == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "email channels unavailable"})
-		return false
+		return "", false
 	}
 	u, err := h.cfg.Users.FindByID(c.Request.Context(), userID)
-	if err != nil || u == nil || u.Email == "" {
-		c.JSON(http.StatusUnprocessableEntity, gin.H{
-			"error":   "no_account_email",
-			"message": "your account has no email address to deliver to",
-		})
-		return false
+	if err != nil || u == nil {
+		return "", true
 	}
-	// Preserve only the non-destination display/formatting fields; hard-set the
-	// destination + transport to the safe own-account/local values.
-	cfg.ToEmail = u.Email
-	cfg.FromEmail = u.Email
-	cfg.SMTPMode = "local"
-	cfg.SMTPHost = ""
-	cfg.SMTPPort = 0
-	cfg.SMTPTLS = ""
-	cfg.SMTPUsername = ""
-	cfg.SMTPPassword = ""
-	return true
+	return u.Email, true
 }
 
 // validateEventKind bounds the routed event kind. A stricter allowlist of

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -368,6 +368,27 @@ func TestMeNotif_EmailChannel_ForcesOwnAddressAndLocalMode(t *testing.T) {
 	require.NotContains(t, rec.Body.String(), "evil.com", "no attacker destination echoed")
 }
 
+func TestMeNotif_EmailChannel_NoAccountEmail_Is422(t *testing.T) {
+	t.Parallel()
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		TenantNotificationsEnabled: true,
+		TenantNotificationKinds:    models.TenantNotificationKinds{"email"},
+	}}
+	// Owner exists but has no account address to force delivery to.
+	users := &fakeUserRepo{user: &models.User{ID: "u1", Email: ""}}
+	repo := &fakeChannelsRepo{}
+	r := newMeNotifRouterU(t, settings, repo, &fakeUserRoutesRepo{}, users, newUserCtxID("u1"))
+
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels", map[string]any{
+		"name":   "mail me",
+		"kind":   "email",
+		"config": map[string]any{},
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "no_account_email")
+	require.Empty(t, repo.rows, "no channel row must be created without an owner address")
+}
+
 func TestMeNotif_EmailChannel_UpdateCannotRepointDestination(t *testing.T) {
 	t.Parallel()
 	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{

--- a/panel-api/internal/notifchannelops/notifchannelops.go
+++ b/panel-api/internal/notifchannelops/notifchannelops.go
@@ -1,0 +1,103 @@
+// Package notifchannelops holds the transport-neutral owner policy for
+// tenant-owned notification channels, so every adapter that can create one —
+// the tenant HTTP handler and the operator CLI — enforces the same rules
+// instead of each re-implementing (or skipping) them.
+//
+// The policy has four parts, all of which restrict a tenant-owned channel:
+//
+//   - the master gate (ServerSettings.TenantNotificationsEnabled),
+//   - the admin-configurable kind allowlist,
+//   - the per-user channel quota, and
+//   - email forcing: a tenant email channel may only deliver to the owner's own
+//     account address over local submission — never an arbitrary destination
+//     (open relay) or a custom SMTP host (SSRF).
+//
+// The package intentionally does NOT import internal/api: name validation and
+// per-kind config validation live there, and each adapter composes them around
+// this policy (name → tenant policy → kind config → persist). It depends only
+// on the models package.
+package notifchannelops
+
+import (
+	"errors"
+	"fmt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// MaxTenantChannelsPerUser bounds how many channels one tenant may own.
+const MaxTenantChannelsPerUser = 10
+
+// Sentinel errors. Adapters map these to their own transport (the HTTP handler
+// to specific status codes + body strings, the CLI to a returned error).
+var (
+	// ErrTenantNotificationsDisabled means the master gate is off, so no
+	// tenant-owned channel may be created at all.
+	ErrTenantNotificationsDisabled = errors.New("tenant notifications are disabled on this server")
+	// ErrKindNotAllowed means the channel kind is not in the admin allowlist for
+	// tenant channels.
+	ErrKindNotAllowed = errors.New("channel kind is not permitted for tenant channels on this server")
+	// ErrNoAccountEmail means an email channel was requested but the owner has no
+	// account address to force delivery to.
+	ErrNoAccountEmail = errors.New("owner account has no email address to deliver to")
+	// ErrTooManyChannels means the owner is already at MaxTenantChannelsPerUser.
+	ErrTooManyChannels = errors.New("tenant channel limit reached")
+)
+
+// ForceOwnEmailConfig rewrites an email channel's config so it can only deliver
+// to the owner's own account address over local submission. It hard-sets the
+// destination + transport to the safe own-account/local values and clears any
+// caller-supplied SMTP host/credentials, preserving only the non-destination
+// display/formatting fields already on cfg. ownerEmail is the owner's account
+// address; an empty ownerEmail yields ErrNoAccountEmail (never a partially
+// forced config). This is the sole guard on the destination — nothing re-forces
+// it at delivery time — so it must run on every create and every edit of a
+// tenant email channel.
+func ForceOwnEmailConfig(ownerEmail string, cfg *models.NotificationChannelConfig) error {
+	if ownerEmail == "" {
+		return ErrNoAccountEmail
+	}
+	cfg.ToEmail = ownerEmail
+	cfg.FromEmail = ownerEmail
+	cfg.SMTPMode = "local"
+	cfg.SMTPHost = ""
+	cfg.SMTPPort = 0
+	cfg.SMTPTLS = ""
+	cfg.SMTPUsername = ""
+	cfg.SMTPPassword = ""
+	return nil
+}
+
+// CheckKindAllowed enforces the two checks that must precede any other work on
+// a tenant-owned channel: the master gate and the admin kind allowlist. A nil
+// or gate-off ServerSettings fails closed with ErrTenantNotificationsDisabled;
+// a kind outside the allowlist yields ErrKindNotAllowed. It runs BEFORE the
+// owner's email is resolved so a disallowed kind is rejected without touching
+// the user repository (the ordering the tenant HTTP handler already relied on).
+func CheckKindAllowed(st *models.ServerSettings, kind string) error {
+	if st == nil || !st.TenantNotificationsEnabled {
+		return ErrTenantNotificationsDisabled
+	}
+	if !st.TenantNotificationKinds.OrDefault().Allows(kind) {
+		return fmt.Errorf("%w: %s", ErrKindNotAllowed, kind)
+	}
+	return nil
+}
+
+// CheckQuota enforces the per-user channel quota. existingCount is how many
+// channels the owner already has (from the channel repository's ListByUser).
+func CheckQuota(existingCount int) error {
+	if existingCount >= MaxTenantChannelsPerUser {
+		return ErrTooManyChannels
+	}
+	return nil
+}
+
+// The three checks compose, in this order, into the full create-time owner
+// policy: CheckKindAllowed → (email kinds) ForceOwnEmailConfig → per-kind config
+// validation (the adapter's own) → CheckQuota. Both the tenant HTTP handler and
+// the operator CLI run all three so a value one adapter refuses can't be
+// smuggled in through the other. Email forcing must run before per-kind config
+// validation so the forced destination fields are what gets validated and
+// persisted, and after the allowlist so a disallowed kind never triggers the
+// owner-email lookup.

--- a/panel-api/internal/notifchannelops/notifchannelops_test.go
+++ b/panel-api/internal/notifchannelops/notifchannelops_test.go
@@ -1,0 +1,114 @@
+package notifchannelops
+
+import (
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func gateOn(kinds ...string) *models.ServerSettings {
+	return &models.ServerSettings{
+		TenantNotificationsEnabled: true,
+		TenantNotificationKinds:    models.TenantNotificationKinds(kinds),
+	}
+}
+
+func TestCheckKindAllowed(t *testing.T) {
+	cases := []struct {
+		name string
+		st   *models.ServerSettings
+		kind string
+		want error
+	}{
+		{"nil settings fail closed", nil, models.NotificationChannelKindNtfy, ErrTenantNotificationsDisabled},
+		{"gate off fail closed", &models.ServerSettings{TenantNotificationsEnabled: false}, models.NotificationChannelKindNtfy, ErrTenantNotificationsDisabled},
+		{"default allowlist allows ntfy", gateOn(), models.NotificationChannelKindNtfy, nil},
+		{"default allowlist denies email", gateOn(), models.NotificationChannelKindEmail, ErrKindNotAllowed},
+		{"default allowlist denies webhook", gateOn(), models.NotificationChannelKindWebhook, ErrKindNotAllowed},
+		{"explicit allowlist allows email", gateOn(models.NotificationChannelKindEmail), models.NotificationChannelKindEmail, nil},
+		{"unknown kind denied", gateOn(), "carrier-pigeon", ErrKindNotAllowed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckKindAllowed(tc.st, tc.kind)
+			if tc.want == nil {
+				if err != nil {
+					t.Fatalf("want nil, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("want errors.Is(%v), got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestCheckQuota(t *testing.T) {
+	if err := CheckQuota(MaxTenantChannelsPerUser - 1); err != nil {
+		t.Fatalf("below limit should pass, got %v", err)
+	}
+	if err := CheckQuota(MaxTenantChannelsPerUser); !errors.Is(err, ErrTooManyChannels) {
+		t.Fatalf("at limit should be ErrTooManyChannels, got %v", err)
+	}
+	if err := CheckQuota(MaxTenantChannelsPerUser + 1); !errors.Is(err, ErrTooManyChannels) {
+		t.Fatalf("over limit should be ErrTooManyChannels, got %v", err)
+	}
+}
+
+func TestForceOwnEmailConfig_NoOwnerEmail(t *testing.T) {
+	cfg := models.NotificationChannelConfig{ToEmail: "attacker@evil.example"}
+	if err := ForceOwnEmailConfig("", &cfg); !errors.Is(err, ErrNoAccountEmail) {
+		t.Fatalf("empty owner email should be ErrNoAccountEmail, got %v", err)
+	}
+}
+
+func TestForceOwnEmailConfig_RewritesEveryDestinationField(t *testing.T) {
+	// A config that tries to smuggle an arbitrary destination + custom SMTP relay
+	// (the open-relay / SSRF attack the forcing exists to stop).
+	cfg := models.NotificationChannelConfig{
+		Priority:     5, // non-destination display field, must survive
+		ToEmail:      "victim@elsewhere.example",
+		FromEmail:    "spoofed@elsewhere.example",
+		SMTPMode:     "smtp",
+		SMTPHost:     "169.254.169.254",
+		SMTPPort:     2525,
+		SMTPTLS:      "none",
+		SMTPUsername: "attacker",
+		SMTPPassword: "hunter2",
+	}
+	if err := ForceOwnEmailConfig("owner@jabali.example", &cfg); err != nil {
+		t.Fatalf("valid owner email should force, got %v", err)
+	}
+	// Destination + transport hard-set to the safe own-account/local values.
+	if cfg.ToEmail != "owner@jabali.example" {
+		t.Errorf("ToEmail = %q, want owner", cfg.ToEmail)
+	}
+	if cfg.FromEmail != "owner@jabali.example" {
+		t.Errorf("FromEmail = %q, want owner", cfg.FromEmail)
+	}
+	if cfg.SMTPMode != "local" {
+		t.Errorf("SMTPMode = %q, want local", cfg.SMTPMode)
+	}
+	// Every caller-supplied relay field must be cleared — assert each one.
+	if cfg.SMTPHost != "" {
+		t.Errorf("SMTPHost = %q, want empty", cfg.SMTPHost)
+	}
+	if cfg.SMTPPort != 0 {
+		t.Errorf("SMTPPort = %d, want 0", cfg.SMTPPort)
+	}
+	if cfg.SMTPTLS != "" {
+		t.Errorf("SMTPTLS = %q, want empty", cfg.SMTPTLS)
+	}
+	if cfg.SMTPUsername != "" {
+		t.Errorf("SMTPUsername = %q, want empty", cfg.SMTPUsername)
+	}
+	if cfg.SMTPPassword != "" {
+		t.Errorf("SMTPPassword = %q, want empty", cfg.SMTPPassword)
+	}
+	// A non-destination field is preserved.
+	if cfg.Priority != 5 {
+		t.Errorf("Priority = %d, want 5 preserved", cfg.Priority)
+	}
+}


### PR DESCRIPTION
## What

The tenant HTTP handler enforces an **owner policy** on every tenant-owned notification channel: the master gate, the admin kind allowlist, own-address email forcing (a tenant email channel may only deliver to the owner's own account address over local submission — no arbitrary destination, no custom SMTP host), and a per-user quota.

The operator CLI `jabali notification channels create --user <id>` also makes a **tenant-owned** channel, but ran only the two admin validators (channel name + per-kind config). So it could create a tenant channel the API would refuse — most importantly an **email channel pointing at an arbitrary destination or a custom SMTP relay**, which the HTTP path forbids. Operator-facing effect: `create --user` now enforces the same policy as the tenant UI. To point a channel at a custom SMTP host, create a **server-wide** channel (omit `--user`).

## How

New leaf package `internal/notifchannelops` holds the transport-neutral policy, imported by both adapters (it does **not** import `internal/api`, so no import cycle):

- `CheckKindAllowed(st, kind)` — master gate + admin kind allowlist.
- `ForceOwnEmailConfig(ownerEmail, cfg)` — rewrite an email channel's config to the owner's own address over local submission, clearing any caller-supplied SMTP host/credentials. The only guard on the destination (nothing re-forces at delivery).
- `CheckQuota(existingCount)` — the per-user channel limit (`MaxTenantChannelsPerUser`, now single-sourced).

Both adapters compose them in the order the handler already used — allowlist → (email) forcing → per-kind config validation → quota — and the order is preserved (allowlist before the owner-email lookup; forcing before config validation so the forced fields are what gets validated). The old `forceOwnEmailConfig` handler method becomes `resolveOwnerEmail` + the shared `ForceOwnEmailConfig`, removing the duplicated copy the update path carried. HTTP status codes and body strings are unchanged.

## Scope

JAB-308 AC1/AC2 slice — no **create** path may bypass owner policy. The admin create/update handler cannot mint a tenant-owned row (its request has no `user_id` and it never sets one), so the CLI `--user` path was the only create path that bypassed the policy. Not in this slice, both operator-only (root) and left for a follow-up: the admin PATCH of a tenant-owned email channel re-validates but does not re-force the destination, and CLI delete is a bare repo delete (routes drop via `ON DELETE CASCADE`, AC5). AC4 (disabled channels can't be tested) shipped in #1570. The parent JAB-308 stays in Backlog.

## Test plan

- [x] `notifchannelops` table test: gate (nil/off → disabled), allowlist (default allows ntfy, denies email/webhook/unknown; explicit allows email), quota (below/at/over), email forcing (empty owner → `ErrNoAccountEmail`; arbitrary destination + custom relay fully reset, non-destination field preserved). Falsified by stubbing the checks.
- [x] New HTTP test for the `no_account_email` 422 branch (owner with an empty address).
- [x] Existing `me_notifications` create/update email-forcing tests pass unmodified.
- [x] CLI source-pin: `create` runs the four calls in order (`CheckKindAllowed` → `ForceOwnEmailConfig` → `ValidateChannelKindConfig` → `CheckQuota`); non-vacuous, falsified by reordering.
- [x] `go build`, `go vet`, `gofmt`, `go test -race` clean across the three packages; rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
