### PR TITLE
fix(domains): clean old SSL cert on rename + refuse custom/shared certs (GH #1579)

### DIFF
--- a/panel-agent/internal/commands/domain_delete.go
+++ b/panel-agent/internal/commands/domain_delete.go
@@ -85,10 +85,26 @@ func domainDeleteHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
+	// GH #1579: a full teardown must leave no stale SSL artifacts for the name —
+	// the self-signed cert dir and any Let's Encrypt lineage. domain.delete is
+	// the shared teardown chokepoint, so this covers both a real delete and a
+	// rename's old-name teardown. Scoped strictly to p.Domain (domainRegex-
+	// validated), so a shared/wildcard cert under a different name is untouched.
+	removeDomainCertArtifacts(ctx, p.Domain)
+
 	return domainDeleteResponse{
 		Domain:  p.Domain,
 		Deleted: true,
 	}, nil
+}
+
+// removeDomainCertArtifacts deletes the on-disk TLS material a domain teardown
+// leaves behind: the self-signed cert directory and the certbot/LE lineage for
+// the exact name. Best-effort — a missing path is a no-op — and name-scoped, so
+// it never reaches an unrelated (e.g. shared/wildcard) certificate.
+func removeDomainCertArtifacts(ctx context.Context, domain string) {
+	_ = os.RemoveAll(filepath.Join(baseSelfSignDir, domain))
+	cleanupCertbotLineage(ctx, sslLERoot, domain)
 }
 
 // removeMailVhostFiles reaps the per-domain mail vhost (`<domain>-mail.conf`)

