### PR TITLE
fix(domains): refuse rename when an FTP subaccount is homed under the docroot (GH #1579)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -42,9 +42,13 @@ type DomainHandlerConfig struct {
 	// for reissuance under the NEW name (its row is domain_id-keyed and survives
 	// the rename, but its lineage still covers mail.<old>). Optional — a panel
 	// without per-domain mail TLS simply skips that heal.
-	MailCerts  repository.MailCertificateRepository
-	Packages   repository.PackageRepository
-	Agent      agent.AgentInterface
+	MailCerts repository.MailCertificateRepository
+	// FtpAccounts lets the GH #1579 rename refuse when an FTP/SFTP subaccount is
+	// homed at or under the docroot being moved — its jail/chroot is not moved
+	// automatically. Optional — nil skips the check (the rename proceeds).
+	FtpAccounts repository.FtpAccountRepository
+	Packages    repository.PackageRepository
+	Agent       agent.AgentInterface
 	Reconciler *reconciler.Reconciler
 	// PortAllocations (GH #1175): shared loopback-port pool for reverse-proxy domains.
 	PortAllocations repository.PortAllocationRepository

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -82,6 +82,9 @@ func (h *domainHandler) rename(c *gin.Context) {
 		SSLCerts:    h.cfg.SSLCerts,
 		MailCerts:   h.cfg.MailCerts,
 		AppInstalls: h.cfg.AppInstalls,
+		// FtpAccounts backs the refusal when an FTP/SFTP subaccount is homed
+		// under the docroot being moved (its jail/chroot is not moved here).
+		FtpAccounts: h.cfg.FtpAccounts,
 		Log:         slog.Default(),
 	}, rec, domain, newName)
 	if err != nil {
@@ -112,11 +115,12 @@ func renameHTTPStatus(code string) int {
 	case "invalid_name", "noop", "custom_docroot", "ambiguous_docroot":
 		return http.StatusBadRequest
 	case "mail_domain_conflict", "panel_primary", "web_disabled",
-		"ssl_custom_cert", "name_taken", "owner_unprovisioned", "owner_unresolved":
+		"ssl_custom_cert", "name_taken", "owner_unprovisioned", "owner_unresolved",
+		"ftp_subaccounts":
 		return http.StatusConflict
 	case "not_found":
 		return http.StatusNotFound
-	case "unavailable":
+	case "unavailable", "ftp_check_failed":
 		return http.StatusServiceUnavailable
 	default: // persist_failed, move_failed, lookup_failed
 		return http.StatusInternalServerError

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -704,6 +704,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				SharedCerts:     deps.SharedCerts,
 				// GH #1579 rename: re-queues the per-domain mail cert for mail.<new>.
 				MailCerts: deps.MailCerts,
+				// GH #1579 rename: refuses when an FTP/SFTP subaccount is homed
+				// under the docroot being moved (its jail/chroot is not moved).
+				FtpAccounts: deps.FtpAccounts,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -32,6 +32,14 @@ type MailCertReissuer interface {
 	ResetForReissue(ctx context.Context, domainID string) (int64, error)
 }
 
+// FtpDocrootLister lists a tenant's FTP/SFTP subaccounts so a rename can refuse
+// when one is homed at (or under) the docroot the rename is about to move
+// (GH #1579). Satisfied by repository.FtpAccountRepository. Optional on Deps:
+// nil skips the check (the rename proceeds — the pre-gate behaviour).
+type FtpDocrootLister interface {
+	ListByUserID(ctx context.Context, userID string) ([]models.FtpAccount, error)
+}
+
 // appTypeWordPress is the ApplicationInstall.AppType whose stored site URL a
 // rename can rewrite (models.ApplicationInstall defaults app_type to this). Only
 // WordPress keeps a rewritable absolute site URL in its OWN database; other app
@@ -80,7 +88,10 @@ func renameErr(code, format string, args ...any) *RenameError {
 //     name and cannot be re-issued automatically for the new one);
 //   - the owner's Linux account is not provisioned yet;
 //   - the docroot path does not contain the old name exactly once (a custom
-//     docroot needs a manual move).
+//     docroot needs a manual move);
+//   - an FTP/SFTP subaccount is homed at or under the docroot being moved — its
+//     jail/chroot is not moved automatically (same posture as GH #1238), so the
+//     owner repoints or removes it first.
 //
 // The per-domain mail TLS cert is re-queued for reissuance: its row is
 // domain_id-keyed (so it survives the rename), and RenameDomain flips it back to
@@ -176,6 +187,41 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	newDocRoot, pruneOldDir, derr := renameDocRootSegment(oldDocRoot, oldName, newName)
 	if derr != nil {
 		return nil, derr
+	}
+
+	// Refuse when an FTP/SFTP subaccount is homed at (or under) the tree this
+	// rename is about to move. The reown relocates the docroot directory, but
+	// ftp_accounts.home_path is STORED (not derived from the domain), and the
+	// reconciler renders each account — an isolated GH #1145 jail bind-mount, or
+	// a shared-access chroot target — against that stored path. Left in place it
+	// would point at a directory that no longer exists. Moving an FTP jail with
+	// the docroot is out of scope here — the same reason GH #1238 user-rename
+	// refuses a tenant that still has FTP subaccounts — so fail closed and name
+	// the accounts to repoint. Gate on pruneOldDir when the nested layout's
+	// wrapper dir is emptied + pruned by the move (that dir goes too), else on
+	// the docroot itself. Match a path SEGMENT boundary so a sibling docroot
+	// (…/olddomain-other) is never falsely caught. Runs before any mutation, so a
+	// refusal leaves the domain fully intact.
+	if d.FtpAccounts != nil {
+		gateRoot := oldDocRoot
+		if pruneOldDir != "" {
+			gateRoot = pruneOldDir
+		}
+		accts, aerr := d.FtpAccounts.ListByUserID(ctx, domain.UserID)
+		if aerr != nil {
+			return nil, renameErr("ftp_check_failed", "could not check FTP subaccounts before renaming %q: %v", oldName, aerr)
+		}
+		var blocking []string
+		for _, a := range accts {
+			if a.HomePath == gateRoot || strings.HasPrefix(a.HomePath, gateRoot+"/") {
+				blocking = append(blocking, a.Username)
+			}
+		}
+		if len(blocking) > 0 {
+			return nil, renameErr("ftp_subaccounts",
+				"%q has FTP/SFTP subaccount(s) homed under its files (%s) — repoint or remove them before renaming (their jails are not moved automatically)",
+				oldName, strings.Join(blocking, ", "))
+		}
 	}
 
 	// The new name must be free. A concurrent claim between here and the write

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -216,6 +216,19 @@ func (m *drMailCerts) ResetForReissue(_ context.Context, domainID string) (int64
 	return m.resetN, nil
 }
 
+type drFtp struct {
+	accts []models.FtpAccount
+	err   error
+}
+
+func (f *drFtp) ListByUserID(_ context.Context, _ string) ([]models.FtpAccount, error) {
+	return f.accts, f.err
+}
+
+func drFtpAcct(username, homePath string) models.FtpAccount {
+	return models.FtpAccount{ID: "ftp-" + username, UserID: "user-1", Username: username, HomePath: homePath}
+}
+
 type drSched struct{ scheduled []string }
 
 func (r *drSched) Schedule(id string) { r.scheduled = append(r.scheduled, id) }
@@ -952,6 +965,145 @@ func TestRenameDomain_WordPressURLRewrite_WWW(t *testing.T) {
 		ag.refreshCalls[0]["new_url"] != "https://www.new.com" {
 		t.Fatalf("www install must rewrite the www host, got %v -> %v",
 			ag.refreshCalls[0]["old_url"], ag.refreshCalls[0]["new_url"])
+	}
+}
+
+// ---- FTP/SFTP subaccount refusal (GH #1579 ftp-docroot gate) ----
+
+// An FTP/SFTP subaccount homed AT the docroot being moved refuses the rename
+// fail-closed (its jail/chroot is not moved automatically), naming the account,
+// and touches nothing on the box.
+func TestRenameDomain_FtpAtDocrootRefuses(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain() // docroot /home/u1/public_html/old.com
+	d, ag, td := drNewDeps(rec, dom, drHappyOwner())
+	d.FtpAccounts = &drFtp{accts: []models.FtpAccount{
+		drFtpAcct("u1_web", "/home/u1/public_html/old.com"),
+	}}
+
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "ftp_subaccounts" {
+		t.Fatalf("code = %q, want ftp_subaccounts", got)
+	}
+	var re *RenameError
+	errors.As(err, &re)
+	if !strings.Contains(re.Message, "u1_web") {
+		t.Fatalf("refusal must name the offending account, got %q", re.Message)
+	}
+	// Fail-closed BEFORE any mutation: no reown, no db.rename, row unchanged.
+	if len(rec.events) != 0 {
+		t.Fatalf("ftp refusal must not run any step, got %v", rec.events)
+	}
+	if ag.reownLast != nil {
+		t.Fatalf("no file move on an ftp refusal")
+	}
+	if len(td.ensured) != 0 {
+		t.Fatalf("no tombstone on an ftp refusal, got %v", td.ensured)
+	}
+	if dom.Name != "old.com" {
+		t.Fatalf("row must be unchanged, got %q", dom.Name)
+	}
+}
+
+// A subaccount homed UNDER the docroot (a subdirectory) also refuses.
+func TestRenameDomain_FtpUnderDocrootRefuses(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.FtpAccounts = &drFtp{accts: []models.FtpAccount{
+		drFtpAcct("u1_up", "/home/u1/public_html/old.com/uploads"),
+	}}
+
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "ftp_subaccounts" {
+		t.Fatalf("code = %q, want ftp_subaccounts", got)
+	}
+}
+
+// Nested/importer layout: a subaccount homed at the WRAPPER dir (the dir the
+// move empties + prunes) refuses too — the gate keys on pruneOldDir, not just
+// the docroot leaf.
+func TestRenameDomain_FtpAtNestedWrapperRefuses(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	dom.DocRoot = "/home/u1/domains/old.com/public_html"
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.FtpAccounts = &drFtp{accts: []models.FtpAccount{
+		drFtpAcct("u1_wrap", "/home/u1/domains/old.com"),
+	}}
+
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "ftp_subaccounts" {
+		t.Fatalf("code = %q, want ftp_subaccounts (wrapper dir is pruned by the move)", got)
+	}
+}
+
+// A sibling docroot that merely SHARES a name prefix (…/old.com-other) is NOT a
+// match — the gate keys on a path-segment boundary, so the rename proceeds.
+func TestRenameDomain_FtpSiblingPrefixNotMatched(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.FtpAccounts = &drFtp{accts: []models.FtpAccount{
+		drFtpAcct("u1_other", "/home/u1/public_html/old.com-other"),
+	}}
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("a sibling-prefix docroot must not block the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed, got %q", dom.Name)
+	}
+}
+
+// A subaccount homed at the tenant ROOT (or any path outside this domain's
+// docroot) does not block — only accounts under the moved tree matter.
+func TestRenameDomain_FtpTenantHomeNotMatched(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.FtpAccounts = &drFtp{accts: []models.FtpAccount{
+		drFtpAcct("u1_home", "/home/u1"),
+		drFtpAcct("u1_site2", "/home/u1/public_html/other.com"),
+	}}
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("tenant-home / other-domain FTP accounts must not block, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed, got %q", dom.Name)
+	}
+}
+
+// The check is fail-closed: a repo error refuses the rename (503-mapped) before
+// anything moves, rather than proceeding blind.
+func TestRenameDomain_FtpListErrorFailsClosed(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.FtpAccounts = &drFtp{err: errors.New("db down")}
+
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "ftp_check_failed" {
+		t.Fatalf("code = %q, want ftp_check_failed", got)
+	}
+	if len(rec.events) != 0 || ag.reownLast != nil {
+		t.Fatalf("ftp check error must refuse before any mutation, got %v", rec.events)
+	}
+}
+
+// A panel without the FTP repo wired (FtpAccounts nil) skips the check — the
+// rename proceeds (the pre-gate behaviour).
+func TestRenameDomain_NoFtpAccountsSkips(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner()) // FtpAccounts left nil
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("nil FtpAccounts must skip the check, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed, got %q", dom.Name)
 	}
 }
 

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -66,7 +66,11 @@ type Deps struct {
 	// URL to the new name (GH #1579) — a WordPress install keeps an absolute
 	// site URL in its OWN database, which the docroot move + DNS/SSL re-key do
 	// not touch. Optional: nil skips the rewrite (the rename still succeeds).
-	AppInstalls  AppInstallLister
+	AppInstalls AppInstallLister
+	// FtpAccounts lets RenameDomain refuse when an FTP/SFTP subaccount is homed
+	// at or under the docroot being moved (GH #1579) — its jail/chroot is not
+	// moved automatically. Optional: nil skips the check (the rename proceeds).
+	FtpAccounts  FtpDocrootLister
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int


### PR DESCRIPTION
## Summary

Deeper gap found while auditing the in-place domain rename (GH #1579): a rename that moves a domain's docroot silently orphaned any **FTP/SFTP subaccount homed under that docroot**.

An FTP account's `home_path` is stored, not derived from the domain (accounts key on `user_id`, not `domain_id`). The rename moves the docroot tree (`domain.reown`) and prunes the old wrapper dir, but nothing rewrites `home_path`, and the ftp reconciler renders each account — an isolated GH #1145 jail bind-mount, or a shared-access chroot target — against its stored `home_path`. After a rename, an account homed at the moved docroot points at a directory that no longer exists.

Moving an FTP jail with the docroot is out of scope here — the same reason GH #1238 user-rename refuses a tenant that still has FTP subaccounts (`userops_rename.go`: "v1 does not move their jails"). So this turns the silent breakage into an explicit refusal.

## Change

`userops.RenameDomain` gains a pre-mutation gate (right after `renameDocRootSegment`, before the name-availability check — so a refusal leaves the domain fully intact):

- Lists the owning tenant's FTP accounts and refuses (`ftp_subaccounts` → **409**) when any `home_path == P` or is under `P + "/"`, where `P` is the wrapper dir the move prunes (nested/importer layout) else the docroot itself. Matching on a path-**segment** boundary means a sibling docroot (`…/old.com-other`) is never falsely caught.
- The refusal message names the offending account(s) so the owner knows what to repoint or remove.
- A repo error is fail-closed (`ftp_check_failed` → **503**) rather than proceeding blind.
- New `FtpDocrootLister` interface + optional `Deps.FtpAccounts` (nil skips — the pre-gate behaviour). Wired `DomainHandlerConfig` → `domains_rename.go` → `app.go`; `deps.FtpAccounts` is constructed unconditionally in `serve.go`, so the gate is always active in production.

## Why refuse, not rewrite

Rewriting `home_path` in the DB without moving the jail is the half-broken state #1238 declined to create: an isolated account's jail bind-mount + AppArmor profile are keyed off the path. A best-effort prefix-rewrite for shared (non-isolated) accounts is a reasonable follow-up, but it needs proof the ftp reconciler converges a changed `home_path` first — out of scope here. The gate is the correct, safe primitive: silent breakage → explicit, actionable 409.

## Testing

- **Unit** — refuses at-docroot, under-docroot, and at the nested wrapper dir; does NOT match a sibling name-prefix (`…/old.com-other`), the tenant home (`/home/u1`), or another domain's docroot; fail-closed on a repo error; nil dep skips; every refusal asserts **zero** mutation events (no reown, no db.rename, no tombstone). Full suite green (userops, api, app/openapi-coverage); `go vet` clean.
- **Box (.60, full end-to-end via the real `POST /domains/:id/rename` with an owner API token)** —
  - FTP account homed at the docroot → rename returns **HTTP 409 `ftp_subaccounts`** naming the account; name unchanged, docroot present, no tombstone (nothing moved).
  - Repoint the same account to the tenant root (`/home/testing44`, not under the docroot) → rename returns **200**: docroot moved + old wrapper pruned, `domains.name`/`doc_root` updated, tombstone for the old name, mailbox carried (Stalwart in-place rename), `mail_certificate` reset → `dns_missing` naming `mail.<new>` (the #1588 reissue path), web cert + recursor forwarder re-keyed to the new name.
  - Renamed back to restore; all test fixtures (seeded FTP row, alias, token, `linux_uid` repair) reverted — box left in its original state.

## Limitation (noted, not fixed here)

An alias forwarder's stored `target` stays `local@<old>` after a rename — cosmetic: it is unused at apply time (alias delivery is by `local_part` → mailbox, and the reconciler pushes `local@<current-domain>` to Stalwart) and only backs the `uq_external_forward` unique key. A separate hygiene fix could rewrite it.

GH #1579
