### PR TITLE
feat(domains): rewrite WordPress site URL on rename (GH #1579)

### DIFF
--- a/panel-agent/internal/commands/migration_refresh.go
+++ b/panel-agent/internal/commands/migration_refresh.go
@@ -217,9 +217,15 @@ func migrationRefreshReconcileHandler(ctx context.Context, raw json.RawMessage) 
 	}
 	warnings := []string{}
 	// 1. Site-URL rewrite when the domain/path changed. SECURITY: OldURL/NewURL
-	// are tenant/operator-supplied; validate them as real http(s) URLs (reject
-	// any leading "-" so they can't smuggle a wp-cli flag) and pass them as
-	// POSITIONAL args after a "--" separator (argument-injection defense).
+	// are tenant/operator-supplied; validate them as real http(s) URLs and reject
+	// any leading "-" so they can't smuggle a wp-cli flag — that leading-"-"
+	// rejection IS the argument-injection defense. They are then passed as the
+	// trailing <old> <new> positionals with the flags FIRST and NO "--"
+	// separator: wp-cli's search-replace (2.12) treats a "--" token alongside
+	// --all-tables as a table filter, so the replacement URL was parsed as a
+	// non-existent table name and the rewrite always failed ("Couldn't find any
+	// tables matching: <new_url>"). Dropping "--" is safe because a value that
+	// could be mistaken for a flag is already rejected above.
 	if p.OldURL != "" && p.NewURL != "" && p.OldURL != p.NewURL {
 		for _, v := range []string{p.OldURL, p.NewURL} {
 			if strings.HasPrefix(v, "-") {
@@ -230,7 +236,7 @@ func migrationRefreshReconcileHandler(ctx context.Context, raw json.RawMessage) 
 				return nil, csInvalidArg("old_url/new_url must be valid http(s) URLs")
 			}
 		}
-		if err := runWPAsTenant(ctx, p.OSUser, p.InstallPath, "search-replace", "--all-tables", "--skip-columns=guid", "--", p.OldURL, p.NewURL); err != nil {
+		if err := runWPAsTenant(ctx, p.OSUser, p.InstallPath, "search-replace", "--all-tables", "--skip-columns=guid", p.OldURL, p.NewURL); err != nil {
 			warnings = append(warnings, "search-replace: "+err.Error())
 		}
 	}

--- a/panel-agent/internal/commands/migration_refresh_searchreplace_test.go
+++ b/panel-agent/internal/commands/migration_refresh_searchreplace_test.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRefreshReconcile_SearchReplaceArgs pins the wp search-replace invocation
+// for migration.refresh_reconcile: the old/new URLs are the trailing positionals
+// AFTER the flags, and there is NO "--" separator. wp-cli 2.12 mis-parses a "--"
+// token alongside --all-tables (it treats the replacement URL as a table filter
+// and fails with "Couldn't find any tables matching: <new_url>"), so a
+// regression here would silently break every site-URL rewrite (GH #1579 / #646).
+func TestRefreshReconcile_SearchReplaceArgs(t *testing.T) {
+	var srArgs []string
+	prev := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if strings.Contains(strings.Join(args, " "), "search-replace") {
+			srArgs = append([]string{name}, args...)
+		}
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { execCommandContext = prev })
+
+	raw, _ := json.Marshal(refreshReconcileParams{
+		OSUser:      "u1",
+		InstallPath: "/home/u1/public_html/site",
+		Domain:      "new.com",
+		OldURL:      "https://old.com",
+		NewURL:      "https://new.com",
+	})
+	if _, err := migrationRefreshReconcileHandler(context.Background(), raw); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if srArgs == nil {
+		t.Fatal("search-replace was never invoked")
+	}
+
+	for _, a := range srArgs {
+		if a == "--" {
+			t.Fatalf(`search-replace must not use a "--" separator (breaks wp-cli 2.12): %v`, srArgs)
+		}
+	}
+
+	// The replacement URL must appear AFTER the flags (as the <new> positional),
+	// not be consumed as a table filter.
+	joined := strings.Join(srArgs, " ")
+	iFlag := strings.Index(joined, "--skip-columns=guid")
+	iOld := strings.Index(joined, "https://old.com")
+	iNew := strings.Index(joined, "https://new.com")
+	if iFlag < 0 || iOld < 0 || iNew < 0 {
+		t.Fatalf("expected flags + both URLs in args: %v", srArgs)
+	}
+	if !(iFlag < iOld && iOld < iNew) {
+		t.Fatalf("expected order flags < old < new, got flag=%d old=%d new=%d (%v)", iFlag, iOld, iNew, srArgs)
+	}
+}

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -17,10 +17,12 @@ type renameDomainRequest struct {
 
 // rename renames an existing domain in place (GH #1579). Owner-scoped: a tenant
 // may rename their own domain, an admin any. Experimental phase 1 — web-only,
-// mail must be off, and the app's own internal config (e.g. a WordPress
-// siteurl) is NOT rewritten; the UI warns about that. The heavy lifting (gate,
-// tombstone the old name, rename the row, move + re-own the docroot, re-render)
-// lives in the shared userops.RenameDomain so any future CLI reuses it.
+// mail must be off. A WordPress install's stored site URL IS rewritten to the
+// new name (best-effort); any install that could not be rewritten comes back in
+// the response `warnings` (surfaced by the UI). Other apps' internal config is
+// unchanged. The heavy lifting (gate, tombstone the old name, rename the row,
+// move + re-own the docroot, rewrite app URLs, re-render) lives in the shared
+// userops.RenameDomain so any future CLI reuses it.
 func (h *domainHandler) rename(c *gin.Context) {
 	ctx := c.Request.Context()
 	domain, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
@@ -64,7 +66,7 @@ func (h *domainHandler) rename(c *gin.Context) {
 		rec = h.cfg.Reconciler
 	}
 
-	if err := userops.RenameDomain(ctx, userops.Deps{
+	warnings, err := userops.RenameDomain(ctx, userops.Deps{
 		Domains:         h.cfg.Domains,
 		DomainTeardowns: h.cfg.DomainTeardowns,
 		Users:           h.cfg.Users,
@@ -72,11 +74,14 @@ func (h *domainHandler) rename(c *gin.Context) {
 		// Mailboxes arms the fail-closed mailbox gate (a rename would purge
 		// retained Stalwart accounts on the old name). DNSZones + SSLCerts let
 		// the rename re-key the zone + reissue the cert for the new name.
-		Mailboxes: h.cfg.Mailboxes,
-		DNSZones:  h.cfg.DNSZones,
-		SSLCerts:  h.cfg.SSLCerts,
-		Log:       slog.Default(),
-	}, rec, domain, newName); err != nil {
+		// AppInstalls lets it rewrite a WordPress install's stored site URL.
+		Mailboxes:   h.cfg.Mailboxes,
+		DNSZones:    h.cfg.DNSZones,
+		SSLCerts:    h.cfg.SSLCerts,
+		AppInstalls: h.cfg.AppInstalls,
+		Log:         slog.Default(),
+	}, rec, domain, newName)
+	if err != nil {
 		var re *userops.RenameError
 		if errors.As(err, &re) {
 			c.JSON(renameHTTPStatus(re.Code), gin.H{"error": re.Code, "message": re.Message})
@@ -86,7 +91,13 @@ func (h *domainHandler) rename(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"id": domain.ID, "name": domain.Name, "doc_root": domain.DocRoot})
+	// warnings carries any best-effort app-URL rewrite that did not complete —
+	// the rename itself succeeded. Always an array (never null) so the client
+	// can render it uniformly.
+	if warnings == nil {
+		warnings = []string{}
+	}
+	c.JSON(http.StatusOK, gin.H{"id": domain.ID, "name": domain.Name, "doc_root": domain.DocRoot, "warnings": warnings})
 }
 
 // renameHTTPStatus maps a RenameError code to an HTTP status. Gate/validation

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2579,13 +2579,15 @@ paths:
         old name's nginx vhost + PowerDNS zone via the durable teardown.
         Experimental phase 1 — refuses when the domain has any mailbox (mail must
         be off AND have no retained mailboxes), is the panel's own primary, or
-        has no website. It does NOT rewrite an installed app's internal config
-        (e.g. a WordPress siteurl); the caller updates that in the app.
+        has no website. For a WordPress install it rewrites the stored site URL
+        to the new name (best-effort); any install that could not be rewritten is
+        reported in the `warnings` array. Other apps' internal config is not
+        changed.
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { name: { type: string } }, required: [name] } } } }
       responses:
