### PR TITLE
feat(domains): carry DMARC dashboard history across a rename (GH #1579)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -47,6 +47,10 @@ type DomainHandlerConfig struct {
 	// homed at or under the docroot being moved — its jail/chroot is not moved
 	// automatically. Optional — nil skips the check (the rename proceeds).
 	FtpAccounts repository.FtpAccountRepository
+	// DMARCAggregate lets the GH #1579 rename move the domain's DMARC aggregate
+	// history onto the new name so the dashboard is not orphaned. Optional — nil
+	// skips the re-key (the rename still succeeds).
+	DMARCAggregate repository.DMARCAggregateRepository
 	Packages    repository.PackageRepository
 	Agent       agent.AgentInterface
 	Reconciler *reconciler.Reconciler

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -85,7 +85,10 @@ func (h *domainHandler) rename(c *gin.Context) {
 		// FtpAccounts backs the refusal when an FTP/SFTP subaccount is homed
 		// under the docroot being moved (its jail/chroot is not moved here).
 		FtpAccounts: h.cfg.FtpAccounts,
-		Log:         slog.Default(),
+		// DMARC moves the domain's DMARC aggregate history onto the new name so
+		// the dashboard is not orphaned.
+		DMARC: h.cfg.DMARCAggregate,
+		Log:   slog.Default(),
 	}, rec, domain, newName)
 	if err != nil {
 		var re *userops.RenameError

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -707,6 +707,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// GH #1579 rename: refuses when an FTP/SFTP subaccount is homed
 				// under the docroot being moved (its jail/chroot is not moved).
 				FtpAccounts: deps.FtpAccounts,
+				// GH #1579 rename: moves the domain's DMARC aggregate history
+				// onto the new name so the dashboard is not orphaned.
+				DMARCAggregate: deps.DMARCAggregate,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/repository/dmarc_aggregate_repository.go
+++ b/panel-api/internal/repository/dmarc_aggregate_repository.go
@@ -38,6 +38,13 @@ type DMARCAggregateRepository interface {
 	// CountFailuresSince counts dkim=fail rows since the cutoff for the
 	// deliverability score widget.
 	CountFailuresSince(ctx context.Context, domain string, since time.Time) (int64, error)
+
+	// ReKeyDomain moves every aggregate row from oldDomain to newDomain so an
+	// in-place domain rename (GH #1579) keeps the DMARC dashboard's history
+	// instead of orphaning it under the old name (the dashboard reads by domain
+	// name). This is the ONLY UPDATE path on an otherwise append-only table, run
+	// once per rename. Returns the rows moved.
+	ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error)
 }
 
 type dmarcRepo struct{ db *gorm.DB }
@@ -113,6 +120,19 @@ func (r *dmarcRepo) MostRecentWindowEnd(ctx context.Context) (time.Time, error) 
 		return time.Time{}, translate(err)
 	}
 	return row.WindowEnd, nil
