### PR TITLE
fix(notifications): admin edit of a tenant email channel re-forces own-address delivery (JAB-308)

### DIFF
--- a/panel-api/internal/api/notifications_channels.go
+++ b/panel-api/internal/api/notifications_channels.go
@@ -13,6 +13,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifchannelops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -36,6 +37,11 @@ type NotificationsChannelsHandlerConfig struct {
 	// SSOKey opens sealed channel secrets for the synchronous "Send test"
 	// path (JAB-171). Nil = secrets used as stored (legacy plaintext).
 	SSOKey *ssokey.Key
+	// Users resolves the OWNER of a tenant-owned channel so an admin edit of a
+	// tenant email channel re-forces own-address delivery, the same invariant
+	// the tenant UI enforces (JAB-308 owner policy). Nil ⇒ an admin cannot
+	// change a tenant email channel's config (fail-closed 503).
+	Users repository.UserRepository
 }
 
 // redactChannelSecrets blanks every secret field on each channel's config so a
@@ -195,6 +201,28 @@ func (h *notificationsChannelsHandler) update(c *gin.Context) {
 		// passes on a preserved secret.
 		merged := *req.Config
 		notifsecret.PreserveEmptySecrets(&merged, existing.Config)
+		// A tenant-owned email channel may only deliver to its owner's own
+		// account address over local submission — the same own-address invariant
+		// the tenant handler forces on create and edit. Re-force it here too so
+		// an admin edit can't repoint a tenant email channel at an arbitrary
+		// destination or a custom SMTP relay (JAB-308: owner policy holds
+		// regardless of adapter). Runs after PreserveEmptySecrets so a preserved
+		// SMTP password is cleared by the forcing, and before validation so the
+		// forced fields are what gets validated. Server-wide channels (no owner)
+		// are untouched — an admin may point those anywhere.
+		if existing.UserID != nil && existing.Kind == models.NotificationChannelKindEmail {
+			ownerEmail, ok := h.resolveTenantOwnerEmail(c, *existing.UserID)
+			if !ok {
+				return
+			}
+			if err := notifchannelops.ForceOwnEmailConfig(ownerEmail, &merged); err != nil {
+				c.JSON(http.StatusUnprocessableEntity, gin.H{
+					"error":   "no_account_email",
+					"message": "the channel owner's account has no email address to deliver to",
+				})
+				return
+			}
+		}
 		if err := validateChannelKindAndConfig(existing.Kind, merged); err != nil {
 			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 			return
@@ -211,6 +239,25 @@ func (h *notificationsChannelsHandler) update(c *gin.Context) {
 	}
 	notifsecret.Redact(&existing.Config)
 	c.JSON(http.StatusOK, existing)
+}
+
+// resolveTenantOwnerEmail loads the account email of a tenant-owned channel's
+// OWNER (userID is the row's UserID, not the admin caller) so an admin edit can
+// re-force own-address delivery. Mirrors the tenant handler's resolveOwnerEmail:
+// a nil users repo is fail-closed 503 (the admin cannot safely edit a tenant
+// email channel without confirming the owner address); a lookup miss returns an
+// empty string, which ForceOwnEmailConfig rejects as no_account_email rather
+// than persisting an unforced destination.
+func (h *notificationsChannelsHandler) resolveTenantOwnerEmail(c *gin.Context, userID string) (string, bool) {
+	if h.cfg.Users == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "owner lookup unavailable"})
+		return "", false
+	}
+	u, err := h.cfg.Users.FindByID(c.Request.Context(), userID)
+	if err != nil || u == nil {
+		return "", true
+	}
+	return u.Email, true
 }
 
 func (h *notificationsChannelsHandler) delete(c *gin.Context) {

--- a/panel-api/internal/api/notifications_channels_test.go
+++ b/panel-api/internal/api/notifications_channels_test.go
@@ -273,6 +273,156 @@ func TestChannels_AdminCanDisableTenantChannel(t *testing.T) {
 	require.NotNil(t, row.UserID)
 }
 
+// mapUserRepo resolves users by id (unlike the single-user fakeUserRepo), so a
+// test can prove an admin edit forces a tenant email channel to the ROW OWNER's
+// address rather than the admin caller's.
+type mapUserRepo struct {
+	repository.UserRepository
+	users map[string]*models.User
+}
+
+func (m *mapUserRepo) FindByID(_ context.Context, id string) (*models.User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, nil
+	}
+	return u, nil
+}
+
+func newChannelsRouterU(t *testing.T, repo repository.NotificationChannelRepository, users repository.UserRepository, auth gin.HandlerFunc) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("/api/v1")
+	if auth != nil {
+		g.Use(auth)
+	}
+	RegisterNotificationsChannelsRoutes(g, NotificationsChannelsHandlerConfig{
+		Channels: repo,
+		Users:    users,
+	})
+	return r
+}
+
+// JAB-308 AC1/AC2: an admin edit of a tenant-owned email channel must re-force
+// the own-address / local-submission invariant, so an admin can't repoint a
+// tenant's email channel at an arbitrary destination or a custom SMTP relay.
+// The forcing must target the ROW OWNER's address, not the admin caller's, and
+// must run after secret-preservation (a stored SMTP password gets cleared, not
+// re-hydrated back onto a forced-local channel).
+func TestChannels_AdminEditTenantEmail_ReforcesOwnerAddress(t *testing.T) {
+	t.Parallel()
+	uid := "u1"
+	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{
+		"t": {ID: "t", Name: "TenantMail", Kind: "email", Enabled: true, UserID: &uid,
+			Config: models.NotificationChannelConfig{
+				ToEmail: "u1@example.com", FromEmail: "u1@example.com", SMTPMode: "local",
+				SMTPPassword: "old-secret", // stored secret; forcing must clear it, not preserve rehydrate it
+			}},
+	}}
+	users := &mapUserRepo{users: map[string]*models.User{
+		"u1":     {ID: "u1", Email: "u1@example.com"},
+		"admin1": {ID: "admin1", Email: "admin@example.com"},
+	}}
+	r := newChannelsRouterU(t, repo, users, newAdminCtx())
+
+	// Admin tries to repoint the tenant channel at an arbitrary destination +
+	// custom relay; omit smtp_password so PreserveEmptySecrets would re-hydrate
+	// the stored one — the forcing must still clear it (order: preserve→force).
+	rec := doNotifJSON(t, r, http.MethodPatch, "/api/v1/admin/notifications/channels/t", map[string]any{
+		"config": map[string]any{
+			"to_email":   "victim@evil.com",
+			"from_email": "spoof@evil.com",
+			"smtp_mode":  "smtp",
+			"smtp_host":  "10.0.0.1",
+			"smtp_port":  2525,
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	row, err := repo.FindByID(context.Background(), "t")
+	require.NoError(t, err)
+	require.Equal(t, "u1@example.com", row.Config.ToEmail, "must force to the ROW OWNER address")
+	require.NotEqual(t, "admin@example.com", row.Config.ToEmail, "must NOT force to the admin caller's address")
+	require.Equal(t, "u1@example.com", row.Config.FromEmail)
+	require.Equal(t, "local", row.Config.SMTPMode)
+	require.Empty(t, row.Config.SMTPHost, "custom relay host must be discarded")
+	require.Empty(t, row.Config.SMTPPassword, "stored secret must be cleared by forcing, not re-hydrated")
+	require.NotContains(t, rec.Body.String(), "evil.com")
+}
+
+// A server-wide (unowned) email channel is NOT a tenant channel, so an admin
+// keeps full control of its destination and custom SMTP relay.
+func TestChannels_AdminEditServerWideEmail_KeepsCustomRelay(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{
+		"s": {ID: "s", Name: "OpsMail", Kind: "email", Enabled: true, // UserID nil = server-wide
+			Config: models.NotificationChannelConfig{ToEmail: "ops@corp.example", FromEmail: "ops@corp.example", SMTPMode: "smtp", SMTPHost: "smtp.corp.example", SMTPPort: 587}},
+	}}
+	users := &mapUserRepo{users: map[string]*models.User{}}
+	r := newChannelsRouterU(t, repo, users, newAdminCtx())
+
+	rec := doNotifJSON(t, r, http.MethodPatch, "/api/v1/admin/notifications/channels/s", map[string]any{
+		"config": map[string]any{
+			"to_email":   "ops2@corp.example",
+			"from_email": "ops2@corp.example",
+			"smtp_mode":  "smtp",
+			"smtp_host":  "smtp2.corp.example",
+			"smtp_port":  2587,
+		},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	row, err := repo.FindByID(context.Background(), "s")
+	require.NoError(t, err)
+	require.Equal(t, "ops2@corp.example", row.Config.ToEmail, "server-wide channel keeps its destination")
+	require.Equal(t, "smtp2.corp.example", row.Config.SMTPHost, "server-wide channel keeps a custom relay")
+	require.Equal(t, "smtp", row.Config.SMTPMode)
+}
+
+// A tenant email channel whose owner has no account address can't be forced to a
+// safe destination, so the edit is refused (422) rather than persisting the
+// arbitrary destination the admin supplied.
+func TestChannels_AdminEditTenantEmail_OwnerNoAddressIs422(t *testing.T) {
+	t.Parallel()
+	uid := "u1"
+	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{
+		"t": {ID: "t", Name: "TenantMail", Kind: "email", Enabled: true, UserID: &uid,
+			Config: models.NotificationChannelConfig{ToEmail: "u1@example.com", FromEmail: "u1@example.com", SMTPMode: "local"}},
+	}}
+	users := &mapUserRepo{users: map[string]*models.User{"u1": {ID: "u1", Email: ""}}}
+	r := newChannelsRouterU(t, repo, users, newAdminCtx())
+
+	rec := doNotifJSON(t, r, http.MethodPatch, "/api/v1/admin/notifications/channels/t", map[string]any{
+		"config": map[string]any{"to_email": "victim@evil.com", "from_email": "victim@evil.com"},
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "no_account_email")
+	row, err := repo.FindByID(context.Background(), "t")
+	require.NoError(t, err)
+	require.Equal(t, "u1@example.com", row.Config.ToEmail, "row must not be persisted on rejection")
+}
+
+// With no Users repo wired (a deploy misconfiguration), an admin cannot resolve
+// a tenant channel's owner to re-force its address, so editing a tenant email
+// channel's config fails closed (503) rather than persisting an unforced
+// destination. Uses the pre-existing harness, which never wired Users — exactly
+// the scenario the fail-closed branch guards.
+func TestChannels_AdminEditTenantEmail_NoUsersRepoIs503(t *testing.T) {
+	t.Parallel()
+	uid := "u1"
+	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{
+		"t": {ID: "t", Name: "TenantMail", Kind: "email", Enabled: true, UserID: &uid,
+			Config: models.NotificationChannelConfig{ToEmail: "u1@example.com", FromEmail: "u1@example.com", SMTPMode: "local"}},
+	}}
+	r := newChannelsRouter(t, repo, nil, newAdminCtx()) // no Users repo
+	rec := doNotifJSON(t, r, http.MethodPatch, "/api/v1/admin/notifications/channels/t", map[string]any{
+		"config": map[string]any{"to_email": "victim@evil.com", "from_email": "victim@evil.com"},
+	})
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code, rec.Body.String())
+	row, err := repo.FindByID(context.Background(), "t")
+	require.NoError(t, err)
+	require.Equal(t, "u1@example.com", row.Config.ToEmail, "row must not be persisted when forcing can't run")
+}
+
 func TestChannels_Delete(t *testing.T) {
 	t.Parallel()
 	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1080,6 +1080,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Log:             deps.Log,
 				StrictRateLimit: rl.Strict(),
 				SSOKey:          deps.SSOKey,
+				Users:           deps.Users,
 			})
 		}
 		// M31.1 follow-up — DLQ inspector (list / replay / drop / clear).