-        "200": { description: Renamed, content: { application/json: { schema: { type: object, properties: { id: { type: string }, name: { type: string }, doc_root: { type: string } } } } } }
+        "200": { description: Renamed, content: { application/json: { schema: { type: object, properties: { id: { type: string }, name: { type: string }, doc_root: { type: string }, warnings: { type: array, items: { type: string }, description: "Best-effort app-URL rewrites that did not complete (empty on a clean rename)" } } } } } }
         "400": { description: Invalid or ambiguous name, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "403": { description: Not the domain owner, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "404": { description: Domain not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -2,9 +2,12 @@ package userops
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -19,6 +22,27 @@ import (
 type MailboxCounter interface {
 	CountByDomainID(ctx context.Context, domainID string) (int64, error)
 }
+
+// AppInstallLister lists the application installs on a domain so a rename can
+// rewrite a WordPress install's stored site URL to the new name (GH #1579).
+// Satisfied by repository.ApplicationInstallRepository. Optional on Deps: nil
+// skips the app-URL rewrite entirely (the rename still succeeds).
+type AppInstallLister interface {
+	ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.ApplicationInstall, error)
+}
+
+// appTypeWordPress is the ApplicationInstall.AppType whose stored site URL a
+// rename can rewrite (models.ApplicationInstall defaults app_type to this). Only
+// WordPress keeps a rewritable absolute site URL in its OWN database; other app
+// types are left untouched.
+const appTypeWordPress = "wordpress"
+
+// refreshableOSUserRE mirrors the migration.refresh_reconcile agent verb's
+// os_user constraint (panel-agent internal/commands/migration_refresh.go). It is
+// stricter than provisioning's usernameRe (it rejects '_'), so a rename whose
+// owner name falls outside it skips the WordPress URL rewrite with a warning
+// rather than sending a call the agent would reject.
+var refreshableOSUserRE = regexp.MustCompile(`^[a-z][a-z0-9-]{0,31}$`)
 
 // RenameError is a typed gate/orchestration failure so the HTTP handler can map
 // a stable code to a 4xx and any future CLI to a usage error.
@@ -52,10 +76,17 @@ func renameErr(code, format string, args ...any) *RenameError {
 //   - the docroot path does not contain the old name exactly once (a custom
 //     docroot needs a manual move).
 //
-// Installed apps are ALLOWED, but their internal configuration (e.g. a
-// WordPress siteurl stored in the app's own database) is NOT rewritten — the
-// caller warns the user. The WordPress reconciler derives its probe path from
-// the domain's current docroot, so the install itself heals to the new path.
+// Installed apps are ALLOWED. A WordPress install's stored site URL (kept in
+// the app's OWN database, which the docroot move + DNS/SSL re-key do not touch)
+// IS rewritten to the new name, best-effort, via migration.refresh_reconcile;
+// any install that could not be rewritten is reported in the returned warnings.
+// Other app types keep their own internal configuration unchanged. The
+// WordPress reconciler derives its probe path from the domain's current
+// docroot, so the install's on-disk path heals regardless.
+//
+// It returns the best-effort app-URL-rewrite warnings alongside the error: an
+// empty slice on a clean rename, one entry per install that could not be
+// rewritten (the rename itself still succeeded).
 //
 // The name is expected to be pre-normalized + format-validated by the caller
 // (the HTTP handler runs normalizeDomainName + validateDomainName, the same
@@ -75,12 +106,12 @@ func renameErr(code, format string, args ...any) *RenameError {
 // Steps 3–5 are best-effort heals AFTER the rename is committed: a rare failure
 // there is logged, not surfaced, because the row+files (the source of truth)
 // are already renamed and the periodic reconcile converges the rest.
-func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *models.Domain, newName string) error {
+func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *models.Domain, newName string) ([]string, error) {
 	if d.Domains == nil || d.Agent == nil || d.Users == nil {
-		return renameErr("unavailable", "rename is not available (domains/users/agent not wired)")
+		return nil, renameErr("unavailable", "rename is not available (domains/users/agent not wired)")
 	}
 	if domain == nil {
-		return renameErr("not_found", "domain not found")
+		return nil, renameErr("not_found", "domain not found")
 	}
 
 	oldName := domain.Name
@@ -89,13 +120,13 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 
 	// ---- gate ----
 	if newName == "" {
-		return renameErr("invalid_name", "a new domain name is required")
+		return nil, renameErr("invalid_name", "a new domain name is required")
 	}
 	if newName == strings.ToLower(oldName) {
-		return renameErr("noop", "the new name is the same as the current name")
+		return nil, renameErr("noop", "the new name is the same as the current name")
 	}
 	if domain.EmailEnabled {
-		return renameErr("mail_active",
+		return nil, renameErr("mail_active",
 			"disable mail on %q before renaming — a rename changes every mailbox address and cannot migrate mail", oldName)
 	}
 	// Fail-closed mailbox gate. The old-name teardown's first step
@@ -104,19 +135,19 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	// EmailEnabled==false is NOT proof there is no mail to lose. Refuse when the
 	// counter is unwired (can't prove zero) or reports any mailbox.
 	if d.Mailboxes == nil {
-		return renameErr("unavailable", "rename is not available (mailbox check not wired)")
+		return nil, renameErr("unavailable", "rename is not available (mailbox check not wired)")
 	}
 	if n, cerr := d.Mailboxes.CountByDomainID(ctx, domain.ID); cerr != nil {
-		return renameErr("unavailable", "could not verify %q has no mailboxes: %v", oldName, cerr)
+		return nil, renameErr("unavailable", "could not verify %q has no mailboxes: %v", oldName, cerr)
 	} else if n > 0 {
-		return renameErr("mailboxes_present",
+		return nil, renameErr("mailboxes_present",
 			"%q still has %d mailbox(es) — delete or migrate them before renaming (a rename would change every mailbox address)", oldName, n)
 	}
 	if domain.IsPanelPrimary {
-		return renameErr("panel_primary", "%q is the panel's own primary domain and cannot be renamed", oldName)
+		return nil, renameErr("panel_primary", "%q is the panel's own primary domain and cannot be renamed", oldName)
 	}
 	if domain.WebDisabled || oldDocRoot == "" {
-		return renameErr("web_disabled", "%q has no website to rename", oldName)
+		return nil, renameErr("web_disabled", "%q has no website to rename", oldName)
 	}
 	// A custom (operator-uploaded) or shared certificate cannot be re-issued for
 	// the new name automatically — its files/lineage cover the OLD name, and the
@@ -125,32 +156,32 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	// domain's real certificate; the owner switches to Let's Encrypt or
 	// self-signed first, or re-uploads for the new name after.
 	if domain.SSLMode == models.SSLModeCustom || domain.SSLMode == models.SSLModeShared {
-		return renameErr("ssl_custom_cert",
+		return nil, renameErr("ssl_custom_cert",
 			"%q uses a %s TLS certificate that cannot be re-issued automatically for a new name — switch it to Let's Encrypt or self-signed before renaming (you can re-apply the certificate for the new name after)",
 			oldName, domain.SSLMode)
 	}
 
 	owner, err := d.Users.FindByID(ctx, domain.UserID)
 	if err != nil || owner == nil {
-		return renameErr("owner_unresolved", "could not resolve the owner of %q", oldName)
+		return nil, renameErr("owner_unresolved", "could not resolve the owner of %q", oldName)
 	}
 	if owner.LinuxUID == nil || *owner.LinuxUID == 0 {
-		return renameErr("owner_unprovisioned", "the owner's Linux account is not fully provisioned yet")
+		return nil, renameErr("owner_unprovisioned", "the owner's Linux account is not fully provisioned yet")
 	}
 
 	newDocRoot, pruneOldDir, derr := renameDocRootSegment(oldDocRoot, oldName, newName)
 	if derr != nil {
-		return derr
+		return nil, derr
 	}
 
 	// The new name must be free. A concurrent claim between here and the write
 	// is still caught by the unique index (Rename returns a conflict).
 	existing, ferr := d.Domains.FindByName(ctx, newName)
 	if ferr != nil && !errors.Is(ferr, repository.ErrNotFound) {
-		return renameErr("lookup_failed", "could not check name availability: %v", ferr)
+		return nil, renameErr("lookup_failed", "could not check name availability: %v", ferr)
 	}
 	if existing != nil {
-		return renameErr("name_taken", "%q already exists", newName)
+		return nil, renameErr("name_taken", "%q already exists", newName)
 	}
 
 	// ---- orchestrate ----
@@ -172,7 +203,7 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		reownParams["prune_empty_dir"] = pruneOldDir
 	}
 	if _, aerr := d.Agent.Call(ctx, "domain.reown", reownParams); aerr != nil {
-		return renameErr("move_failed", "could not move the site files for %q: %v", oldName, aerr)
+		return nil, renameErr("move_failed", "could not move the site files for %q: %v", oldName, aerr)
 	}
 
 	// 2. Rename the row (name + doc_root as a unit) — the authoritative flip.
@@ -181,9 +212,9 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	//    sweep tearing down a live domain.
 	if rerr := d.Domains.Rename(ctx, domain.ID, newName, newDocRoot); rerr != nil {
 		if errors.Is(rerr, repository.ErrConflict) {
-			return renameErr("name_taken", "%q already exists", newName)
+			return nil, renameErr("name_taken", "%q already exists", newName)
 		}
-		return renameErr("persist_failed", "could not rename %q: %v", oldName, rerr)
+		return nil, renameErr("persist_failed", "could not rename %q: %v", oldName, rerr)
 	}
 	domain.Name = newName
 	domain.DocRoot = newDocRoot
@@ -230,11 +261,141 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		}
 	}
 
+	// 4c. Rewrite a WordPress install's stored site URL from the old name to the
+	//     new one. The docroot move + DNS/SSL re-key do NOT touch a WordPress
+	//     install's own database, where an absolute site URL is stored; left
+	//     stale it redirects visitors back to the old name. Best-effort per
+	//     install, surfaced as warnings (never fails the committed rename).
+	var warnings []string
+	if d.AppInstalls != nil {
+		warnings = rewriteAppSiteURLs(ctx, d, domain, owner, oldName, newName)
+	}
+
 	// 5. Force a prompt re-render + zone push + cert reissue for the new name.
 	if rec != nil {
 		rec.Schedule(domain.ID)
 	}
-	return nil
+	return warnings, nil
+}
+
+// rewriteAppSiteURLs best-effort rewrites the stored site URL of every
+// WordPress install on the (already-renamed) domain from oldName to newName,
+// via the migration.refresh_reconcile agent verb (wp search-replace across all
+// tables + cache flush + FPM reload). It returns a human-readable warning for
+// each install it could not rewrite; the rename itself already succeeded, so a
+// failure here is a heal to retry, not a reason to roll back.
+//
+// Only WordPress installs are handled — other app types keep their own
+// configuration and the panel does not know how to rewrite it. A domain with no
+// WordPress install produces no warning.
+func rewriteAppSiteURLs(ctx context.Context, d Deps, domain *models.Domain, owner *models.User, oldName, newName string) []string {
+	installs, lerr := d.AppInstalls.ListByDomainIDs(ctx, []string{domain.ID})
+	if lerr != nil {
+		logRenameHeal(d.Log, "list app installs", oldName, newName, lerr)
+		return []string{fmt.Sprintf(
+			"could not check for WordPress installs to update after the rename — update any WordPress site URL manually: %v", lerr)}
+	}
+	// Only WordPress keeps a rewritable absolute site URL in its own database.
+	var wp []models.ApplicationInstall
+	for _, inst := range installs {
+		if inst.AppType == appTypeWordPress {
+			wp = append(wp, inst)
+		}
+	}
+	if len(wp) == 0 {
+		return nil
+	}
+
+	osUser := ""
+	if owner.Username != nil {
+		osUser = *owner.Username
+	}
+	// The refresh verb runs wp-cli as this OS user and validates the name against
+	// a stricter shape than provisioning (no '_'). If the owner's name is outside
+	// it, skip the rewrite with a clear warning rather than send a rejected call.
+	if !refreshableOSUserRE.MatchString(osUser) {
+		return []string{fmt.Sprintf(
+			"the WordPress site URL was not updated automatically — update it manually (change %q to %q in the site's settings)",
+			oldName, newName)}
+	}
+
+	var warnings []string
+	for _, inst := range wp {
+		installPath := filepath.Join(domain.DocRoot, inst.Subdirectory)
+		// A www-canonical install stores its site URL with the "www." host, so
+		// rewrite that host; otherwise the bare name. (The scheme-anchored
+		// old_url means neither pass matches an unrelated host.)
+		oldHost, newHost := oldName, newName
+		if inst.UseWWW {
+			oldHost, newHost = "www."+oldName, "www."+newName
+		}
+		// The stored site URL may use either scheme, and the served scheme may
+		// have changed; rewrite both. Each pass is a no-op when scheme://old is
+		// absent (wp search-replace simply matches nothing). Dedupe reasons: a
+		// broken install fails identically on both passes.
+		seen := map[string]bool{}
+		var reasons []string
+		addReason := func(r string) {
+			if r != "" && !seen[r] {
+				seen[r] = true
+				reasons = append(reasons, r)
+			}
+		}
+		for _, scheme := range []string{"https://", "http://"} {
+			raw, aerr := d.Agent.Call(ctx, "migration.refresh_reconcile", map[string]any{
+				"os_user":      osUser,
+				"install_path": installPath,
+				"domain":       newName,
+				"old_url":      scheme + oldHost,
+				"new_url":      scheme + newHost,
+			})
+			if aerr != nil {
+				addReason(aerr.Error())
+				break // a transport/validation error will recur on the next pass
+			}
+			// The verb reports a wp search-replace FAILURE inside its warnings
+			// (nil error), not as a call error — and always adds a benign
+			// page-cache note — so inspect the response and surface only genuine
+			// search-replace failures. Ignoring the response would let a failed
+			// rewrite masquerade as a clean rename.
+			for _, f := range refreshReconcileFailures(raw) {
+				addReason(f)
+			}
+		}
+		if len(reasons) > 0 {
+			logRenameHeal(d.Log, "rewrite WordPress site URL", oldName, newName, errors.New(strings.Join(reasons, "; ")))
+			warnings = append(warnings, fmt.Sprintf(
+				"could not update the WordPress site URL for the install at %q — update it manually: %s",
+				installPath, strings.Join(reasons, "; ")))
+		}
+	}
+	return warnings
+}
+
+// refreshReconcileFailures inspects a migration.refresh_reconcile response. The
+// verb reports a wp search-replace failure in its `warnings` (prefixed
+// "search-replace:") with a nil call error, and always adds a benign page-cache
+// note — so a non-nil call error is not the only failure signal, and not every
+// warning is a failure. It returns only the genuine search-replace failure
+// messages (empty when the rewrite succeeded).
+func refreshReconcileFailures(raw json.RawMessage) []string {
+	var resp struct {
+		OK       bool     `json:"ok"`
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return []string{"unexpected response from the update tool"}
+	}
+	var fails []string
+	for _, w := range resp.Warnings {
+		if strings.HasPrefix(w, "search-replace:") {
+			fails = append(fails, w)
+		}
+	}
+	if !resp.OK && len(fails) == 0 {
+		fails = append(fails, "the update tool reported failure")
+	}
+	return fails
 }
 
 // logRenameHeal records a best-effort post-commit heal failure without failing

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,18 +51,50 @@ func (u *drUsers) FindByID(_ context.Context, _ string) (*models.User, error) {
 type drAgent struct {
 	rec     *drRecorder
 	callErr error
-	last    map[string]any
+	// errByMethod fails only the named agent methods (checked before callErr),
+	// so a test can let domain.reown succeed while migration.refresh_reconcile
+	// fails.
+	errByMethod  map[string]error
+	last         map[string]any
+	refreshCalls []map[string]any // migration.refresh_reconcile params, in order
+	// refreshResp, when set, is the migration.refresh_reconcile response body —
+	// so a test can simulate the verb reporting a search-replace failure (or a
+	// benign page-cache note) inside its warnings with a nil call error.
+	refreshResp json.RawMessage
 }
 
 func (a *drAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
 	a.rec.events = append(a.rec.events, "agent."+method)
 	if m, ok := params.(map[string]any); ok {
 		a.last = m
+		if method == "migration.refresh_reconcile" {
+			a.refreshCalls = append(a.refreshCalls, m)
+		}
+	}
+	if a.errByMethod != nil {
+		if e, ok := a.errByMethod[method]; ok {
+			return nil, e
+		}
 	}
 	if a.callErr != nil {
 		return nil, a.callErr
 	}
+	if method == "migration.refresh_reconcile" {
+		if a.refreshResp != nil {
+			return a.refreshResp, nil
+		}
+		return json.RawMessage(`{"ok":true,"warnings":[]}`), nil
+	}
 	return json.RawMessage(`{}`), nil
+}
+
+type drAppInstalls struct {
+	installs []models.ApplicationInstall
+	err      error
+}
+
+func (a *drAppInstalls) ListByDomainIDs(_ context.Context, _ []string) ([]models.ApplicationInstall, error) {
+	return a.installs, a.err
 }
 
 type drTeardowns struct {
@@ -216,7 +249,7 @@ func TestRenameDomain_Gates(t *testing.T) {
 				tc.mutate(dom)
 			}
 			d, ag, _ := drNewDeps(rec, dom, tc.owner)
-			err := RenameDomain(context.Background(), d, &drSched{}, dom, tc.newName)
+			_, err := RenameDomain(context.Background(), d, &drSched{}, dom, tc.newName)
 			if got := drCodeOf(t, err); got != tc.want {
 				t.Fatalf("code = %q, want %q", got, tc.want)
 			}
@@ -235,7 +268,7 @@ func TestRenameDomain_MailboxesPresent(t *testing.T) {
 	dom := drWebDomain()
 	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
 	d.Mailboxes = &drMailboxes{count: 3}
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "mailboxes_present" {
 		t.Fatalf("code = %q, want mailboxes_present", got)
 	}
@@ -249,7 +282,7 @@ func TestRenameDomain_MailboxCheckUnwired(t *testing.T) {
 	dom := drWebDomain()
 	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
 	d.Mailboxes = nil // fail-closed: cannot prove zero mailboxes
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "unavailable" {
 		t.Fatalf("code = %q, want unavailable", got)
 	}
@@ -263,7 +296,7 @@ func TestRenameDomain_MailboxCountError(t *testing.T) {
 	dom := drWebDomain()
 	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
 	d.Mailboxes = &drMailboxes{err: errors.New("db down")}
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "unavailable" {
 		t.Fatalf("code = %q, want unavailable (can't verify zero mailboxes)", got)
 	}
@@ -277,7 +310,7 @@ func TestRenameDomain_NameTaken(t *testing.T) {
 	dom := drWebDomain()
 	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
 	d.Domains.(*drDomains).byName["new.com"] = &models.Domain{ID: "other", Name: "new.com"}
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "name_taken" {
 		t.Fatalf("code = %q, want name_taken", got)
 	}
@@ -294,7 +327,7 @@ func TestRenameDomain_HappyPath(t *testing.T) {
 	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
 	sched := &drSched{}
 
-	if err := RenameDomain(context.Background(), d, sched, dom, "New.com"); err != nil {
+	if _, err := RenameDomain(context.Background(), d, sched, dom, "New.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -355,7 +388,7 @@ func TestRenameDomain_DefaultLayoutNoPrune(t *testing.T) {
 	rec := &drRecorder{}
 	dom := drWebDomain() // /home/u1/public_html/old.com
 	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
-	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, ok := ag.last["prune_empty_dir"]; ok {
@@ -370,7 +403,7 @@ func TestRenameDomain_NestedLayoutPrunesOldDir(t *testing.T) {
 	dom := drWebDomain()
 	dom.DocRoot = "/home/u1/domains/old.com/public_html"
 	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
-	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if ag.last["new_doc_root"] != "/home/u1/domains/new.com/public_html" {
@@ -393,7 +426,7 @@ func TestRenameDomain_HappyPath_NoZoneNoCert(t *testing.T) {
 	d.DNSZones.(*drDNSZones).zone = nil // FindByDomainID -> ErrNotFound
 	d.SSLCerts.(*drSSLCerts).cert = nil
 
-	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	want := []string{"agent.domain.reown", "db.rename", "tombstone.ensure"}
@@ -414,7 +447,7 @@ func TestRenameDomain_PersistFailureAfterMove(t *testing.T) {
 	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
 	d.Domains.(*drDomains).renameErr = errors.New("db down")
 
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "persist_failed" {
 		t.Fatalf("code = %q, want persist_failed", got)
 	}
@@ -437,7 +470,7 @@ func TestRenameDomain_PersistConflictIsNameTaken(t *testing.T) {
 	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
 	d.Domains.(*drDomains).renameErr = repository.ErrConflict
 
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "name_taken" {
 		t.Fatalf("code = %q, want name_taken (conflict from unique index)", got)
 	}
@@ -451,7 +484,7 @@ func TestRenameDomain_MoveFailureBeforeCommit(t *testing.T) {
 	d, _, td := drNewDeps(rec, dom, drHappyOwner())
 	d.Agent.(*drAgent).callErr = errors.New("agent unreachable")
 
-	err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "move_failed" {
 		t.Fatalf("code = %q, want move_failed", got)
 	}
@@ -478,11 +511,233 @@ func TestRenameDomain_HealFailureStillSucceeds(t *testing.T) {
 	d.DNSZones.(*drDNSZones).updErr = errors.New("zone update failed")
 	d.SSLCerts.(*drSSLCerts).resetErr = errors.New("cert reset failed")
 
-	if err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("a post-commit heal failure must not fail the rename, got %v", err)
 	}
 	if dom.Name != "new.com" {
 		t.Fatalf("row should be renamed despite heal failure, got %q", dom.Name)
+	}
+}
+
+// ---- WordPress site-URL rewrite (GH #1579 app-URL slice) ----
+
+// A WordPress install on the domain gets its stored site URL rewritten after
+// the rename: two migration.refresh_reconcile passes (https then http) against
+// the NEW docroot + new name, after the DNS/SSL heals and before Schedule.
+func TestRenameDomain_WordPressURLRewrite(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: ""},
+	}}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("clean rewrite must produce no warnings, got %v", warnings)
+	}
+
+	// The rewrite runs AFTER the DNS/SSL heals.
+	want := []string{
+		"agent.domain.reown", "db.rename", "tombstone.ensure", "zone.rename", "cert.reset",
+		"agent.migration.refresh_reconcile", "agent.migration.refresh_reconcile",
+	}
+	if len(rec.events) != len(want) {
+		t.Fatalf("events = %v, want %v", rec.events, want)
+	}
+	for i := range want {
+		if rec.events[i] != want[i] {
+			t.Fatalf("event[%d] = %q, want %q (all: %v)", i, rec.events[i], want[i], rec.events)
+		}
+	}
+
+	if len(ag.refreshCalls) != 2 {
+		t.Fatalf("want 2 refresh calls (https + http), got %d: %v", len(ag.refreshCalls), ag.refreshCalls)
+	}
+	https, http := ag.refreshCalls[0], ag.refreshCalls[1]
+	if https["old_url"] != "https://old.com" || https["new_url"] != "https://new.com" {
+		t.Fatalf("https pass urls = %v -> %v", https["old_url"], https["new_url"])
+	}
+	if http["old_url"] != "http://old.com" || http["new_url"] != "http://new.com" {
+		t.Fatalf("http pass urls = %v -> %v", http["old_url"], http["new_url"])
+	}
+	// Runs as the owner, against the NEW docroot, with the NEW domain name.
+	if https["os_user"] != "u1" {
+		t.Fatalf("os_user = %v, want u1", https["os_user"])
+	}
+	if https["install_path"] != "/home/u1/public_html/new.com" {
+		t.Fatalf("install_path = %v, want the new docroot", https["install_path"])
+	}
+	if https["domain"] != "new.com" {
+		t.Fatalf("domain = %v, want new.com", https["domain"])
+	}
+}
+
+// A WordPress install in a subdirectory rewrites against docroot/<subdir>.
+func TestRenameDomain_WordPressURLRewrite_Subdirectory(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: "blog"},
+	}}
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ag.refreshCalls) != 2 {
+		t.Fatalf("want 2 refresh calls, got %d", len(ag.refreshCalls))
+	}
+	if got := ag.refreshCalls[0]["install_path"]; got != "/home/u1/public_html/new.com/blog" {
+		t.Fatalf("install_path = %v, want .../new.com/blog", got)
+	}
+}
+
+// A non-WordPress install is never rewritten (the panel does not know its
+// internal config) and produces no warning.
+func TestRenameDomain_NonWordPressAppNoRewrite(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "dokuwiki", Subdirectory: ""},
+	}}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("non-WordPress app must not warn, got %v", warnings)
+	}
+	if len(ag.refreshCalls) != 0 {
+		t.Fatalf("non-WordPress app must not trigger a rewrite, got %v", ag.refreshCalls)
+	}
+}
+
+// An owner whose name is outside the refresh verb's stricter shape (underscore)
+// skips the rewrite with a warning rather than sending a rejected call.
+func TestRenameDomain_WordPressRewrite_UnderscoreOwnerWarns(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	uname := "u_1"
+	owner := &models.User{ID: "user-1", Username: &uname, LinuxUID: drUIDPtr(1001)}
+	d, ag, _ := drNewDeps(rec, dom, owner)
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: ""},
+	}}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ag.refreshCalls) != 0 {
+		t.Fatalf("underscore owner must not send a refresh call, got %v", ag.refreshCalls)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("underscore owner must produce exactly one warning, got %v", warnings)
+	}
+}
+
+// A refresh-verb failure surfaces as a warning but never fails the committed
+// rename (the row + files are already renamed).
+func TestRenameDomain_WordPressRewrite_AgentErrorWarns(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.errByMethod = map[string]error{"migration.refresh_reconcile": errors.New("wp-cli boom")}
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: ""},
+	}}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("a rewrite failure must not fail the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed despite rewrite failure, got %q", dom.Name)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("rewrite failure must produce one warning, got %v", warnings)
+	}
+}
+
+// The verb reports a wp search-replace failure INSIDE its warnings with a nil
+// call error — that must surface as a warning (not a silent clean rename).
+func TestRenameDomain_WordPressRewrite_SearchReplaceWarningSurfaced(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.refreshResp = json.RawMessage(
+		`{"ok":true,"warnings":["search-replace: wp-cli boom","page cache purge deferred to reconcile/nginx.cache.purge"]}`)
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: ""},
+	}}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("a search-replace failure must not fail the rename, got %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("want exactly one surfaced warning, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0], "search-replace: wp-cli boom") {
+		t.Fatalf("warning must carry the search-replace failure, got %q", warnings[0])
+	}
+	// The benign page-cache note must NOT be surfaced as a failure, and the
+	// dedupe must collapse the identical failure from both scheme passes.
+	if strings.Contains(warnings[0], "page cache") {
+		t.Fatalf("benign page-cache note must not surface, got %q", warnings[0])
+	}
+	if strings.Count(warnings[0], "search-replace: wp-cli boom") != 1 {
+		t.Fatalf("identical failure from both passes must be deduped, got %q", warnings[0])
+	}
+}
+
+// A response carrying ONLY the benign page-cache note (which the verb always
+// adds on a real box) is a clean success — no warning is surfaced.
+func TestRenameDomain_WordPressRewrite_BenignNoteNotSurfaced(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.refreshResp = json.RawMessage(
+		`{"ok":true,"warnings":["page cache purge deferred to reconcile/nginx.cache.purge"]}`)
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: ""},
+	}}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("benign-only warnings must produce no surfaced warning, got %v", warnings)
+	}
+}
+
+// A www-canonical install stores its site URL with the "www." host, so the
+// rewrite must target www.old -> www.new.
+func TestRenameDomain_WordPressURLRewrite_WWW(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.AppInstalls = &drAppInstalls{installs: []models.ApplicationInstall{
+		{ID: "app-1", DomainID: dom.ID, AppType: "wordpress", Subdirectory: "", UseWWW: true},
+	}}
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ag.refreshCalls) != 2 {
+		t.Fatalf("want 2 refresh calls, got %d", len(ag.refreshCalls))
+	}
+	if ag.refreshCalls[0]["old_url"] != "https://www.old.com" ||
+		ag.refreshCalls[0]["new_url"] != "https://www.new.com" {
+		t.Fatalf("www install must rewrite the www host, got %v -> %v",
+			ag.refreshCalls[0]["old_url"], ag.refreshCalls[0]["new_url"])
 	}
 }
 

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -62,8 +62,13 @@ type Deps struct {
 	// DNSZones + SSLCerts let RenameDomain re-key the domain_id-scoped zone row
 	// and force an SSL reissue for the NEW name (GH #1579). Both optional: a
 	// panel without PowerDNS / with no cert row simply skips that heal.
-	DNSZones     repository.DNSZoneRepository
-	SSLCerts     repository.SSLCertificateRepository
+	DNSZones repository.DNSZoneRepository
+	SSLCerts repository.SSLCertificateRepository
+	// AppInstalls lets RenameDomain rewrite a WordPress install's stored site
+	// URL to the new name (GH #1579) — a WordPress install keeps an absolute
+	// site URL in its OWN database, which the docroot move + DNS/SSL re-key do
+	// not touch. Optional: nil skips the rewrite (the rename still succeeds).
+	AppInstalls  AppInstallLister
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int

--- a/panel-ui/src/components/domains/RenameDomainButton.test.tsx
+++ b/panel-ui/src/components/domains/RenameDomainButton.test.tsx
@@ -1,7 +1,8 @@
 // GH #1579: the Rename domain modal gates submit on a valid, different FQDN
 // plus an explicit acknowledgment, normalizes the name, and posts to
-// /domains/:id/rename. The warnings (experimental + "app internals not changed")
-// are load-bearing per johnnyq's ask, so assert they render.
+// /domains/:id/rename. The notices (experimental + WordPress-URL-auto-updated)
+// are load-bearing per johnnyq's ask, so assert they render. Any app-URL
+// rewrite warnings returned on the 200 body are surfaced to the user.
 import { App } from "antd";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,12 +13,16 @@ vi.mock("../../apiClient", () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
 vi.mock("../../lib/feedback", () => ({
-  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+  feedback: { message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } },
 }));
 
 import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback";
 
 const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+const fb = feedback as unknown as {
+  message: { warning: ReturnType<typeof vi.fn> };
+};
 
 const renderBtn = (onRenamed = vi.fn()) => {
   render(
@@ -41,11 +46,17 @@ beforeEach(() => {
 });
 
 describe("RenameDomainButton", () => {
-  it("shows the experimental + app-internals warnings when opened", () => {
+  it("shows the experimental + WordPress-URL notices when opened", () => {
     renderBtn();
     const dialog = openModal();
     expect(dialog.getByText(/experimental feature/i)).toBeInTheDocument();
-    expect(dialog.getByText(/does not change WordPress/i)).toBeInTheDocument();
+    // The phrase also appears in the acknowledgment checkbox, so scope to the
+    // alert title node.
+    expect(
+      dialog.getByText(/WordPress site URL is updated automatically/i, {
+        selector: ".ant-alert-title",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("keeps submit disabled until a valid, different name AND the acknowledgment", () => {
@@ -83,6 +94,27 @@ describe("RenameDomainButton", () => {
 
     await waitFor(() =>
       expect(mocked.post).toHaveBeenCalledWith("/domains/d1/rename", { name: "new.com" }),
+    );
+    await waitFor(() => expect(onRenamed).toHaveBeenCalled());
+  });
+
+  it("surfaces app-URL rewrite warnings returned on the response", async () => {
+    mocked.post.mockResolvedValueOnce({
+      data: { id: "d1", name: "new.com", warnings: ["could not update the WordPress site URL"] },
+    });
+    const onRenamed = renderBtn();
+    const dialog = openModal();
+
+    fireEvent.change(dialog.getByPlaceholderText("new-domain.com"), {
+      target: { value: "new.com" },
+    });
+    fireEvent.click(dialog.getByRole("checkbox"));
+    fireEvent.click(okButton(dialog));
+
+    await waitFor(() =>
+      expect(fb.message.warning).toHaveBeenCalledWith(
+        "could not update the WordPress site URL",
+      ),
     );
     await waitFor(() => expect(onRenamed).toHaveBeenCalled());
   });

--- a/panel-ui/src/components/domains/RenameDomainButton.tsx
+++ b/panel-ui/src/components/domains/RenameDomainButton.tsx
@@ -4,9 +4,10 @@
 // Experimental phase 1: the backend refuses when mail is active, when the domain
 // is the panel's own primary, or when it has no website. It moves the docroot,
 // tears down the old name's nginx vhost + DNS zone, and re-provisions the new
-// name (SSL is reissued by the reconciler). It does NOT rewrite an installed
-// app's internal configuration (e.g. a WordPress siteurl stored in the app's
-// own database) — the modal warns about that and the user updates it in the app.
+// name (SSL is reissued by the reconciler). For a WordPress install it rewrites
+// the stored site URL to the new name (best-effort, via wp search-replace); any
+// install it could not rewrite is returned in `warnings` and surfaced here.
+// Other apps' internal configuration is not changed — the modal notes that.
 import { useState } from "react";
 import { Alert, Button, Checkbox, Input, Modal, Typography } from "antd";
 import { EditOutlined } from "@icons";
@@ -48,8 +49,14 @@ export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProp
     if (!canSubmit) return;
     setBusy(true);
     try {
-      await apiClient.post(`/domains/${domain.id}/rename`, { name: normalized });
+      const resp = await apiClient.post<{ warnings?: string[] }>(
+        `/domains/${domain.id}/rename`,
+        { name: normalized },
+      );
       feedback.message.success(`Renamed to ${normalized}`);
+      // Best-effort app-URL rewrites that did not complete (e.g. a WordPress
+      // site URL that must be updated by hand) come back as warnings.
+      (resp.data?.warnings ?? []).forEach((w) => feedback.message.warning(w));
       close();
       onRenamed();
     } catch (err) {
@@ -87,8 +94,8 @@ export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProp
           type="info"
           showIcon
           style={{ marginBottom: 12 }}
-          message="Your app's internal settings are not changed"
-          description="This does not change WordPress — or any other CMS/app — settings stored inside the app (for example the site URL). After renaming, update the site URL in the app itself."
+          message="WordPress site URL is updated automatically"
+          description="For a WordPress install, the site URL is rewritten to the new name automatically (via wp search-replace). Other apps' internal settings are not changed — update those in the app itself. If the automatic rewrite can't run, you'll see a warning to update it by hand."
         />
         <Typography.Paragraph style={{ marginBottom: 4 }}>
           Renaming <Typography.Text code>{domain.name}</Typography.Text> will:
@@ -98,6 +105,7 @@ export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProp
           <li>Rebuild the web server (nginx) configuration for the new name</li>
           <li>Reissue the SSL certificate for the new name</li>
           <li>Recreate the managed DNS zone under the new name and remove the old one</li>
+          <li>Rewrite a WordPress install's site URL to the new name (other apps unchanged)</li>
         </ul>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 4 }}>
           Mail must be off and the domain must have no mailboxes — renaming would
@@ -112,8 +120,8 @@ export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProp
           style={{ marginBottom: 12 }}
         />
         <Checkbox checked={ack} onChange={(e) => setAck(e.target.checked)}>
-          I understand this is experimental and does not change my app's internal
-          settings.
+          I understand this is experimental. A WordPress site URL is updated
+          automatically; other apps' internal settings are not.
         </Checkbox>
       </Modal>
     </>


### PR DESCRIPTION
## Summary

Beyond-issue follow-up to #1583/#1584/#1585 (in-place web-domain rename):
a rename now rewrites a **WordPress install's stored site URL** to the new
name. A WordPress install keeps an absolute site URL in its own database, which
the docroot move + DNS/SSL re-key do not touch — left stale it redirects
visitors back to the old name.

**What it does.** After the rename commits, `RenameDomain` best-effort rewrites
every WordPress install on the domain via the existing
`migration.refresh_reconcile` agent verb (`wp search-replace --all-tables` +
cache flush + FPM reload), for both the `https` and `http` scheme, against the
new docroot (+ the install's subdirectory) and the new name. A www-canonical
install (`UseWWW`) rewrites its `www.` host. Non-WordPress apps are left
untouched (the panel does not know their internal config).

**Failures are surfaced, not swallowed.** This is a post-commit heal like the
DNS/SSL re-key — it never fails the committed rename. The verb reports a
`wp search-replace` failure *inside* its `warnings` with a nil call error (and
always adds a benign page-cache note), so the response is inspected and only
genuine `search-replace:` failures (and transport errors) are surfaced, deduped
across the two scheme passes. They come back as `warnings` on the 200 response
and are shown in the rename modal, so a silent failure can't look like success.
`RenameDomain` now returns `([]string, error)`; the handler puts the warnings on
the body (always an array).

**Also fixes a latent verb bug.** The verb's `wp search-replace` invocation put
the URLs after a `--` separator. wp-cli 2.12 mis-parses `--` alongside
`--all-tables` — it treats the replacement URL as a table filter and fails
(`Couldn't find any tables matching: <new_url>`), so the rewrite silently
failed on **every** call, the #646 migration-refresh path included. The URLs are
now the trailing positionals after the flags with no `--`; the leading-`-`
rejection right above the call is the argument-injection defense (a value that
could be read as a flag is already rejected). A regression test pins the arg
order.

## Test plan

- [x] `go build ./...` (panel-api + panel-agent), `go vet` clean
- [x] `go test ./internal/userops/...` — new WordPress cases: rewrite runs after
      the DNS/SSL heals with correct params; subdirectory install path; www host;
      non-WordPress app skipped; underscore owner warns without a call; transport
      error warns; **verb search-replace failure surfaced**; benign page-cache
      note NOT surfaced
- [x] `go test ./internal/commands/` — `TestRefreshReconcile_SearchReplaceArgs`
      pins no `--` and URLs-after-flags
- [x] UI `tsc --noEmit` + `eslint` clean
- [x] **Box-verified on the test host** (deployed both binaries, wp-cli 2.12,
      real WordPress install):
  - full end-to-end through the panel: rename a WP domain →
    `HTTP 200, "warnings": []`, and `wp option get siteurl`/`home` both
    auto-flipped from the old name to the new name
  - the failure path: before the arg-order fix, the same rename returned
    `200` with `warnings: ["… search-replace: exit status 1"]` — proving the
    verb's in-`warnings` failure is surfaced, not silently dropped

## Notes / known limitations

- The 2–4 `wp search-replace --all-tables` passes run synchronously inside the
  POST. On a very large WordPress database this could approach the agent-call
  timeout; on timeout it degrades to a warning (the rename is already
  committed), but a slow site could see a 502 at the HTTP layer. Acceptable for
  phase 1; a future move could make the rewrite asynchronous.

GH #1579
