### PR TITLE
fix(domains): prune the emptied old-name docroot dir on rename (GH #1579)

### DIFF
--- a/panel-agent/internal/commands/domain_reown.go
+++ b/panel-agent/internal/commands/domain_reown.go
@@ -28,6 +28,13 @@ type domainReownParams struct {
 	OldDocRoot string `json:"old_doc_root"`
 	NewDocRoot string `json:"new_doc_root"`
 	NewUID     int    `json:"new_uid"`
+	// PruneEmptyDir (GH #1579 rename) is an ancestor of OldDocRoot whose
+	// basename is the OLD domain name (e.g. /home/<u>/domains/<oldname> for the
+	// nested docroot layout). After the docroot leaf moves out of it, that dir
+	// is left empty; when set, prune it if — and only if — it is now empty.
+	// Optional and opt-in: chown (GH #1238) never sets it, so its behaviour is
+	// unchanged. The default docroot layout (leaf == domain name) leaves it "".
+	PruneEmptyDir string `json:"prune_empty_dir,omitempty"`
 }
 
 type domainReownResponse struct {
@@ -61,8 +68,10 @@ func domainReownHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	oldExists := oldErr == nil
 	newExists := newErr == nil
 
-	// Idempotent: already moved.
+	// Idempotent: already moved. Still attempt the empty-parent prune — a prior
+	// run may have moved the docroot but died before pruning.
 	if !oldExists && newExists {
+		pruneEmptyRenameDir(p.PruneEmptyDir, p.OldDocRoot)
 		return domainReownResponse{NewDocRoot: p.NewDocRoot, AlreadyDone: true}, nil
 	}
 	if !oldExists {
@@ -96,7 +105,44 @@ func domainReownHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("set docroot mode: %v", err)}
 	}
 
+	// The docroot leaf has moved out of its old-name wrapper dir (nested layout);
+	// remove that wrapper if it is now empty. Best-effort — a non-empty dir
+	// (extra siblings the rename did not move) is left untouched.
+	pruneEmptyRenameDir(p.PruneEmptyDir, p.OldDocRoot)
+
 	return domainReownResponse{NewDocRoot: p.NewDocRoot}, nil
+}
+
+// pruneEmptyRenameDir removes dir when it is a safe, now-empty old-name wrapper
+// left behind by a rename move. It is deliberately conservative:
+//   - only acts when dir is set (the default docroot layout passes "");
+//   - refuses anything not under /home/ or not a clean absolute path;
+//   - refuses a dir that is not a strict ANCESTOR of oldDocRoot (so it can only
+//     ever be the wrapper the move emptied, never the docroot or an unrelated
+//     path);
+//   - uses os.Remove, which removes an EMPTY directory and fails (ignored) on a
+//     non-empty one — so extra sibling files the rename did not move are kept.
+func pruneEmptyRenameDir(dir, oldDocRoot string) {
+	if !shouldPruneRenameDir(dir, oldDocRoot) {
+		return
+	}
+	_ = os.Remove(dir) // rmdir; no-op (error ignored) when non-empty or absent.
+}
+
+// shouldPruneRenameDir is the pure guard for pruneEmptyRenameDir: it returns
+// true only for a set, clean, /home-rooted path that is a STRICT ANCESTOR of
+// oldDocRoot (so it can only be the wrapper the move emptied — never the docroot
+// itself, an unrelated path, or "").
+func shouldPruneRenameDir(dir, oldDocRoot string) bool {
+	if dir == "" {
+		return false
+	}
+	if !strings.HasPrefix(dir, "/home/") || filepath.Clean(dir) != dir {
+		return false
+	}
+	// Strict ancestor: oldDocRoot starts with dir + "/". Rules out dir ==
+	// oldDocRoot and any sideways path.
+	return strings.HasPrefix(oldDocRoot, dir+"/")
 }
 
 // ensureOwnedSetgidDir creates dir (if absent) and sets it to uid:gid + setgid

--- a/panel-agent/internal/commands/domain_reown_test.go
+++ b/panel-agent/internal/commands/domain_reown_test.go
@@ -28,3 +28,28 @@ func TestDomainReown_ValidatesInput(t *testing.T) {
 		})
 	}
 }
