### PR TITLE
feat(packages): CLI package create/edit expose the full entitlement set (JAB-306)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3905,18 +3905,35 @@ jabali package create [flags]
 
 **Flags:**
 
+- `--backup-kinds` — CSV of allowed backup destination kinds (empty=none)
+- `--backup-retention` — retention policy at the cap: reject or prune (empty=reject)
 - `--bw-mb` — bandwidth quota in MB (0=unlimited) (default `0`)
 - `--cgi` — enable CGI
 - `--cpu` — CPU quota percent across all cores (0=unlimited) (default `0`)
 - `--databases` — max databases (0=unlimited) (default `0`)
 - `--disk-mb` — disk quota in MB (0=unlimited) (default `0`)
+- `--docker-app-slugs` — CSV allowlist of catalog slugs tenants may install (empty=server default)
 - `--domains` — max domains (0=unlimited) (default `0`)
 - `--emails` — max email accounts (0=unlimited) (default `0`)
+- `--fpm-advanced` — unlock tenant advanced FPM knobs (implies --fpm-user-can-edit)
+- `--fpm-max-children` — FPM pm.max_children cap (0=default 20) (default `0`)
+- `--fpm-user-can-edit` — let tenants pick an FPM performance mode
+- `--fpm-version-defaults` — JSON map of per-version FPM defaults (empty={})
+- `--fpm-worker-mem-mb` — FPM advisory per-worker memory budget in MB (0=default 64) (default `0`)
 - `--io-read-mbps` — disk read bandwidth limit in MB/s (0=unlimited) (default `0`)
 - `--io-write-mbps` — disk write bandwidth limit in MB/s (0=unlimited) (default `0`)
+- `--max-backup-schedules` — max tenant scheduled backups (0=default 1) (default `0`)
+- `--max-backups` — tenant backup retention cap (0=backups not included) (default `0`)
+- `--max-db-users` — max database users (0=unlimited) (default `0`)
+- `--max-docker-apps` — max tenant docker apps (0=docker apps not included) (default `0`)
+- `--max-ftp-accounts` — max tenant FTP/SFTP subaccounts (0=feature not included) (default `0`)
+- `--max-python-apps` — max tenant python apps (0=python apps not included) (default `0`)
 - `--max-tasks` — max processes/threads per user slice (0=unlimited) (default `0`)
 - `--memory-mb` — memory limit in MB (0=unlimited) (default `0`)
 - `--name` — package name (required)
+- `--nspawn-image` — pin users to an nspawn rootfs version (empty=server default)
+- `--php-exec` — opt out of the PHP command-exec lockdown (exec/proc_open work)
+- `--scheduled-backups` — allow tenant scheduled backups
 - `--ssh` — enable SSH access
 
 #### `jabali package delete`
@@ -3941,18 +3958,35 @@ jabali package edit <package-id> [flags]
 
 **Flags:**
 
+- `--backup-kinds` — CSV of allowed backup destination kinds
+- `--backup-retention` — retention policy at the cap: reject or prune
 - `--bw-mb` — bandwidth MB (default `0`)
 - `--cgi` — CGI access (true/false)
 - `--cpu` — CPU quota percent (default `0`)
 - `--databases` — max databases (default `0`)
 - `--disk-mb` — disk quota MB (default `0`)
+- `--docker-app-slugs` — CSV allowlist of catalog slugs tenants may install
 - `--domains` — max domains (default `0`)
 - `--emails` — max emails (default `0`)
+- `--fpm-advanced` — tenant advanced FPM knobs (true/false, true implies fpm-user-can-edit)
+- `--fpm-max-children` — FPM pm.max_children cap (default `0`)
+- `--fpm-user-can-edit` — tenant FPM performance mode (true/false)
+- `--fpm-version-defaults` — JSON map of per-version FPM defaults
+- `--fpm-worker-mem-mb` — FPM advisory per-worker memory budget MB (default `0`)
 - `--io-read-mbps` — io read MB/s (default `0`)
 - `--io-write-mbps` — io write MB/s (default `0`)
+- `--max-backup-schedules` — max tenant scheduled backups (default `0`)
+- `--max-backups` — tenant backup retention cap (default `0`)
+- `--max-db-users` — max database users (default `0`)
+- `--max-docker-apps` — max tenant docker apps (default `0`)
+- `--max-ftp-accounts` — max tenant FTP/SFTP subaccounts (default `0`)
+- `--max-python-apps` — max tenant python apps (default `0`)
 - `--max-tasks` — max processes/threads (default `0`)
 - `--memory-mb` — memory limit MB (default `0`)
 - `--name` — package name
+- `--nspawn-image` — pin users to an nspawn rootfs version (empty clears the pin)
+- `--php-exec` — PHP command-exec opt-out (true/false)
+- `--scheduled-backups` — tenant scheduled backups (true/false)
 - `--ssh` — SSH access (true/false)
 
 #### `jabali package list`

--- a/panel-api/cmd/server/package_cmd.go
+++ b/panel-api/cmd/server/package_cmd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -74,22 +75,114 @@ func newPackageListCmd() *cobra.Command {
 	}
 }
 
