### PR TITLE
fix(mail): hide Create Mail Domain when mail is disabled server-wide

### DIFF
--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -15,6 +15,13 @@ vi.mock("../../../apiClient", () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
 
+// GH #1479: the Create button gates on the global mail capability. Mock it so
+// the state is explicit (default: mail on).
+const caps = vi.hoisted(() => ({ value: { mail_enabled: true } as Record<string, boolean> }));
+vi.mock("../../../hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({ data: caps.value }),
+}));
+
 import { apiClient } from "../../../apiClient";
 
 const mocked = apiClient as unknown as {
@@ -83,6 +90,7 @@ beforeEach(() => {
   mockList();
   mocked.post.mockReset().mockResolvedValue({ data: {} });
   mocked.delete.mockReset().mockResolvedValue({ data: {} });
+  caps.value = { mail_enabled: true };
 });
 
 describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
@@ -172,6 +180,26 @@ describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
     expect(screen.queryByText("No mail")).not.toBeInTheDocument();
     expect(screen.queryByText("Microsoft 365")).not.toBeInTheDocument();
     expect(screen.queryByText("Jabali mail (this server)")).not.toBeInTheDocument();
+  });
+
+  // GH #1479 (johnnyq follow-up): when mail is disabled server-wide, offering to
+  // create a mail domain makes no sense — the button is gone from both the
+  // header and the empty state, and the empty state says mail is off.
+  it("hides Create Mail Domain when mail is disabled server-wide", async () => {
+    caps.value = { mail_enabled: false };
+    renderPage();
+    await screen.findByText("on.test"); // rows still load
+    expect(screen.queryByRole("button", { name: /Create Mail Domain/i })).not.toBeInTheDocument();
+  });
+
+  it("shows a mail-off empty state (no Create button) when disabled and no domains", async () => {
+    caps.value = { mail_enabled: false };
+    mocked.get
+      .mockReset()
+      .mockResolvedValue({ data: { data: [], total: 0, page: 1, page_size: 0 } });
+    renderPage();
+    expect(await screen.findByText("Mail is disabled on this server.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Create Mail Domain/i })).not.toBeInTheDocument();
   });
 
   // GH #1479: the mail-mode create posts the right domain shape (web off, mail on

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -31,6 +31,7 @@ import { humanBytes } from "../../../utils/bytes";
 import { getSSLTagColor, getSSLTagLabel } from "../../../utils/sslState";
 import { apiClient } from "../../../apiClient";
 import { feedback } from "../../../lib/feedback";
+import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 import { UserDomainDrawer } from "../domains/UserDomainDrawer";
 
 interface MailDomainRow {
@@ -63,6 +64,11 @@ export function MailDomainsPage() {
   // GH #1479: Create Mail Domain drawer (reuses the tenant Add-domain drawer in
   // its mail mode — web-off, mail on, TLS/webmail/DNS-records options).
   const [createOpen, setCreateOpen] = useState(false);
+  // GH #1479 (johnnyq): don't offer "Create Mail Domain" when mail is disabled
+  // server-wide — there's nothing to provision. Default-on while caps load, so a
+  // mail-enabled server never flashes the button away. Mirrors the sidebar gate.
+  const { data: caps } = useServerCapabilities();
+  const mailEnabled = caps?.mail_enabled !== false;
   const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
   const rows = query.items;
 
@@ -227,13 +233,15 @@ export function MailDomainsPage() {
     <Card
       title="Mail Domains"
       extra={
-        <Button
-          type="primary"
-          icon={<PlusOutlined />}
-          onClick={() => setCreateOpen(true)}
-        >
-          Create Mail Domain
-        </Button>
+        mailEnabled ? (
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => setCreateOpen(true)}
+          >
+            Create Mail Domain
+          </Button>
+        ) : null
       }
     >
       <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
@@ -245,11 +253,17 @@ export function MailDomainsPage() {
       ) : rows.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="No domains have mail active yet. Create a mail domain here, or enable mail on an existing domain from the Domains page."
+          description={
+            mailEnabled
+              ? "No domains have mail active yet. Create a mail domain here, or enable mail on an existing domain from the Domains page."
+              : "Mail is disabled on this server."
+          }
         >
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>
-            Create Mail Domain
-          </Button>
+          {mailEnabled && (
+            <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateOpen(true)}>
+              Create Mail Domain
+            </Button>
+          )}
         </Empty>
       ) : (
         <Table<MailDomainRow>


### PR DESCRIPTION
## What

GH #1479 (johnnyq follow-up): *"it shouldn't show if email is disabled globally."* The **Create Mail Domain** button appeared on the tenant Mail Domains page even on servers where the mail module is disabled server-wide — offering to provision mail there makes no sense.

## How

Gate both button sites on the `mail_enabled` server capability (`useServerCapabilities`):

- **Card header** — the Create button is hidden when mail is off.
- **Empty state** — no Create button; the description reads *"Mail is disabled on this server."* instead of inviting a create.

Default-on while capabilities load, so a mail-enabled server never flashes the button away — matches the sidebar/route gates.

The rest of #1479 (the button, its drawer, dropping the mail-provider select) already shipped; this closes the last review point.

## Test plan

- [x] `tsc -b`, `eslint` clean
- [x] `MailDomainsPage.test` — new: mail-off hides the button (with rows) and shows the mail-off empty state (no rows); existing 6 tests still green (8 total)
- [ ] Manual: on a mail-disabled server the Mail Domains page shows no Create button; on a normal server it's unchanged

GH #1479