### PR TITLE
feat(domains): carry mail across an in-place web-domain rename (GH #1579)

### DIFF
--- a/panel-agent/internal/commands/mail_domain_rename.go
+++ b/panel-agent/internal/commands/mail_domain_rename.go
@@ -1,0 +1,256 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// mail.domain.rename carries a domain's mail across an in-place web-domain
+// rename (GH #1579). Stalwart keys every account on (localpart, domainId) and
+// stores its messages under that account's stable internal id, so renaming the
+// registry Domain ENTITY in place — keeping its id — carries every account, its
+// stored messages, and its (domainId-keyed) DKIM signature to the new address.
+// The panel's DB trigger resyncs mailboxes.email_cached, so the SQL directory
+// then authenticates + delivers at the new address. This is why a rename no
+// longer has to refuse (and its old-name teardown purge) a domain that has mail.
+//
+// The verb is called twice by RenameDomain: once with dry_run=true BEFORE any
+// file move, to catch a genuine conflict (the new name already carries mail)
+// while nothing is committed; then for real AFTER the docroot move and BEFORE
+// the DB rename, so the registry entity is named `new` before the trigger flips
+// email_cached to `@new` (avoiding a window where the directory resolves an
+// address whose domain the registry doesn't yet know).
+type mailDomainRenameParams struct {
+	Old    string `json:"old"`
+	New    string `json:"new"`
+	DryRun bool   `json:"dry_run"`
+}
+
+// mailDomainRenameResult reports the outcome. Status is one of:
+//   - "renamed"          the registry Domain was renamed in place (real run).
+//   - "already"          old is gone from the registry and new is present — the
+//                        rename's Stalwart half is already done (idempotent
+//                        retry); the caller proceeds to the DB rename.
+//   - "not_in_registry"  neither name is in the registry — the domain has no
+//                        Stalwart mail entity; the caller proceeds (the DB
+//                        trigger alone carries any retained mailbox rows).
+//   - "ok"               dry_run only: the rename would proceed (no conflict).
+//   - "conflict"         both names carry mail (new has accounts) — the caller
+//                        refuses; carrying mail into an occupied name is unsafe.
+type mailDomainRenameResult struct {
+	Status            string   `json:"status"`
+	CatchallRewritten bool     `json:"catchall_rewritten"`
+	Warnings          []string `json:"warnings,omitempty"`
+}
+
+// mailDomainNameRE is a defensive shape check on the names the verb sends to
+// Stalwart. The panel already normalizes + validates, and JMAP filter values are
+// JSON-encoded (no injection surface); this just rejects obvious garbage.
+var mailDomainNameRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$`)
+
+func mailDomainRenameHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p mailDomainRenameParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	p.Old = strings.ToLower(strings.TrimSpace(p.Old))
+	p.New = strings.ToLower(strings.TrimSpace(p.New))
+	if p.Old == "" || p.New == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "old and new are required"}
+	}
+	if p.Old == p.New {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "old and new must differ"}
+	}
+	if !mailDomainNameRE.MatchString(p.Old) || !mailDomainNameRE.MatchString(p.New) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "old/new is not a valid domain name"}
+	}
+
+	oldID, err := domainIDByName(ctx, p.Old)
+	if err != nil {
+		return nil, err
+	}
+	newID, err := domainIDByName(ctx, p.New)
+	if err != nil {
+		return nil, err
+	}
+
+	// old already gone from the registry: the domain never had a Stalwart entity,
+	// or a prior run already renamed it. If new is also present it must still be
+	// checked for accounts — an EMPTY new is a harmless orphan (the panel's own
+	// FindByName(new) gate guarantees no other panel domain owns `new`), but a
+	// non-empty new holds another domain's mail. Proceeding would let the DB
+	// trigger point this domain's retained mailboxes at `@new` and adopt those
+	// accounts, so refuse (fail closed toward tenant isolation). The one case this
+	// gives up is a mail-carrying rename whose DB flip failed AFTER a successful
+	// carry (old renamed, new holds our accounts) — that retry now conflicts and
+	// needs manual recovery; documented as a limitation.
+	if oldID == "" {
+		if newID == "" {
+			return mailDomainRenameResult{Status: "not_in_registry"}, nil
+		}
+		n, cerr := countAccountsInDomain(ctx, newID)
+		if cerr != nil {
+			return nil, cerr
+		}
+		if n > 0 {
+			return mailDomainRenameResult{Status: "conflict"}, nil
+		}
+		return mailDomainRenameResult{Status: "already"}, nil
+	}
+
+	// old is present. If new is ALSO present it is either an empty orphan left by
+	// a prior domain delete (purge_accounts destroys accounts but not the Domain
+	// entity — a common leftover) or a genuine, occupied name. Count accounts on
+	// it with the reliable unfiltered enumeration (the `filter:{domainId}` form is
+	// honoured on some Stalwart builds and silently returns 0 on others — trusting
+	// it here could destroy a name that actually holds another tenant's mail).
+	if newID != "" {
+		n, cerr := countAccountsInDomain(ctx, newID)
+		if cerr != nil {
+			return nil, cerr
+		}
+		if n > 0 {
+			return mailDomainRenameResult{Status: "conflict"}, nil
+		}
+	}
+
+	if p.DryRun {
+		return mailDomainRenameResult{Status: "ok"}, nil
+	}
+
+	// Real run. Clear an empty orphan on `new` first so the in-place rename does
+	// not collide with a duplicate name.
+	if newID != "" {
+		if derr := domainDestroy(ctx, newID); derr != nil {
+			return nil, derr
+		}
+	}
+
+	// Rename the registry Domain entity in place — the load-bearing step. Keeping
+	// its id is what carries the accounts, their message stores, and DKIM.
+	if rerr := renameDomainEntity(ctx, oldID, p.New); rerr != nil {
+		return nil, rerr
+	}
+
+	// Best-effort: rewrite a catch-all that pointed at an address on the old name.
+	// It is a literal string on the Domain entity, so the in-place rename leaves
+	// it stale. Safe to run here, BEFORE the caller commits the DB rename (while
+	// the directory's email_cached is still @old): Stalwart validates the new
+	// catchAllAddress against the x:Account it targets — which exists under the
+	// just-renamed domain id — not against the SQL directory, so a not-yet-synced
+	// directory does not reject it (box-verified). A failure here never fails the
+	// rename (mail already carries); it comes back as a warning.
+	res := mailDomainRenameResult{Status: "renamed"}
+	rewritten, w := rewriteCatchAllOnRename(ctx, oldID, p.Old, p.New)
+	res.CatchallRewritten = rewritten
+	if w != "" {
+		res.Warnings = append(res.Warnings, w)
+	}
+	return res, nil
+}
+
+// countAccountsInDomain counts registry Accounts whose domainId matches, using
+// the same reliable enumeration as mail.domain.purge_accounts (unfiltered query
+// + get + client-side match) rather than a server-side domainId filter.
+func countAccountsInDomain(ctx context.Context, domainID string) (int, error) {
+	var q jmapQueryResult
+	if err := jmapCall(ctx, "x:Account/query", map[string]any{"limit": 100000}, &q); err != nil {
+		return 0, err
+	}
+	if len(q.IDs) == 0 {
+		return 0, nil
+	}
+	var got jmapGetResult
+	if err := jmapCall(ctx, "x:Account/get", map[string]any{
+		"ids":        q.IDs,
+		"properties": []string{"domainId"},
+	}, &got); err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, raw := range got.List {
+		var acct struct {
+			DomainID string `json:"domainId"`
+		}
+		if jErr := json.Unmarshal(raw, &acct); jErr != nil {
+			continue
+		}
+		if acct.DomainID == domainID {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// renameDomainEntity renames a registry Domain in place via x:Domain/set update,
+// keeping its id. A refused or missing update is a hard error (fail-closed: the
+// caller has not committed the DB rename yet).
+func renameDomainEntity(ctx context.Context, domainID, newName string) error {
+	args := map[string]any{
+		"update": map[string]any{
+			domainID: map[string]any{"name": newName},
+		},
+	}
+	var result jmapSetResult
+	if err := jmapCall(ctx, "x:Domain/set", args, &result); err != nil {
+		return err
+	}
+	if _, ok := result.Updated[domainID]; ok {
+		return nil
+	}
+	if reason, ok := result.NotUpdated[domainID]; ok {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("stalwart x:Domain/set rename refused: %s", string(reason)),
+		}
+	}
+	return &agentwire.AgentError{
+		Code:    agentwire.CodeInternal,
+		Message: "stalwart x:Domain/set rename: neither updated nor notUpdated contained the id",
+	}
+}
+
+// rewriteCatchAllOnRename reads the domain's catchAllAddress and, if it is an
+// address on the OLD name (localpart@old), rewrites it to localpart@new. Returns
+// (rewritten, warning). Any read/patch failure yields a warning, never an error —
+// the catch-all is opt-in and non-fatal.
+func rewriteCatchAllOnRename(ctx context.Context, domainID, oldName, newName string) (bool, string) {
+	var got jmapGetResult
+	if err := jmapCall(ctx, "x:Domain/get", map[string]any{
+		"ids":        []string{domainID},
+		"properties": []string{"catchAllAddress"},
+	}, &got); err != nil {
+		return false, fmt.Sprintf("could not read the catch-all address to update it for the new name: %v", err)
+	}
+	if len(got.List) == 0 {
+		return false, ""
+	}
+	var d struct {
+		CatchAllAddress *string `json:"catchAllAddress"`
+	}
+	if err := json.Unmarshal(got.List[0], &d); err != nil {
+		return false, ""
+	}
+	if d.CatchAllAddress == nil || *d.CatchAllAddress == "" {
+		return false, ""
+	}
+	suffix := "@" + oldName
+	if !strings.HasSuffix(*d.CatchAllAddress, suffix) {
+		// Catch-all points somewhere else (e.g. an external address) — leave it.
+		return false, ""
+	}
+	newTarget := strings.TrimSuffix(*d.CatchAllAddress, suffix) + "@" + newName
+	if err := updateDomainCatchall(ctx, domainID, newTarget); err != nil {
+		return false, fmt.Sprintf("mail carried to the new name, but the catch-all address still points at the old name (update it manually to %q): %v", newTarget, err)
+	}
+	return true, ""
+}
+
+func init() {
+	Default.Register("mail.domain.rename", mailDomainRenameHandler)
+}

--- a/panel-agent/internal/commands/mail_domain_rename_test.go
+++ b/panel-agent/internal/commands/mail_domain_rename_test.go
@@ -1,0 +1,258 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// fakeStalwart is a tiny in-memory registry the JMAP fake routes against, so the
+// mail.domain.rename tests can drive every status branch and assert the exact
+// mutations (rename in place, orphan destroy, catch-all rewrite).
+type fakeStalwart struct {
+	domains  map[string]string // name -> id
+	catchall map[string]string // domainId -> catchAllAddress ("" = none)
+	accounts map[string]string // accountId -> domainId
+
+	renamed   map[string]string // domainId -> new name (recorded x:Domain/set update name)
+	destroyed []string          // recorded x:Domain/set destroy ids
+	catchSet  map[string]string // domainId -> new catchAllAddress (recorded)
+}
+
+func (f *fakeStalwart) idByName(name string) string { return f.domains[name] }
+
+func (f *fakeStalwart) routes() map[string]jmapHandler {
+	if f.renamed == nil {
+		f.renamed = map[string]string{}
+	}
+	if f.catchSet == nil {
+		f.catchSet = map[string]string{}
+	}
+	return map[string]jmapHandler{
+		"x:Domain/query": func(args json.RawMessage) (any, *jmapFakeError) {
+			var a struct {
+				Filter struct {
+					Name string `json:"name"`
+				} `json:"filter"`
+			}
+			_ = json.Unmarshal(args, &a)
+			if id := f.domains[a.Filter.Name]; id != "" {
+				return map[string]any{"ids": []string{id}}, nil
+			}
+			return map[string]any{"ids": []string{}}, nil
+		},
+		"x:Account/query": func(json.RawMessage) (any, *jmapFakeError) {
+			ids := make([]string, 0, len(f.accounts))
+			for id := range f.accounts {
+				ids = append(ids, id)
+			}
+			return map[string]any{"ids": ids}, nil
+		},
+		"x:Account/get": func(args json.RawMessage) (any, *jmapFakeError) {
+			var a struct {
+				IDs []string `json:"ids"`
+			}
+			_ = json.Unmarshal(args, &a)
+			list := make([]map[string]any, 0, len(a.IDs))
+			for _, id := range a.IDs {
+				list = append(list, map[string]any{"id": id, "domainId": f.accounts[id]})
+			}
+			return map[string]any{"list": list}, nil
+		},
+		"x:Domain/get": func(args json.RawMessage) (any, *jmapFakeError) {
+			var a struct {
+				IDs []string `json:"ids"`
+			}
+			_ = json.Unmarshal(args, &a)
+			list := make([]map[string]any, 0, len(a.IDs))
+			for _, id := range a.IDs {
+				var ca any
+				if v, ok := f.catchall[id]; ok && v != "" {
+					ca = v
+				}
+				list = append(list, map[string]any{"id": id, "catchAllAddress": ca})
+			}
+			return map[string]any{"list": list}, nil
+		},
+		"x:Domain/set": func(args json.RawMessage) (any, *jmapFakeError) {
+			var a struct {
+				Update  map[string]map[string]any `json:"update"`
+				Destroy []string                  `json:"destroy"`
+			}
+			_ = json.Unmarshal(args, &a)
+			if len(a.Destroy) > 0 {
+				f.destroyed = append(f.destroyed, a.Destroy...)
+				return map[string]any{"destroyed": a.Destroy}, nil
+			}
+			updated := map[string]any{}
+			for id, patch := range a.Update {
+				if name, ok := patch["name"].(string); ok {
+					f.renamed[id] = name
+				}
+				if ca, ok := patch["catchAllAddress"]; ok {
+					if s, isStr := ca.(string); isStr {
+						f.catchSet[id] = s
+					} else {
+						f.catchSet[id] = "" // cleared to null
+					}
+				}
+				updated[id] = nil
+			}
+			return map[string]any{"updated": updated}, nil
+		},
+	}
+}
+
+func callRename(t *testing.T, f *fakeStalwart, old, new string, dry bool) mailDomainRenameResult {
+	t.Helper()
+	srv := newJMAPServer(t, f.routes())
+	wireJMAP(t, srv)
+	raw, _ := json.Marshal(mailDomainRenameParams{Old: old, New: new, DryRun: dry})
+	out, err := mailDomainRenameHandler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	res, ok := out.(mailDomainRenameResult)
+	if !ok {
+		t.Fatalf("unexpected result type %T", out)
+	}
+	return res
+}
+
+func TestMailDomainRename_NotInRegistry(t *testing.T) {
+	f := &fakeStalwart{domains: map[string]string{}}
+	if res := callRename(t, f, "old.com", "new.com", true); res.Status != "not_in_registry" {
+		t.Fatalf("status: got %q want not_in_registry", res.Status)
+	}
+}
+
+func TestMailDomainRename_Already(t *testing.T) {
+	// old gone, new present, new EMPTY -> idempotent-retry / harmless orphan; proceed.
+	f := &fakeStalwart{domains: map[string]string{"new.com": "n1"}}
+	if res := callRename(t, f, "old.com", "new.com", true); res.Status != "already" {
+		t.Fatalf("status: got %q want already", res.Status)
+	}
+}
+
+func TestMailDomainRename_AlreadyWithAccountsIsConflict(t *testing.T) {
+	// old gone, new present AND new holds accounts -> another domain's mail.
+	// Refuse (fail closed toward tenant isolation) rather than let the DB trigger
+	// point this domain's retained mailboxes at an occupied name. Must hold even
+	// in dry_run, so the panel refuses BEFORE it moves any files.
+	f := &fakeStalwart{
+		domains:  map[string]string{"new.com": "n1"},
+		accounts: map[string]string{"a1": "n1"},
+	}
+	for _, dry := range []bool{true, false} {
+		res := callRename(t, f, "old.com", "new.com", dry)
+		if res.Status != "conflict" {
+			t.Fatalf("dry=%v status: got %q want conflict", dry, res.Status)
+		}
+		if len(f.renamed) != 0 || len(f.destroyed) != 0 {
+			t.Fatalf("dry=%v mutated: renamed=%v destroyed=%v", dry, f.renamed, f.destroyed)
+		}
+	}
+}
+
+func TestMailDomainRename_DryRunOK_NoMutation(t *testing.T) {
+	f := &fakeStalwart{domains: map[string]string{"old.com": "o1"}}
+	res := callRename(t, f, "old.com", "new.com", true)
+	if res.Status != "ok" {
+		t.Fatalf("status: got %q want ok", res.Status)
+	}
+	if len(f.renamed) != 0 || len(f.destroyed) != 0 {
+		t.Fatalf("dry_run mutated: renamed=%v destroyed=%v", f.renamed, f.destroyed)
+	}
+}
+
+func TestMailDomainRename_ConflictRefuses(t *testing.T) {
+	// both present AND new has an account -> conflict, no mutation.
+	f := &fakeStalwart{
+		domains:  map[string]string{"old.com": "o1", "new.com": "n1"},
+		accounts: map[string]string{"a1": "n1"},
+	}
+	res := callRename(t, f, "old.com", "new.com", false)
+	if res.Status != "conflict" {
+		t.Fatalf("status: got %q want conflict", res.Status)
+	}
+	if len(f.renamed) != 0 || len(f.destroyed) != 0 {
+		t.Fatalf("conflict mutated: renamed=%v destroyed=%v", f.renamed, f.destroyed)
+	}
+}
+
+func TestMailDomainRename_RenamesInPlace(t *testing.T) {
+	f := &fakeStalwart{
+		domains:  map[string]string{"old.com": "o1"},
+		catchall: map[string]string{"o1": ""},
+	}
+	res := callRename(t, f, "old.com", "new.com", false)
+	if res.Status != "renamed" {
+		t.Fatalf("status: got %q want renamed", res.Status)
+	}
+	if f.renamed["o1"] != "new.com" {
+		t.Fatalf("expected o1 renamed to new.com, got %v", f.renamed)
+	}
+	if res.CatchallRewritten {
+		t.Fatalf("no catch-all set, should not report a rewrite")
+	}
+}
+
+func TestMailDomainRename_DestroysEmptyOrphanThenRenames(t *testing.T) {
+	// new is an empty orphan (0 accounts) -> destroy it, then rename old in place.
+	f := &fakeStalwart{
+		domains:  map[string]string{"old.com": "o1", "new.com": "n1"},
+		accounts: map[string]string{"a1": "o1"}, // accounts only on OLD
+	}
+	res := callRename(t, f, "old.com", "new.com", false)
+	if res.Status != "renamed" {
+		t.Fatalf("status: got %q want renamed", res.Status)
+	}
+	if len(f.destroyed) != 1 || f.destroyed[0] != "n1" {
+		t.Fatalf("expected empty orphan n1 destroyed, got %v", f.destroyed)
+	}
+	if f.renamed["o1"] != "new.com" {
+		t.Fatalf("expected o1 renamed to new.com, got %v", f.renamed)
+	}
+}
+
+func TestMailDomainRename_RewritesCatchAll(t *testing.T) {
+	f := &fakeStalwart{
+		domains:  map[string]string{"old.com": "o1"},
+		catchall: map[string]string{"o1": "postmaster@old.com"},
+	}
+	res := callRename(t, f, "old.com", "new.com", false)
+	if res.Status != "renamed" || !res.CatchallRewritten {
+		t.Fatalf("got status=%q catchall=%v; want renamed + rewritten", res.Status, res.CatchallRewritten)
+	}
+	if f.catchSet["o1"] != "postmaster@new.com" {
+		t.Fatalf("catch-all: got %q want postmaster@new.com", f.catchSet["o1"])
+	}
+}
+
+func TestMailDomainRename_ExternalCatchAllLeftAlone(t *testing.T) {
+	f := &fakeStalwart{
+		domains:  map[string]string{"old.com": "o1"},
+		catchall: map[string]string{"o1": "ops@external.example"},
+	}
+	res := callRename(t, f, "old.com", "new.com", false)
+	if res.CatchallRewritten {
+		t.Fatalf("external catch-all should not be rewritten")
+	}
+	if _, set := f.catchSet["o1"]; set {
+		t.Fatalf("external catch-all should be left untouched, got %v", f.catchSet)
+	}
+}
+
+func TestMailDomainRename_BadParams(t *testing.T) {
+	for _, tc := range []mailDomainRenameParams{
+		{Old: "", New: "new.com"},
+		{Old: "old.com", New: ""},
+		{Old: "same.com", New: "same.com"},
+		{Old: "old.com", New: "-bad-"},
+	} {
+		raw, _ := json.Marshal(tc)
+		if _, err := mailDomainRenameHandler(context.Background(), raw); err == nil {
+			t.Fatalf("expected error for params %+v", tc)
+		}
+	}
+}

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -71,11 +71,10 @@ func (h *domainHandler) rename(c *gin.Context) {
 		DomainTeardowns: h.cfg.DomainTeardowns,
 		Users:           h.cfg.Users,
 		Agent:           h.cfg.Agent,
-		// Mailboxes arms the fail-closed mailbox gate (a rename would purge
-		// retained Stalwart accounts on the old name). DNSZones + SSLCerts let
-		// the rename re-key the zone + reissue the cert for the new name.
-		// AppInstalls lets it rewrite a WordPress install's stored site URL.
-		Mailboxes:   h.cfg.Mailboxes,
+		// DNSZones + SSLCerts let the rename re-key the zone + reissue the cert
+		// for the new name; AppInstalls lets it rewrite a WordPress install's
+		// stored site URL. Mail is carried by the mail.domain.rename agent verb
+		// (via h.cfg.Agent), so no mailbox repo is needed here.
 		DNSZones:    h.cfg.DNSZones,
 		SSLCerts:    h.cfg.SSLCerts,
 		AppInstalls: h.cfg.AppInstalls,
@@ -108,7 +107,7 @@ func renameHTTPStatus(code string) int {
 	switch code {
 	case "invalid_name", "noop", "custom_docroot", "ambiguous_docroot":
 		return http.StatusBadRequest
-	case "mail_active", "mailboxes_present", "panel_primary", "web_disabled",
+	case "mail_domain_conflict", "panel_primary", "web_disabled",
 		"ssl_custom_cert", "name_taken", "owner_unprovisioned", "owner_unresolved":
 		return http.StatusConflict
 	case "not_found":

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2577,12 +2577,15 @@ paths:
         domain_id. Moves + re-owns the docroot, renames the DB row, re-keys the
         DNS zone and forces an SSL reissue for the new name, and tears down the
         old name's nginx vhost + PowerDNS zone via the durable teardown.
-        Experimental phase 1 — refuses when the domain has any mailbox (mail must
-        be off AND have no retained mailboxes), is the panel's own primary, or
-        has no website. For a WordPress install it rewrites the stored site URL
-        to the new name (best-effort); any install that could not be rewritten is
-        reported in the `warnings` array. Other apps' internal config is not
-        changed.
+        Experimental — mail is CARRIED to the new name: the Stalwart registry
+        domain is renamed in place, so every mailbox account, its stored
+        messages, and its DKIM signature follow the stable domain id. Refuses
+        when the new name already carries mail in Stalwart (mail_domain_conflict),
+        the domain is the panel's own primary, or it has no website. For a
+        WordPress install it rewrites the stored site URL to the new name
+        (best-effort); any install that could not be rewritten — and a catch-all
+        address that could not be re-pointed — is reported in the `warnings`
+        array. Other apps' internal config is not changed.
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { name: { type: string } }, required: [name] } } } }
@@ -2591,8 +2594,8 @@ paths:
         "400": { description: Invalid or ambiguous name, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "403": { description: Not the domain owner, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "404": { description: Domain not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
-        "409": { description: Refused — mail/mailboxes present, panel primary, web disabled, or name taken, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
-        "503": { description: Rename not available (mailbox check unwired), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "409": { description: "Refused — mail_domain_conflict (new name already carries mail), panel primary, web disabled, custom/shared cert, or name taken", content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "503": { description: Rename not available (dependencies not wired, or mail check unreachable), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
 
 
   # --- Branding (auto) ---

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -611,22 +611,36 @@ func (r *domainRepo) SetSharedCertificate(ctx context.Context, id string, shared
 }
 
 func (r *domainRepo) Rename(ctx context.Context, id, newName, newDocRoot string) error {
-	updates := map[string]interface{}{
-		"name":       newName,
-		"doc_root":   newDocRoot,
-		"updated_at": time.Now().UTC(),
-	}
-	res := r.db.WithContext(ctx).Model(&models.Domain{}).
-		Where("id = ?", id).
-		Updates(updates)
-	if res.Error != nil {
-		// The unique index on name surfaces a concurrent claim as a conflict.
-		return translate(res.Error)
-	}
-	if res.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	now := time.Now().UTC()
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.Domain{}).
+			Where("id = ?", id).
+			Updates(map[string]interface{}{
+				"name":       newName,
+				"doc_root":   newDocRoot,
+				"updated_at": now,
+			})
+		if res.Error != nil {
+			// The unique index on name surfaces a concurrent claim as a conflict.
+			return translate(res.Error)
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		// Resync the denormalized email_cached on shared MAILBOX resources (M52).
+		// Unlike mailboxes / mail_groups — whose email_cached is kept current by
+		// the AFTER UPDATE domains triggers (migrations 000054 / 000170) — a shared
+		// resource's email_cached is maintained in Go (see models.SharedResource),
+		// so the domains rename does not cascade to it. Only kind='mailbox' rows
+		// carry an address. GH #1579 mail-carrying rename.
+		if err := tx.Exec(
+			"UPDATE shared_resources SET email_cached = CONCAT(local_part, '@', ?), updated_at = ? "+
+				"WHERE domain_id = ? AND kind = 'mailbox' AND local_part IS NOT NULL",
+			newName, now, id).Error; err != nil {
+			return translate(err)
+		}
+		return nil
+	})
 }
 
 func (r *domainRepo) UpdateSSLMode(ctx context.Context, id string, mode string) error {

--- a/panel-api/internal/repository/domain_repository_test.go
+++ b/panel-api/internal/repository/domain_repository_test.go
@@ -1,0 +1,50 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Rename flips the domain row AND, in the same transaction, resyncs the
+// denormalized email_cached on shared MAILBOX resources — which (unlike
+// mailboxes / mail_groups) has no AFTER UPDATE trigger and is maintained in Go.
+// GH #1579 mail-carrying rename.
+func TestDomain_Rename_ResyncsSharedResourceEmail(t *testing.T) {
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewDomainRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `domains` SET").
+		WillReturnResult(sqlmock.NewResult(0, 1)) // 1 row renamed
+	mock.ExpectExec("UPDATE shared_resources SET email_cached = CONCAT").
+		WillReturnResult(sqlmock.NewResult(0, 2)) // 2 shared mailboxes resynced
+	mock.ExpectCommit()
+
+	err := repo.Rename(context.Background(), "dom-1", "new.com", "/home/u1/public_html/new.com")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A rename of a missing row (0 rows affected) is ErrNotFound and rolls back —
+// the shared-resource resync never runs.
+func TestDomain_Rename_MissingRowIsNotFound(t *testing.T) {
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewDomainRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `domains` SET").
+		WillReturnResult(sqlmock.NewResult(0, 0)) // no such row
+	mock.ExpectRollback()
+
+	err := repo.Rename(context.Background(), "gone", "new.com", "/home/u1/public_html/new.com")
+	require.True(t, errors.Is(err, repository.ErrNotFound), "missing row → ErrNotFound, got %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -15,14 +15,6 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// MailboxCounter reports how many mailboxes a domain has. Satisfied by
-// repository.MailboxRepository. RenameDomain uses it as a fail-closed gate: the
-// durable teardown of the OLD name purges every Stalwart account on it, so a
-// rename is refused unless the domain has zero mailboxes.
-type MailboxCounter interface {
-	CountByDomainID(ctx context.Context, domainID string) (int64, error)
-}
-
 // AppInstallLister lists the application installs on a domain so a rename can
 // rewrite a WordPress install's stored site URL to the new name (GH #1579).
 // Satisfied by repository.ApplicationInstallRepository. Optional on Deps: nil
@@ -62,12 +54,17 @@ func renameErr(code, format string, args ...any) *RenameError {
 // the new name, and tears down the OLD name's server artifacts (nginx vhost +
 // old PowerDNS zone, via the durable JAB-236 tombstone the reconciler retries).
 //
-// Phase 1 is deliberately limited to a plain web domain. It refuses when:
-//   - the domain still has any mailbox (see below) or mail is flagged active —
-//     a rename changes every mailbox address, which is a mailbox migration, not
-//     a rename; the durable teardown of the old name would also PURGE those
-//     retained Stalwart accounts (mail-disable is soft), so this gate is
-//     fail-closed: a nil Mailboxes repo refuses too;
+// Mail is CARRIED, not refused. Stalwart keys every account on
+// (localpart, domainId) and stores its messages under that account's stable
+// internal id, so renaming the registry Domain entity in place — via the
+// mail.domain.rename agent verb, which keeps the id — carries every account,
+// its stored messages, and its DKIM signature to the new address; the DB
+// trigger resyncs mailboxes.email_cached so the SQL directory authenticates and
+// delivers at the new address. The verb runs BEFORE the DB rename so the entity
+// is named `new` before the trigger flips email_cached. It still refuses when:
+//   - the new name already carries mail in Stalwart (verb status "conflict") —
+//     carrying mail into an occupied name would collide; caught by a dry-run
+//     BEFORE any files move, and re-checked on the real run;
 //   - the domain is the panel's own primary domain (self-lockout);
 //   - the domain has no website to move (web disabled / no docroot);
 //   - the domain uses a custom or shared TLS certificate (it covers the old
@@ -75,6 +72,11 @@ func renameErr(code, format string, args ...any) *RenameError {
 //   - the owner's Linux account is not provisioned yet;
 //   - the docroot path does not contain the old name exactly once (a custom
 //     docroot needs a manual move).
+//
+// Not carried (documented limitations, non-fatal): the per-domain mail TLS cert
+// still covers mail.<old> until reissued; a webmail send-as identity created
+// before the rename keeps the old address until re-added. The catch-all address
+// (a literal string on the Domain entity) IS rewritten by the verb, best-effort.
 //
 // Installed apps are ALLOWED. A WordPress install's stored site URL (kept in
 // the app's OWN database, which the docroot move + DNS/SSL re-key do not touch)
@@ -95,13 +97,19 @@ func renameErr(code, format string, args ...any) *RenameError {
 // Ordering is chosen so the two AUTHORITATIVE mutations (move the files, then
 // rename the row) happen first and every step is idempotent, so a mid-run
 // failure is recoverable by re-running (same shape as ChangeDomainOwner):
+//  0. dry-run the mail-domain rename BEFORE anything moves, so a conflict (the
+//     new name already carries mail) fails while nothing is committed;
 //  1. move the docroot on the box (domain.reown, same owner uid — idempotent);
-//  2. rename the DB row (name + doc_root together) — the point of no return;
-//  3. tombstone the OLD name (safe only now that no live row carries it) so the
-//     reconciler durably tears down the old vhost + old PowerDNS zone;
-//  4. re-key the DNS zone row (name) + reset the SSL cert to pending, so the
+//  2. carry mail: rename the Stalwart registry Domain in place (mail.domain.rename)
+//     BEFORE the DB rename, so the entity is named `new` before the trigger flips
+//     email_cached — fail-closed (nothing persisted yet; reown is re-runnable);
+//  3. rename the DB row (name + doc_root together) — the point of no return;
+//  4. tombstone the OLD name (safe only now that no live row carries it) so the
+//     reconciler durably tears down the old vhost + old PowerDNS zone; its
+//     purge_accounts step is a no-op — the Stalwart entity is already `new`;
+//  5. re-key the DNS zone row (name) + reset the SSL cert to pending, so the
 //     reconciler re-pushes the zone and reissues the cert under the NEW name;
-//  5. schedule a prompt re-render of the new name.
+//  6. schedule a prompt re-render of the new name.
 //
 // Steps 3–5 are best-effort heals AFTER the rename is committed: a rare failure
 // there is logged, not surfaced, because the row+files (the source of truth)
@@ -124,24 +132,6 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	}
 	if newName == strings.ToLower(oldName) {
 		return nil, renameErr("noop", "the new name is the same as the current name")
-	}
-	if domain.EmailEnabled {
-		return nil, renameErr("mail_active",
-			"disable mail on %q before renaming — a rename changes every mailbox address and cannot migrate mail", oldName)
-	}
-	// Fail-closed mailbox gate. The old-name teardown's first step
-	// (mail.domain.purge_accounts) destroys every Stalwart account on the
-	// domain, and mail-disable is soft (mailboxes are retained), so
-	// EmailEnabled==false is NOT proof there is no mail to lose. Refuse when the
-	// counter is unwired (can't prove zero) or reports any mailbox.
-	if d.Mailboxes == nil {
-		return nil, renameErr("unavailable", "rename is not available (mailbox check not wired)")
-	}
-	if n, cerr := d.Mailboxes.CountByDomainID(ctx, domain.ID); cerr != nil {
-		return nil, renameErr("unavailable", "could not verify %q has no mailboxes: %v", oldName, cerr)
-	} else if n > 0 {
-		return nil, renameErr("mailboxes_present",
-			"%q still has %d mailbox(es) — delete or migrate them before renaming (a rename would change every mailbox address)", oldName, n)
 	}
 	if domain.IsPanelPrimary {
 		return nil, renameErr("panel_primary", "%q is the panel's own primary domain and cannot be renamed", oldName)
@@ -184,6 +174,18 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		return nil, renameErr("name_taken", "%q already exists", newName)
 	}
 
+	// Dry-run the mail-domain rename BEFORE moving any files, so a genuine
+	// conflict (the new name already carries mail in Stalwart) fails the rename
+	// while nothing is committed. Fail-closed: an agent error here refuses.
+	if dryRaw, aerr := d.Agent.Call(ctx, "mail.domain.rename", map[string]any{
+		"old": oldName, "new": newName, "dry_run": true,
+	}); aerr != nil {
+		return nil, renameErr("unavailable", "could not check mail before renaming %q: %v", oldName, aerr)
+	} else if st, _ := mailRenameStatus(dryRaw); st == mailRenameConflict {
+		return nil, renameErr("mail_domain_conflict",
+			"%q already has mail configured in Stalwart — delete or migrate it before renaming %q into it", newName, oldName)
+	}
+
 	// ---- orchestrate ----
 	// 1. Move the docroot tree old -> new under the SAME owner uid, BEFORE the
 	//    DB row is renamed. Idempotent agent-side (reown returns AlreadyDone
@@ -206,6 +208,24 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		return nil, renameErr("move_failed", "could not move the site files for %q: %v", oldName, aerr)
 	}
 
+	// 1b. Carry mail: rename the Stalwart registry Domain in place BEFORE the DB
+	//     rename, so the entity is named `new` before the trigger flips
+	//     email_cached to `@new`. Fail-closed: nothing is persisted yet (the DB
+	//     row still holds the old name) and reown is idempotent, so a failure here
+	//     is fully re-runnable. Statuses renamed | already | not_in_registry all
+	//     proceed; a conflict (racing another rename since the dry-run) refuses.
+	var mailWarnings []string
+	if mailRaw, aerr := d.Agent.Call(ctx, "mail.domain.rename", map[string]any{
+		"old": oldName, "new": newName,
+	}); aerr != nil {
+		return nil, renameErr("mail_rename_failed", "could not carry mail to the new name for %q: %v", oldName, aerr)
+	} else if st, w := mailRenameStatus(mailRaw); st == mailRenameConflict {
+		return nil, renameErr("mail_domain_conflict",
+			"%q already has mail configured in Stalwart — delete or migrate it before renaming %q into it", newName, oldName)
+	} else {
+		mailWarnings = w
+	}
+
 	// 2. Rename the row (name + doc_root as a unit) — the authoritative flip.
 	//    Files already moved; a failure here is re-runnable (reown -> AlreadyDone
 	//    on the retry). No tombstone exists yet, so a failure can never leave the
@@ -222,7 +242,9 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	// 3. Tombstone the OLD name so the reconciler durably tears down the old
 	//    nginx vhost + old PowerDNS zone. Safe now: no live row carries oldName,
 	//    so the sweep cannot tear down a live domain. Its purge_accounts step is
-	//    a no-op here — the mailbox gate above guarantees zero accounts.
+	//    a no-op here — the mail carry (step 1b) already renamed the Stalwart
+	//    entity to `new`, so the old name is gone from the registry and there are
+	//    no accounts under it to purge.
 	if d.DomainTeardowns != nil {
 		if terr := d.DomainTeardowns.Ensure(ctx, oldName); terr != nil {
 			logRenameHeal(d.Log, "tombstone old name", oldName, newName, terr)
@@ -266,9 +288,9 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	//     install's own database, where an absolute site URL is stored; left
 	//     stale it redirects visitors back to the old name. Best-effort per
 	//     install, surfaced as warnings (never fails the committed rename).
-	var warnings []string
+	warnings := mailWarnings
 	if d.AppInstalls != nil {
-		warnings = rewriteAppSiteURLs(ctx, d, domain, owner, oldName, newName)
+		warnings = append(warnings, rewriteAppSiteURLs(ctx, d, domain, owner, oldName, newName)...)
 	}
 
 	// 5. Force a prompt re-render + zone push + cert reissue for the new name.
@@ -276,6 +298,26 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		rec.Schedule(domain.ID)
 	}
 	return warnings, nil
+}
+
+// mail.domain.rename status values the panel branches on. Only "conflict" is a
+// refusal; renamed | already | not_in_registry all proceed.
+const mailRenameConflict = "conflict"
+
+// mailRenameStatus decodes a mail.domain.rename agent response into its status
+// and any best-effort warnings (e.g. a catch-all that could not be rewritten).
+// An undecodable body yields an empty status (treated as "proceed"): the verb is
+// a heal around an already-idempotent rename, so a malformed ack must not both
+// fail to signal conflict AND block the rename.
+func mailRenameStatus(raw json.RawMessage) (status string, warnings []string) {
+	var resp struct {
+		Status   string   `json:"status"`
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", nil
+	}
+	return resp.Status, resp.Warnings
 }
 
 // rewriteAppSiteURLs best-effort rewrites the stored site URL of every

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -51,24 +51,36 @@ func (u *drUsers) FindByID(_ context.Context, _ string) (*models.User, error) {
 type drAgent struct {
 	rec     *drRecorder
 	callErr error
-	// errByMethod fails only the named agent methods (checked before callErr),
-	// so a test can let domain.reown succeed while migration.refresh_reconcile
-	// fails.
+	// errByMethod fails the named agent methods (checked before callErr), so a
+	// test can let some verbs succeed while another fails.
 	errByMethod  map[string]error
 	last         map[string]any
+	reownLast    map[string]any   // captured domain.reown params (stable across later calls)
 	refreshCalls []map[string]any // migration.refresh_reconcile params, in order
-	// refreshResp, when set, is the migration.refresh_reconcile response body —
-	// so a test can simulate the verb reporting a search-replace failure (or a
-	// benign page-cache note) inside its warnings with a nil call error.
+	// refreshResp, when set, is the migration.refresh_reconcile response body.
 	refreshResp json.RawMessage
+
+	// mail.domain.rename fakes. The verb is called twice — dry_run then real.
+	mailRenameCalls  []map[string]any
+	mailDryStatus    string   // default "ok"
+	mailRealStatus   string   // default "not_in_registry"
+	mailRealWarnings []string // surfaced on the real call
+	mailRealErr      error    // fails ONLY the real (non-dry) call
 }
 
 func (a *drAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
 	a.rec.events = append(a.rec.events, "agent."+method)
-	if m, ok := params.(map[string]any); ok {
-		a.last = m
-		if method == "migration.refresh_reconcile" {
-			a.refreshCalls = append(a.refreshCalls, m)
+	var m map[string]any
+	if mm, ok := params.(map[string]any); ok {
+		m = mm
+		a.last = mm
+		switch method {
+		case "domain.reown":
+			a.reownLast = mm
+		case "migration.refresh_reconcile":
+			a.refreshCalls = append(a.refreshCalls, mm)
+		case "mail.domain.rename":
+			a.mailRenameCalls = append(a.mailRenameCalls, mm)
 		}
 	}
 	if a.errByMethod != nil {
@@ -79,11 +91,34 @@ func (a *drAgent) Call(_ context.Context, method string, params any) (json.RawMe
 	if a.callErr != nil {
 		return nil, a.callErr
 	}
-	if method == "migration.refresh_reconcile" {
+	switch method {
+	case "migration.refresh_reconcile":
 		if a.refreshResp != nil {
 			return a.refreshResp, nil
 		}
 		return json.RawMessage(`{"ok":true,"warnings":[]}`), nil
+	case "mail.domain.rename":
+		dry, _ := m["dry_run"].(bool)
+		if dry {
+			st := a.mailDryStatus
+			if st == "" {
+				st = "ok"
+			}
+			return json.RawMessage(`{"status":"` + st + `"}`), nil
+		}
+		if a.mailRealErr != nil {
+			return nil, a.mailRealErr
+		}
+		st := a.mailRealStatus
+		if st == "" {
+			st = "not_in_registry"
+		}
+		resp := map[string]any{"status": st}
+		if len(a.mailRealWarnings) > 0 {
+			resp["warnings"] = a.mailRealWarnings
+		}
+		b, _ := json.Marshal(resp)
+		return b, nil
 	}
 	return json.RawMessage(`{}`), nil
 }
@@ -116,15 +151,6 @@ func (t *drTeardowns) List(_ context.Context) ([]models.DomainTeardown, error) {
 	return nil, nil
 }
 func (t *drTeardowns) MarkAttempt(_ context.Context, _, _ string) error { return nil }
-
-type drMailboxes struct {
-	count int64
-	err   error
-}
-
-func (m *drMailboxes) CountByDomainID(_ context.Context, _ string) (int64, error) {
-	return m.count, m.err
-}
 
 type drDNSZones struct {
 	repository.DNSZoneRepository
@@ -191,9 +217,9 @@ func drWebDomain() *models.Domain {
 	}
 }
 
-// drNewDeps wires a fully-armed rename: zero mailboxes, a zone row on the old
-// name, and a cert row — so the happy path exercises the zone re-key + cert
-// reset heals.
+// drNewDeps wires a fully-armed rename: a zone row on the old name and a cert
+// row, so the happy path exercises the zone re-key + cert reset heals. The mail
+// carry defaults to not_in_registry (a plain web domain), so it proceeds.
 func drNewDeps(rec *drRecorder, dom *models.Domain, owner *models.User) (Deps, *drAgent, *drTeardowns) {
 	ag := &drAgent{rec: rec}
 	td := &drTeardowns{rec: rec}
@@ -202,7 +228,6 @@ func drNewDeps(rec *drRecorder, dom *models.Domain, owner *models.User) (Deps, *
 		Users:           &drUsers{user: owner},
 		DomainTeardowns: td,
 		Agent:           ag,
-		Mailboxes:       &drMailboxes{count: 0},
 		DNSZones:        &drDNSZones{rec: rec, zone: &models.DNSZone{ID: "zone-1", DomainID: dom.ID, Name: dom.Name}},
 		SSLCerts:        &drSSLCerts{rec: rec, cert: &models.SSLCertificate{ID: "cert-1", DomainID: dom.ID}},
 	}
@@ -221,6 +246,21 @@ func drCodeOf(t *testing.T, err error) string {
 	return re.Code
 }
 
+func assertEvents(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// The two mail.domain.rename calls (dry-run then real) bracket the docroot move.
+const evDryMail = "agent.mail.domain.rename"
+
 // ---- gate matrix ----
 
 func TestRenameDomain_Gates(t *testing.T) {
@@ -233,7 +273,6 @@ func TestRenameDomain_Gates(t *testing.T) {
 	}{
 		{"empty name", nil, drHappyOwner(), "", "invalid_name"},
 		{"no-op same name", nil, drHappyOwner(), "OLD.com", "noop"},
-		{"mail active", func(d *models.Domain) { d.EmailEnabled = true }, drHappyOwner(), "new.com", "mail_active"},
 		{"panel primary", func(d *models.Domain) { d.IsPanelPrimary = true }, drHappyOwner(), "new.com", "panel_primary"},
 		{"web disabled", func(d *models.Domain) { d.WebDisabled = true }, drHappyOwner(), "new.com", "web_disabled"},
 		{"custom cert", func(d *models.Domain) { d.SSLMode = models.SSLModeCustom }, drHappyOwner(), "new.com", "ssl_custom_cert"},
@@ -261,47 +300,138 @@ func TestRenameDomain_Gates(t *testing.T) {
 	}
 }
 
-// ---- mailbox gate (fail-closed) ----
+// ---- mail carry (GH #1579 task b) ----
 
-func TestRenameDomain_MailboxesPresent(t *testing.T) {
+// A conflict at the DRY-RUN (the new name already carries mail) refuses BEFORE
+// any files move — only the dry-run call ran, no reown, no DB rename.
+func TestRenameDomain_MailConflictRefusesBeforeMove(t *testing.T) {
 	rec := &drRecorder{}
 	dom := drWebDomain()
-	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
-	d.Mailboxes = &drMailboxes{count: 3}
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.mailDryStatus = "conflict"
+
 	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
-	if got := drCodeOf(t, err); got != "mailboxes_present" {
-		t.Fatalf("code = %q, want mailboxes_present", got)
+	if got := drCodeOf(t, err); got != "mail_domain_conflict" {
+		t.Fatalf("code = %q, want mail_domain_conflict", got)
 	}
-	if len(rec.events) != 0 {
-		t.Fatalf("mailboxes-present must refuse before any step, got %v", rec.events)
+	assertEvents(t, rec.events, []string{evDryMail})
+	if ag.reownLast != nil {
+		t.Fatalf("a dry-run conflict must refuse before the file move")
+	}
+	if dom.Name != "old.com" {
+		t.Fatalf("row must be unchanged, got %q", dom.Name)
 	}
 }
 
-func TestRenameDomain_MailboxCheckUnwired(t *testing.T) {
+// A conflict on the REAL run (raced another rename since the dry-run) refuses
+// after the move but before the DB flip; the row is unchanged.
+func TestRenameDomain_MailConflictOnRealRun(t *testing.T) {
 	rec := &drRecorder{}
 	dom := drWebDomain()
-	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
-	d.Mailboxes = nil // fail-closed: cannot prove zero mailboxes
+	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
+	ag.mailDryStatus = "ok"
+	ag.mailRealStatus = "conflict"
+
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "mail_domain_conflict" {
+		t.Fatalf("code = %q, want mail_domain_conflict", got)
+	}
+	assertEvents(t, rec.events, []string{evDryMail, "agent.domain.reown", evDryMail})
+	if dom.Name != "old.com" {
+		t.Fatalf("row must be unchanged on a real-run conflict, got %q", dom.Name)
+	}
+	if len(td.ensured) != 0 {
+		t.Fatalf("no tombstone before the DB flip, got %v", td.ensured)
+	}
+}
+
+// The dry-run mail check is fail-closed: an agent error there refuses the rename
+// before anything moves.
+func TestRenameDomain_MailDryRunErrorFailsClosed(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.errByMethod = map[string]error{"mail.domain.rename": errors.New("stalwart down")}
+
 	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "unavailable" {
 		t.Fatalf("code = %q, want unavailable", got)
 	}
-	if len(rec.events) != 0 {
-		t.Fatalf("unwired mailbox check must refuse before any step, got %v", rec.events)
+	if ag.reownLast != nil {
+		t.Fatalf("a dry-run agent error must refuse before the file move")
 	}
 }
 
-func TestRenameDomain_MailboxCountError(t *testing.T) {
+// The real mail rename is fail-closed: an agent error after the move refuses,
+// and NOTHING is persisted (the DB row still holds the old name, no tombstone).
+func TestRenameDomain_MailRealRenameFailsClosed(t *testing.T) {
 	rec := &drRecorder{}
 	dom := drWebDomain()
-	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
-	d.Mailboxes = &drMailboxes{err: errors.New("db down")}
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.mailRealErr = errors.New("stalwart down mid-run")
+
 	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
-	if got := drCodeOf(t, err); got != "unavailable" {
-		t.Fatalf("code = %q, want unavailable (can't verify zero mailboxes)", got)
+	if got := drCodeOf(t, err); got != "mail_rename_failed" {
+		t.Fatalf("code = %q, want mail_rename_failed", got)
 	}
-	if len(rec.events) != 0 {
-		t.Fatalf("mailbox count error must refuse before any step, got %v", rec.events)
+	if ag.reownLast == nil {
+		t.Fatalf("reown should have run before the mail rename")
+	}
+	for _, e := range rec.events {
+		if e == "db.rename" || e == "tombstone.ensure" {
+			t.Fatalf("nothing must persist on a mail-rename failure, got %v", rec.events)
+		}
+	}
+	if dom.Name != "old.com" {
+		t.Fatalf("row must be unchanged, got %q", dom.Name)
+	}
+}
+
+// A catch-all the verb could not rewrite comes back as a warning on the 200 —
+// the rename itself (mail carried) still succeeds.
+func TestRenameDomain_MailCatchallWarningSurfaced(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	ag.mailRealStatus = "renamed"
+	ag.mailRealWarnings = []string{"mail carried to the new name, but the catch-all address still points at the old name"}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed, got %q", dom.Name)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "catch-all") {
+		t.Fatalf("catch-all warning must surface, got %v", warnings)
+	}
+}
+
+// The mail carry runs twice (dry then real) and brackets the docroot move; it
+// passes the OLD and NEW names to the verb.
+func TestRenameDomain_MailCarryCallShape(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ag.mailRenameCalls) != 2 {
+		t.Fatalf("want 2 mail.domain.rename calls (dry + real), got %d", len(ag.mailRenameCalls))
+	}
+	dry, real := ag.mailRenameCalls[0], ag.mailRenameCalls[1]
+	if dry["dry_run"] != true {
+		t.Fatalf("first call must be dry_run, got %v", dry)
+	}
+	if real["dry_run"] == true {
+		t.Fatalf("second call must be the real run, got %v", real)
+	}
+	for _, c := range ag.mailRenameCalls {
+		if c["old"] != "old.com" || c["new"] != "new.com" {
+			t.Fatalf("mail rename call = %v, want old.com -> new.com", c)
+		}
 	}
 }
 
@@ -331,20 +461,13 @@ func TestRenameDomain_HappyPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Order is load-bearing: move the files, THEN rename the row (the
-	// authoritative flip), THEN tombstone the now-freed old name, THEN heal
-	// DNS + SSL for the new name. Files-before-DB makes a mid-run failure
-	// re-runnable, and tombstoning only after the flip means the sweep can
-	// never tear down a live domain.
-	want := []string{"agent.domain.reown", "db.rename", "tombstone.ensure", "zone.rename", "cert.reset"}
-	if len(rec.events) != len(want) {
-		t.Fatalf("events = %v, want %v", rec.events, want)
-	}
-	for i := range want {
-		if rec.events[i] != want[i] {
-			t.Fatalf("event[%d] = %q, want %q (all: %v)", i, rec.events[i], want[i], rec.events)
-		}
-	}
+	// Order is load-bearing: dry-run the mail carry, move the files, carry mail
+	// (Stalwart rename in place) BEFORE the DB flip, then rename the row, then
+	// tombstone the now-freed old name, then heal DNS + SSL for the new name.
+	assertEvents(t, rec.events, []string{
+		evDryMail, "agent.domain.reown", evDryMail, "db.rename",
+		"tombstone.ensure", "zone.rename", "cert.reset",
+	})
 
 	// Tombstone is for the OLD name; never deleted on success.
 	if len(td.ensured) != 1 || td.ensured[0] != "old.com" {
@@ -355,14 +478,14 @@ func TestRenameDomain_HappyPath(t *testing.T) {
 	}
 
 	// reown moves old -> new docroot under the OWNER's uid (not a new uid).
-	if ag.last["old_doc_root"] != "/home/u1/public_html/old.com" {
-		t.Fatalf("old_doc_root = %v", ag.last["old_doc_root"])
+	if ag.reownLast["old_doc_root"] != "/home/u1/public_html/old.com" {
+		t.Fatalf("old_doc_root = %v", ag.reownLast["old_doc_root"])
 	}
-	if ag.last["new_doc_root"] != "/home/u1/public_html/new.com" {
-		t.Fatalf("new_doc_root = %v", ag.last["new_doc_root"])
+	if ag.reownLast["new_doc_root"] != "/home/u1/public_html/new.com" {
+		t.Fatalf("new_doc_root = %v", ag.reownLast["new_doc_root"])
 	}
-	if ag.last["new_uid"] != int(1001) {
-		t.Fatalf("new_uid = %v (%T), want 1001", ag.last["new_uid"], ag.last["new_uid"])
+	if ag.reownLast["new_uid"] != int(1001) {
+		t.Fatalf("new_uid = %v (%T), want 1001", ag.reownLast["new_uid"], ag.reownLast["new_uid"])
 	}
 
 	// The DNS zone row is re-keyed to the new name and the cert row reset.
@@ -391,8 +514,8 @@ func TestRenameDomain_DefaultLayoutNoPrune(t *testing.T) {
 	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, ok := ag.last["prune_empty_dir"]; ok {
-		t.Fatalf("default layout must not set prune_empty_dir, got %v", ag.last["prune_empty_dir"])
+	if _, ok := ag.reownLast["prune_empty_dir"]; ok {
+		t.Fatalf("default layout must not set prune_empty_dir, got %v", ag.reownLast["prune_empty_dir"])
 	}
 }
 
@@ -406,11 +529,11 @@ func TestRenameDomain_NestedLayoutPrunesOldDir(t *testing.T) {
 	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ag.last["new_doc_root"] != "/home/u1/domains/new.com/public_html" {
-		t.Fatalf("new_doc_root = %v", ag.last["new_doc_root"])
+	if ag.reownLast["new_doc_root"] != "/home/u1/domains/new.com/public_html" {
+		t.Fatalf("new_doc_root = %v", ag.reownLast["new_doc_root"])
 	}
-	if ag.last["prune_empty_dir"] != "/home/u1/domains/old.com" {
-		t.Fatalf("prune_empty_dir = %v, want /home/u1/domains/old.com", ag.last["prune_empty_dir"])
+	if ag.reownLast["prune_empty_dir"] != "/home/u1/domains/old.com" {
+		t.Fatalf("prune_empty_dir = %v, want /home/u1/domains/old.com", ag.reownLast["prune_empty_dir"])
 	}
 	if dom.DocRoot != "/home/u1/domains/new.com/public_html" {
 		t.Fatalf("domain docroot not updated: %q", dom.DocRoot)
@@ -429,10 +552,9 @@ func TestRenameDomain_HappyPath_NoZoneNoCert(t *testing.T) {
 	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := []string{"agent.domain.reown", "db.rename", "tombstone.ensure"}
-	if len(rec.events) != len(want) {
-		t.Fatalf("events = %v, want %v", rec.events, want)
-	}
+	assertEvents(t, rec.events, []string{
+		evDryMail, "agent.domain.reown", evDryMail, "db.rename", "tombstone.ensure",
+	})
 }
 
 // ---- failure handling ----
@@ -452,7 +574,7 @@ func TestRenameDomain_PersistFailureAfterMove(t *testing.T) {
 		t.Fatalf("code = %q, want persist_failed", got)
 	}
 	// Files moved (reown ran) but the row is still old.com.
-	if ag.last == nil {
+	if ag.reownLast == nil {
 		t.Fatalf("reown should have run before the DB rename")
 	}
 	if dom.Name != "old.com" {
@@ -476,13 +598,14 @@ func TestRenameDomain_PersistConflictIsNameTaken(t *testing.T) {
 	}
 }
 
-// The file move is the FIRST step; if it fails, nothing is persisted — no DB
-// rename, no tombstone, the row is untouched.
+// The file move is the first mutation; if it fails, nothing is persisted — no DB
+// rename, no tombstone, the row is untouched. (The dry-run mail check ran first
+// and passed.)
 func TestRenameDomain_MoveFailureBeforeCommit(t *testing.T) {
 	rec := &drRecorder{}
 	dom := drWebDomain()
-	d, _, td := drNewDeps(rec, dom, drHappyOwner())
-	d.Agent.(*drAgent).callErr = errors.New("agent unreachable")
+	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
+	ag.errByMethod = map[string]error{"domain.reown": errors.New("agent unreachable")}
 
 	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
 	if got := drCodeOf(t, err); got != "move_failed" {
@@ -541,18 +664,11 @@ func TestRenameDomain_WordPressURLRewrite(t *testing.T) {
 	}
 
 	// The rewrite runs AFTER the DNS/SSL heals.
-	want := []string{
-		"agent.domain.reown", "db.rename", "tombstone.ensure", "zone.rename", "cert.reset",
+	assertEvents(t, rec.events, []string{
+		evDryMail, "agent.domain.reown", evDryMail, "db.rename", "tombstone.ensure",
+		"zone.rename", "cert.reset",
 		"agent.migration.refresh_reconcile", "agent.migration.refresh_reconcile",
-	}
-	if len(rec.events) != len(want) {
-		t.Fatalf("events = %v, want %v", rec.events, want)
-	}
-	for i := range want {
-		if rec.events[i] != want[i] {
-			t.Fatalf("event[%d] = %q, want %q (all: %v)", i, rec.events[i], want[i], rec.events)
-		}
-	}
+	})
 
 	if len(ag.refreshCalls) != 2 {
 		t.Fatalf("want 2 refresh calls (https + http), got %d: %v", len(ag.refreshCalls), ag.refreshCalls)

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -52,13 +52,6 @@ type Deps struct {
 	// account-cascade, and billing-cancel deletes all release without any
 	// caller having to remember to.
 	PortAllocations repository.PortAllocationRepository
-	// Mailboxes gates the GH #1579 rename: a rename runs the durable teardown
-	// on the OLD name, whose first step (mail.domain.purge_accounts) destroys
-	// every Stalwart account on that domain. Mail-disable is SOFT (mailboxes
-	// are retained), so gating on EmailEnabled alone would let a rename purge
-	// retained mailboxes. RenameDomain refuses when this repo is nil
-	// (fail-closed) or reports any mailbox for the domain.
-	Mailboxes MailboxCounter
 	// DNSZones + SSLCerts let RenameDomain re-key the domain_id-scoped zone row
 	// and force an SSL reissue for the NEW name (GH #1579). Both optional: a
 	// panel without PowerDNS / with no cert row simply skips that heal.

--- a/panel-ui/src/components/domains/RenameDomainButton.tsx
+++ b/panel-ui/src/components/domains/RenameDomainButton.tsx
@@ -1,13 +1,17 @@
 // RenameDomainButton — GH #1579. Renames an existing web domain in place
 // (POST /domains/:id/rename) instead of the create-new-and-move workaround.
 //
-// Experimental phase 1: the backend refuses when mail is active, when the domain
-// is the panel's own primary, or when it has no website. It moves the docroot,
-// tears down the old name's nginx vhost + DNS zone, and re-provisions the new
-// name (SSL is reissued by the reconciler). For a WordPress install it rewrites
-// the stored site URL to the new name (best-effort, via wp search-replace); any
-// install it could not rewrite is returned in `warnings` and surfaced here.
-// Other apps' internal configuration is not changed — the modal notes that.
+// Experimental: the backend refuses when the new name already carries mail in
+// Stalwart (mail_domain_conflict), when the domain is the panel's own primary,
+// or when it has no website. It moves the docroot, tears down the old name's
+// nginx vhost + DNS zone, and re-provisions the new name (SSL is reissued by the
+// reconciler). Mail is CARRIED to the new name — the Stalwart registry domain is
+// renamed in place, so mailboxes, stored messages, and DKIM follow; users just
+// reconfigure their mail clients to mail.<newname>. For a WordPress install it
+// rewrites the stored site URL to the new name (best-effort, via wp
+// search-replace); any install it could not rewrite — and a catch-all it could
+// not re-point — is returned in `warnings` and surfaced here. Other apps'
+// internal configuration is not changed — the modal notes that.
 import { useState } from "react";
 import { Alert, Button, Checkbox, Input, Modal, Typography } from "antd";
 import { EditOutlined } from "@icons";
@@ -105,11 +109,14 @@ export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProp
           <li>Rebuild the web server (nginx) configuration for the new name</li>
           <li>Reissue the SSL certificate for the new name</li>
           <li>Recreate the managed DNS zone under the new name and remove the old one</li>
+          <li>Carry mail to the new name — mailboxes, stored messages, and DKIM move automatically</li>
           <li>Rewrite a WordPress install's site URL to the new name (other apps unchanged)</li>
         </ul>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 4 }}>
-          Mail must be off and the domain must have no mailboxes — renaming would
-          change every mailbox address. Delete or migrate any mailboxes first.
+          Mail is carried to the new name automatically. Each mailbox keeps its
+          messages and password; after the rename, reconfigure mail clients to
+          use <Typography.Text code>mail.{normalized || "new-domain.com"}</Typography.Text> for
+          IMAP/SMTP. The per-domain mail certificate is reissued separately.
         </Typography.Paragraph>
         <Input
           autoFocus
@@ -120,8 +127,9 @@ export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProp
           style={{ marginBottom: 12 }}
         />
         <Checkbox checked={ack} onChange={(e) => setAck(e.target.checked)}>
-          I understand this is experimental. A WordPress site URL is updated
-          automatically; other apps' internal settings are not.
+          I understand this is experimental. Mail is carried to the new name and
+          mail clients must be reconfigured to the new mail host. A WordPress
+          site URL is updated automatically; other apps' internal settings are not.
         </Checkbox>
       </Modal>
     </>


### PR DESCRIPTION
Carry mail across an in-place web-domain rename

## What

The experimental in-place web-domain rename (`POST /domains/{id}/rename`) previously **refused** any domain that had mail — it required mail to be off *and* to have no retained mailbox rows. This PR removes that refusal and instead **carries the mail** to the new name.

Stalwart keys every account on `(localpart, domainId)` and stores its messages under that account's stable internal id, and the DKIM signature is keyed on `domainId`. So renaming the Stalwart registry **Domain entity in place** — keeping its id — carries every mailbox account, its stored messages, and its DKIM signature to the new address. The panel's DB trigger then resyncs `mailboxes.email_cached`, so the SQL directory authenticates and delivers at the new address. Box-verified end-to-end: a real message APPENDed at `u1@old` is readable at `u1@new` after the rename, under the same Stalwart account id, with the old name gone.

## How

**New agent verb `mail.domain.rename`** (`panel-agent/internal/commands/mail_domain_rename.go`):
- Resolves the old and new names to registry domain ids.
- `old` absent, `new` absent → `not_in_registry` (no Stalwart entity; the DB trigger alone carries any retained mailbox rows).
- `old` present, `new` present and holding accounts → `conflict` (the new name already carries another domain's mail; refuse).
- Real run: destroys an empty orphan on `new` (a domain delete leaves an empty `x:Domain` behind — `purge_accounts` destroys accounts but not the Domain entity, so this is a common leftover), renames the `x:Domain` entity in place (`x:Domain/set update`, fail-closed on a refused/missing update), then best-effort re-points a catch-all that named the old name.
- **Account counting is done with an unfiltered enumeration** (`x:Account/query` + `x:Account/get` + client-side match on `domainId`), **not** a server-side `filter:{domainId}`: that filter is honoured on some Stalwart builds and silently returns 0 on others, and trusting it here could destroy a name that actually holds another tenant's mail.

**Called twice by `RenameDomain`** (`panel-api/internal/userops/domain_rename.go`):
- Once with `dry_run=true` **before** any file move, so a genuine conflict (new name already carries mail) is caught while nothing is committed → 409 `mail_domain_conflict`.
- Then for real **after** the docroot move and **before** the DB rename, so the registry entity is named `new` before the trigger flips `email_cached` — no window where the directory resolves an address whose domain the registry doesn't yet know. An agent error here fails the rename closed (`mail_rename_failed` / `unavailable`); catch-all warnings are surfaced in the response `warnings`.

**`shared_resources.email_cached` resync** (`panel-api/internal/repository/domain_repository.go`): the DB triggers resync `mailboxes` and `mail_groups`, but `shared_resources` (kind `mailbox`) has no trigger and is maintained in Go. `Rename` now wraps the domain row update and the `shared_resources` `email_cached` resync in one transaction.

**Tenant-isolation guard on the `already` path:** if `old` is gone but `new` is present, the verb still counts accounts on `new`. An **empty** `new` is a harmless orphan (the panel's own `FindByName(new)` gate guarantees no other panel domain owns it) → `already`, proceed. A **non-empty** `new` holds another domain's mail → `conflict`, refuse. This fails closed toward tenant isolation. It gives up one case: a mail-carrying rename whose DB flip failed *after* a successful carry (old already renamed, new holds our accounts) now conflicts on retry and needs manual recovery — rename the Stalwart entity back to the old name (or clear it) and re-run. This trade is deliberate: that retry requires a single-row PK `db.rename` to fail after a successful reown + carry, whereas the orphan-adoption risk it closes needs only a prior failed destroy (which the delete path explicitly tolerates).

## Limitations (documented, not fixed here)

- The per-domain mail TLS certificate (`mail_certificate`, keyed on `domain_id`) still bakes `mail.<old>` into its SAN; it is reissued separately.
- Users must reconfigure their mail clients to `mail.<newname>` for IMAP/SMTP.
- Autoresponders (account-keyed) and MTA-STS (reconciler-derived) self-heal; a catch-all that pointed at the old name is re-pointed best-effort and reported in `warnings` if it could not be.

## Tests

- `mail_domain_rename_test.go`: every status branch, including `AlreadyWithAccountsIsConflict` (dry + real), empty-orphan destroy, catch-all rewrite vs external catch-all left alone, and bad-params.
- `domain_rename_test.go`: dry-run conflict refuses before the move, real-run conflict, dry-run/real agent error fail closed, catch-all warning surfaced, mail-carry call shape, updated happy-path event order.
- `domain_repository_test.go`: the `shared_resources.email_cached` resync runs in the same transaction, and a missing row rolls back to `ErrNotFound`.
- UI copy updated (mail is carried, reconfigure clients) with the existing 4 vitest tests green.
- Go build/vet + panel-api (userops/repository/api/app) + panel-agent commands + UI tsc/eslint/vitest all pass. Deployed to the test box and box-verified end-to-end (mail carry, conflict refuse, not-in-registry).

GH #1579