### PR DESCRIPTION
## What

A tenant-owned email notification channel may only deliver to its owner's own account address over local submission. The tenant handler forces that on create and on edit, and the operator CLI forces it on create. The **admin channel PATCH** was the one edit path that re-validated a merged config but never re-forced it — so an admin editing a tenant-owned email channel could repoint it at an arbitrary destination or a custom SMTP relay, breaking the own-address invariant the tenant UI guarantees. Operator-initiated (not a tenant escalation), but it left the owner policy incomplete on one adapter.

This routes the admin update through the same shared guard (`notifchannelops.ForceOwnEmailConfig`) the other adapters use. When the row being edited is tenant-owned (`UserID` set) and its kind is email, the handler resolves the owner's account email and re-forces the merged config **after** `PreserveEmptySecrets` (so a stored SMTP password is cleared, not re-hydrated onto a forced-local channel) and **before** validation (so the forced fields are what gets validated and persisted) — the same ordering the tenant handler uses.

For an operator: an admin edit of a tenant's email channel now keeps it pointed at the tenant's own address, exactly like the tenant UI. Custom SMTP relays remain fully available on **server-wide** channels.

## Scope / fail-closed behaviour

- **Server-wide channels (no owner):** untouched. An admin keeps full control of destination + custom SMTP relay.
- **Enabled/Name-only edits:** no owner lookup, so the existing admin-override behaviour (an admin can disable any channel, including a tenant one) is unchanged and needs no users repository.
- The admin handler gains a `Users` repository (wired from `deps.Users`) to resolve the row owner's email. If it is unwired the admin cannot change a tenant email channel's config (**fail-closed 503**); if the owner has no account address the edit is **refused 422 `no_account_email`** rather than persisting the arbitrary destination.
- The `UserID != nil` guard is also what keeps `*existing.UserID` nil-safe on server-wide rows.