+}
+
+func (r *dmarcRepo) ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error) {
+	// No unique key spans `domain`, so moving rows onto an existing name never
+	// collides; ingest still dedupes app-side via ExistsForReport. A no-match
+	// (domain never received a DMARC report) updates zero rows — a clean no-op.
+	res := r.db.WithContext(ctx).Model(&models.DMARCAggregate{}).
+		Where("domain = ?", oldDomain).
+		Update("domain", newDomain)
+	if res.Error != nil {
+		return 0, translate(res.Error)
+	}
+	return res.RowsAffected, nil
 }
 
 func (r *dmarcRepo) CountFailuresSince(ctx context.Context, domain string, since time.Time) (int64, error) {

--- a/panel-api/internal/repository/dmarc_aggregate_repository_test.go
+++ b/panel-api/internal/repository/dmarc_aggregate_repository_test.go
@@ -1,0 +1,52 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ReKeyDomain (GH #1579) moves every aggregate row from the old domain name to
+// the new one and returns the rows moved. The SQL is pinned so the WHERE stays
+// scoped to the old name (a broad UPDATE would rewrite other domains' history).
+func TestDMARC_ReKeyDomain_MovesRowsToNewName(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewDMARCAggregateRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .dmarc_aggregate. SET .domain.=.?.*WHERE domain = .?`).
+		WithArgs("new.com", "old.com").
+		WillReturnResult(sqlmock.NewResult(0, 3)) // three rows re-keyed
+	mock.ExpectCommit()
+
+	n, err := repo.ReKeyDomain(context.Background(), "old.com", "new.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A domain that never received a DMARC report moves nothing: zero rows, no error.
+func TestDMARC_ReKeyDomain_NoMatchIsZero(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewDMARCAggregateRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .dmarc_aggregate. SET .domain.=.?.*WHERE domain = .?`).
+		WithArgs("new.com", "nodmarc.com").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	n, err := repo.ReKeyDomain(context.Background(), "nodmarc.com", "new.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -32,6 +32,15 @@ type MailCertReissuer interface {
 	ResetForReissue(ctx context.Context, domainID string) (int64, error)
 }
 
+// DMARCReKeyer moves a domain's stored DMARC aggregate history from the old name
+// to the new one on a rename (GH #1579), so the per-domain DMARC dashboard (which
+// reads by domain name) is not orphaned. Satisfied by
+// repository.DMARCAggregateRepository. Optional on Deps: nil skips the re-key
+// (the rename still succeeds; the old rows stay readable under the old name).
+type DMARCReKeyer interface {
+	ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error)
+}
+
 // FtpDocrootLister lists a tenant's FTP/SFTP subaccounts so a rename can refuse
 // when one is homed at (or under) the docroot the rename is about to move
 // (GH #1579). Satisfied by repository.FtpAccountRepository. Optional on Deps:
@@ -97,7 +106,9 @@ func renameErr(code, format string, args ...any) *RenameError {
 // domain_id-keyed (so it survives the rename), and RenameDomain flips it back to
 // pending so the reconciler reissues it for mail.<new> on its next tick instead
 // of serving mail.<old> until the 30-day renewal window (best-effort; a domain
-// with no mail cert simply skips). Not carried (documented limitation, non-fatal):
+// with no mail cert simply skips). The domain's stored DMARC aggregate history
+// is moved to the new name too (best-effort) so the DMARC dashboard, which reads
+// by domain name, is not orphaned. Not carried (documented limitation, non-fatal):
 // a webmail send-as identity created before the rename keeps the old address
 // until re-added. The catch-all address (a literal string on the Domain entity)
 // IS rewritten by the verb, best-effort.
@@ -355,6 +366,18 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	if d.MailCerts != nil {
 		if _, mrerr := d.MailCerts.ResetForReissue(ctx, domain.ID); mrerr != nil {
 			logRenameHeal(d.Log, "reset mail cert", oldName, newName, mrerr)
+		}
+	}
+
+	// 4e. Move the domain's DMARC aggregate history onto the new name. The
+	//     dashboard reads rows by domain NAME (not id), so without this a rename
+	//     orphans every stored report — the domain's DMARC view goes blank until
+	//     new reports arrive under the new name. Best-effort: a failure leaves the
+	//     old rows readable under the old name; a domain that never received a
+	//     DMARC report moves nothing.
+	if d.DMARC != nil {
+		if _, drerr := d.DMARC.ReKeyDomain(ctx, oldName, newName); drerr != nil {
+			logRenameHeal(d.Log, "rekey DMARC history", oldName, newName, drerr)
 		}
 	}
 

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -229,6 +229,24 @@ func drFtpAcct(username, homePath string) models.FtpAccount {
 	return models.FtpAccount{ID: "ftp-" + username, UserID: "user-1", Username: username, HomePath: homePath}
 }
 
+type drDMARC struct {
+	rec              *drRecorder
+	rekeyErr         error
+	rekeyN           int64
+	oldSeen, newSeen string
+	called           bool
+}
+
+func (m *drDMARC) ReKeyDomain(_ context.Context, oldDomain, newDomain string) (int64, error) {
+	m.called = true
+	m.oldSeen, m.newSeen = oldDomain, newDomain
+	if m.rekeyErr != nil {
+		return 0, m.rekeyErr
+	}
+	m.rec.events = append(m.rec.events, "dmarc.rekey")
+	return m.rekeyN, nil
+}
+
 type drSched struct{ scheduled []string }
 
 func (r *drSched) Schedule(id string) { r.scheduled = append(r.scheduled, id) }
@@ -965,6 +983,83 @@ func TestRenameDomain_WordPressURLRewrite_WWW(t *testing.T) {
 		ag.refreshCalls[0]["new_url"] != "https://www.new.com" {
 		t.Fatalf("www install must rewrite the www host, got %v -> %v",
 			ag.refreshCalls[0]["old_url"], ag.refreshCalls[0]["new_url"])
+	}
+}
+
+// ---- DMARC dashboard re-key (GH #1579 dmarc slice) ----
+
+// The domain's DMARC aggregate history is moved to the new name after the
+// rename: ReKeyDomain is called with (oldName, newName), AFTER the DB rename, and
+// never fails the rename.
+func TestRenameDomain_DMARCReKey(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	dm := &drDMARC{rec: rec, rekeyN: 2}
+	d.DMARC = dm
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !dm.called {
+		t.Fatalf("ReKeyDomain must be called on a rename")
+	}
+	if dm.oldSeen != "old.com" || dm.newSeen != "new.com" {
+		t.Fatalf("ReKeyDomain args = (%q,%q), want (old.com,new.com)", dm.oldSeen, dm.newSeen)
+	}
+	// The re-key runs after the DB rename (post-commit heal, ordering not
+	// load-bearing but asserted for consistency with the other heals).
+	di, ri := -1, -1
+	for i, e := range rec.events {
+		switch e {
+		case "db.rename":
+			di = i
+		case "dmarc.rekey":
+			ri = i
+		}
+	}
+	if di == -1 || ri == -1 || ri < di {
+		t.Fatalf("dmarc.rekey (%d) must come after db.rename (%d): %v", ri, di, rec.events)
+	}
+}
+
+// A DMARC re-key failure is a best-effort post-commit heal: logged, not
+// surfaced, never fails the already-committed rename.
+func TestRenameDomain_DMARCReKeyFailureStillSucceeds(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.DMARC = &drDMARC{rec: rec, rekeyErr: errors.New("dmarc rekey failed")}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("a DMARC re-key failure must not fail the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed despite the re-key failure, got %q", dom.Name)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("a DMARC re-key failure must not surface a warning, got %v", warnings)
+	}
+}
+
+// A panel without the DMARC repo wired (DMARC nil) still renames — the re-key is
+// simply skipped.
+func TestRenameDomain_NoDMARCSkips(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner()) // DMARC left nil
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range rec.events {
+		if e == "dmarc.rekey" {
+			t.Fatalf("nil DMARC must not run a re-key, got %v", rec.events)
+		}
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should still be renamed, got %q", dom.Name)
 	}
 }
 

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -70,7 +70,11 @@ type Deps struct {
 	// FtpAccounts lets RenameDomain refuse when an FTP/SFTP subaccount is homed
 	// at or under the docroot being moved (GH #1579) — its jail/chroot is not
 	// moved automatically. Optional: nil skips the check (the rename proceeds).
-	FtpAccounts  FtpDocrootLister
+	FtpAccounts FtpDocrootLister
+	// DMARC moves the domain's stored DMARC aggregate history onto the new name
+	// on a rename (GH #1579) so the DMARC dashboard is not orphaned. Optional:
+	// nil skips the re-key (the rename still succeeds).
+	DMARC        DMARCReKeyer
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int


### PR DESCRIPTION
## Summary

Continuing the in-place domain rename (GH #1579): carry the domain's **DMARC dashboard history** across a rename so it isn't orphaned.

The per-domain DMARC dashboard reads `dmarc_aggregate` by domain **name** (`ListByDomainSince`: `WHERE domain = ?`), but the rows key on the literal name, not `domain_id`. A rename left every stored report under the old name — the domain's DMARC view went blank until fresh reports arrived under the new name (like the bandwidth-stats orphaning, but for a security-relevant view).

## Change

`RenameDomain` moves the domain's DMARC aggregate history onto the new name as a best-effort post-commit heal (alongside the DNS / SSL / mail-cert heals):

- **`DMARCAggregateRepository.ReKeyDomain(old, new)`** — `UPDATE dmarc_aggregate SET domain=new WHERE domain=old`, returning rows moved. This is the sole UPDATE path on an otherwise append-only table, run once per rename. No unique key spans `domain`, so moving rows onto an existing name never collides (ingest still dedupes via `ExistsForReport`); a domain that never received a report moves nothing.
- **`userops.RenameDomain`** — new `DMARCReKeyer` interface + optional `Deps.DMARC`; step 4e re-keys with `(oldName, newName)` after the DB rename. Best-effort: a failure is logged, never fails the committed rename; nil skips.
- Wired `DomainHandlerConfig` → `domains_rename.go` → `app.go`; `deps.DMARCAggregate` is assigned unconditionally in `serve.go`, so the heal is always active in production.

## Testing

- **Unit** — repo `ReKeyDomain` (SQL-pinned; `WHERE domain = ?` scoped to the old name so a broad UPDATE can't rewrite other domains' history; no-match returns 0). Rename: re-key called with `(old, new)` after `db.rename`; failure-still-succeeds; nil skips. Full suite green (repository, userops, api, app); `go vet` clean.
- **Box (.60, full end-to-end via the real `POST /domains/:id/rename` with an owner API token)** — seeded 3 `dmarc_aggregate` rows under `testing44.net`; rename → all 3 moved to `testing45.net` (cnt / reporter / disposition preserved), 0 orphaned; rename back → all 3 returned to `testing44.net` (the heal runs on every rename). Fixtures + `linux_uid` repair reverted, transient tombstones cleared, `testing44.net` left live + intact.

GH #1579
