### PR TITLE
feat(domains): reissue the per-domain mail cert on rename (GH #1579)

### DIFF
--- a/panel-agent/internal/commands/domain_delete.go
+++ b/panel-agent/internal/commands/domain_delete.go
@@ -99,12 +99,20 @@ func domainDeleteHandler(ctx context.Context, params json.RawMessage) (any, erro
 }
 
 // removeDomainCertArtifacts deletes the on-disk TLS material a domain teardown
-// leaves behind: the self-signed cert directory and the certbot/LE lineage for
-// the exact name. Best-effort — a missing path is a no-op — and name-scoped, so
-// it never reaches an unrelated (e.g. shared/wildcard) certificate.
+// leaves behind: the self-signed cert directory, the web certbot/LE lineage for
+// the exact name, AND the per-domain mail lineage (mail.<domain>) that
+// ssl.mail.issue created. Best-effort — a missing path is a no-op — and
+// name-scoped, so it never reaches an unrelated (e.g. shared/wildcard)
+// certificate. Reaping the mail lineage here matters: left behind it keeps an
+// auto-renewing renewal conf pointing at a name that no longer resolves, which
+// makes `certbot renew` noisy (and, with broken live files, can abort renew
+// box-wide — the #738 scar). domain.delete is the shared teardown chokepoint, so
+// this covers both a real delete and a rename's old-name teardown; on a rename
+// the reissued cert lands under the distinct mail.<new> lineage, untouched.
 func removeDomainCertArtifacts(ctx context.Context, domain string) {
 	_ = os.RemoveAll(filepath.Join(baseSelfSignDir, domain))
 	cleanupCertbotLineage(ctx, sslLERoot, domain)
+	cleanupCertbotLineage(ctx, sslLERoot, "mail."+domain)
 }
 
 // removeMailVhostFiles reaps the per-domain mail vhost (`<domain>-mail.conf`)

--- a/panel-agent/internal/commands/domain_delete_cert_test.go
+++ b/panel-agent/internal/commands/domain_delete_cert_test.go
@@ -44,3 +44,47 @@ func TestRemoveDomainCertArtifacts(t *testing.T) {
 		t.Fatalf("sibling cert dir must survive, stat err = %v", err)
 	}
 }
