### PR TITLE
fix(reconciler): carry tenant ini overrides on the PHP-pool sweep re-apply

### DIFF
--- a/panel-api/internal/phppoolops/phppoolops.go
+++ b/panel-api/internal/phppoolops/phppoolops.go
@@ -197,16 +197,7 @@ func ReconcileViaAgent(deps ReconcileDeps, pool models.PHPPool) error {
 		return err
 	}
 
-	adminValues := []map[string]string{}
-	adminFlags := []map[string]string{}
-	for _, override := range overridesList {
-		kv := map[string]string{"name": override.Directive, "value": override.Value}
-		if override.Kind == "flag" {
-			adminFlags = append(adminFlags, kv)
-		} else {
-			adminValues = append(adminValues, kv)
-		}
-	}
+	adminValues, adminFlags := SplitIniOverrides(overridesList)
 
 	// GH #329: resolve the pool's slug so a versioned pool applies to its own
 	// socket/instance rather than the default per-user one. isDefault = the
@@ -266,4 +257,25 @@ func ReconcileViaAgent(deps ReconcileDeps, pool models.PHPPool) error {
 	pool.LastError = nil
 	_ = deps.Pools.Update(ctx, &pool)
 	return nil
+}
+
+// SplitIniOverrides partitions a pool's tenant ini overrides into the agent
+// php.pool.apply admin_values / admin_flags param shape ({name,value} maps),
+// keyed by Kind ("flag" -> admin_flags, everything else -> admin_values). Both
+// reconcile paths build the params from this one helper — ReconcileViaAgent
+// (the settings/version-save path) and reconciler.applyPHPPool (the periodic
+// sweep, GH #1550) — so a sweep re-apply can no longer drop the overrides the
+// save path carries. Returns non-nil empty slices for an empty input.
+func SplitIniOverrides(overrides []models.PHPPoolIniOverride) (adminValues, adminFlags []map[string]string) {
+	adminValues = []map[string]string{}
+	adminFlags = []map[string]string{}
+	for _, override := range overrides {
+		kv := map[string]string{"name": override.Directive, "value": override.Value}
+		if override.Kind == "flag" {
+			adminFlags = append(adminFlags, kv)
+		} else {
+			adminValues = append(adminValues, kv)
+		}
+	}
+	return adminValues, adminFlags
 }

--- a/panel-api/internal/phppoolops/phppoolops_test.go
+++ b/panel-api/internal/phppoolops/phppoolops_test.go
@@ -329,3 +329,32 @@ func TestReconcileViaAgent_AgentError_SetsErrorStatus(t *testing.T) {
 	require.NotNil(t, pools.statuses[0].lastErr)
 	assert.Contains(t, *pools.statuses[0].lastErr, "socket down")
 }
