### PR TITLE
feat(domains): rename a web domain in place (experimental)

### DIFF
--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -48,6 +48,14 @@ func (m *mockDomainRepo) Update(ctx context.Context, d *models.Domain) error {
 	return nil
 }
 
+func (m *mockDomainRepo) Rename(_ context.Context, id, newName, newDocRoot string) error {
+	if d, ok := m.domains[id]; ok {
+		d.Name = newName
+		d.DocRoot = newDocRoot
+	}
+	return nil
+}
+
 func (m *mockDomainRepo) BulkSetEnabledByUserID(_ context.Context, _ string, _ bool) (int64, error) {
 	return 0, nil
 }

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -38,9 +38,14 @@ type DomainHandlerConfig struct {
 	Users           repository.UserRepository
 	SSLCerts        repository.SSLCertificateRepository
 	SharedCerts     repository.SharedCertificateRepository
-	Packages        repository.PackageRepository
-	Agent           agent.AgentInterface
-	Reconciler      *reconciler.Reconciler
+	// Mailboxes arms the GH #1579 rename's fail-closed mailbox gate: a rename
+	// runs the old name's durable teardown, whose first step purges every
+	// Stalwart account on the domain. REQUIRED for the rename route — nil makes
+	// the handler refuse (503) rather than risk purging retained mailboxes.
+	Mailboxes  repository.MailboxRepository
+	Packages   repository.PackageRepository
+	Agent      agent.AgentInterface
+	Reconciler *reconciler.Reconciler
 	// PortAllocations (GH #1175): shared loopback-port pool for reverse-proxy domains.
 	PortAllocations repository.PortAllocationRepository
 	// DNSZones + DNSRecords feed the auto-enable-email path on create.
@@ -99,6 +104,9 @@ func RegisterDomainRoutes(g *gin.RouterGroup, cfg DomainHandlerConfig) {
 	domains.PATCH("/:id", h.update)
 	domains.DELETE("/:id", h.delete)
 	domains.GET("/:id/bandwidth", h.bandwidth)
+	// GH #1579: rename a domain in place (owner-scoped; admin or the domain's
+	// own tenant). Experimental phase 1 — web-only, mail must be off.
+	domains.POST("/:id/rename", h.rename)
 
 	// GH #1238: reassign a domain to a new tenant (move + re-own the docroot,
 	// repoint the DB row). Admin-only AND behind the JAB-380 recent-auth

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+type renameDomainRequest struct {
+	Name string `json:"name" binding:"required"`
+}
+
+// rename renames an existing domain in place (GH #1579). Owner-scoped: a tenant
+// may rename their own domain, an admin any. Experimental phase 1 — web-only,
+// mail must be off, and the app's own internal config (e.g. a WordPress
+// siteurl) is NOT rewritten; the UI warns about that. The heavy lifting (gate,
+// tombstone the old name, rename the row, move + re-own the docroot, re-render)
+// lives in the shared userops.RenameDomain so any future CLI reuses it.
+func (h *domainHandler) rename(c *gin.Context) {
+	ctx := c.Request.Context()
+	domain, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+	if !claims.IsAdmin && domain.UserID != claims.UserID {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	var req renameDomainRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	// Same normalize + RFC-shape validation the create source of truth runs, so
+	// a rename can never produce a name create would have rejected.
+	newName := normalizeDomainName(req.Name)
+	if verr := validateDomainName(newName); verr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_name", "message": verr.Error()})
+		return
+	}
+
+	// *reconciler.Reconciler satisfies RenameReconciler, but pass it as a truly
+	// nil interface when unwired so RenameDomain's nil check holds (a typed-nil
+	// pointer in an interface is not == nil).
+	var rec userops.RenameReconciler
+	if h.cfg.Reconciler != nil {
+		rec = h.cfg.Reconciler
+	}
+
+	if err := userops.RenameDomain(ctx, userops.Deps{
+		Domains:         h.cfg.Domains,
+		DomainTeardowns: h.cfg.DomainTeardowns,
+		Users:           h.cfg.Users,
+		Agent:           h.cfg.Agent,
+		// Mailboxes arms the fail-closed mailbox gate (a rename would purge
+		// retained Stalwart accounts on the old name). DNSZones + SSLCerts let
+		// the rename re-key the zone + reissue the cert for the new name.
+		Mailboxes: h.cfg.Mailboxes,
+		DNSZones:  h.cfg.DNSZones,
+		SSLCerts:  h.cfg.SSLCerts,
+		Log:       slog.Default(),
+	}, rec, domain, newName); err != nil {
+		var re *userops.RenameError
+		if errors.As(err, &re) {
+			c.JSON(renameHTTPStatus(re.Code), gin.H{"error": re.Code, "message": re.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"id": domain.ID, "name": domain.Name, "doc_root": domain.DocRoot})
+}
+
+// renameHTTPStatus maps a RenameError code to an HTTP status. Gate/validation
+// reasons are 4xx; an infrastructure failure while carrying out the rename
+// (moving files, or persisting the row) is 5xx and re-runnable — the file move
+// and the row rename are ordered so a retry finishes cleanly.
+func renameHTTPStatus(code string) int {
+	switch code {
+	case "invalid_name", "noop", "custom_docroot", "ambiguous_docroot":
+		return http.StatusBadRequest
+	case "mail_active", "mailboxes_present", "panel_primary", "web_disabled",
+		"name_taken", "owner_unprovisioned", "owner_unresolved":
+		return http.StatusConflict
+	case "not_found":
+		return http.StatusNotFound
+	case "unavailable":
+		return http.StatusServiceUnavailable
+	default: // persist_failed, move_failed, lookup_failed
+		return http.StatusInternalServerError
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2568,6 +2568,30 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /domains/{id}/rename:
+    post:
+      tags: [Domains]
+      summary: Rename a web domain in place (owner-scoped, experimental, GH #1579)
+      description: |
+        Renames an existing web domain to a new name in place, preserving its
+        domain_id. Moves + re-owns the docroot, renames the DB row, re-keys the
+        DNS zone and forces an SSL reissue for the new name, and tears down the
+        old name's nginx vhost + PowerDNS zone via the durable teardown.
+        Experimental phase 1 — refuses when the domain has any mailbox (mail must
+        be off AND have no retained mailboxes), is the panel's own primary, or
+        has no website. It does NOT rewrite an installed app's internal config
+        (e.g. a WordPress siteurl); the caller updates that in the app.
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { name: { type: string } }, required: [name] } } } }
+      responses:
+        "200": { description: Renamed, content: { application/json: { schema: { type: object, properties: { id: { type: string }, name: { type: string }, doc_root: { type: string } } } } } }
+        "400": { description: Invalid or ambiguous name, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "403": { description: Not the domain owner, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "404": { description: Domain not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "409": { description: Refused — mail/mailboxes present, panel primary, web disabled, or name taken, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "503": { description: Rename not available (mailbox check unwired), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
 
   # --- Branding (auto) ---
 

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -163,6 +163,11 @@ func (m *MockDomainRepository) Update(ctx context.Context, domain *models.Domain
 	return args.Error(0)
 }
 
+func (m *MockDomainRepository) Rename(ctx context.Context, id, newName, newDocRoot string) error {
+	args := m.Called(ctx, id, newName, newDocRoot)
+	return args.Error(0)
+}
+
 func (m *MockDomainRepository) ListByUserID(ctx context.Context, userID string, opts repository.ListOptions) ([]models.Domain, int64, error) {
 	args := m.Called(ctx, userID, opts.Offset, opts.Limit)
 	if args.Get(0) == nil {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -702,6 +702,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Reconciler:      deps.Reconciler,
 				SSLCerts:        deps.SSLCerts,
 				SharedCerts:     deps.SharedCerts,
+				// GH #1579 rename: arms the fail-closed mailbox gate.
+				Mailboxes: deps.Mailboxes,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -128,6 +128,14 @@ func (f *fakeDomainRepo) Update(ctx context.Context, d *models.Domain) error {
 	return nil
 }
 
+func (f *fakeDomainRepo) Rename(_ context.Context, id, newName, newDocRoot string) error {
+	if d, ok := f.domains[id]; ok {
+		d.Name = newName
+		d.DocRoot = newDocRoot
+	}
+	return nil
+}
+
 func (f *fakeDomainRepo) UpdateCacheTTL(_ context.Context, _ string, _ int) error {
 	return nil
 }

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -31,6 +31,13 @@ type DomainRepository interface {
 	// (GH #1238 owner-change). Dedicated method: the Update allowlist excludes
 	// user_id, so a full-model Update would silently drop the transfer.
 	TransferOwner(ctx context.Context, domainID, newUserID, newDocRoot string) error
+	// Rename changes a domain's name and doc_root together (GH #1579 domain
+	// rename). Dedicated setter: the generic Update allowlist includes name, but
+	// a rename must move name + doc_root as a unit and is only ever driven by
+	// userops.RenameDomain (which tears down the old name's artifacts + moves the
+	// files). Keeping it a distinct method means no other edit path can rename a
+	// row without that orchestration.
+	Rename(ctx context.Context, id, newName, newDocRoot string) error
 	// BulkSetEnabledByUserID flips domains.is_enabled for every row
 	// owned by the user. Returns the count of changed rows. Used by
 	// the admin user-suspend handler so a single API call takes every
@@ -595,6 +602,25 @@ func (r *domainRepo) SetSharedCertificate(ctx context.Context, id string, shared
 			"updated_at":            time.Now().UTC(),
 		})
 	if res.Error != nil {
+		return translate(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *domainRepo) Rename(ctx context.Context, id, newName, newDocRoot string) error {
+	updates := map[string]interface{}{
+		"name":       newName,
+		"doc_root":   newDocRoot,
+		"updated_at": time.Now().UTC(),
+	}
+	res := r.db.WithContext(ctx).Model(&models.Domain{}).
+		Where("id = ?", id).
+		Updates(updates)
+	if res.Error != nil {
+		// The unique index on name surfaces a concurrent claim as a conflict.
 		return translate(res.Error)
 	}
 	if res.RowsAffected == 0 {

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -1,0 +1,254 @@
+package userops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// MailboxCounter reports how many mailboxes a domain has. Satisfied by
+// repository.MailboxRepository. RenameDomain uses it as a fail-closed gate: the
+// durable teardown of the OLD name purges every Stalwart account on it, so a
+// rename is refused unless the domain has zero mailboxes.
+type MailboxCounter interface {
+	CountByDomainID(ctx context.Context, domainID string) (int64, error)
+}
+
+// RenameError is a typed gate/orchestration failure so the HTTP handler can map
+// a stable code to a 4xx and any future CLI to a usage error.
+type RenameError struct {
+	Code    string
+	Message string
+}
+
+func (e *RenameError) Error() string { return e.Message }
+
+func renameErr(code, format string, args ...any) *RenameError {
+	return &RenameError{Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+// RenameDomain renames an existing domain in place (GH #1579): it moves the
+// served docroot, re-keys the domain's DNS zone and forces an SSL reissue for
+// the new name, and tears down the OLD name's server artifacts (nginx vhost +
+// old PowerDNS zone, via the durable JAB-236 tombstone the reconciler retries).
+//
+// Phase 1 is deliberately limited to a plain web domain. It refuses when:
+//   - the domain still has any mailbox (see below) or mail is flagged active —
+//     a rename changes every mailbox address, which is a mailbox migration, not
+//     a rename; the durable teardown of the old name would also PURGE those
+//     retained Stalwart accounts (mail-disable is soft), so this gate is
+//     fail-closed: a nil Mailboxes repo refuses too;
+//   - the domain is the panel's own primary domain (self-lockout);
+//   - the domain has no website to move (web disabled / no docroot);
+//   - the owner's Linux account is not provisioned yet;
+//   - the docroot path does not contain the old name exactly once (a custom
+//     docroot needs a manual move).
+//
+// Installed apps are ALLOWED, but their internal configuration (e.g. a
+// WordPress siteurl stored in the app's own database) is NOT rewritten — the
+// caller warns the user. The WordPress reconciler derives its probe path from
+// the domain's current docroot, so the install itself heals to the new path.
+//
+// The name is expected to be pre-normalized + format-validated by the caller
+// (the HTTP handler runs normalizeDomainName + validateDomainName, the same
+// path domain create uses). This function owns the domain-logic gates.
+//
+// Ordering is chosen so the two AUTHORITATIVE mutations (move the files, then
+// rename the row) happen first and every step is idempotent, so a mid-run
+// failure is recoverable by re-running (same shape as ChangeDomainOwner):
+//  1. move the docroot on the box (domain.reown, same owner uid — idempotent);
+//  2. rename the DB row (name + doc_root together) — the point of no return;
+//  3. tombstone the OLD name (safe only now that no live row carries it) so the
+//     reconciler durably tears down the old vhost + old PowerDNS zone;
+//  4. re-key the DNS zone row (name) + reset the SSL cert to pending, so the
+//     reconciler re-pushes the zone and reissues the cert under the NEW name;
+//  5. schedule a prompt re-render of the new name.
+//
+// Steps 3–5 are best-effort heals AFTER the rename is committed: a rare failure
+// there is logged, not surfaced, because the row+files (the source of truth)
+// are already renamed and the periodic reconcile converges the rest.
+func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *models.Domain, newName string) error {
+	if d.Domains == nil || d.Agent == nil || d.Users == nil {
+		return renameErr("unavailable", "rename is not available (domains/users/agent not wired)")
+	}
+	if domain == nil {
+		return renameErr("not_found", "domain not found")
+	}
+
+	oldName := domain.Name
+	oldDocRoot := domain.DocRoot
+	newName = strings.ToLower(strings.TrimSpace(newName))
+
+	// ---- gate ----
+	if newName == "" {
+		return renameErr("invalid_name", "a new domain name is required")
+	}
+	if newName == strings.ToLower(oldName) {
+		return renameErr("noop", "the new name is the same as the current name")
+	}
+	if domain.EmailEnabled {
+		return renameErr("mail_active",
+			"disable mail on %q before renaming — a rename changes every mailbox address and cannot migrate mail", oldName)
+	}
+	// Fail-closed mailbox gate. The old-name teardown's first step
+	// (mail.domain.purge_accounts) destroys every Stalwart account on the
+	// domain, and mail-disable is soft (mailboxes are retained), so
+	// EmailEnabled==false is NOT proof there is no mail to lose. Refuse when the
+	// counter is unwired (can't prove zero) or reports any mailbox.
+	if d.Mailboxes == nil {
+		return renameErr("unavailable", "rename is not available (mailbox check not wired)")
+	}
+	if n, cerr := d.Mailboxes.CountByDomainID(ctx, domain.ID); cerr != nil {
+		return renameErr("unavailable", "could not verify %q has no mailboxes: %v", oldName, cerr)
+	} else if n > 0 {
+		return renameErr("mailboxes_present",
+			"%q still has %d mailbox(es) — delete or migrate them before renaming (a rename would change every mailbox address)", oldName, n)
+	}
+	if domain.IsPanelPrimary {
+		return renameErr("panel_primary", "%q is the panel's own primary domain and cannot be renamed", oldName)
+	}
+	if domain.WebDisabled || oldDocRoot == "" {
+		return renameErr("web_disabled", "%q has no website to rename", oldName)
+	}
+
+	owner, err := d.Users.FindByID(ctx, domain.UserID)
+	if err != nil || owner == nil {
+		return renameErr("owner_unresolved", "could not resolve the owner of %q", oldName)
+	}
+	if owner.LinuxUID == nil || *owner.LinuxUID == 0 {
+		return renameErr("owner_unprovisioned", "the owner's Linux account is not fully provisioned yet")
+	}
+
+	newDocRoot, derr := renameDocRootSegment(oldDocRoot, oldName, newName)
+	if derr != nil {
+		return derr
+	}
+
+	// The new name must be free. A concurrent claim between here and the write
+	// is still caught by the unique index (Rename returns a conflict).
+	existing, ferr := d.Domains.FindByName(ctx, newName)
+	if ferr != nil && !errors.Is(ferr, repository.ErrNotFound) {
+		return renameErr("lookup_failed", "could not check name availability: %v", ferr)
+	}
+	if existing != nil {
+		return renameErr("name_taken", "%q already exists", newName)
+	}
+
+	// ---- orchestrate ----
+	// 1. Move the docroot tree old -> new under the SAME owner uid, BEFORE the
+	//    DB row is renamed. Idempotent agent-side (reown returns AlreadyDone
+	//    when the source is gone and the target exists), so a re-run after a
+	//    later mid-failure finishes cleanly. Nothing is persisted yet: a failure
+	//    here leaves the domain fully intact.
+	if _, aerr := d.Agent.Call(ctx, "domain.reown", map[string]any{
+		"old_doc_root": oldDocRoot,
+		"new_doc_root": newDocRoot,
+		"new_uid":      int(*owner.LinuxUID),
+	}); aerr != nil {
+		return renameErr("move_failed", "could not move the site files for %q: %v", oldName, aerr)
+	}
+
+	// 2. Rename the row (name + doc_root as a unit) — the authoritative flip.
+	//    Files already moved; a failure here is re-runnable (reown -> AlreadyDone
+	//    on the retry). No tombstone exists yet, so a failure can never leave the
+	//    sweep tearing down a live domain.
+	if rerr := d.Domains.Rename(ctx, domain.ID, newName, newDocRoot); rerr != nil {
+		if errors.Is(rerr, repository.ErrConflict) {
+			return renameErr("name_taken", "%q already exists", newName)
+		}
+		return renameErr("persist_failed", "could not rename %q: %v", oldName, rerr)
+	}
+	domain.Name = newName
+	domain.DocRoot = newDocRoot
+
+	// 3. Tombstone the OLD name so the reconciler durably tears down the old
+	//    nginx vhost + old PowerDNS zone. Safe now: no live row carries oldName,
+	//    so the sweep cannot tear down a live domain. Its purge_accounts step is
+	//    a no-op here — the mailbox gate above guarantees zero accounts.
+	if d.DomainTeardowns != nil {
+		if terr := d.DomainTeardowns.Ensure(ctx, oldName); terr != nil {
+			logRenameHeal(d.Log, "tombstone old name", oldName, newName, terr)
+		}
+	}
+
+	// 4a. Re-key the domain's DNS zone row to the new name. DB record names are
+	//     stored relative and compiled to FQDN against zone.Name, so this single
+	//     Update re-qualifies every record (bootstrap AND custom) to the new
+	//     name; the reconciler pushes the new zone on its next pass because the
+	//     compiled FQDNs — and thus the dispatch hash — change.
+	if d.DNSZones != nil {
+		if zone, zerr := d.DNSZones.FindByDomainID(ctx, domain.ID); zerr == nil && zone != nil {
+			if zone.Name != newName {
+				zone.Name = newName
+				if uerr := d.DNSZones.Update(ctx, zone); uerr != nil {
+					logRenameHeal(d.Log, "rename DNS zone", oldName, newName, uerr)
+				}
+			}
+		} else if zerr != nil && !errors.Is(zerr, repository.ErrNotFound) {
+			logRenameHeal(d.Log, "load DNS zone", oldName, newName, zerr)
+		}
+	}
+
+	// 4b. Reset the SSL cert row to pending so the ACME loop reissues for the
+	//     NEW name. The row is keyed by domain_id and carries no name, so a
+	//     status reset is all it takes; the old cert files on disk are orphaned
+	//     (cosmetic). No cert row (SSL never provisioned) simply skips.
+	if d.SSLCerts != nil {
+		if cert, cerr := d.SSLCerts.FindByDomainID(ctx, domain.ID); cerr == nil && cert != nil {
+			if rerr := d.SSLCerts.ResetForRetry(ctx, cert.ID, time.Now().UTC()); rerr != nil {
+				logRenameHeal(d.Log, "reset SSL cert", oldName, newName, rerr)
+			}
+		} else if cerr != nil && !errors.Is(cerr, repository.ErrNotFound) {
+			logRenameHeal(d.Log, "load SSL cert", oldName, newName, cerr)
+		}
+	}
+
+	// 5. Force a prompt re-render + zone push + cert reissue for the new name.
+	if rec != nil {
+		rec.Schedule(domain.ID)
+	}
+	return nil
+}
+
+// logRenameHeal records a best-effort post-commit heal failure without failing
+// the rename — the row + files are already renamed, and the periodic reconcile
+// converges nginx/DNS/SSL regardless.
+func logRenameHeal(log *slog.Logger, step, oldName, newName string, err error) {
+	if log == nil {
+		return
+	}
+	log.Warn("domain rename: post-commit heal step failed (reconciler will converge)",
+		"step", step, "old", oldName, "new", newName, "err", err)
+}
+
+// renameDocRootSegment produces the new docroot by replacing the single path
+// segment that equals the old domain name with the new name. It handles both
+// the default layout (/home/<user>/public_html/<name>) and the importer layout
+// (/home/<user>/domains/<name>/public_html). A docroot that contains the old
+// name zero times (fully custom) or more than once (ambiguous) is refused — the
+// operator moves it manually rather than the panel guessing.
+func renameDocRootSegment(docRoot, oldName, newName string) (string, *RenameError) {
+	segs := strings.Split(docRoot, "/")
+	idx := -1
+	for i, s := range segs {
+		if s == oldName {
+			if idx != -1 {
+				return "", renameErr("ambiguous_docroot",
+					"docroot %q contains the domain name more than once — rename it manually", docRoot)
+			}
+			idx = i
+		}
+	}
+	if idx == -1 {
+		return "", renameErr("custom_docroot",
+			"docroot %q does not contain the domain name — rename it manually", docRoot)
+	}
+	segs[idx] = newName
+	return strings.Join(segs, "/"), nil
+}

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -1,0 +1,480 @@
+package userops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ---- fakes (all append to one recorder so step ORDER can be asserted) ----
+
+type drRecorder struct{ events []string }
+
+type drDomains struct {
+	repository.DomainRepository
+	rec       *drRecorder
+	byName    map[string]*models.Domain // pre-existing names (FindByName)
+	renameErr error
+}
+
+func (d *drDomains) FindByName(_ context.Context, name string) (*models.Domain, error) {
+	if dm, ok := d.byName[name]; ok {
+		return dm, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (d *drDomains) Rename(_ context.Context, _, _, _ string) error {
+	if d.renameErr != nil {
+		return d.renameErr
+	}
+	d.rec.events = append(d.rec.events, "db.rename")
+	return nil
+}
+
+type drUsers struct {
+	repository.UserRepository
+	user *models.User
+	err  error
+}
+
+func (u *drUsers) FindByID(_ context.Context, _ string) (*models.User, error) {
+	return u.user, u.err
+}
+
+type drAgent struct {
+	rec     *drRecorder
+	callErr error
+	last    map[string]any
+}
+
+func (a *drAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.rec.events = append(a.rec.events, "agent."+method)
+	if m, ok := params.(map[string]any); ok {
+		a.last = m
+	}
+	if a.callErr != nil {
+		return nil, a.callErr
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type drTeardowns struct {
+	rec     *drRecorder
+	ensured []string
+	deleted []string
+}
+
+func (t *drTeardowns) Ensure(_ context.Context, name string) error {
+	t.rec.events = append(t.rec.events, "tombstone.ensure")
+	t.ensured = append(t.ensured, name)
+	return nil
+}
+func (t *drTeardowns) Delete(_ context.Context, name string) error {
+	t.deleted = append(t.deleted, name)
+	return nil
+}
+func (t *drTeardowns) List(_ context.Context) ([]models.DomainTeardown, error) {
+	return nil, nil
+}
+func (t *drTeardowns) MarkAttempt(_ context.Context, _, _ string) error { return nil }
+
+type drMailboxes struct {
+	count int64
+	err   error
+}
+
+func (m *drMailboxes) CountByDomainID(_ context.Context, _ string) (int64, error) {
+	return m.count, m.err
+}
+
+type drDNSZones struct {
+	repository.DNSZoneRepository
+	rec       *drRecorder
+	zone      *models.DNSZone // nil => FindByDomainID returns ErrNotFound
+	updErr    error
+	renamedTo string
+}
+
+func (z *drDNSZones) FindByDomainID(_ context.Context, _ string) (*models.DNSZone, error) {
+	if z.zone == nil {
+		return nil, repository.ErrNotFound
+	}
+	return z.zone, nil
+}
+func (z *drDNSZones) Update(_ context.Context, zone *models.DNSZone) error {
+	if z.updErr != nil {
+		return z.updErr
+	}
+	z.rec.events = append(z.rec.events, "zone.rename")
+	z.renamedTo = zone.Name
+	return nil
+}
+
+type drSSLCerts struct {
+	repository.SSLCertificateRepository
+	rec      *drRecorder
+	cert     *models.SSLCertificate // nil => FindByDomainID returns ErrNotFound
+	resetErr error
+	resetID  string
+}
+
+func (s *drSSLCerts) FindByDomainID(_ context.Context, _ string) (*models.SSLCertificate, error) {
+	if s.cert == nil {
+		return nil, repository.ErrNotFound
+	}
+	return s.cert, nil
+}
+func (s *drSSLCerts) ResetForRetry(_ context.Context, id string, _ time.Time) error {
+	if s.resetErr != nil {
+		return s.resetErr
+	}
+	s.rec.events = append(s.rec.events, "cert.reset")
+	s.resetID = id
+	return nil
+}
+
+type drSched struct{ scheduled []string }
+
+func (r *drSched) Schedule(id string) { r.scheduled = append(r.scheduled, id) }
+
+func drUIDPtr(v uint32) *uint32 { return &v }
+
+// drHappyOwner is a fully provisioned tenant.
+func drHappyOwner() *models.User {
+	uname := "u1"
+	return &models.User{ID: "user-1", Username: &uname, LinuxUID: drUIDPtr(1001)}
+}
+
+func drWebDomain() *models.Domain {
+	return &models.Domain{
+		ID: "dom-1", UserID: "user-1", Name: "old.com",
+		DocRoot: "/home/u1/public_html/old.com",
+	}
+}
+
+// drNewDeps wires a fully-armed rename: zero mailboxes, a zone row on the old
+// name, and a cert row — so the happy path exercises the zone re-key + cert
+// reset heals.
+func drNewDeps(rec *drRecorder, dom *models.Domain, owner *models.User) (Deps, *drAgent, *drTeardowns) {
+	ag := &drAgent{rec: rec}
+	td := &drTeardowns{rec: rec}
+	d := Deps{
+		Domains:         &drDomains{rec: rec, byName: map[string]*models.Domain{}},
+		Users:           &drUsers{user: owner},
+		DomainTeardowns: td,
+		Agent:           ag,
+		Mailboxes:       &drMailboxes{count: 0},
+		DNSZones:        &drDNSZones{rec: rec, zone: &models.DNSZone{ID: "zone-1", DomainID: dom.ID, Name: dom.Name}},
+		SSLCerts:        &drSSLCerts{rec: rec, cert: &models.SSLCertificate{ID: "cert-1", DomainID: dom.ID}},
+	}
+	return d, ag, td
+}
+
+func drCodeOf(t *testing.T, err error) string {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var re *RenameError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *RenameError, got %T: %v", err, err)
+	}
+	return re.Code
+}
+
+// ---- gate matrix ----
+
+func TestRenameDomain_Gates(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*models.Domain)
+		owner   *models.User
+		newName string
+		want    string
+	}{
+		{"empty name", nil, drHappyOwner(), "", "invalid_name"},
+		{"no-op same name", nil, drHappyOwner(), "OLD.com", "noop"},
+		{"mail active", func(d *models.Domain) { d.EmailEnabled = true }, drHappyOwner(), "new.com", "mail_active"},
+		{"panel primary", func(d *models.Domain) { d.IsPanelPrimary = true }, drHappyOwner(), "new.com", "panel_primary"},
+		{"web disabled", func(d *models.Domain) { d.WebDisabled = true }, drHappyOwner(), "new.com", "web_disabled"},
+		{"owner unprovisioned", nil, &models.User{ID: "user-1"}, "new.com", "owner_unprovisioned"},
+		{"custom docroot", func(d *models.Domain) { d.DocRoot = "/srv/www/site" }, drHappyOwner(), "new.com", "custom_docroot"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &drRecorder{}
+			dom := drWebDomain()
+			if tc.mutate != nil {
+				tc.mutate(dom)
+			}
+			d, ag, _ := drNewDeps(rec, dom, tc.owner)
+			err := RenameDomain(context.Background(), d, &drSched{}, dom, tc.newName)
+			if got := drCodeOf(t, err); got != tc.want {
+				t.Fatalf("code = %q, want %q", got, tc.want)
+			}
+			// A gate refusal must never touch the box or move the row.
+			if len(ag.rec.events) != 0 {
+				t.Fatalf("gate refusal must not run any step, got events %v", ag.rec.events)
+			}
+		})
+	}
+}
+
+// ---- mailbox gate (fail-closed) ----
+
+func TestRenameDomain_MailboxesPresent(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Mailboxes = &drMailboxes{count: 3}
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "mailboxes_present" {
+		t.Fatalf("code = %q, want mailboxes_present", got)
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("mailboxes-present must refuse before any step, got %v", rec.events)
+	}
+}
+
+func TestRenameDomain_MailboxCheckUnwired(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Mailboxes = nil // fail-closed: cannot prove zero mailboxes
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "unavailable" {
+		t.Fatalf("code = %q, want unavailable", got)
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("unwired mailbox check must refuse before any step, got %v", rec.events)
+	}
+}
+
+func TestRenameDomain_MailboxCountError(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Mailboxes = &drMailboxes{err: errors.New("db down")}
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "unavailable" {
+		t.Fatalf("code = %q, want unavailable (can't verify zero mailboxes)", got)
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("mailbox count error must refuse before any step, got %v", rec.events)
+	}
+}
+
+func TestRenameDomain_NameTaken(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Domains.(*drDomains).byName["new.com"] = &models.Domain{ID: "other", Name: "new.com"}
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "name_taken" {
+		t.Fatalf("code = %q, want name_taken", got)
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("name-taken must refuse before any step, got %v", rec.events)
+	}
+}
+
+// ---- happy path: order, reown params, zone/cert heal, schedule ----
+
+func TestRenameDomain_HappyPath(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
+	sched := &drSched{}
+
+	if err := RenameDomain(context.Background(), d, sched, dom, "New.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Order is load-bearing: move the files, THEN rename the row (the
+	// authoritative flip), THEN tombstone the now-freed old name, THEN heal
+	// DNS + SSL for the new name. Files-before-DB makes a mid-run failure
+	// re-runnable, and tombstoning only after the flip means the sweep can
+	// never tear down a live domain.
+	want := []string{"agent.domain.reown", "db.rename", "tombstone.ensure", "zone.rename", "cert.reset"}
+	if len(rec.events) != len(want) {
+		t.Fatalf("events = %v, want %v", rec.events, want)
+	}
+	for i := range want {
+		if rec.events[i] != want[i] {
+			t.Fatalf("event[%d] = %q, want %q (all: %v)", i, rec.events[i], want[i], rec.events)
+		}
+	}
+
+	// Tombstone is for the OLD name; never deleted on success.
+	if len(td.ensured) != 1 || td.ensured[0] != "old.com" {
+		t.Fatalf("tombstone ensured = %v, want [old.com]", td.ensured)
+	}
+	if len(td.deleted) != 0 {
+		t.Fatalf("tombstone must not be deleted on success, got %v", td.deleted)
+	}
+
+	// reown moves old -> new docroot under the OWNER's uid (not a new uid).
+	if ag.last["old_doc_root"] != "/home/u1/public_html/old.com" {
+		t.Fatalf("old_doc_root = %v", ag.last["old_doc_root"])
+	}
+	if ag.last["new_doc_root"] != "/home/u1/public_html/new.com" {
+		t.Fatalf("new_doc_root = %v", ag.last["new_doc_root"])
+	}
+	if ag.last["new_uid"] != int(1001) {
+		t.Fatalf("new_uid = %v (%T), want 1001", ag.last["new_uid"], ag.last["new_uid"])
+	}
+
+	// The DNS zone row is re-keyed to the new name and the cert row reset.
+	if got := d.DNSZones.(*drDNSZones).renamedTo; got != "new.com" {
+		t.Fatalf("zone renamed to %q, want new.com", got)
+	}
+	if got := d.SSLCerts.(*drSSLCerts).resetID; got != "cert-1" {
+		t.Fatalf("cert reset id = %q, want cert-1", got)
+	}
+
+	// The in-memory domain reflects the new name + docroot for the caller.
+	if dom.Name != "new.com" || dom.DocRoot != "/home/u1/public_html/new.com" {
+		t.Fatalf("domain not updated in place: name=%q docroot=%q", dom.Name, dom.DocRoot)
+	}
+	if len(sched.scheduled) != 1 || sched.scheduled[0] != "dom-1" {
+		t.Fatalf("Schedule = %v, want [dom-1]", sched.scheduled)
+	}
+}
+
+// A rename with no DNS zone / no cert row (SSL never provisioned) still
+// succeeds — those heals are best-effort and skip cleanly.
+func TestRenameDomain_HappyPath_NoZoneNoCert(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.DNSZones.(*drDNSZones).zone = nil // FindByDomainID -> ErrNotFound
+	d.SSLCerts.(*drSSLCerts).cert = nil
+
+	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"agent.domain.reown", "db.rename", "tombstone.ensure"}
+	if len(rec.events) != len(want) {
+		t.Fatalf("events = %v, want %v", rec.events, want)
+	}
+}
+
+// ---- failure handling ----
+
+// A DB rename failure AFTER the files have already moved: the row is unchanged
+// (still the live handle for old.com) and NO tombstone was ever written (it
+// only comes after the flip), so nothing needs rolling back and the sweep can't
+// touch the live domain. A re-run finishes: reown -> AlreadyDone, then rename.
+func TestRenameDomain_PersistFailureAfterMove(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
+	d.Domains.(*drDomains).renameErr = errors.New("db down")
+
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "persist_failed" {
+		t.Fatalf("code = %q, want persist_failed", got)
+	}
+	// Files moved (reown ran) but the row is still old.com.
+	if ag.last == nil {
+		t.Fatalf("reown should have run before the DB rename")
+	}
+	if dom.Name != "old.com" {
+		t.Fatalf("row must be unchanged on persist failure, got %q", dom.Name)
+	}
+	// No tombstone was written, so there is nothing to (and nothing did) delete.
+	if len(td.ensured) != 0 || len(td.deleted) != 0 {
+		t.Fatalf("no tombstone should exist on persist failure, ensured=%v deleted=%v", td.ensured, td.deleted)
+	}
+}
+
+func TestRenameDomain_PersistConflictIsNameTaken(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Domains.(*drDomains).renameErr = repository.ErrConflict
+
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "name_taken" {
+		t.Fatalf("code = %q, want name_taken (conflict from unique index)", got)
+	}
+}
+
+// The file move is the FIRST step; if it fails, nothing is persisted — no DB
+// rename, no tombstone, the row is untouched.
+func TestRenameDomain_MoveFailureBeforeCommit(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, td := drNewDeps(rec, dom, drHappyOwner())
+	d.Agent.(*drAgent).callErr = errors.New("agent unreachable")
+
+	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "move_failed" {
+		t.Fatalf("code = %q, want move_failed", got)
+	}
+	// No DB rename, no tombstone, row unchanged.
+	for _, e := range rec.events {
+		if e == "db.rename" || e == "tombstone.ensure" {
+			t.Fatalf("no persistence must happen on a pre-commit move failure, got %v", rec.events)
+		}
+	}
+	if dom.Name != "old.com" {
+		t.Fatalf("row must be unchanged on move failure, got %q", dom.Name)
+	}
+	if len(td.ensured) != 0 {
+		t.Fatalf("no tombstone on move failure, got %v", td.ensured)
+	}
+}
+
+// A post-commit heal failure (zone re-key errors) does NOT fail the rename —
+// the row + files are already renamed and the reconciler converges the rest.
+func TestRenameDomain_HealFailureStillSucceeds(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.DNSZones.(*drDNSZones).updErr = errors.New("zone update failed")
+	d.SSLCerts.(*drSSLCerts).resetErr = errors.New("cert reset failed")
+
+	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("a post-commit heal failure must not fail the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed despite heal failure, got %q", dom.Name)
+	}
+}
+
+// ---- docroot segment rewrite ----
+
+func TestRenameDocRootSegment(t *testing.T) {
+	tests := []struct {
+		name, docRoot, old, new, want, wantErr string
+	}{
+		{"default layout", "/home/u/public_html/old.com", "old.com", "new.com", "/home/u/public_html/new.com", ""},
+		{"importer layout", "/home/u/domains/old.com/public_html", "old.com", "new.com", "/home/u/domains/new.com/public_html", ""},
+		{"custom (no name segment)", "/srv/www/site", "old.com", "new.com", "", "custom_docroot"},
+		{"ambiguous (name twice)", "/home/old.com/public_html/old.com", "old.com", "new.com", "", "ambiguous_docroot"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := renameDocRootSegment(tc.docRoot, tc.old, tc.new)
+			if tc.wantErr != "" {
+				if err == nil || err.Code != tc.wantErr {
+					t.Fatalf("err = %v, want code %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -52,10 +52,22 @@ type Deps struct {
 	// account-cascade, and billing-cancel deletes all release without any
 	// caller having to remember to.
 	PortAllocations repository.PortAllocationRepository
-	Agent           AgentCaller
-	KratosClient    *kratosclient.Client
-	BcryptCost      int
-	Log             *slog.Logger
+	// Mailboxes gates the GH #1579 rename: a rename runs the durable teardown
+	// on the OLD name, whose first step (mail.domain.purge_accounts) destroys
+	// every Stalwart account on that domain. Mail-disable is SOFT (mailboxes
+	// are retained), so gating on EmailEnabled alone would let a rename purge
+	// retained mailboxes. RenameDomain refuses when this repo is nil
+	// (fail-closed) or reports any mailbox for the domain.
+	Mailboxes MailboxCounter
+	// DNSZones + SSLCerts let RenameDomain re-key the domain_id-scoped zone row
+	// and force an SSL reissue for the NEW name (GH #1579). Both optional: a
+	// panel without PowerDNS / with no cert row simply skips that heal.
+	DNSZones     repository.DNSZoneRepository
+	SSLCerts     repository.SSLCertificateRepository
+	Agent        AgentCaller
+	KratosClient *kratosclient.Client
+	BcryptCost   int
+	Log          *slog.Logger
 }
 
 // CreateInput is the shared input shape. Both callers (REST + the

--- a/panel-ui/src/components/domains/RenameDomainButton.test.tsx
+++ b/panel-ui/src/components/domains/RenameDomainButton.test.tsx
@@ -1,0 +1,89 @@
+// GH #1579: the Rename domain modal gates submit on a valid, different FQDN
+// plus an explicit acknowledgment, normalizes the name, and posts to
+// /domains/:id/rename. The warnings (experimental + "app internals not changed")
+// are load-bearing per johnnyq's ask, so assert they render.
+import { App } from "antd";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RenameDomainButton } from "./RenameDomainButton";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock("../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+
+import { apiClient } from "../../apiClient";
+
+const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+const renderBtn = (onRenamed = vi.fn()) => {
+  render(
+    <App>
+      <RenameDomainButton domain={{ id: "d1", name: "old.com" }} onRenamed={onRenamed} />
+    </App>,
+  );
+  return onRenamed;
+};
+
+const openModal = () => {
+  fireEvent.click(screen.getByRole("button", { name: /rename domain/i }));
+  return within(screen.getByRole("dialog"));
+};
+
+const okButton = (dialog: ReturnType<typeof within>) =>
+  dialog.getByRole("button", { name: /rename domain/i });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("RenameDomainButton", () => {
+  it("shows the experimental + app-internals warnings when opened", () => {
+    renderBtn();
+    const dialog = openModal();
+    expect(dialog.getByText(/experimental feature/i)).toBeInTheDocument();
+    expect(dialog.getByText(/does not change WordPress/i)).toBeInTheDocument();
+  });
+
+  it("keeps submit disabled until a valid, different name AND the acknowledgment", () => {
+    renderBtn();
+    const dialog = openModal();
+    expect(okButton(dialog)).toBeDisabled();
+
+    // valid new name, but no acknowledgment yet
+    fireEvent.change(dialog.getByPlaceholderText("new-domain.com"), {
+      target: { value: "new.com" },
+    });
+    expect(okButton(dialog)).toBeDisabled();
+
+    // acknowledge -> enabled
+    fireEvent.click(dialog.getByRole("checkbox"));
+    expect(okButton(dialog)).toBeEnabled();
+
+    // same as current name -> disabled again
+    fireEvent.change(dialog.getByPlaceholderText("new-domain.com"), {
+      target: { value: "OLD.com" },
+    });
+    expect(okButton(dialog)).toBeDisabled();
+  });
+
+  it("posts the normalized name and calls onRenamed on success", async () => {
+    mocked.post.mockResolvedValueOnce({ data: { id: "d1", name: "new.com" } });
+    const onRenamed = renderBtn();
+    const dialog = openModal();
+
+    fireEvent.change(dialog.getByPlaceholderText("new-domain.com"), {
+      target: { value: "  New.COM  " },
+    });
+    fireEvent.click(dialog.getByRole("checkbox"));
+    fireEvent.click(okButton(dialog));
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/domains/d1/rename", { name: "new.com" }),
+    );
+    await waitFor(() => expect(onRenamed).toHaveBeenCalled());
+  });
+});

--- a/panel-ui/src/components/domains/RenameDomainButton.tsx
+++ b/panel-ui/src/components/domains/RenameDomainButton.tsx
@@ -1,0 +1,121 @@
+// RenameDomainButton — GH #1579. Renames an existing web domain in place
+// (POST /domains/:id/rename) instead of the create-new-and-move workaround.
+//
+// Experimental phase 1: the backend refuses when mail is active, when the domain
+// is the panel's own primary, or when it has no website. It moves the docroot,
+// tears down the old name's nginx vhost + DNS zone, and re-provisions the new
+// name (SSL is reissued by the reconciler). It does NOT rewrite an installed
+// app's internal configuration (e.g. a WordPress siteurl stored in the app's
+// own database) — the modal warns about that and the user updates it in the app.
+import { useState } from "react";
+import { Alert, Button, Checkbox, Input, Modal, Typography } from "antd";
+import { EditOutlined } from "@icons";
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback";
+
+interface RenameDomainButtonProps {
+  domain: { id: string; name: string };
+  // Called after a successful rename so the parent can refetch the (same-id)
+  // domain and show the new name.
+  onRenamed: () => void;
+}
+
+// A light client-side FQDN shape check to disable the button early; the server
+// runs the authoritative validateDomainName.
+const looksLikeFQDN = (s: string): boolean =>
+  /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/.test(s);
+
+export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [ack, setAck] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const normalized = newName.trim().toLowerCase();
+  const canSubmit =
+    ack &&
+    !busy &&
+    looksLikeFQDN(normalized) &&
+    normalized !== domain.name.toLowerCase();
+
+  const close = () => {
+    setOpen(false);
+    setNewName("");
+    setAck(false);
+  };
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setBusy(true);
+    try {
+      await apiClient.post(`/domains/${domain.id}/rename`, { name: normalized });
+      feedback.message.success(`Renamed to ${normalized}`);
+      close();
+      onRenamed();
+    } catch (err) {
+      feedback.message.error(
+        err instanceof Error ? err.message : "Could not rename the domain",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Button icon={<EditOutlined />} onClick={() => setOpen(true)}>
+        Rename domain
+      </Button>
+
+      <Modal
+        open={open}
+        title={`Rename ${domain.name}`}
+        okText="Rename domain"
+        okButtonProps={{ disabled: !canSubmit, loading: busy }}
+        onOk={submit}
+        onCancel={close}
+        destroyOnClose
+      >
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Experimental feature"
+          description="Renaming a domain is new. If anything looks wrong afterwards, please file a bug report."
+        />
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Your app's internal settings are not changed"
+          description="This does not change WordPress — or any other CMS/app — settings stored inside the app (for example the site URL). After renaming, update the site URL in the app itself."
+        />
+        <Typography.Paragraph style={{ marginBottom: 4 }}>
+          Renaming <Typography.Text code>{domain.name}</Typography.Text> will:
+        </Typography.Paragraph>
+        <ul style={{ margin: "0 0 12px", paddingLeft: 18 }}>
+          <li>Move the website files to the new domain's document root</li>
+          <li>Rebuild the web server (nginx) configuration for the new name</li>
+          <li>Reissue the SSL certificate for the new name</li>
+          <li>Recreate the managed DNS zone under the new name and remove the old one</li>
+        </ul>
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 4 }}>
+          Mail must be off and the domain must have no mailboxes — renaming would
+          change every mailbox address. Delete or migrate any mailboxes first.
+        </Typography.Paragraph>
+        <Input
+          autoFocus
+          placeholder="new-domain.com"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onPressEnter={submit}
+          style={{ marginBottom: 12 }}
+        />
+        <Checkbox checked={ack} onChange={(e) => setAck(e.target.checked)}>
+          I understand this is experimental and does not change my app's internal
+          settings.
+        </Checkbox>
+      </Modal>
+    </>
+  );
+}

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -30,6 +30,7 @@ import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsP
 import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
 import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
 import { DomainPHPSettingsPanel } from "../../../components/domains/DomainPHPSettingsPanel";
+import { RenameDomainButton } from "../../../components/domains/RenameDomainButton";
 import { DomainEnvVarsCard } from "../php-settings/DomainEnvVarsCard";
 import { OverviewTab } from "./tabs/OverviewTab";
 
@@ -166,6 +167,10 @@ export const WebDomainPage = () => {
         <Typography.Title level={3} style={{ margin: 0 }}>
           <GlobalOutlined /> {domain.name}
         </Typography.Title>
+        <RenameDomainButton
+          domain={{ id: domain.id, name: domain.name }}
+          onRenamed={() => void domainQ.refetch?.()}
+        />
       </Space>
 
       <Card


### PR DESCRIPTION
## Summary

Adds an experimental **Rename domain** feature: `POST /domains/:id/rename`
(owner-scoped — a tenant renames their own domain, an admin any) plus a
"Rename domain" button on the tenant Web Domain page. The `domain_id` is
preserved, so every FK keyed on it survives; only the natural-key surfaces
(name, docroot, nginx vhost, DNS zone, SSL cert) are re-keyed to the new name.

Shared `userops.RenameDomain` orchestrates in a retry-safe order that mirrors
`ChangeDomainOwner` (files-before-DB, so a mid-run failure re-runs cleanly):

1. `domain.reown` — move + re-own the docroot under the **same** owner uid
   (idempotent; nothing persisted yet).
2. rename the DB row (name + doc_root) — the authoritative flip.
3. tombstone the **old** name (only now that no live row carries it, so the
   durable teardown sweep can never tear down a live domain) — removes the old
   nginx vhost + old PowerDNS zone.
4. re-key the DNS zone row to the new name and reset the SSL cert row to
   pending. DB DNS records are stored **relative** and compiled to FQDN against
   the zone name, so one zone `Update` re-qualifies every record (bootstrap AND
   custom) and the reconciler pushes the new zone (compiled FQDNs — and thus the
   dispatch hash — change). The cert row carries no name, so a status reset makes
   the ACME loop reissue for the new name.
5. schedule a prompt reconcile.

Steps 3–5 are best-effort heals after the commit: a rare failure there is
logged, not surfaced — the row + files (the source of truth) are already
renamed and the periodic reconcile converges the rest.

## Fail-closed mail gate (data-loss fix)

The old name's teardown runs `mail.domain.purge_accounts`, which destroys every
Stalwart account on the domain, and mail-disable is **soft** (mailboxes are
retained). So a rename is refused unless the domain has **zero mailboxes**:
`RenameDomain` requires a mailbox counter (nil → 503) and refuses when it
reports any mailbox or errors (can't prove zero). Without this gate, renaming a
mail-disabled-but-not-emptied domain would silently purge its retained
mailboxes.

Other phase-1 refusals: the panel's own primary domain, a web-disabled domain,
an unprovisioned owner, and a custom docroot that doesn't contain the old name
exactly once (needs a manual move).

## Apps are warned, not blocked

Installed apps are allowed but **not** rewritten: an app's internal config (e.g.
a WordPress `siteurl` in the app's own database) still points at the old name.
The WordPress reconciler derives its probe path from the domain's current
docroot, so the install heals to the new path, but the site URL inside the app
must be updated by the user. The modal warns that this is experimental, asks the
user to file bugs, and states plainly that it does **not** change WordPress/CMS
settings stored inside the app; submit is gated on an explicit acknowledgment.

## Decisions worth a reviewer's eye

- **No recent-auth step-up.** Delete has none either, so this is consistent, but
  a rename mutates a live domain's serving in place. If a JAB-380 step-up is
  wanted here it's a ~5-line follow-up (`DomainHandlerConfig.KratosClient` is
  already wired for chown).
- **Known residual:** the old name's certificate files on disk are orphaned
  (cosmetic) after the reissue for the new name.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/userops/... ./internal/api/... ./internal/app/... ./internal/repository/... ./internal/reconciler/...` — all pass (incl. the app-package openapi route-coverage test, which enforces the new route is documented in `openapi.yaml`)
- [x] New `userops.RenameDomain` tests: gate matrix, fail-closed mailbox gate (present / unwired / count-error), name-taken, happy path (order + reown params + zone re-key + cert reset + schedule), no-zone/no-cert happy path, persist-failure-after-move, persist-conflict → name_taken, move-failure-before-commit, post-commit-heal-failure-still-succeeds, docroot segment rewrite
- [x] UI: `tsc -b` clean, `eslint` clean, `vitest run` — RenameDomainButton (warnings render, submit gating, normalized POST) + all `src/shells/user/domains/` (39 tests)
- [ ] Manual: rename a plain web domain on the test box; confirm nginx/DNS/SSL converge for the new name and the old vhost/zone are torn down

GH #1579