+
+// TestRemoveDomainCertArtifacts_ReapsMailLineage covers the GH #1579 mail-cert
+// slice: a teardown must also reap the per-domain mail lineage (mail.<domain>),
+// not just the web lineage, or it leaves an auto-renewing renewal conf pointing
+// at a name that no longer resolves (the #738 scar). Uses the renewal-conf floor
+// (cleanupCertbotLineage removes the conf directly when certbot can't complete),
+// with sslLERoot pointed at a temp dir. A sibling name's mail conf must survive.
+func TestRemoveDomainCertArtifacts_ReapsMailLineage(t *testing.T) {
+	tmpLE := t.TempDir()
+	origLE := sslLERoot
+	sslLERoot = tmpLE
+	defer func() { sslLERoot = origLE }()
+	// Isolate the self-signed arm to its own temp so it can't interfere.
+	origSS := baseSelfSignDir
+	baseSelfSignDir = t.TempDir()
+	defer func() { baseSelfSignDir = origSS }()
+
+	renewalDir := filepath.Join(tmpLE, "renewal")
+	if err := os.MkdirAll(renewalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConf := func(name string) string {
+		p := filepath.Join(renewalDir, name+".conf")
+		if err := os.WriteFile(p, []byte("# renewal conf"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	webConf := writeConf("old.example.com")
+	mailConf := writeConf("mail.old.example.com")
+	siblingMailConf := writeConf("mail.keep.example.com")
+
+	removeDomainCertArtifacts(context.Background(), "old.example.com")
+
+	if _, err := os.Stat(webConf); !os.IsNotExist(err) {
+		t.Fatalf("web renewal conf should be reaped, stat err = %v", err)
+	}
+	if _, err := os.Stat(mailConf); !os.IsNotExist(err) {
+		t.Fatalf("mail renewal conf should be reaped, stat err = %v", err)
+	}
+	if _, err := os.Stat(siblingMailConf); err != nil {
+		t.Fatalf("a sibling domain's mail lineage must survive (name-scoped), stat err = %v", err)
+	}
+}

--- a/panel-agent/internal/commands/ssl_install_custom.go
+++ b/panel-agent/internal/commands/ssl_install_custom.go
@@ -27,7 +27,10 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
 
-const sslLERoot = "/etc/letsencrypt"
+// sslLERoot is the certbot config dir. A var (not const) so tests can point the
+// lineage-cleanup arms of removeDomainCertArtifacts / ssl.mail.delete at a temp
+// dir — mirrors baseSelfSignDir.
+var sslLERoot = "/etc/letsencrypt"
 
 type sslInstallCustomParams struct {
 	Domain  string `json:"domain"`

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -38,11 +38,11 @@ type DomainHandlerConfig struct {
 	Users           repository.UserRepository
 	SSLCerts        repository.SSLCertificateRepository
 	SharedCerts     repository.SharedCertificateRepository
-	// Mailboxes arms the GH #1579 rename's fail-closed mailbox gate: a rename
-	// runs the old name's durable teardown, whose first step purges every
-	// Stalwart account on the domain. REQUIRED for the rename route — nil makes
-	// the handler refuse (503) rather than risk purging retained mailboxes.
-	Mailboxes  repository.MailboxRepository
+	// MailCerts lets the GH #1579 rename re-queue the per-domain mail TLS cert
+	// for reissuance under the NEW name (its row is domain_id-keyed and survives
+	// the rename, but its lineage still covers mail.<old>). Optional — a panel
+	// without per-domain mail TLS simply skips that heal.
+	MailCerts  repository.MailCertificateRepository
 	Packages   repository.PackageRepository
 	Agent      agent.AgentInterface
 	Reconciler *reconciler.Reconciler

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -16,13 +16,15 @@ type renameDomainRequest struct {
 }
 
 // rename renames an existing domain in place (GH #1579). Owner-scoped: a tenant
-// may rename their own domain, an admin any. Experimental phase 1 — web-only,
-// mail must be off. A WordPress install's stored site URL IS rewritten to the
-// new name (best-effort); any install that could not be rewritten comes back in
-// the response `warnings` (surfaced by the UI). Other apps' internal config is
+// may rename their own domain, an admin any. Experimental. Mail is CARRIED to the
+// new name (the Stalwart registry domain is renamed in place, so mailboxes,
+// stored messages, and DKIM follow) and the per-domain mail cert is re-queued for
+// mail.<new>. A WordPress install's stored site URL IS rewritten to the new name
+// (best-effort); any install that could not be rewritten comes back in the
+// response `warnings` (surfaced by the UI). Other apps' internal config is
 // unchanged. The heavy lifting (gate, tombstone the old name, rename the row,
-// move + re-own the docroot, rewrite app URLs, re-render) lives in the shared
-// userops.RenameDomain so any future CLI reuses it.
+// move + re-own the docroot, carry mail, rewrite app URLs, re-render) lives in
+// the shared userops.RenameDomain so any future CLI reuses it.
 func (h *domainHandler) rename(c *gin.Context) {
 	ctx := c.Request.Context()
 	domain, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
@@ -71,12 +73,14 @@ func (h *domainHandler) rename(c *gin.Context) {
 		DomainTeardowns: h.cfg.DomainTeardowns,
 		Users:           h.cfg.Users,
 		Agent:           h.cfg.Agent,
-		// DNSZones + SSLCerts let the rename re-key the zone + reissue the cert
-		// for the new name; AppInstalls lets it rewrite a WordPress install's
-		// stored site URL. Mail is carried by the mail.domain.rename agent verb
-		// (via h.cfg.Agent), so no mailbox repo is needed here.
+		// DNSZones + SSLCerts let the rename re-key the zone + reissue the web
+		// cert for the new name; MailCerts re-queues the per-domain mail cert for
+		// mail.<new>; AppInstalls lets it rewrite a WordPress install's stored site
+		// URL. Mail data is carried by the mail.domain.rename agent verb (via
+		// h.cfg.Agent), so no mailbox repo is needed here.
 		DNSZones:    h.cfg.DNSZones,
 		SSLCerts:    h.cfg.SSLCerts,
+		MailCerts:   h.cfg.MailCerts,
 		AppInstalls: h.cfg.AppInstalls,
 		Log:         slog.Default(),
 	}, rec, domain, newName)

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -702,8 +702,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Reconciler:      deps.Reconciler,
 				SSLCerts:        deps.SSLCerts,
 				SharedCerts:     deps.SharedCerts,
-				// GH #1579 rename: arms the fail-closed mailbox gate.
-				Mailboxes: deps.Mailboxes,
+				// GH #1579 rename: re-queues the per-domain mail cert for mail.<new>.
+				MailCerts: deps.MailCerts,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/repository/mail_certificate_repository.go
+++ b/panel-api/internal/repository/mail_certificate_repository.go
@@ -33,6 +33,13 @@ type MailCertificateRepository interface {
 	// 7 days. Renewals (rows with issued_at NOT NULL) don't count
 	// against LE's new-order rate limit and are excluded.
 	CountFirstIssueAttemptsLastWeek(ctx context.Context) (int64, error)
+	// ResetForReissue re-queues a domain's mail cert for issuance under a
+	// (possibly new) name by flipping a settled row back to pending, so the
+	// reconciler reissues promptly instead of waiting for the 30-day renewal
+	// window. Used by the in-place domain rename (GH #1579): the row is
+	// domain_id-keyed and survives the rename, but its lineage still covers
+	// mail.<old>. Returns the number of rows reset (0 = no mail cert, or skipped).
+	ResetForReissue(ctx context.Context, domainID string) (int64, error)
 }
 
 type mailCertRepo struct{ db *gorm.DB }
@@ -182,6 +189,41 @@ func (r *mailCertRepo) MarkDNSMissing(ctx context.Context, id, errMsg string) er
 
 func (r *mailCertRepo) Delete(ctx context.Context, id string) error {
 	return translate(r.db.WithContext(ctx).Delete(&models.MailCertificate{}, "id = ?", id).Error)
+}
+
+// ResetForReissue flips a settled mail cert row (issued / failed / dns_missing)
+// back to pending for one domain, clearing last_error + the retry gate so the
+// reconciler dispatches ssl.mail.issue on its next tick — which reads the
+// CURRENT domain name, so the reissue covers mail.<new>. Deliberately scoped:
+//   - disabled rows (operator opted out) are left untouched — a rename must not
+//     silently re-enable mail TLS;
+//   - pending / issuing rows are left untouched — they are already converging
+//     (issuing especially: overwriting it would race the in-flight verb's own
+//     terminal write and could double-dispatch).
+//
+// issued_at is preserved, so the reconciler treats the reissue as a renewal
+// (exempt from the LE new-order soft cap) rather than a first issuance — a
+// rename should not be gated by the weekly cap for a domain that already had a
+// cert. A never-issued failed row keeps issued_at NULL and still counts as a
+// first issue. Returns rows affected (0 when the domain has no mail cert or its
+// row was in a skipped state).
+func (r *mailCertRepo) ResetForReissue(ctx context.Context, domainID string) (int64, error) {
+	res := r.db.WithContext(ctx).Model(&models.MailCertificate{}).
+		Where("domain_id = ? AND status IN ?", domainID, []string{
+			models.MailCertStatusIssued,
+			models.MailCertStatusFailed,
+			models.MailCertStatusDNSMissing,
+		}).
+		Updates(map[string]any{
+			"status":        models.MailCertStatusPending,
+			"last_error":    nil,
+			"next_retry_at": nil,
+			"updated_at":    time.Now(),
+		})
+	if res.Error != nil {
+		return 0, translate(res.Error)
+	}
+	return res.RowsAffected, nil
 }
 
 func (r *mailCertRepo) CountFirstIssueAttemptsLastWeek(ctx context.Context) (int64, error) {

--- a/panel-api/internal/repository/mail_certificate_repository_test.go
+++ b/panel-api/internal/repository/mail_certificate_repository_test.go
@@ -114,3 +114,44 @@ func TestMailCert_MarkDNSMissing_SetsHourBackoff(t *testing.T) {
 	require.NoError(t, repo.MarkDNSMissing(context.Background(), "mc-1", "no A record for mail.example.com"))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// ResetForReissue (GH #1579) flips a settled row back to pending and returns the
+// rows affected. The WHERE clause is state-guarded to status IN (issued, failed,
+// dns_missing) so a disabled (opted-out) or in-flight (pending/issuing) row is
+// never reset — asserted by pinning the SQL.
+func TestMailCert_ResetForReissue_FlipsSettledToPending(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewMailCertificateRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .mail_certificate. SET.*WHERE domain_id = .? AND status IN`).
+		WillReturnResult(sqlmock.NewResult(0, 1)) // one settled row reset
+	mock.ExpectCommit()
+
+	n, err := repo.ResetForReissue(context.Background(), "dom-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A domain with no mail cert (or whose only row is disabled/in-flight) matches
+// no rows: ResetForReissue returns 0 and no error, so the rename's best-effort
+// heal is a clean no-op.
+func TestMailCert_ResetForReissue_NoMatchIsZero(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewMailCertificateRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .mail_certificate. SET.*WHERE domain_id = .? AND status IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0)) // nothing matched
+	mock.ExpectCommit()
+
+	n, err := repo.ResetForReissue(context.Background(), "dom-none")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -23,6 +23,15 @@ type AppInstallLister interface {
 	ListByDomainIDs(ctx context.Context, domainIDs []string) ([]models.ApplicationInstall, error)
 }
 
+// MailCertReissuer re-queues a domain's per-domain mail TLS certificate for
+// reissuance after a rename (GH #1579), so the reconciler reissues it for
+// mail.<new> instead of leaving the mail.<old> cert until it nears expiry.
+// Satisfied by repository.MailCertificateRepository. Optional on Deps: nil skips
+// the reset (the reconciler's renewal window eventually reissues regardless).
+type MailCertReissuer interface {
+	ResetForReissue(ctx context.Context, domainID string) (int64, error)
+}
+
 // appTypeWordPress is the ApplicationInstall.AppType whose stored site URL a
 // rename can rewrite (models.ApplicationInstall defaults app_type to this). Only
 // WordPress keeps a rewritable absolute site URL in its OWN database; other app
@@ -73,10 +82,14 @@ func renameErr(code, format string, args ...any) *RenameError {
 //   - the docroot path does not contain the old name exactly once (a custom
 //     docroot needs a manual move).
 //
-// Not carried (documented limitations, non-fatal): the per-domain mail TLS cert
-// still covers mail.<old> until reissued; a webmail send-as identity created
-// before the rename keeps the old address until re-added. The catch-all address
-// (a literal string on the Domain entity) IS rewritten by the verb, best-effort.
+// The per-domain mail TLS cert is re-queued for reissuance: its row is
+// domain_id-keyed (so it survives the rename), and RenameDomain flips it back to
+// pending so the reconciler reissues it for mail.<new> on its next tick instead
+// of serving mail.<old> until the 30-day renewal window (best-effort; a domain
+// with no mail cert simply skips). Not carried (documented limitation, non-fatal):
+// a webmail send-as identity created before the rename keeps the old address
+// until re-added. The catch-all address (a literal string on the Domain entity)
+// IS rewritten by the verb, best-effort.
 //
 // Installed apps are ALLOWED. A WordPress install's stored site URL (kept in
 // the app's OWN database, which the docroot move + DNS/SSL re-key do not touch)
@@ -107,8 +120,9 @@ func renameErr(code, format string, args ...any) *RenameError {
 //  4. tombstone the OLD name (safe only now that no live row carries it) so the
 //     reconciler durably tears down the old vhost + old PowerDNS zone; its
 //     purge_accounts step is a no-op — the Stalwart entity is already `new`;
-//  5. re-key the DNS zone row (name) + reset the SSL cert to pending, so the
-//     reconciler re-pushes the zone and reissues the cert under the NEW name;
+//  5. re-key the DNS zone row (name) + reset the web SSL cert AND the per-domain
+//     mail cert to pending, so the reconciler re-pushes the zone and reissues
+//     both certs under the NEW name;
 //  6. schedule a prompt re-render of the new name.
 //
 // Steps 3–5 are best-effort heals AFTER the rename is committed: a rare failure
@@ -280,6 +294,21 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 			}
 		} else if cerr != nil && !errors.Is(cerr, repository.ErrNotFound) {
 			logRenameHeal(d.Log, "load SSL cert", oldName, newName, cerr)
+		}
+	}
+
+	// 4d. Re-queue the per-domain mail TLS cert for reissuance under the NEW name.
+	//     The row is keyed by domain_id (survives the rename) but its lineage
+	//     still covers mail.<old>; flipping a settled row back to pending makes
+	//     the reconciler reissue promptly for mail.<new> — it reads the current
+	//     domain name at dispatch — instead of serving the old cert until the
+	//     30-day renewal window. Best-effort: a domain with no mail cert (mail
+	//     off, or TLS never provisioned) resets nothing; a disabled/in-flight row
+	//     is left untouched by ResetForReissue. The old mail.<old> lineage on disk
+	//     is reaped by the old-name teardown (domain.delete).
+	if d.MailCerts != nil {
+		if _, mrerr := d.MailCerts.ResetForReissue(ctx, domain.ID); mrerr != nil {
+			logRenameHeal(d.Log, "reset mail cert", oldName, newName, mrerr)
 		}
 	}
 

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -198,6 +198,24 @@ func (s *drSSLCerts) ResetForRetry(_ context.Context, id string, _ time.Time) er
 	return nil
 }
 
+type drMailCerts struct {
+	rec      *drRecorder
+	resetErr error
+	resetN   int64  // rows ResetForReissue reports affected
+	resetID  string // captured domain_id
+	called   bool
+}
+
+func (m *drMailCerts) ResetForReissue(_ context.Context, domainID string) (int64, error) {
+	m.called = true
+	m.resetID = domainID
+	if m.resetErr != nil {
+		return 0, m.resetErr
+	}
+	m.rec.events = append(m.rec.events, "mailcert.reset")
+	return m.resetN, nil
+}
+
 type drSched struct{ scheduled []string }
 
 func (r *drSched) Schedule(id string) { r.scheduled = append(r.scheduled, id) }
@@ -230,6 +248,7 @@ func drNewDeps(rec *drRecorder, dom *models.Domain, owner *models.User) (Deps, *
 		Agent:           ag,
 		DNSZones:        &drDNSZones{rec: rec, zone: &models.DNSZone{ID: "zone-1", DomainID: dom.ID, Name: dom.Name}},
 		SSLCerts:        &drSSLCerts{rec: rec, cert: &models.SSLCertificate{ID: "cert-1", DomainID: dom.ID}},
+		MailCerts:       &drMailCerts{rec: rec, resetN: 1},
 	}
 	return d, ag, td
 }
@@ -466,7 +485,7 @@ func TestRenameDomain_HappyPath(t *testing.T) {
 	// tombstone the now-freed old name, then heal DNS + SSL for the new name.
 	assertEvents(t, rec.events, []string{
 		evDryMail, "agent.domain.reown", evDryMail, "db.rename",
-		"tombstone.ensure", "zone.rename", "cert.reset",
+		"tombstone.ensure", "zone.rename", "cert.reset", "mailcert.reset",
 	})
 
 	// Tombstone is for the OLD name; never deleted on success.
@@ -553,7 +572,7 @@ func TestRenameDomain_HappyPath_NoZoneNoCert(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertEvents(t, rec.events, []string{
-		evDryMail, "agent.domain.reown", evDryMail, "db.rename", "tombstone.ensure",
+		evDryMail, "agent.domain.reown", evDryMail, "db.rename", "tombstone.ensure", "mailcert.reset",
 	})
 }
 
@@ -642,6 +661,85 @@ func TestRenameDomain_HealFailureStillSucceeds(t *testing.T) {
 	}
 }
 
+// ---- per-domain mail TLS cert reissue (GH #1579 mail-cert slice) ----
+
+// The mail cert is re-queued for reissuance after the rename: ResetForReissue is
+// called with the domain id, AFTER the DB rename (so the reconciler dispatches
+// for the NEW name), and it does not fail the rename.
+func TestRenameDomain_MailCertReissueReset(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mc := d.MailCerts.(*drMailCerts)
+	if !mc.called {
+		t.Fatalf("ResetForReissue must be called on a rename")
+	}
+	if mc.resetID != "dom-1" {
+		t.Fatalf("ResetForReissue domain id = %q, want dom-1", mc.resetID)
+	}
+	// Order invariant: the reset must run AFTER db.rename — the reconciler reads
+	// the current domain name at dispatch, so a pre-commit reset would reissue for
+	// the OLD name.
+	di, mi := -1, -1
+	for i, e := range rec.events {
+		switch e {
+		case "db.rename":
+			di = i
+		case "mailcert.reset":
+			mi = i
+		}
+	}
+	if di == -1 || mi == -1 || mi < di {
+		t.Fatalf("mailcert.reset (%d) must come after db.rename (%d): %v", mi, di, rec.events)
+	}
+}
+
+// A mail-cert reset failure is a best-effort post-commit heal: it is logged, not
+// surfaced, and never fails the already-committed rename.
+func TestRenameDomain_MailCertResetFailureStillSucceeds(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.MailCerts.(*drMailCerts).resetErr = errors.New("mail cert reset failed")
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("a mail-cert reset failure must not fail the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed despite the reset failure, got %q", dom.Name)
+	}
+	// A heal failure is not a user-facing warning (unlike the app-URL rewrite).
+	if len(warnings) != 0 {
+		t.Fatalf("mail-cert reset failure must not surface a warning, got %v", warnings)
+	}
+}
+
+// A panel without per-domain mail TLS wired (MailCerts nil) still renames — the
+// reset is simply skipped.
+func TestRenameDomain_NoMailCertsSkips(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.MailCerts = nil
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range rec.events {
+		if e == "mailcert.reset" {
+			t.Fatalf("nil MailCerts must not run a reset, got %v", rec.events)
+		}
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should still be renamed, got %q", dom.Name)
+	}
+}
+
 // ---- WordPress site-URL rewrite (GH #1579 app-URL slice) ----
 
 // A WordPress install on the domain gets its stored site URL rewritten after
@@ -666,7 +764,7 @@ func TestRenameDomain_WordPressURLRewrite(t *testing.T) {
 	// The rewrite runs AFTER the DNS/SSL heals.
 	assertEvents(t, rec.events, []string{
 		evDryMail, "agent.domain.reown", evDryMail, "db.rename", "tombstone.ensure",
-		"zone.rename", "cert.reset",
+		"zone.rename", "cert.reset", "mailcert.reset",
 		"agent.migration.refresh_reconcile", "agent.migration.refresh_reconcile",
 	})
 

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -57,6 +57,11 @@ type Deps struct {
 	// panel without PowerDNS / with no cert row simply skips that heal.
 	DNSZones repository.DNSZoneRepository
 	SSLCerts repository.SSLCertificateRepository
+	// MailCerts re-queues the per-domain mail TLS cert for reissuance under the
+	// NEW name on a rename (GH #1579) — the row is domain_id-keyed and survives
+	// the rename, but its lineage still covers mail.<old>. Optional: nil skips
+	// the reset (the reconciler's renewal window eventually reissues regardless).
+	MailCerts MailCertReissuer
 	// AppInstalls lets RenameDomain rewrite a WordPress install's stored site
 	// URL to the new name (GH #1579) — a WordPress install keeps an absolute
 	// site URL in its OWN database, which the docroot move + DNS/SSL re-key do


### PR DESCRIPTION
## Summary

Slice (c) of the in-place web-domain rename (GH #1579): reissue the **per-domain mail TLS certificate** for `mail.<new>` on a rename, instead of serving the old-name cert until it nears expiry.

The `mail_certificate` row is keyed by `domain_id` (a `uniqueIndex`), so it survives the in-place rename — but its lineage/SAN still cover `mail.<old>`. This mirrors the web-cert `ResetForRetry` reset that #1585 added: flip the row back to `pending` and let the reconciler reissue it under the new name on its next tick.

## Changes

- **`repository.MailCertificateRepository.ResetForReissue(ctx, domainID)`** — flips a settled row back to `pending` and returns the rows affected. State-guarded: `WHERE domain_id = ? AND status IN (issued, failed, dns_missing)`, so a `disabled` (opted-out) or in-flight (`pending`/`issuing`) row is never disturbed. It clears `last_error`/`next_retry_at` but **preserves `issued_at`** — the reconciler treats a row with a non-nil `issued_at` as a renewal, which is exempt from the Let's Encrypt first-issue soft cap (40/wk). A reissue after a rename is a renewal, not a fresh first issue, so it must not consume first-issue budget.
- **`userops.RenameDomain`** — new best-effort step 4d (between the web-SSL reset and the WordPress-URL rewrite): if `Deps.MailCerts` is wired, call `ResetForReissue(domain.ID)`; a failure is logged and never fails the already-committed rename. Added the `MailCertReissuer` interface + `Deps.MailCerts`; wired through `DomainHandlerConfig` → `domains_rename.go` → `app.go`.
- **`panel-agent domain.delete` — `removeDomainCertArtifacts`** now also reaps the per-domain **mail** lineage (`mail.<domain>`), not just the web lineage and self-signed dir. `domain.delete` is the shared teardown chokepoint, so this runs on both a rename's old-name tombstone **and** a plain domain delete — the latter had the same latent leak (an orphaned auto-renewing `renewal/mail.<old>.conf` pointing at a name that no longer resolves; the #738 renewal-abort scar).

## Why panel-only (no agent verb change)

The `ssl.mail.issue` verb is already fully name-driven: it builds the SAN set from the domain param (`mail.`/`autoconfig.`/`autodiscover.`/`mta-sts.<domain>`) and names the certbot lineage after the primary SAN (`mail.<domain>`), with no fixed `--cert-name` and no `--expand`. Because the reconciler reads the domain's **current** name at dispatch (`lookupDomainName` = `FindByID().Name`), a `pending` row after a rename reissues for `mail.<new>` with no agent change. The old `mail.<old>` lineage is reaped by the teardown above; a rename lands the new cert under the distinct `mail.<new>` lineage.

## Incidental cleanup

- `DomainHandlerConfig.Mailboxes` (a dead `MailboxRepository` field) removed — unused since the mail-carry landed; replaced by the `MailCerts` field the rename now needs.
- `panel-agent` `sslLERoot` const → var, so the teardown-reap arm can be pointed at a temp dir in tests (mirrors the existing `baseSelfSignDir` seam). Used only as a path string; `-race` clean, no parallel reader.

## Limitations

- The name-only teardown reaps `renewal/mail.<old>.conf`; a certbot-**suffixed** re-issued lineage (`mail.<old>-0001.conf`) is not matched by name. This is the identical residual the web arm already carries from #1585, and it is covered on mail-disable by the panel-side `ssl.mail.delete` (which receives the `lineage_path`). Documented, consistent, not regressed here.
- `lineage_path` on the row stays `mail.<old>` until the reissue lands — harmless: Stalwart serves from its registry entry (replaced by the deploy-hook keyed on `domain_id`), not the on-disk lineage.

## Testing

- **Unit** — `ResetForReissue` (SQL-pinned: flips settled→pending returns 1; no-match returns 0); rename wiring (`MailCertReissueReset` asserts called with the domain id and ordered after `db.rename`; reset-failure-still-succeeds; no-MailCerts-skips); agent reap (`ReapsMailLineage` — web + mail reaped against a real temp FS, sibling survives). Full suite green: repository, userops, api, app (openapi-coverage), panel-agent commands; `go vet` clean; `-race` clean on `panel-agent/internal/commands`.
- **Box (.60, both binaries from this branch)** —
  - Reconciler: a `pending` mail cert dispatched `ssl.mail.issue` for the domain's **current** name (`domain=testing44.net`, `last_error` named `mail.testing44.net`), row transitioned pending→dns_missing. Confirms reissue-by-current-name end to end.
  - Agent `domain.delete`: reaped both the web lineage and the new **mail** lineage plus the self-signed dir; a sibling domain's `mail.*.conf` survived (name-scoped).
  - Wiring: `deps.MailCerts` is unconditionally constructed at the composition root (`serve.go`) and the mail-cert reconciler is live on the box, so step 4d always runs.

GH #1579