+
+// TestShouldPruneRenameDir covers the GH #1579 empty-old-wrapper prune guard:
+// it must fire only for a clean, /home-rooted STRICT ancestor of the old
+// docroot, so it can never remove the docroot itself or an unrelated path.
+func TestShouldPruneRenameDir(t *testing.T) {
+	cases := []struct {
+		name, dir, oldDocRoot string
+		want                  bool
+	}{
+		{"nested wrapper", "/home/u/domains/old.com", "/home/u/domains/old.com/public_html", true},
+		{"empty dir (default layout)", "", "/home/u/public_html/old.com", false},
+		{"dir equals docroot", "/home/u/domains/old.com", "/home/u/domains/old.com", false},
+		{"not under /home", "/srv/www/old.com", "/srv/www/old.com/public_html", false},
+		{"not clean", "/home/u/domains/old.com/..", "/home/u/domains/old.com/public_html", false},
+		{"sideways (not ancestor)", "/home/u/domains/other", "/home/u/domains/old.com/public_html", false},
+		{"prefix but not path-boundary", "/home/u/domains/old", "/home/u/domains/old.com/public_html", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldPruneRenameDir(tc.dir, tc.oldDocRoot); got != tc.want {
+				t.Fatalf("shouldPruneRenameDir(%q, %q) = %v, want %v", tc.dir, tc.oldDocRoot, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -125,7 +125,7 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		return renameErr("owner_unprovisioned", "the owner's Linux account is not fully provisioned yet")
 	}
 
-	newDocRoot, derr := renameDocRootSegment(oldDocRoot, oldName, newName)
+	newDocRoot, pruneOldDir, derr := renameDocRootSegment(oldDocRoot, oldName, newName)
 	if derr != nil {
 		return derr
 	}
@@ -146,11 +146,19 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	//    when the source is gone and the target exists), so a re-run after a
 	//    later mid-failure finishes cleanly. Nothing is persisted yet: a failure
 	//    here leaves the domain fully intact.
-	if _, aerr := d.Agent.Call(ctx, "domain.reown", map[string]any{
+	reownParams := map[string]any{
 		"old_doc_root": oldDocRoot,
 		"new_doc_root": newDocRoot,
 		"new_uid":      int(*owner.LinuxUID),
-	}); aerr != nil {
+	}
+	// Nested docroot layout (/home/<u>/domains/<name>/public_html): the leaf
+	// moves out of the old-name wrapper dir, leaving it empty — ask the agent to
+	// prune it if empty. Empty for the default layout (leaf == name), where the
+	// move renames the leaf itself and nothing is left behind.
+	if pruneOldDir != "" {
+		reownParams["prune_empty_dir"] = pruneOldDir
+	}
+	if _, aerr := d.Agent.Call(ctx, "domain.reown", reownParams); aerr != nil {
 		return renameErr("move_failed", "could not move the site files for %q: %v", oldName, aerr)
 	}
 
@@ -233,22 +241,34 @@ func logRenameHeal(log *slog.Logger, step, oldName, newName string, err error) {
 // (/home/<user>/domains/<name>/public_html). A docroot that contains the old
 // name zero times (fully custom) or more than once (ambiguous) is refused — the
 // operator moves it manually rather than the panel guessing.
-func renameDocRootSegment(docRoot, oldName, newName string) (string, *RenameError) {
+//
+// It also returns pruneOldDir: the old-name wrapper directory that the docroot
+// move empties and the agent should prune. It is the path up to and including
+// the old-name segment ONLY when that segment is not the docroot leaf (the
+// nested layout, /home/<u>/domains/<oldname>). For the default layout the
+// old-name segment IS the leaf — the move renames it in place, leaving nothing
+// behind — so pruneOldDir is "".
+func renameDocRootSegment(docRoot, oldName, newName string) (newDocRoot, pruneOldDir string, err *RenameError) {
 	segs := strings.Split(docRoot, "/")
 	idx := -1
 	for i, s := range segs {
 		if s == oldName {
 			if idx != -1 {
-				return "", renameErr("ambiguous_docroot",
+				return "", "", renameErr("ambiguous_docroot",
 					"docroot %q contains the domain name more than once — rename it manually", docRoot)
 			}
 			idx = i
 		}
 	}
 	if idx == -1 {
-		return "", renameErr("custom_docroot",
+		return "", "", renameErr("custom_docroot",
 			"docroot %q does not contain the domain name — rename it manually", docRoot)
 	}
+	if idx < len(segs)-1 {
+		// Old name is a wrapper dir, not the docroot leaf — it is emptied by the
+		// move and can be pruned.
+		pruneOldDir = strings.Join(segs[:idx+1], "/")
+	}
 	segs[idx] = newName
-	return strings.Join(segs, "/"), nil
+	return strings.Join(segs, "/"), pruneOldDir, nil
 }

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -347,6 +347,41 @@ func TestRenameDomain_HappyPath(t *testing.T) {
 	}
 }
 
+// Default docroot layout (leaf == name): the move renames the leaf in place, so
+// no old-name wrapper dir is left — the reown call must NOT ask to prune one.
+func TestRenameDomain_DefaultLayoutNoPrune(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain() // /home/u1/public_html/old.com
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := ag.last["prune_empty_dir"]; ok {
+		t.Fatalf("default layout must not set prune_empty_dir, got %v", ag.last["prune_empty_dir"])
+	}
+}
+
+// Nested/importer docroot layout: the docroot leaf moves out of the old-name
+// wrapper dir, so the reown call must ask the agent to prune that empty wrapper.
+func TestRenameDomain_NestedLayoutPrunesOldDir(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	dom.DocRoot = "/home/u1/domains/old.com/public_html"
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ag.last["new_doc_root"] != "/home/u1/domains/new.com/public_html" {
+		t.Fatalf("new_doc_root = %v", ag.last["new_doc_root"])
+	}
+	if ag.last["prune_empty_dir"] != "/home/u1/domains/old.com" {
+		t.Fatalf("prune_empty_dir = %v, want /home/u1/domains/old.com", ag.last["prune_empty_dir"])
+	}
+	if dom.DocRoot != "/home/u1/domains/new.com/public_html" {
+		t.Fatalf("domain docroot not updated: %q", dom.DocRoot)
+	}
+}
+
 // A rename with no DNS zone / no cert row (SSL never provisioned) still
 // succeeds — those heals are best-effort and skip cleanly.
 func TestRenameDomain_HappyPath_NoZoneNoCert(t *testing.T) {
@@ -453,16 +488,20 @@ func TestRenameDomain_HealFailureStillSucceeds(t *testing.T) {
 
 func TestRenameDocRootSegment(t *testing.T) {
 	tests := []struct {
-		name, docRoot, old, new, want, wantErr string
+		name, docRoot, old, new, want, wantPrune, wantErr string
 	}{
-		{"default layout", "/home/u/public_html/old.com", "old.com", "new.com", "/home/u/public_html/new.com", ""},
-		{"importer layout", "/home/u/domains/old.com/public_html", "old.com", "new.com", "/home/u/domains/new.com/public_html", ""},
-		{"custom (no name segment)", "/srv/www/site", "old.com", "new.com", "", "custom_docroot"},
-		{"ambiguous (name twice)", "/home/old.com/public_html/old.com", "old.com", "new.com", "", "ambiguous_docroot"},
+		// Default layout: the name IS the docroot leaf → move renames it in place,
+		// nothing to prune.
+		{"default layout", "/home/u/public_html/old.com", "old.com", "new.com", "/home/u/public_html/new.com", "", ""},
+		// Nested/importer layout: the name is a wrapper dir → move empties it, so
+		// it must be pruned.
+		{"importer layout", "/home/u/domains/old.com/public_html", "old.com", "new.com", "/home/u/domains/new.com/public_html", "/home/u/domains/old.com", ""},
+		{"custom (no name segment)", "/srv/www/site", "old.com", "new.com", "", "", "custom_docroot"},
+		{"ambiguous (name twice)", "/home/old.com/public_html/old.com", "old.com", "new.com", "", "", "ambiguous_docroot"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := renameDocRootSegment(tc.docRoot, tc.old, tc.new)
+			got, prune, err := renameDocRootSegment(tc.docRoot, tc.old, tc.new)
 			if tc.wantErr != "" {
 				if err == nil || err.Code != tc.wantErr {
 					t.Fatalf("err = %v, want code %q", err, tc.wantErr)
@@ -474,6 +513,9 @@ func TestRenameDocRootSegment(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+			if prune != tc.wantPrune {
+				t.Fatalf("pruneOldDir = %q, want %q", prune, tc.wantPrune)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1583. Renaming a domain whose docroot uses the nested/importer
layout (`/home/<u>/domains/<name>/public_html`) moved the `public_html` leaf
into the new-name wrapper but left the old `/home/<u>/domains/<oldname>/`
directory behind, empty. The default layout (`/home/<u>/public_html/<name>`) has
no such leftover — there the name IS the docroot leaf, so the move renames it in
place.

`RenameDomain` now computes the old-name wrapper dir (the path up to and
including the old-name segment, only when that segment is not the docroot leaf)
and passes it to the agent as `domain.reown`'s new optional `prune_empty_dir`
param. The agent removes it with `os.Remove` after the move — which deletes an
**empty** directory and fails harmlessly on a non-empty one, so any sibling
files the rename did not move are preserved. A pure guard (`shouldPruneRenameDir`)
restricts the prune to a clean, `/home`-rooted **strict ancestor** of the old
docroot, so it can never target the docroot itself or an unrelated path.

`prune_empty_dir` is opt-in: chown (#1238), the other `domain.reown` caller,
never sets it, so its behaviour is unchanged.

## Test plan

- [x] `go build ./...` (panel-api + panel-agent), `go vet` clean
- [x] `go test ./internal/userops/...` — `renameDocRootSegment` now returns the prune dir (default layout → "", nested → wrapper path); new `TestRenameDomain_DefaultLayoutNoPrune` / `TestRenameDomain_NestedLayoutPrunesOldDir` assert the reown call carries `prune_empty_dir` only for the nested layout
- [x] `go test ./internal/commands/...` — `TestShouldPruneRenameDir` covers the guard (nested wrapper prunes; empty/dir-equals-docroot/non-/home/non-clean/sideways/prefix-not-boundary all refused)
- [x] **Box-verified on the test host**: deployed both binaries, created a nested-docroot domain, renamed it over HTTP → HTTP 200, old `domains/<oldname>/` wrapper **gone**, new docroot present. Re-ran without the fix reproduced the empty leftover.

GH #1579
