### PR TITLE
feat(domains): inline Install and Delete on the Web Domains app column (GH #1543 D2)

### DIFF
--- a/panel-ui/src/components/domains/DomainApplicationCell.test.tsx
+++ b/panel-ui/src/components/domains/DomainApplicationCell.test.tsx
@@ -3,7 +3,7 @@
 // live status instead of a version while it settles, an em dash when empty, and
 // a "+N more" link when a domain hosts several installs.
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 vi.mock("../../hooks/useMagicLink", () => ({
@@ -53,5 +53,40 @@ describe("DomainApplicationCell (GH #1543)", () => {
     renderCell([app(), app({ id: "i2", subdirectory: "blog" })]);
     const link = screen.getByRole("link", { name: "+1 more" });
     expect(link).toHaveAttribute("href", "/jabali-panel/applications");
+  });
+
+  // D2: inline mutations, driven by callbacks the tenant grid supplies.
+  it("offers Install on an empty domain when onInstall is wired (D2)", () => {
+    const onInstall = vi.fn();
+    render(
+      <MemoryRouter>
+        <DomainApplicationCell applications={[]} onInstall={onInstall} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Install/ }));
+    expect(onInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the primary install when onDelete is wired (D2)", () => {
+    const onDelete = vi.fn();
+    const primary = app();
+    render(
+      <MemoryRouter>
+        <DomainApplicationCell
+          applications={[primary, app({ id: "i2", subdirectory: "blog" })]}
+          onDelete={onDelete}
+        />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete app" }));
+    expect(onDelete).toHaveBeenCalledWith(primary);
+  });
+
+  it("has no Install or Delete controls without the callbacks (read-only)", () => {
+    renderCell([app()]); // no onInstall/onDelete
+    expect(screen.queryByRole("button", { name: "Delete app" })).not.toBeInTheDocument();
+    // Login still shows for a ready SSO app; Delete must not.
+    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
   });
 });

--- a/panel-ui/src/components/domains/DomainApplicationCell.tsx
+++ b/panel-ui/src/components/domains/DomainApplicationCell.tsx
@@ -10,7 +10,8 @@
 // appDisplayName lives under shells/user/applications; importing it here mirrors
 // DomainInventory already importing shells/DomainRedirectsButton — the domain
 // inventory module and the applications module are peers, not layered.
-import { Button, Space, Tag, Typography } from "antd";
+import { Button, Space, Tag, Tooltip, Typography } from "antd";
+import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
 import { Link } from "react-router";
 import type { DomainApplicationSummary } from "./types";
 import { ApplicationStatusTag } from "../applications/ApplicationStatusTag";
@@ -23,6 +24,13 @@ import { appDisplayName } from "../../shells/user/applications/CmsIcon";
 
 interface DomainApplicationCellProps {
   applications?: DomainApplicationSummary[];
+  // GH #1543 D2: inline mutations. Supplied only on the tenant grid (undefined
+  // ⇒ read-only: no Install button, no Delete). onInstall opens the install
+  // modal pinned to this domain; onDelete removes the primary install (extras
+  // are managed on the Applications page). deletingId spins the matching row.
+  onInstall?: () => void;
+  onDelete?: (app: DomainApplicationSummary) => void;
+  deletingId?: string | null;
 }
 
 // The Login control is its own component so useMagicLink (one mint state per
@@ -42,14 +50,29 @@ const AppLoginButton = ({ app }: { app: DomainApplicationSummary }) => {
   );
 };
 
-export const DomainApplicationCell = ({ applications }: DomainApplicationCellProps) => {
+export const DomainApplicationCell = ({
+  applications,
+  onInstall,
+  onDelete,
+  deletingId,
+}: DomainApplicationCellProps) => {
   const apps = applications ?? [];
   if (apps.length === 0) {
-    return <span style={{ color: "#bbb" }}>—</span>;
+    // Empty: offer Install when the grid wired it (tenant), else a plain dash.
+    return onInstall ? (
+      <Button size="small" icon={<PlusOutlined />} onClick={onInstall}>
+        Install
+      </Button>
+    ) : (
+      <span style={{ color: "#bbb" }}>—</span>
+    );
   }
 
   const primary = apps[0];
   const extra = apps.length - 1;
+  // A settling/deleting primary is already spinning via its status tag; also
+  // spin the Delete button while its own request is in flight.
+  const deleting = deletingId === primary.id;
 
   return (
     <Space size={6} wrap>
@@ -62,6 +85,19 @@ export const DomainApplicationCell = ({ applications }: DomainApplicationCellPro
         <ApplicationStatusTag status={primary.status} lastError={primary.last_error} />
       )}
       {canApplicationLogin(primary) && <AppLoginButton app={primary} />}
+      {onDelete && (
+        <Tooltip title="Delete this app">
+          <Button
+            type="text"
+            size="small"
+            danger
+            loading={deleting}
+            icon={<DeleteOutlined />}
+            aria-label="Delete app"
+            onClick={() => onDelete(primary)}
+          />
+        </Tooltip>
+      )}
       {extra > 0 && (
         <Link to="/jabali-panel/applications" style={{ fontSize: 12 }}>
           +{extra} more

--- a/panel-ui/src/components/domains/DomainInventory.tsx
+++ b/panel-ui/src/components/domains/DomainInventory.tsx
@@ -32,7 +32,10 @@ import { DomainChownAction } from "../../shells/admin/domains/DomainChownAction"
 
 import { buildDomainDataColumns, type DomainInventoryAudience } from "./domainColumns";
 import { buildDomainMenuItems, type DomainModalType } from "./domainActions";
-import type { Domain } from "./types";
+import type { Domain, DomainApplicationSummary } from "./types";
+import { InstallApplicationModal } from "../../shells/user/applications/InstallApplicationModal";
+import { useDeleteApplication } from "../applications/useDeleteApplication";
+import { useTransitionalPoll } from "../applications/useTransitionalPoll";
 
 export type { DomainInventoryAudience } from "./domainColumns";
 
@@ -45,6 +48,9 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
   const { data: caps } = useServerCapabilities();
   const [activeModal, setActiveModal] = useState<ActiveModal>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
+  // GH #1543 D2: the domain whose Install button was clicked (opens the install
+  // modal pinned to it). Tenant-only; admin never renders the Application column.
+  const [installFor, setInstallFor] = useState<Domain | null>(null);
 
   const ownerId = audience.kind === "admin" ? audience.ownerId : undefined;
   const query = useTableURL<Domain>({
@@ -54,6 +60,15 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
     extraParams: ownerId ? { user_id: ownerId } : undefined,
   });
   const deleteMutation = useDeleteMutation({ resource: "domains" });
+  const { deletingId: deletingAppId, deleteApplication } = useDeleteApplication();
+
+  // GH #1543 D2: while any installed app on a visible row is still settling
+  // (installing/deleting/…), poll the domains list so its status/version and
+  // the Application column catch up. Tenant-only data; admin rows carry no apps.
+  useTransitionalPoll(
+    audience.kind === "tenant" ? query.items.flatMap((d) => d.applications ?? []) : [],
+    query.refetch,
+  );
 
   // One PATCH path for every row-level flag flip (enable/disable, preview URL,
   // bot challenge). All three now invalidate both the list and the single-row
@@ -137,6 +152,26 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
     });
   };
 
+  // GH #1543 D2: inline One-Click app actions on the tenant Application column.
+  const handleInstallApp = (r: Domain) => setInstallFor(r);
+
+  const handleDeleteApp = (app: DomainApplicationSummary, r: Domain) => {
+    feedback.modal.confirm({
+      title: `Delete the ${app.app_type} app on "${r.name}"?`,
+      content:
+        "The database, files, and any associated cron jobs will be removed. This cannot be undone.",
+      okText: "Delete",
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        // useDeleteApplication invalidates the applications query keys; the
+        // Application column lives on the domains list, so refresh that too.
+        await deleteApplication({ id: app.id, domain_name: r.name, domain_id: r.id });
+        qc.invalidateQueries({ queryKey: ["list", "domains"] });
+        query.refetch();
+      },
+    });
+  };
+
   const handleTableChange: React.ComponentProps<typeof Table<Domain>>["onChange"] = (
     pagination,
     _filters,
@@ -155,7 +190,16 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
     audience.kind === "admin" ? t("domainlist.more_actions") : t("userdomainlist.more_actions");
 
   const columns: ColumnsType<Domain> = [
-    ...buildDomainDataColumns(audience, { t: (k: string) => t(k), query }),
+    ...buildDomainDataColumns(audience, {
+      t: (k: string) => t(k),
+      query,
+      // Tenant-only: the Application column's inline Install/Delete. Admin never
+      // renders the column, so it gets no actions.
+      appActions:
+        audience.kind === "tenant"
+          ? { onInstall: handleInstallApp, onDelete: handleDeleteApp, deletingId: deletingAppId }
+          : undefined,
+    }),
     {
       key: "actions",
       title: audience.kind === "admin" ? t("domainlist.actions") : t("userdomainlist.actions"),
@@ -211,33 +255,50 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
   ];
 
   return (
-    <SearchableTableStringQ<Domain>
-      rowKey="id"
-      loading={query.isLoading}
-      dataSource={query.items}
-      columns={columns}
-      initialSearch={query.params.q}
-      searchPlaceholder="Search by domain name"
-      onSearchChange={(q) => query.setParams({ q, page: 1 })}
-      pagination={{
-        current: query.params.page,
-        pageSize: query.params.pageSize,
-        total: query.total,
-      }}
-      onChange={handleTableChange}
-      locale={
-        audience.kind === "admin"
-          ? {
-              emptyText: (
-                <EmptyWithCTA
-                  description={t("domainlist.no_domains_yet")}
-                  ctaLabel="Create domain"
-                  onCta={() => navigate("create")}
-                />
-              ),
-            }
-          : undefined
-      }
-    />
+    <>
+      <SearchableTableStringQ<Domain>
+        rowKey="id"
+        loading={query.isLoading}
+        dataSource={query.items}
+        columns={columns}
+        initialSearch={query.params.q}
+        searchPlaceholder="Search by domain name"
+        onSearchChange={(q) => query.setParams({ q, page: 1 })}
+        pagination={{
+          current: query.params.page,
+          pageSize: query.params.pageSize,
+          total: query.total,
+        }}
+        onChange={handleTableChange}
+        locale={
+          audience.kind === "admin"
+            ? {
+                emptyText: (
+                  <EmptyWithCTA
+                    description={t("domainlist.no_domains_yet")}
+                    ctaLabel="Create domain"
+                    onCta={() => navigate("create")}
+                  />
+                ),
+              }
+            : undefined
+        }
+      />
+      {/* GH #1543 D2: install a One-Click app pinned to the row's domain. Hosted
+          here (not in the cell) so it survives the cell unmounting on refetch,
+          and only mounted while installing so its registry/domain queries stay
+          idle otherwise. */}
+      {audience.kind === "tenant" && installFor !== null && (
+        <InstallApplicationModal
+          open
+          presetDomainId={installFor.id}
+          onClose={() => setInstallFor(null)}
+          onSuccess={() => {
+            setInstallFor(null);
+            query.refetch();
+          }}
+        />
+      )}
+    </>
   );
 };

--- a/panel-ui/src/components/domains/domainColumns.tsx
+++ b/panel-ui/src/components/domains/domainColumns.tsx
@@ -13,7 +13,7 @@ import { columnSearchProps } from "../columnSearch";
 import { humanBytes } from "../../utils/bytes";
 import { getSSLTag } from "../../utils/sslState";
 import { adminLinks } from "../admin/entityLinks";
-import { serviceBadge, type Domain } from "./types";
+import { serviceBadge, type Domain, type DomainApplicationSummary } from "./types";
 import { DomainApplicationCell } from "./DomainApplicationCell";
 
 // A discriminated union — audience policy stays internal to the module rather
@@ -122,14 +122,25 @@ const renderSSL = (record: Domain, audience: DomainInventoryAudience) => {
   return <Tag color={color}>{label}</Tag>;
 };
 
+// GH #1543 D2: the tenant Application column's inline mutations. The cell owns
+// no state — it calls back into DomainInventory, which hosts the install modal,
+// the delete confirm, and the transitional poll. Optional (admin never supplies
+// it, and the column it drives is tenant-only).
+export type DomainColumnAppActions = {
+  onInstall: (r: Domain) => void;
+  onDelete: (app: DomainApplicationSummary, r: Domain) => void;
+  deletingId: string | null;
+};
+
 type ColumnCtx = {
   t: (key: string) => string;
   query: { params: { q?: string }; setParams: (p: { q: string; page: number }) => void };
+  appActions?: DomainColumnAppActions;
 };
 
 export const buildDomainDataColumns = (
   audience: DomainInventoryAudience,
-  { t, query }: ColumnCtx,
+  { t, query, appActions }: ColumnCtx,
 ): ColumnsType<Domain> => {
   // Each screen keeps its own i18n namespace so no header text shifts.
   const title = (key: string) =>
@@ -235,7 +246,12 @@ export const buildDomainDataColumns = (
       title: "Application",
       responsive: ["md"],
       render: (_: unknown, record: Domain) => (
-        <DomainApplicationCell applications={record.applications} />
+        <DomainApplicationCell
+          applications={record.applications}
+          onInstall={appActions ? () => appActions.onInstall(record) : undefined}
+          onDelete={appActions ? (app) => appActions.onDelete(app, record) : undefined}
+          deletingId={appActions?.deletingId ?? null}
+        />
       ),
     });
   }

--- a/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
+++ b/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
@@ -39,6 +39,10 @@ type Props = {
   // a Catalog card). When provided, the in-drawer app picker is hidden and
   // the chosen app_type wins over the wordpress default.
   presetAppType?: string;
+  // presetDomainId pins the install to one domain (GH #1543: opened from the
+  // Web Domains list's Install button). When provided, the domain is seeded and
+  // its picker is locked — the caller already chose the target row.
+  presetDomainId?: string;
 };
 
 type CreatedResult = {
@@ -308,6 +312,7 @@ export const InstallApplicationModal = ({
   onSuccess,
   defaultAdminEmail,
   presetAppType,
+  presetDomainId,
 }: Props) => {
   const { t } = useTranslation();
   const [form] = Form.useForm<Record<string, unknown>>();
@@ -403,6 +408,13 @@ export const InstallApplicationModal = ({
       : (wp?.name ?? apps[0]?.name ?? "wordpress");
     form.setFieldsValue({ app_type: defaultName });
   }, [open, apps, presetAppType, form]);
+
+  // GH #1543: seed the domain when opened from a specific Web Domains row. The
+  // picker is locked (disabled below), so this is the domain the install targets.
+  useEffect(() => {
+    if (!open || !presetDomainId) return;
+    form.setFieldsValue({ domain_id: presetDomainId });
+  }, [open, presetDomainId, form]);
 
   // When the user switches App, clear every per-app field and apply
   // the new descriptor's defaults. Without this, a "site_title" left
@@ -667,6 +679,7 @@ export const InstallApplicationModal = ({
               <Select
                 placeholder={t("installapplicationmodal.select_a_domain")}
                 loading={loadingDomains}
+                disabled={!!presetDomainId}
                 options={availableDomains.map((d) => ({
                   value: d.id,
                   label: d.name,


### PR DESCRIPTION
## What

Part **D** of GH #1543, **slice 2 of 2**: the Application column on the tenant Web Domains list gains its **inline mutations**, completing "full inline". [D1 (#1572)](https://github.com/shukiv/jabali-panel/pull/1572) shipped the read side (badge + version/status + **Login**); this adds **Install**, **Delete**, and a live **poll**.

```
Web Domains list (tenant)
──────────────────────────────────────
Domain      Application
site.tld    [WordPress] 6.5.3  Login  🗑
shop.tld    [WordPress] installing…
empty.tld   [ + Install ]
```

## How

- **Install** — an empty domain's cell shows an **Install** button; `DomainInventory` hosts `InstallApplicationModal` pinned to that domain via a new **`presetDomainId`** prop (the domain is seeded and its picker **locked**). The modal keeps its app-type picker, so any cataloged app installs, not just WordPress. It **mounts only while installing**, so its registry/domain queries stay idle otherwise.
- **Delete** — the primary (docroot) install gets a Delete control that confirms, then runs the shared `useDeleteApplication` and — because the column lives on the **domains** list, not the applications list — **also invalidates the domains list key and refetches**. Extra installs stay managed on the Applications page (the "+N more" link).
- **Poll** — `useTransitionalPoll` over the visible rows' apps refetches the domains list while any install is still settling, so "installing…" doesn't freeze in the grid. Tenant-only data; admin rows carry no apps.

The cell stays **state-free** — it calls back into `DomainInventory`, which owns the modal, the delete confirm and the poll. All app wiring is gated to the **tenant** audience; the admin grid and the standalone Applications page are unchanged.

## Part E

The Applications page keeps Catalog, Scan, Migrate-from-remote, Clone and cache toggle/settings — so the originally-planned **E ("remove the Applications menu") is a rename/re-scope, not a removal**. With D done, #1543's mockup scope (A–D) is delivered; E is a separate decision.

## Test plan

- [x] `tsc -b`, `eslint` clean on changed files
- [x] `DomainApplicationCell.test` — Install shows + fires `onInstall` on an empty domain; Delete fires `onDelete(primary)`; read-only (no callbacks) shows neither, keeps Login
- [x] `domainColumns.test` + `UserDomainList.test` still green (11 tests across the 3 files)
- [x] Rebased onto latest origin/main
- [ ] Manual: empty domain → Install (domain pre-selected + locked) → row shows installing… then ready+Login; Delete confirms and clears the row; admin list + Applications page unchanged

GH #1543