--- a/panel-agent/internal/commands/domain_delete_cert_test.go
+++ b/panel-agent/internal/commands/domain_delete_cert_test.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoveDomainCertArtifacts covers the GH #1579 teardown SSL cleanup: the
+// self-signed cert directory for the exact name is removed, and an absent name
+// is a harmless no-op. (The LE lineage arm is cleanupCertbotLineage, which
+// no-ops without a renewal conf and is covered by its own tests.)
+func TestRemoveDomainCertArtifacts(t *testing.T) {
+	tmp := t.TempDir()
+	orig := baseSelfSignDir
+	baseSelfSignDir = tmp
+	defer func() { baseSelfSignDir = orig }()
+
+	certDir := filepath.Join(tmp, "old.example.com")
+	if err := os.MkdirAll(certDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(certDir, "fullchain.pem"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeDomainCertArtifacts(context.Background(), "old.example.com")
+
+	if _, err := os.Stat(certDir); !os.IsNotExist(err) {
+		t.Fatalf("self-signed cert dir should be removed, stat err = %v", err)
+	}
+
+	// A name with no artifacts must not panic or error.
+	removeDomainCertArtifacts(context.Background(), "never-existed.example.com")
+
+	// A sibling domain's cert dir must survive (name-scoped removal).
+	sib := filepath.Join(tmp, "keep.example.com")
+	if err := os.MkdirAll(sib, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	removeDomainCertArtifacts(context.Background(), "old.example.com")
+	if _, err := os.Stat(sib); err != nil {
+		t.Fatalf("sibling cert dir must survive, stat err = %v", err)
+	}
+}

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -98,7 +98,7 @@ func renameHTTPStatus(code string) int {
 	case "invalid_name", "noop", "custom_docroot", "ambiguous_docroot":
 		return http.StatusBadRequest
 	case "mail_active", "mailboxes_present", "panel_primary", "web_disabled",
-		"name_taken", "owner_unprovisioned", "owner_unresolved":
+		"ssl_custom_cert", "name_taken", "owner_unprovisioned", "owner_unresolved":
 		return http.StatusConflict
 	case "not_found":
 		return http.StatusNotFound

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -46,6 +46,8 @@ func renameErr(code, format string, args ...any) *RenameError {
 //     fail-closed: a nil Mailboxes repo refuses too;
 //   - the domain is the panel's own primary domain (self-lockout);
 //   - the domain has no website to move (web disabled / no docroot);
+//   - the domain uses a custom or shared TLS certificate (it covers the old
+//     name and cannot be re-issued automatically for the new one);
 //   - the owner's Linux account is not provisioned yet;
 //   - the docroot path does not contain the old name exactly once (a custom
 //     docroot needs a manual move).
@@ -115,6 +117,17 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	}
 	if domain.WebDisabled || oldDocRoot == "" {
 		return renameErr("web_disabled", "%q has no website to rename", oldName)
+	}
+	// A custom (operator-uploaded) or shared certificate cannot be re-issued for
+	// the new name automatically — its files/lineage cover the OLD name, and the
+	// rename's cert reset would only trigger an ACME/self-signed attempt that
+	// replaces it. Refuse (fail-closed) so a rename never silently drops a
+	// domain's real certificate; the owner switches to Let's Encrypt or
+	// self-signed first, or re-uploads for the new name after.
+	if domain.SSLMode == models.SSLModeCustom || domain.SSLMode == models.SSLModeShared {
+		return renameErr("ssl_custom_cert",
+			"%q uses a %s TLS certificate that cannot be re-issued automatically for a new name — switch it to Let's Encrypt or self-signed before renaming (you can re-apply the certificate for the new name after)",
+			oldName, domain.SSLMode)
 	}
 
 	owner, err := d.Users.FindByID(ctx, domain.UserID)

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -203,6 +203,8 @@ func TestRenameDomain_Gates(t *testing.T) {
 		{"mail active", func(d *models.Domain) { d.EmailEnabled = true }, drHappyOwner(), "new.com", "mail_active"},
 		{"panel primary", func(d *models.Domain) { d.IsPanelPrimary = true }, drHappyOwner(), "new.com", "panel_primary"},
 		{"web disabled", func(d *models.Domain) { d.WebDisabled = true }, drHappyOwner(), "new.com", "web_disabled"},
+		{"custom cert", func(d *models.Domain) { d.SSLMode = models.SSLModeCustom }, drHappyOwner(), "new.com", "ssl_custom_cert"},
+		{"shared cert", func(d *models.Domain) { d.SSLMode = models.SSLModeShared }, drHappyOwner(), "new.com", "ssl_custom_cert"},
 		{"owner unprovisioned", nil, &models.User{ID: "user-1"}, "new.com", "owner_unprovisioned"},
 		{"custom docroot", func(d *models.Domain) { d.DocRoot = "/srv/www/site" }, drHappyOwner(), "new.com", "custom_docroot"},
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1583/#1584 completing the issue's **"remove the old SSL
certificate/configuration"** / **"no stale references"** requirement, plus a
correctness fix for custom/shared certs.

**1. Old SSL artifacts were orphaned on rename (and delete).** The shared
teardown chokepoint — the `domain.delete` agent handler — removed the nginx
vhost, mail vhost, relay cred and logs, but left the domain's TLS material on
disk. It now also removes the self-signed cert directory
(`/etc/ssl/jabali-selfsigned/<name>`) and the certbot/Let's Encrypt lineage for
the exact name (`cleanupCertbotLineage`). Because `domain.delete` is the
chokepoint for both a real delete and a rename's old-name teardown, this fixes
the stale cert on rename **and** the identical leak on a plain delete. Removal
is name-scoped (`p.Domain` is `domainRegex`-validated), so a shared/wildcard
cert stored under a different name is never touched.

**2. Custom / shared certificates could be clobbered.** `RenameDomain` resets
the domain's cert row to `pending` so the reconciler reissues for the new name —
correct for Let's Encrypt and self-signed, but the ACME retry loop
(`tryACMEOrFallback`) is **not** `ssl_mode`-gated, so for a `custom`
(operator-uploaded) or `shared` cert that reset would trigger an
ACME/self-signed attempt that replaces the real certificate. `RenameDomain` now
refuses (fail-closed, `409 ssl_custom_cert`) when `ssl_mode` is `custom` or
`shared`; the owner switches to Let's Encrypt / self-signed first, or re-applies
the cert for the new name after.

**PHP-FPM pool/socket** (another issue requirement) needs no work: the pool slug
and socket path key on `username` + PHP version (`/run/php/jabali-<user>/fpm.sock`),
not the domain name, and the domain binds by `domain_id` — both survive a rename
unchanged.

## Test plan

- [x] `go build ./...` (panel-api + panel-agent), `go vet` clean
- [x] `go test ./internal/userops/...` — gate matrix now covers `custom`/`shared` → `ssl_custom_cert`
- [x] `go test ./internal/commands/...` — `TestRemoveDomainCertArtifacts` (self-signed dir removed, absent name no-ops, sibling name survives); existing `TestDomainDeleteHandler` still passes
- [x] **Box-verified on the test host** (deployed both binaries): `custom` and `shared` rename → `409 ssl_custom_cert`; `le` rename → `200`, and after the teardown sweep the old `/etc/ssl/jabali-selfsigned/<oldname>` dir was **gone** (and the old vhost gone)

GH #1579