+
+// ---- SplitIniOverrides: the single override-partition helper both the sweep
+// (reconciler.applyPHPPool) and the save path (ReconcileViaAgent) build params
+// from, so they can never drift (GH #1550). ----
+
+func TestSplitIniOverrides(t *testing.T) {
+	values, flags := phppoolops.SplitIniOverrides([]models.PHPPoolIniOverride{
+		{Directive: "memory_limit", Value: "256M", Kind: "value"},
+		{Directive: "display_errors", Value: "On", Kind: "flag"},
+		{Directive: "upload_max_filesize", Value: "64M", Kind: "value"},
+	})
+	assert.Equal(t, []map[string]string{
+		{"name": "memory_limit", "value": "256M"},
+		{"name": "upload_max_filesize", "value": "64M"},
+	}, values)
+	assert.Equal(t, []map[string]string{
+		{"name": "display_errors", "value": "On"},
+	}, flags)
+}
+
+func TestSplitIniOverrides_Empty(t *testing.T) {
+	values, flags := phppoolops.SplitIniOverrides(nil)
+	// Non-nil empty slices — the agent ranges over them, so nil would be fine
+	// too, but empty non-nil keeps the JSON shape stable ([] not null).
+	require.NotNil(t, values)
+	require.NotNil(t, flags)
+	assert.Empty(t, values)
+	assert.Empty(t, flags)
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1670,6 +1670,27 @@ func (r *Reconciler) applyPHPPool(ctx context.Context, user *models.User, pool *
 		"xdebug_enabled":                    pool.XdebugEnabled,
 	}
 
+	// GH #1550: carry the pool's tenant php_admin_value / php_admin_flag
+	// overrides. The agent renders the whole pool conf from these params (no
+	// merge), so a sweep re-apply that omits them wipes every override the
+	// tenant set until their next PHP-settings save. Mirrors the shape
+	// phppoolops.ReconcileViaAgent (the save path) builds. Fail-closed on a
+	// read error: skip the apply and retry next tick rather than re-render the
+	// pool with no overrides. A nil repo (unwired) leaves the keys off, which
+	// the agent treats as "no overrides" — matching the prior behaviour.
+	if r.phpPoolIniOverrides != nil {
+		overrides, oerr := r.phpPoolIniOverrides.ListByPool(ctx, pool.ID)
+		if oerr != nil {
+			errMsg := fmt.Sprintf("list ini overrides: %v", oerr)
+			r.log.Error("failed to list PHP pool ini overrides", "pool_id", pool.ID, "err", oerr)
+			r.phpPools.SetStatus(ctx, pool.ID, "error", &errMsg)
+			return
+		}
+		adminValues, adminFlags := phppoolops.SplitIniOverrides(overrides)
+		params["admin_values"] = adminValues
+		params["admin_flags"] = adminFlags
+	}
+
 	// GH #402: if the user's package opts out of the #401 command-exec
 	// lockdown, send disable_functions="" (explicit opt-out -> agent emits no
 	// line). Omitting the key entirely (the default) lets the agent apply its

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2247,9 +2247,15 @@ func (f *fakePackageRepoMin) EnsureDefaults(context.Context) error              
 type fakeIniOverrideRepo struct {
 	repository.PHPPoolIniOverrideRepository
 	byPool map[string][]models.PHPPoolIniOverride
+	// err, when set, makes ListByPool fail — models a DB read error so the
+	// override-aware apply paths can be tested for fail-closed behaviour.
+	err error
 }
 
 func (f *fakeIniOverrideRepo) ListByPool(_ context.Context, poolID string) ([]models.PHPPoolIniOverride, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
 	return f.byPool[poolID], nil
 }
 
@@ -2280,7 +2286,9 @@ func newPoolReconcilerWithPkg(pkg *models.HostingPackage, packageID *string) (*R
 		WithPHPPools(phpPoolRepo)
 	// Wire an empty ini-override repo so the GH #1422 fan-out routes through the
 	// override-aware ReconcileViaAgent (a nil repo makes it a fail-closed no-op).
-	// applyPHPPool-driven tests ignore overrides, so an empty repo is harmless.
+	// applyPHPPool now reads it too (GH #1550), so an empty repo means every
+	// sweep apply carries empty admin_values/admin_flags — harmless for tests
+	// that don't assert those keys.
 	r.WithPHPPoolIniOverrides(&fakeIniOverrideRepo{byPool: map[string][]models.PHPPoolIniOverride{}})
 	if pkg != nil {
 		r.WithPackages(&fakePackageRepoMin{pkgs: map[string]*models.HostingPackage{pkg.ID: pkg}})
@@ -2308,6 +2316,62 @@ func TestApplyPHPPool_DisableFunctionsByPackage(t *testing.T) {
 	p2 := applyCallParams(t, agent2)
 	_, ok2 := p2["disable_functions"]
 	require.False(t, ok2, "default package must NOT send disable_functions (agent uses safe default)")
+}
+
+// GH #1550: the periodic sweep (applyPHPPool) must carry the pool's tenant
+// php_admin_value / php_admin_flag overrides. The agent re-renders the whole
+// pool conf from these params, so a sweep re-apply that omitted them wiped
+// every override the tenant set until their next PHP-settings save. Assert the
+// sweep's apply sends admin_values / admin_flags partitioned by Kind.
+func TestApplyPHPPool_CarriesIniOverrides(t *testing.T) {
+	r, agent, _ := newPoolReconcilerWithPkg(nil, nil)
+	r.WithPHPPoolIniOverrides(&fakeIniOverrideRepo{byPool: map[string][]models.PHPPoolIniOverride{
+		"pool-1": {
+			{Directive: "memory_limit", Value: "256M", Kind: "value"},
+			{Directive: "display_errors", Value: "On", Kind: "flag"},
+		},
+	}})
+
+	r.ReconcilePHPPools(context.Background())
+
+	p := applyCallParams(t, agent)
+	require.Equal(t, []map[string]string{{"name": "memory_limit", "value": "256M"}},
+		p["admin_values"], "sweep must carry the pool's php_admin_value overrides")
+	require.Equal(t, []map[string]string{{"name": "display_errors", "value": "On"}},
+		p["admin_flags"], "sweep must carry the pool's php_admin_flag overrides")
+}
+
+// GH #1550: a DB read error while loading overrides must fail closed — skip the
+// apply and mark the pool error for a next-tick retry — rather than re-render
+// the pool with no overrides (which is the very bug this fixes, differently
+// triggered). The agent must NOT be called.
+func TestApplyPHPPool_IniOverrideListErrorFailsClosed(t *testing.T) {
+	r, agent, poolRepo := newPoolReconcilerWithPkg(nil, nil)
+	r.WithPHPPoolIniOverrides(&fakeIniOverrideRepo{err: errors.New("db down")})
+
+	r.ReconcilePHPPools(context.Background())
+
+	require.Empty(t, filterCallsByPrefix(agent.calls, "php.pool.apply"),
+		"an override-list read error must skip the apply (fail-closed)")
+	require.Equal(t, "error", poolRepo.pools["pool-1"].Status,
+		"the pool must be marked error so the next tick retries")
+}
+
+// GH #1550: an unwired (nil) override repo leaves the admin_values / admin_flags
+// keys off the params entirely, which the agent treats as "no overrides" —
+// matching the behaviour before this change. Fail-safe: a missing wiring can
+// only omit overrides, never fabricate them.
+func TestApplyPHPPool_NilIniOverrideRepoOmitsKeys(t *testing.T) {
+	r, agent, _ := newPoolReconcilerWithPkg(nil, nil)
+	r.phpPoolIniOverrides = nil
+
+	r.ReconcilePHPPools(context.Background())
+
+	p := applyCallParams(t, agent)
+	_, hasValues := p["admin_values"]
+	_, hasFlags := p["admin_flags"]
+	require.False(t, hasValues, "nil override repo must leave admin_values off the params")
+	require.False(t, hasFlags, "nil override repo must leave admin_flags off the params")
 }
 
 // GH #1422: flipping php_exec_enabled must reach a domain pinned to a


### PR DESCRIPTION
## What

The periodic PHP-pool sweep (`reconciler.applyPHPPool`) rebuilt the `php.pool.apply` params without the pool's `php_admin_value` / `php_admin_flag` overrides. The agent re-renders the whole pool conf from those params (no merge), so every sweep of a pending/error/socket-missing pool silently wiped the tenant's overrides until their next PHP-settings save re-sent them.

`applyPHPPool` is now override-aware: it loads the pool's ini overrides and adds `admin_values` / `admin_flags` to the params, mirroring the save path (`phppoolops.ReconcileViaAgent`). Both paths build that shape from one new helper, `phppoolops.SplitIniOverrides`, so they can't drift.

## Why not route the sweep through `ReconcileViaAgent` (the issue's first option)

That path was written before it was noticed that `ReconcileViaAgent` writes pool status **`"ready"`**, whereas the sweep keys self-heal and re-apply on **`"active"`** — `activePoolSocketMissing` returns `false` for any non-`"active"` pool. Swapping to it would therefore silently disable JAB-388 socket self-heal for exactly the pools the sweep owns. It also has **no socket-ready wait** and **no nginx regeneration**, both of which `applyPHPPool` does. Keeping `applyPHPPool` and adding the overrides fixes the drop while preserving the sweep's `"active"` status, socket wait, and nginx regen.

## Fail-closed

- A DB read error on the override list **skips the apply and marks the pool `error`** for a next-tick retry, rather than re-rendering with no overrides (the bug, differently triggered).
- A nil (unwired) override repo omits the keys — the agent treats that as "no overrides", matching prior behaviour. A missing wiring can only omit overrides, never fabricate them.

## Noted, not fixed here

A settings-saved pool sits at status `"ready"` and is therefore never socket self-heal eligible either — a pre-existing gap in the `activePoolSocketMissing` `"active"`-only guard. Separate issue.

## Tests

- `reconciler`: sweep carries `admin_values`/`admin_flags` partitioned by Kind; override-list read error fails closed (agent not called, pool `error`); nil override repo omits the keys.
- `phppoolops`: `SplitIniOverrides` partition + non-nil-empty on empty input.
- Full `reconciler` + `phppoolops` packages pass with `-race`.

GH #1550