## Wire delta (narrow)

`PATCH /admin/notifications/channels/:id` gains a 422 (`no_account_email`) and a 503 (users repo unwired), both only for a **tenant-owned email row whose request carries a config body**. Server-wide rows and non-email tenant rows are byte-identical; a tenant email row with a config body now has its destination forced — that is the fix.

## JAB-308 acceptance criteria

This closes the last open leg of JAB-308's owner policy. All five ACs are now met:

- **AC1** — policy derives from the row owner regardless of adapter: tenant create+edit, CLI create, admin edit; admin create cannot mint a tenant-owned row.
- **AC2** — a tenant email channel cannot target an arbitrary SMTP host/address.
- **AC3** — empty masked secrets preserve sealed values on both HTTP edit paths (`me_notifications.go` `updateChannel` + admin `notifications_channels.go` `update`, both call `notifsecret.PreserveEmptySecrets`); the CLI has no edit subcommand.
- **AC4** — disabled channels cannot be tested (shipped in #1570).
- **AC5** — deletion removes dependent routes + webhook endpoints: `user_notification_routes.channel_id` (migration 000237) and `webhook_endpoints.channel_id` (migration 000064) are both `ON DELETE CASCADE`, so an admin, tenant, or CLI delete drops both; the admin handler's explicit webhook cleanup is redundant belt-and-suspenders.

## Tests

Four behavioural tests on the admin PATCH (fake repos, no source-pin):

- A tenant email row's arbitrary destination + custom relay is forced back to the owner's own address over local submission and a stored secret is cleared — a map-keyed user fake proves it forces to the **row owner**, not the admin caller (falsified by targeting the admin id).
- A server-wide email row keeps its custom relay (falsified by dropping the `UserID` check, which also proves the nil-safety of the deref).
- A tenant email row whose owner has no address is refused 422 without the arbitrary destination being persisted.
- A tenant email edit on a deploy with **no users repository wired** fails closed 503 (falsified by making that branch proceed).

The preserve-before-force ordering is falsified by reordering (the stored secret re-hydrates). `go build`, `go vet`, `gofmt` and `go test -race` across the `api`, `app` and `notifchannelops` packages are clean, rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