+// packageCreateFlags collects every `package create` flag so the row build is a
+// pure function of the flag values — testable without a live DB. Bool flags are
+// plain booleans here (create has no "leave unchanged" state; absence = false,
+// same as the REST create request's zero value).
+type packageCreateFlags struct {
+	name string
+
+	diskMB, bwMB, domains, emails, databases      uint32
+	cpuPercent, memoryMB, ioReadMbps, ioWriteMbps uint32
+	maxTasks                                      uint32
+
+	maxDBUsers, maxDockerApps, maxPythonApps, maxFTP uint32
+
+	maxBackups, maxBackupSchedules uint32
+	scheduledBackups               bool
+	backupKinds, backupRetention   string
+
+	sshEnabled, cgiEnabled, phpExec bool
+
+	fpmMaxChildren, fpmWorkerMemMB uint32
+	fpmUserCanEdit, fpmAdvanced    bool
+	fpmVersionDefaults             string
+
+	dockerAppSlugs string
+	nspawnImage    string
+}
+
+// buildPackageFromCreateFlags maps create-flag values onto a hosting_packages
+// row and applies the SAME defaulting the REST create handler does
+// (internal/api/packages.go:166-242), so an equivalent CLI invocation persists
+// the identical row. We apply the FPM/retention/version defaults explicitly
+// rather than leaning on the GORM `default:` column tags (which only fill a
+// field left at its zero value) so "equivalent inputs → identical rows" is
+// provable by reading the two blocks side by side. packageops.Validate is the
+// shared final gate the caller runs on the returned row.
+func buildPackageFromCreateFlags(f packageCreateFlags) (*models.HostingPackage, error) {
+	now := time.Now().UTC()
+	p := &models.HostingPackage{
+		ID:               ids.NewULID(),
+		Name:             f.name,
+		DiskQuotaMB:      f.diskMB,
+		BandwidthQuotaMB: f.bwMB,
+		MaxDomains:       f.domains,
+		MaxEmailAccounts: f.emails,
+		MaxDatabases:     f.databases,
+		CPUQuotaPercent:  f.cpuPercent,
+		MemoryLimitMB:    f.memoryMB,
+		IOReadMbps:       f.ioReadMbps,
+		IOWriteMbps:      f.ioWriteMbps,
+		MaxTasks:         f.maxTasks,
+		MaxDatabaseUsers: f.maxDBUsers,
+		MaxDockerApps:    f.maxDockerApps,
+		MaxPythonApps:    f.maxPythonApps,
+		MaxFTPAccounts:   f.maxFTP,
+
+		MaxBackups:                    f.maxBackups,
+		MaxBackupSchedules:            f.maxBackupSchedules,
+		ScheduledBackupsEnabled:       f.scheduledBackups,
+		AllowedBackupDestinationKinds: f.backupKinds,
+		BackupRetentionPolicy:         f.backupRetention,
+
+		SSHEnabled:         f.sshEnabled,
+		CGIEnabled:         f.cgiEnabled,
+		PHPExecEnabled:     f.phpExec,
+		FpmMaxChildrenCap:  f.fpmMaxChildren,
+		FpmWorkerMemMb:     f.fpmWorkerMemMB,
+		FpmUserCanEdit:     f.fpmUserCanEdit,
+		FpmAdvancedMode:    f.fpmAdvanced,
+		FpmVersionDefaults: f.fpmVersionDefaults,
+		DockerAppSlugs:     f.dockerAppSlugs,
+
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	// FPM policy defaults (mirror packages.go:166-182).
+	if p.FpmMaxChildrenCap == 0 {
+		p.FpmMaxChildrenCap = 20
+	}
+	if p.FpmWorkerMemMb == 0 {
+		p.FpmWorkerMemMb = 64
+	}
+	if p.FpmVersionDefaults == "" {
+		p.FpmVersionDefaults = "{}"
+	}
+	if p.FpmAdvancedMode {
+		p.FpmUserCanEdit = true // advanced implies can-edit
+	}
+	// Backup destination kinds: canonicalise (dedup/lowercase) so a CLI-supplied
+	// list stores byte-for-byte what the REST path would (packages.go:183-189).
+	normKinds, err := models.NormalizeBackupKindsCSV(p.AllowedBackupDestinationKinds)
+	if err != nil {
+		return nil, fmt.Errorf("invalid backup kinds: %w", err)
+	}
+	p.AllowedBackupDestinationKinds = normKinds
+	// Retention policy: empty → the safe "reject" default (packages.go:190-196).
+	if p.BackupRetentionPolicy == "" {
+		p.BackupRetentionPolicy = models.BackupRetentionReject
+	}
+	// nspawn image: empty → server default (NULL). A non-empty value is pinned
+	// and pattern-checked by packageops.Validate.
+	if v := strings.TrimSpace(f.nspawnImage); v != "" {
+		p.NspawnImageVersion = &v
+	}
+	return p, nil
+}
+
 func newPackageCreateCmd() *cobra.Command {
-	var (
-		name        string
-		diskMB      uint32
-		bwMB        uint32
-		domains     uint32
-		emails      uint32
-		databases   uint32
-		cpuPercent  uint32
-		memoryMB    uint32
-		ioReadMbps  uint32
-		ioWriteMbps uint32
-		maxTasks    uint32
-		sshEnabled  bool
-		cgiEnabled  bool
-	)
+	var f packageCreateFlags
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -103,36 +196,20 @@ func newPackageCreateCmd() *cobra.Command {
 			if err := initDB(); err != nil {
 				return err
 			}
-			now := time.Now().UTC()
-			p := &models.HostingPackage{
-				ID:               ids.NewULID(),
-				Name:             name,
-				DiskQuotaMB:      diskMB,
-				BandwidthQuotaMB: bwMB,
-				MaxDomains:       domains,
-				MaxEmailAccounts: emails,
-				MaxDatabases:     databases,
-				CPUQuotaPercent:  cpuPercent,
-				MemoryLimitMB:    memoryMB,
-				IOReadMbps:       ioReadMbps,
-				IOWriteMbps:      ioWriteMbps,
-				MaxTasks:         maxTasks,
-				SSHEnabled:       sshEnabled,
-				CGIEnabled:       cgiEnabled,
-				CreatedAt:        now,
-				UpdatedAt:        now,
+			p, err := buildPackageFromCreateFlags(f)
+			if err != nil {
+				return err
 			}
-			// JAB-306: the operator CLI persists direct-to-DB, so it must run
-			// the same invariant check the REST handler does — otherwise an
-			// out-of-range limit the API rejects with 422 (e.g. --cpu 999999)
-			// would silently land in the row. Unset FPM/backup fields fall to
-			// their GORM column defaults at INSERT and pass.
+			// JAB-306: the operator CLI persists direct-to-DB, so it must run the
+			// same invariant check the REST handler does — otherwise an
+			// out-of-range value the API rejects with 422 (e.g. --cpu 999999 or
+			// --fpm-max-children 3000) would silently land in the row.
 			if err := packageops.Validate(p); err != nil {
 				return fmt.Errorf("invalid package: %w", err)
 			}
 			if err := packageRepoFromDB().Create(ctx, p); err != nil {
 				if errors.Is(err, repository.ErrConflict) {
-					return fmt.Errorf("package name %q already exists", name)
+					return fmt.Errorf("package name %q already exists", f.name)
 				}
 				return fmt.Errorf("create package: %w", err)
 			}
@@ -145,39 +222,182 @@ func newPackageCreateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", "package name (required)")
-	cmd.Flags().Uint32Var(&diskMB, "disk-mb", 0, "disk quota in MB (0=unlimited)")
-	cmd.Flags().Uint32Var(&bwMB, "bw-mb", 0, "bandwidth quota in MB (0=unlimited)")
-	cmd.Flags().Uint32Var(&domains, "domains", 0, "max domains (0=unlimited)")
-	cmd.Flags().Uint32Var(&emails, "emails", 0, "max email accounts (0=unlimited)")
-	cmd.Flags().Uint32Var(&databases, "databases", 0, "max databases (0=unlimited)")
-	cmd.Flags().Uint32Var(&cpuPercent, "cpu", 0, "CPU quota percent across all cores (0=unlimited)")
-	cmd.Flags().Uint32Var(&memoryMB, "memory-mb", 0, "memory limit in MB (0=unlimited)")
-	cmd.Flags().Uint32Var(&ioReadMbps, "io-read-mbps", 0, "disk read bandwidth limit in MB/s (0=unlimited)")
-	cmd.Flags().Uint32Var(&ioWriteMbps, "io-write-mbps", 0, "disk write bandwidth limit in MB/s (0=unlimited)")
-	cmd.Flags().Uint32Var(&maxTasks, "max-tasks", 0, "max processes/threads per user slice (0=unlimited)")
-	cmd.Flags().BoolVar(&sshEnabled, "ssh", false, "enable SSH access")
-	cmd.Flags().BoolVar(&cgiEnabled, "cgi", false, "enable CGI")
+	registerPackageCreateFlags(cmd, &f)
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
 
+// registerPackageCreateFlags wires every hosting_packages entitlement onto the
+// create command. Every field of the REST create request has a flag here — the
+// JAB-306 AC3 parity guarantee ("new entitlement fields cannot be omitted by one
+// adapter"), enforced by TestPackageCLI_EntitlementFlagParity.
+func registerPackageCreateFlags(cmd *cobra.Command, f *packageCreateFlags) {
+	fl := cmd.Flags()
+	fl.StringVar(&f.name, "name", "", "package name (required)")
+	fl.Uint32Var(&f.diskMB, "disk-mb", 0, "disk quota in MB (0=unlimited)")
+	fl.Uint32Var(&f.bwMB, "bw-mb", 0, "bandwidth quota in MB (0=unlimited)")
+	fl.Uint32Var(&f.domains, "domains", 0, "max domains (0=unlimited)")
+	fl.Uint32Var(&f.emails, "emails", 0, "max email accounts (0=unlimited)")
+	fl.Uint32Var(&f.databases, "databases", 0, "max databases (0=unlimited)")
+	fl.Uint32Var(&f.cpuPercent, "cpu", 0, "CPU quota percent across all cores (0=unlimited)")
+	fl.Uint32Var(&f.memoryMB, "memory-mb", 0, "memory limit in MB (0=unlimited)")
+	fl.Uint32Var(&f.ioReadMbps, "io-read-mbps", 0, "disk read bandwidth limit in MB/s (0=unlimited)")
+	fl.Uint32Var(&f.ioWriteMbps, "io-write-mbps", 0, "disk write bandwidth limit in MB/s (0=unlimited)")
+	fl.Uint32Var(&f.maxTasks, "max-tasks", 0, "max processes/threads per user slice (0=unlimited)")
+	fl.Uint32Var(&f.maxDBUsers, "max-db-users", 0, "max database users (0=unlimited)")
+	fl.Uint32Var(&f.maxDockerApps, "max-docker-apps", 0, "max tenant docker apps (0=docker apps not included)")
+	fl.Uint32Var(&f.maxPythonApps, "max-python-apps", 0, "max tenant python apps (0=python apps not included)")
+	fl.Uint32Var(&f.maxFTP, "max-ftp-accounts", 0, "max tenant FTP/SFTP subaccounts (0=feature not included)")
+	fl.Uint32Var(&f.maxBackups, "max-backups", 0, "tenant backup retention cap (0=backups not included)")
+	fl.Uint32Var(&f.maxBackupSchedules, "max-backup-schedules", 0, "max tenant scheduled backups (0=default 1)")
+	fl.BoolVar(&f.scheduledBackups, "scheduled-backups", false, "allow tenant scheduled backups")
+	fl.StringVar(&f.backupKinds, "backup-kinds", "", "CSV of allowed backup destination kinds (empty=none)")
+	fl.StringVar(&f.backupRetention, "backup-retention", "", "retention policy at the cap: reject or prune (empty=reject)")
+	fl.BoolVar(&f.sshEnabled, "ssh", false, "enable SSH access")
+	fl.BoolVar(&f.cgiEnabled, "cgi", false, "enable CGI")
+	fl.BoolVar(&f.phpExec, "php-exec", false, "opt out of the PHP command-exec lockdown (exec/proc_open work)")
+	fl.Uint32Var(&f.fpmMaxChildren, "fpm-max-children", 0, "FPM pm.max_children cap (0=default 20)")
+	fl.Uint32Var(&f.fpmWorkerMemMB, "fpm-worker-mem-mb", 0, "FPM advisory per-worker memory budget in MB (0=default 64)")
+	fl.BoolVar(&f.fpmUserCanEdit, "fpm-user-can-edit", false, "let tenants pick an FPM performance mode")
+	fl.BoolVar(&f.fpmAdvanced, "fpm-advanced", false, "unlock tenant advanced FPM knobs (implies --fpm-user-can-edit)")
+	fl.StringVar(&f.fpmVersionDefaults, "fpm-version-defaults", "", `JSON map of per-version FPM defaults (empty={})`)
+	fl.StringVar(&f.dockerAppSlugs, "docker-app-slugs", "", "CSV allowlist of catalog slugs tenants may install (empty=server default)")
+	fl.StringVar(&f.nspawnImage, "nspawn-image", "", "pin users to an nspawn rootfs version (empty=server default)")
+}
+
+// packageEditFlags mirrors packageCreateFlags for the edit command. The six
+// boolean entitlements are tri-state strings ("" leave unchanged, "true",
+// "false") so an edit only touches a toggle the operator names — the same
+// convention the original --ssh/--cgi edit flags use.
+type packageEditFlags struct {
+	name string
+
+	diskMB, bwMB, domains, emails, databases      uint32
+	cpuPercent, memoryMB, ioReadMbps, ioWriteMbps uint32
+	maxTasks                                      uint32
+
+	maxDBUsers, maxDockerApps, maxPythonApps, maxFTP uint32
+
+	maxBackups, maxBackupSchedules uint32
+	backupKinds, backupRetention   string
+
+	fpmMaxChildren, fpmWorkerMemMB                  uint32
+	fpmVersionDefaults, dockerAppSlugs, nspawnImage string
+
+	// tri-state toggles.
+	sshEnabled, cgiEnabled, phpExec               string
+	scheduledBackups, fpmUserCanEdit, fpmAdvanced string
+}
+
+// applyPackageEditFlags applies the named edit flags onto a loaded row and
+// reports whether anything changed. `changed` is cmd.Flags().Changed (passed in
+// so the builder is a pure function testable without cobra plumbing). Every
+// per-field copy is gated on the operator naming that flag, mirroring the REST
+// update handler (internal/api/packages.go:296-419) — an omitted flag never
+// heals an untouched field. Backup-kinds normalisation, retention defaulting,
+// nspawn clear-on-empty and the unconditional advanced→can-edit implication all
+// match the REST update path. packageops.Validate is the shared final gate the
+// caller runs afterwards.
+func applyPackageEditFlags(changed func(string) bool, p *models.HostingPackage, f packageEditFlags) (bool, error) {
+	dirty := false
+	u32 := func(flag string, dst *uint32, v uint32) {
+		if changed(flag) {
+			*dst = v
+			dirty = true
+		}
+	}
+	str := func(flag string, dst *string, v string) {
+		if changed(flag) {
+			*dst = v
+			dirty = true
+		}
+	}
+	var triErr error
+	tri := func(flag string, dst *bool, v string) {
+		switch v {
+		case "":
+			// unset — leave the toggle unchanged.
+		case "true":
+			*dst = true
+			dirty = true
+		case "false":
+			*dst = false
+			dirty = true
+		default:
+			// Fail loud on a garbage value ("--php-exec=yes") instead of silently
+			// ignoring it — a silently-dropped security toggle is exactly the
+			// reported-success-that-does-nothing trap (feedback_silent_exit0_failures).
+			if triErr == nil {
+				triErr = fmt.Errorf("--%s: want true or false, got %q", flag, v)
+			}
+		}
+	}
+
+	str("name", &p.Name, f.name)
+	u32("disk-mb", &p.DiskQuotaMB, f.diskMB)
+	u32("bw-mb", &p.BandwidthQuotaMB, f.bwMB)
+	u32("domains", &p.MaxDomains, f.domains)
+	u32("emails", &p.MaxEmailAccounts, f.emails)
+	u32("databases", &p.MaxDatabases, f.databases)
+	u32("cpu", &p.CPUQuotaPercent, f.cpuPercent)
+	u32("memory-mb", &p.MemoryLimitMB, f.memoryMB)
+	u32("io-read-mbps", &p.IOReadMbps, f.ioReadMbps)
+	u32("io-write-mbps", &p.IOWriteMbps, f.ioWriteMbps)
+	u32("max-tasks", &p.MaxTasks, f.maxTasks)
+	u32("max-db-users", &p.MaxDatabaseUsers, f.maxDBUsers)
+	u32("max-docker-apps", &p.MaxDockerApps, f.maxDockerApps)
+	u32("max-python-apps", &p.MaxPythonApps, f.maxPythonApps)
+	u32("max-ftp-accounts", &p.MaxFTPAccounts, f.maxFTP)
+	u32("max-backups", &p.MaxBackups, f.maxBackups)
+	u32("max-backup-schedules", &p.MaxBackupSchedules, f.maxBackupSchedules)
+	u32("fpm-max-children", &p.FpmMaxChildrenCap, f.fpmMaxChildren)
+	u32("fpm-worker-mem-mb", &p.FpmWorkerMemMb, f.fpmWorkerMemMB)
+	str("fpm-version-defaults", &p.FpmVersionDefaults, f.fpmVersionDefaults)
+	str("docker-app-slugs", &p.DockerAppSlugs, f.dockerAppSlugs)
+
+	tri("ssh", &p.SSHEnabled, f.sshEnabled)
+	tri("cgi", &p.CGIEnabled, f.cgiEnabled)
+	tri("php-exec", &p.PHPExecEnabled, f.phpExec)
+	tri("scheduled-backups", &p.ScheduledBackupsEnabled, f.scheduledBackups)
+	tri("fpm-user-can-edit", &p.FpmUserCanEdit, f.fpmUserCanEdit)
+	tri("fpm-advanced", &p.FpmAdvancedMode, f.fpmAdvanced)
+	if triErr != nil {
+		return false, triErr
+	}
+
+	if changed("backup-kinds") {
+		nk, err := models.NormalizeBackupKindsCSV(f.backupKinds)
+		if err != nil {
+			return false, fmt.Errorf("invalid backup kinds: %w", err)
+		}
+		p.AllowedBackupDestinationKinds = nk
+		dirty = true
+	}
+	if changed("backup-retention") {
+		v := f.backupRetention
+		if v == "" {
+			v = models.BackupRetentionReject
+		}
+		p.BackupRetentionPolicy = v
+		dirty = true
+	}
+	if changed("nspawn-image") {
+		if v := strings.TrimSpace(f.nspawnImage); v == "" {
+			p.NspawnImageVersion = nil // empty clears the pin (server default)
+		} else {
+			p.NspawnImageVersion = &v
+		}
+		dirty = true
+	}
+	// Advanced implies can-edit — unconditional, matching packages.go:399.
+	if p.FpmAdvancedMode {
+		p.FpmUserCanEdit = true
+	}
+	return dirty, nil
+}
+
 func newPackageEditCmd() *cobra.Command {
-	var (
-		name        string
-		diskMB      uint32
-		bwMB        uint32
-		domains     uint32
-		emails      uint32
-		databases   uint32
-		cpuPercent  uint32
-		memoryMB    uint32
-		ioReadMbps  uint32
-		ioWriteMbps uint32
-		maxTasks    uint32
-		sshEnabled  string
-		cgiEnabled  string
-	)
+	var f packageEditFlags
 
 	cmd := &cobra.Command{
 		Use:   "edit <package-id>",
@@ -199,71 +419,16 @@ func newPackageEditCmd() *cobra.Command {
 				return err
 			}
 
-			changed := false
-			if cmd.Flags().Changed("name") {
-				p.Name = name
-				changed = true
+			didChange, err := applyPackageEditFlags(cmd.Flags().Changed, p, f)
+			if err != nil {
+				return err
 			}
-			if cmd.Flags().Changed("disk-mb") {
-				p.DiskQuotaMB = diskMB
-				changed = true
-			}
-			if cmd.Flags().Changed("bw-mb") {
-				p.BandwidthQuotaMB = bwMB
-				changed = true
-			}
-			if cmd.Flags().Changed("domains") {
-				p.MaxDomains = domains
-				changed = true
-			}
-			if cmd.Flags().Changed("emails") {
-				p.MaxEmailAccounts = emails
-				changed = true
-			}
-			if cmd.Flags().Changed("databases") {
-				p.MaxDatabases = databases
-				changed = true
-			}
-			if cmd.Flags().Changed("cpu") {
-				p.CPUQuotaPercent = cpuPercent
-				changed = true
-			}
-			if cmd.Flags().Changed("memory-mb") {
-				p.MemoryLimitMB = memoryMB
-				changed = true
-			}
-			if cmd.Flags().Changed("io-read-mbps") {
-				p.IOReadMbps = ioReadMbps
-				changed = true
-			}
-			if cmd.Flags().Changed("io-write-mbps") {
-				p.IOWriteMbps = ioWriteMbps
-				changed = true
-			}
-			if cmd.Flags().Changed("max-tasks") {
-				p.MaxTasks = maxTasks
-				changed = true
-			}
-			if sshEnabled == "true" {
-				p.SSHEnabled = true
-				changed = true
-			} else if sshEnabled == "false" {
-				p.SSHEnabled = false
-				changed = true
-			}
-			if cgiEnabled == "true" {
-				p.CGIEnabled = true
-				changed = true
-			} else if cgiEnabled == "false" {
-				p.CGIEnabled = false
-				changed = true
-			}
-			if !changed {
+			if !didChange {
 				return fmt.Errorf("no changes specified")
 			}
 			p.UpdatedAt = time.Now().UTC()
 			// JAB-306: same invariant gate as create + the REST handler, so an
-			// edit can't drive a limit out of the bounds the API enforces. The
+			// edit can't drive a value out of the bounds the API enforces. The
 			// loaded row already carries valid FPM/backup values, so this only
 			// rejects an operator's out-of-range edit — never "heals" untouched
 			// fields.
@@ -282,20 +447,47 @@ func newPackageEditCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", "package name")
-	cmd.Flags().Uint32Var(&diskMB, "disk-mb", 0, "disk quota MB")
-	cmd.Flags().Uint32Var(&bwMB, "bw-mb", 0, "bandwidth MB")
-	cmd.Flags().Uint32Var(&domains, "domains", 0, "max domains")
-	cmd.Flags().Uint32Var(&emails, "emails", 0, "max emails")
-	cmd.Flags().Uint32Var(&databases, "databases", 0, "max databases")
-	cmd.Flags().Uint32Var(&cpuPercent, "cpu", 0, "CPU quota percent")
-	cmd.Flags().Uint32Var(&memoryMB, "memory-mb", 0, "memory limit MB")
-	cmd.Flags().Uint32Var(&ioReadMbps, "io-read-mbps", 0, "io read MB/s")
-	cmd.Flags().Uint32Var(&ioWriteMbps, "io-write-mbps", 0, "io write MB/s")
-	cmd.Flags().Uint32Var(&maxTasks, "max-tasks", 0, "max processes/threads")
-	cmd.Flags().StringVar(&sshEnabled, "ssh", "", "SSH access (true/false)")
-	cmd.Flags().StringVar(&cgiEnabled, "cgi", "", "CGI access (true/false)")
+	registerPackageEditFlags(cmd, &f)
 	return cmd
+}
+
+// registerPackageEditFlags wires the entitlement flags onto the edit command.
+// The uint32/string flags share the create names; the six boolean toggles are
+// tri-state strings (true/false) so an edit only flips a toggle the operator
+// names. Parity with the REST update request is enforced by
+// TestPackageCLI_EntitlementFlagParity.
+func registerPackageEditFlags(cmd *cobra.Command, f *packageEditFlags) {
+	fl := cmd.Flags()
+	fl.StringVar(&f.name, "name", "", "package name")
+	fl.Uint32Var(&f.diskMB, "disk-mb", 0, "disk quota MB")
+	fl.Uint32Var(&f.bwMB, "bw-mb", 0, "bandwidth MB")
+	fl.Uint32Var(&f.domains, "domains", 0, "max domains")
+	fl.Uint32Var(&f.emails, "emails", 0, "max emails")
+	fl.Uint32Var(&f.databases, "databases", 0, "max databases")
+	fl.Uint32Var(&f.cpuPercent, "cpu", 0, "CPU quota percent")
+	fl.Uint32Var(&f.memoryMB, "memory-mb", 0, "memory limit MB")
+	fl.Uint32Var(&f.ioReadMbps, "io-read-mbps", 0, "io read MB/s")
+	fl.Uint32Var(&f.ioWriteMbps, "io-write-mbps", 0, "io write MB/s")
+	fl.Uint32Var(&f.maxTasks, "max-tasks", 0, "max processes/threads")
+	fl.Uint32Var(&f.maxDBUsers, "max-db-users", 0, "max database users")
+	fl.Uint32Var(&f.maxDockerApps, "max-docker-apps", 0, "max tenant docker apps")
+	fl.Uint32Var(&f.maxPythonApps, "max-python-apps", 0, "max tenant python apps")
+	fl.Uint32Var(&f.maxFTP, "max-ftp-accounts", 0, "max tenant FTP/SFTP subaccounts")
+	fl.Uint32Var(&f.maxBackups, "max-backups", 0, "tenant backup retention cap")
+	fl.Uint32Var(&f.maxBackupSchedules, "max-backup-schedules", 0, "max tenant scheduled backups")
+	fl.StringVar(&f.backupKinds, "backup-kinds", "", "CSV of allowed backup destination kinds")
+	fl.StringVar(&f.backupRetention, "backup-retention", "", "retention policy at the cap: reject or prune")
+	fl.Uint32Var(&f.fpmMaxChildren, "fpm-max-children", 0, "FPM pm.max_children cap")
+	fl.Uint32Var(&f.fpmWorkerMemMB, "fpm-worker-mem-mb", 0, "FPM advisory per-worker memory budget MB")
+	fl.StringVar(&f.fpmVersionDefaults, "fpm-version-defaults", "", "JSON map of per-version FPM defaults")
+	fl.StringVar(&f.dockerAppSlugs, "docker-app-slugs", "", "CSV allowlist of catalog slugs tenants may install")
+	fl.StringVar(&f.nspawnImage, "nspawn-image", "", "pin users to an nspawn rootfs version (empty clears the pin)")
+	fl.StringVar(&f.sshEnabled, "ssh", "", "SSH access (true/false)")
+	fl.StringVar(&f.cgiEnabled, "cgi", "", "CGI access (true/false)")
+	fl.StringVar(&f.phpExec, "php-exec", "", "PHP command-exec opt-out (true/false)")
+	fl.StringVar(&f.scheduledBackups, "scheduled-backups", "", "tenant scheduled backups (true/false)")
+	fl.StringVar(&f.fpmUserCanEdit, "fpm-user-can-edit", "", "tenant FPM performance mode (true/false)")
+	fl.StringVar(&f.fpmAdvanced, "fpm-advanced", "", "tenant advanced FPM knobs (true/false, true implies fpm-user-can-edit)")
 }
 
 func newPackageDeleteCmd() *cobra.Command {

--- a/panel-api/cmd/server/package_cmd_flags_test.go
+++ b/panel-api/cmd/server/package_cmd_flags_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/packageops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/phppoolops"
+)
+
+// packageFieldFlag maps each operator-editable hosting_packages field (by its
+// json tag — the wire name the REST create/update request uses) to the CLI flag
+// that sets it. This is the concrete form of JAB-306 AC3 ("new entitlement
+// fields cannot be omitted by one adapter"): the parity test below requires
+// every editable model field to appear here AND every flag to be registered on
+// both `package create` and `package edit`.
+var packageFieldFlag = map[string]string{
+	"name":                             "name",
+	"disk_quota_mb":                    "disk-mb",
+	"cpu_quota_percent":                "cpu",
+	"memory_limit_mb":                  "memory-mb",
+	"io_read_mbps":                     "io-read-mbps",
+	"io_write_mbps":                    "io-write-mbps",
+	"max_tasks":                        "max-tasks",
+	"bandwidth_quota_mb":               "bw-mb",
+	"max_domains":                      "domains",
+	"max_email_accounts":               "emails",
+	"max_databases":                    "databases",
+	"max_database_users":               "max-db-users",
+	"max_docker_apps":                  "max-docker-apps",
+	"max_python_apps":                  "max-python-apps",
+	"max_ftp_accounts":                 "max-ftp-accounts",
+	"max_backups":                      "max-backups",
+	"scheduled_backups_enabled":        "scheduled-backups",
+	"max_backup_schedules":             "max-backup-schedules",
+	"allowed_backup_destination_kinds": "backup-kinds",
+	"backup_retention_policy":          "backup-retention",
+	"ssh_enabled":                      "ssh",
+	"cgi_enabled":                      "cgi",
+	"php_exec_enabled":                 "php-exec",
+	"fpm_max_children_cap":             "fpm-max-children",
+	"fpm_worker_mem_mb":                "fpm-worker-mem-mb",
+	"fpm_user_can_edit":                "fpm-user-can-edit",
+	"fpm_advanced_mode":                "fpm-advanced",
+	"fpm_version_defaults":             "fpm-version-defaults",
+	"docker_app_slugs":                 "docker-app-slugs",
+	"nspawn_image_version":             "nspawn-image",
+}
+
+// packageNonEditableJSON are hosting_packages columns that are identity /
+// bookkeeping, not operator-editable entitlements — they legitimately have no
+// CLI flag.
+var packageNonEditableJSON = map[string]bool{
+	"id":         true,
+	"created_at": true,
+	"updated_at": true,
+}
+
+// TestPackageCLI_EntitlementFlagParity is the AC3 guarantee: the operator CLI
+// exposes every hosting_packages entitlement the REST adapter does, so a field
+// can never be set through one adapter but silently defaulted through the other.
+// It is grounded in the model struct (the source of truth), so a new column
+// added without a matching create/edit flag fails here.
+func TestPackageCLI_EntitlementFlagParity(t *testing.T) {
+	// 1. Every editable model field maps to a flag (catches a new column with no
+	//    CLI flag mapping).
+	rt := reflect.TypeOf(models.HostingPackage{})
+	for i := 0; i < rt.NumField(); i++ {
+		tag := strings.Split(rt.Field(i).Tag.Get("json"), ",")[0]
+		if tag == "" || tag == "-" || packageNonEditableJSON[tag] {
+			continue
+		}
+		if _, ok := packageFieldFlag[tag]; !ok {
+			t.Errorf("hosting_packages.%s has no CLI flag — add one to package create/edit (JAB-306 AC3), or mark it non-editable", tag)
+		}
+	}
+
+	// 2. Every mapped flag is registered on BOTH create and edit (catches a
+	//    dropped flag registration in either adapter).
+	create := newPackageCreateCmd()
+	edit := newPackageEditCmd()
+	for tag, flag := range packageFieldFlag {
+		if create.Flags().Lookup(flag) == nil {
+			t.Errorf("create: field %q → --%s not registered", tag, flag)
+		}
+		if edit.Flags().Lookup(flag) == nil {
+			t.Errorf("edit: field %q → --%s not registered", tag, flag)
+		}
+	}
+}
+
+// --- create builder transforms (mirror internal/api/packages.go create) ---
+
+func TestBuildPackageFromCreateFlags_AppliesFpmAndRetentionDefaults(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x"})
+	require.NoError(t, err)
+	require.Equal(t, uint32(20), p.FpmMaxChildrenCap, "unset FPM cap defaults to 20")
+	require.Equal(t, uint32(64), p.FpmWorkerMemMb, "unset FPM worker mem defaults to 64")
+	require.Equal(t, "{}", p.FpmVersionDefaults, "unset FPM version defaults to {}")
+	require.Equal(t, models.BackupRetentionReject, p.BackupRetentionPolicy, "unset retention defaults to reject")
+	require.Nil(t, p.NspawnImageVersion, "unset nspawn image stays NULL (server default)")
+}
+
+func TestBuildPackageFromCreateFlags_AdvancedImpliesCanEdit(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", fpmAdvanced: true})
+	require.NoError(t, err)
+	require.True(t, p.FpmUserCanEdit, "--fpm-advanced must imply --fpm-user-can-edit")
+}
+
+func TestBuildPackageFromCreateFlags_NormalizesBackupKinds(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", backupKinds: " s3 , S3 , local "})
+	require.NoError(t, err)
+	require.Equal(t, "s3,local", p.AllowedBackupDestinationKinds, "kinds are lower-cased, trimmed, deduped, order-preserving")
+}
+
+func TestBuildPackageFromCreateFlags_PinsNspawnImage(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", nspawnImage: "  debian-12  "})
+	require.NoError(t, err)
+	require.NotNil(t, p.NspawnImageVersion)
+	require.Equal(t, "debian-12", *p.NspawnImageVersion, "nspawn image is trimmed and pinned")
+}
+
+// The four Validate branches the prior slice noted were "not settable from CLI
+// today" are now reachable from live CLI input — prove each rejects.
+
+func TestBuildPackageFromCreateFlags_ValidateRejectsFpmCapOverMax(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", fpmMaxChildren: phppoolops.AdminMaxChildrenCap + 1})
+	require.NoError(t, err)
+	require.ErrorIs(t, packageops.Validate(p), packageops.ErrFpmCapTooHigh)
+}
+
+func TestBuildPackageFromCreateFlags_RejectsUnknownBackupKind(t *testing.T) {
+	_, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", backupKinds: "not-a-real-kind"})
+	require.Error(t, err, "an unknown backup kind is rejected at build time")
+}
+
+func TestBuildPackageFromCreateFlags_ValidateRejectsBadRetention(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", backupRetention: "delete-everything"})
+	require.NoError(t, err)
+	require.ErrorIs(t, packageops.Validate(p), packageops.ErrInvalidBackupRetentionPolicy)
+}
+
+func TestBuildPackageFromCreateFlags_ValidateRejectsBadNspawn(t *testing.T) {
+	p, err := buildPackageFromCreateFlags(packageCreateFlags{name: "x", nspawnImage: "Bad/Image!"})
+	require.NoError(t, err)
+	require.ErrorIs(t, packageops.Validate(p), packageops.ErrInvalidNspawnImage)
+}
+
+// --- edit builder transforms (mirror internal/api/packages.go update) ---
+
+// changedSet returns a cmd.Flags().Changed stand-in that reports the named flags
+// as set — lets us drive applyPackageEditFlags without cobra/DB plumbing.
+func changedSet(flags ...string) func(string) bool {
+	set := map[string]bool{}
+	for _, f := range flags {
+		set[f] = true
+	}
+	return func(s string) bool { return set[s] }
+}
+
+func TestApplyPackageEditFlags_OnlyNamedFieldsChange(t *testing.T) {
+	// A field the operator did not name must never be healed — the trap the
+	// per-field gating exists to avoid.
+	p := &models.HostingPackage{MaxDomains: 5, BackupRetentionPolicy: "prune"}
+	changed, err := applyPackageEditFlags(changedSet("disk-mb"), p, packageEditFlags{diskMB: 100})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, uint32(100), p.DiskQuotaMB)
+	require.Equal(t, uint32(5), p.MaxDomains, "unnamed field must not change")
+	require.Equal(t, "prune", p.BackupRetentionPolicy, "unnamed retention must not be healed to reject")
+}
+
+func TestApplyPackageEditFlags_NoFlagsIsNoChange(t *testing.T) {
+	p := &models.HostingPackage{}
+	changed, err := applyPackageEditFlags(changedSet(), p, packageEditFlags{})
+	require.NoError(t, err)
+	require.False(t, changed, "no flags named ⇒ no change")
+}
+
+func TestApplyPackageEditFlags_AdvancedImpliesCanEdit(t *testing.T) {
+	p := &models.HostingPackage{FpmUserCanEdit: false}
+	changed, err := applyPackageEditFlags(changedSet(), p, packageEditFlags{fpmAdvanced: "true"})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.True(t, p.FpmAdvancedMode)
+	require.True(t, p.FpmUserCanEdit, "--fpm-advanced=true implies can-edit on edit too")
+}
+
+func TestApplyPackageEditFlags_NspawnEmptyClearsPin(t *testing.T) {
+	v := "debian-12"
+	p := &models.HostingPackage{NspawnImageVersion: &v}
+	changed, err := applyPackageEditFlags(changedSet("nspawn-image"), p, packageEditFlags{nspawnImage: ""})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Nil(t, p.NspawnImageVersion, "empty --nspawn-image clears the pin (back to server default)")
+}
+
+func TestApplyPackageEditFlags_NormalizesBackupKinds(t *testing.T) {
+	p := &models.HostingPackage{}
+	changed, err := applyPackageEditFlags(changedSet("backup-kinds"), p, packageEditFlags{backupKinds: " GCS , gcs , b2 "})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "gcs,b2", p.AllowedBackupDestinationKinds)
+}
+
+func TestApplyPackageEditFlags_RejectsUnknownBackupKind(t *testing.T) {
+	p := &models.HostingPackage{}
+	_, err := applyPackageEditFlags(changedSet("backup-kinds"), p, packageEditFlags{backupKinds: "nope"})
+	require.Error(t, err)
+}
+
+func TestApplyPackageEditFlags_TriStateFalseClearsToggle(t *testing.T) {
+	p := &models.HostingPackage{SSHEnabled: true}
+	changed, err := applyPackageEditFlags(changedSet(), p, packageEditFlags{sshEnabled: "false"})
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, p.SSHEnabled, "--ssh=false disables")
+}
+
+func TestApplyPackageEditFlags_TriStateGarbageIsError(t *testing.T) {
+	// A garbage toggle value fails loud instead of silently no-opping a security
+	// toggle (php-exec here) — and nothing is persisted.
+	p := &models.HostingPackage{PHPExecEnabled: false}
+	changed, err := applyPackageEditFlags(changedSet(), p, packageEditFlags{phpExec: "yes"})
+	require.Error(t, err)
+	require.False(t, changed)
+	require.False(t, p.PHPExecEnabled, "row untouched on a bad toggle value")
+}


### PR DESCRIPTION
## What

The REST package create/update request carries the complete `hosting_packages` entitlement set, but the operator CLI (`jabali package create|edit`) persisted only the older resource-limit subset (disk/bw/domains/emails/dbs/cpu/memory/io/tasks + ssh/cgi). Every other entitlement — database-user/FTP/docker/python caps, the tenant backup limits, the PHP exec opt-out, the FPM performance-tier policy, the docker-app allowlist and the nspawn image pin — could **not** be set from the CLI at all; it fell to the GORM column defaults and could only be changed through the REST API.

For an operator: the CLI can now set every hosting-package entitlement the admin UI can — backup limits, FPM policy, PHP exec, docker/python/FTP caps, nspawn pin.

This is **JAB-306 AC3** ("new entitlement fields cannot be omitted by one adapter") plus the **AC1** identical-rows guarantee for the newly exposed fields.

## How

A flag for every remaining entitlement on both `create` and `edit`, with the REST handler's create-defaulting / update-normalisation mirrored so equivalent inputs persist the identical row:

- **Create** applies the same defaults the REST create handler does, explicitly rather than leaning on the GORM `default:` tags (so identical-rows is provable by reading the two blocks side by side): FPM cap `0→20`, worker mem `0→64`, version-defaults `""→"{}"`, `fpm_advanced` implies `fpm_user_can_edit`, backup kinds canonicalised (lower/trim/dedup, order-preserving), retention `""→reject`, nspawn image trimmed + pinned (empty → server default).
- **Edit** gates every field on the operator naming that flag (mirroring the REST update handler) so an omitted flag never heals an untouched field — except the `advanced→can-edit` implication, which is unconditional by design (REST `packages.go:399`). The six boolean toggles use the existing tri-state string convention (`""`/`"true"`/`"false"`) the original `--ssh`/`--cgi` edit flags use — now with a **loud error** on a garbage value (`--php-exec=yes`) instead of the pre-existing silent ignore (a silently-dropped security toggle is the reported-success-that-does-nothing trap). An empty `--nspawn-image` clears the pin.

`packageops.Validate` is unchanged and remains the shared final gate both paths run before the repository write — but four of its branches (FPM cap over the admin ceiling, bad retention policy, unknown backup kind, malformed nspawn image) were previously unreachable from the CLI because it had no flags for those fields. They are now reachable from live CLI input, and each is covered.

Edit persists via the package repo's `Update` Select allowlist, which already lists all 17 newly exposed columns (verified in this checkout, `package_repository.go:106-126`) — no silent-drop.

The `create`/`edit` RunE bodies are refactored around two pure builders (`buildPackageFromCreateFlags`, `applyPackageEditFlags`) so the row build is a function of the flag values, testable without a live DB.

## Scope boundary

This is AC3 + AC1 for the exposed fields. The REST update handler additionally fans out an SSH reconcile / PHP-pool reapply to every user on the package when `ssh_enabled` or `php_exec_enabled` flips (`packages.go:442-450`); the CLI edit does not, leaning on the 60s reconciler sweep. That asymmetry is **AC4** ("SSH/PHP changes fan out exactly once after persistence") and remains a later slice — the parent JAB-306 stays open.

## Tests (`package_cmd_flags_test.go`)

- **`TestPackageCLI_EntitlementFlagParity`** — the AC3 guarantee, grounded in the model struct (the REST request struct is unexported): every editable `hosting_packages` json field must map to a flag registered on **both** create and edit. A new column with no flag, or a dropped flag registration, fails here (both falsified RED).
- Create-builder transforms: FPM/retention defaults, `advanced→can-edit` (falsified RED), backup-kind canonicalisation, nspawn pin, and the four `Validate` branches now reachable from CLI input each reject.
- Edit-builder transforms: only-named-fields-change (the per-field gating, falsified RED), no-op when nothing named, `advanced→can-edit` on edit, nspawn clear-on-empty, backup-kind normalise + reject, tri-state false, and a garbage toggle value errors without persisting (falsified RED).
- The existing `Validate`-before-Create/Update source-pin still passes after the builder extraction.
- `docs/site/platform/cli-reference.md` regenerated (golden reflects the new flags on package create/edit).

`go build ./...`, `go vet` and `go test -race ./cmd/server` are clean, rebased on latest `main`. Direct-DB write, no agent/reconciler/fleet surface — no live box verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
