### PR TITLE
feat(domains): carry TLS-RPT dashboard history across a rename (GH #1579)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -47,10 +47,11 @@ type DomainHandlerConfig struct {
 	// homed at or under the docroot being moved — its jail/chroot is not moved
 	// automatically. Optional — nil skips the check (the rename proceeds).
 	FtpAccounts repository.FtpAccountRepository
-	// DMARCAggregate lets the GH #1579 rename move the domain's DMARC aggregate
-	// history onto the new name so the dashboard is not orphaned. Optional — nil
-	// skips the re-key (the rename still succeeds).
-	DMARCAggregate repository.DMARCAggregateRepository
+	// DMARCAggregate / TLSRPTAggregate let the GH #1579 rename move the domain's
+	// DMARC + TLS-RPT report history onto the new name so those dashboards are not
+	// orphaned. Optional — nil skips the re-key (the rename still succeeds).
+	DMARCAggregate  repository.DMARCAggregateRepository
+	TLSRPTAggregate repository.TLSRPTAggregateRepository
 	Packages    repository.PackageRepository
 	Agent       agent.AgentInterface
 	Reconciler *reconciler.Reconciler

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -85,10 +85,11 @@ func (h *domainHandler) rename(c *gin.Context) {
 		// FtpAccounts backs the refusal when an FTP/SFTP subaccount is homed
 		// under the docroot being moved (its jail/chroot is not moved here).
 		FtpAccounts: h.cfg.FtpAccounts,
-		// DMARC moves the domain's DMARC aggregate history onto the new name so
-		// the dashboard is not orphaned.
-		DMARC: h.cfg.DMARCAggregate,
-		Log:   slog.Default(),
+		// DMARC / TLSRPT move the domain's aggregate report history onto the new
+		// name so those dashboards are not orphaned.
+		DMARC:  h.cfg.DMARCAggregate,
+		TLSRPT: h.cfg.TLSRPTAggregate,
+		Log:    slog.Default(),
 	}, rec, domain, newName)
 	if err != nil {
 		var re *userops.RenameError

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -707,9 +707,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// GH #1579 rename: refuses when an FTP/SFTP subaccount is homed
 				// under the docroot being moved (its jail/chroot is not moved).
 				FtpAccounts: deps.FtpAccounts,
-				// GH #1579 rename: moves the domain's DMARC aggregate history
-				// onto the new name so the dashboard is not orphaned.
-				DMARCAggregate: deps.DMARCAggregate,
+				// GH #1579 rename: moves the domain's DMARC + TLS-RPT report
+				// history onto the new name so those dashboards are not orphaned.
+				DMARCAggregate:  deps.DMARCAggregate,
+				TLSRPTAggregate: deps.TLSRPTAggregate,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/repository/tlsrpt_aggregate_repository.go
+++ b/panel-api/internal/repository/tlsrpt_aggregate_repository.go
@@ -20,6 +20,13 @@ type TLSRPTAggregateRepository interface {
 	CountFailuresSince(ctx context.Context, domain string, since time.Time) (int64, error)
 	PruneOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 	MostRecentWindowEnd(ctx context.Context) (time.Time, error)
+
+	// ReKeyDomain moves every aggregate row from oldDomain to newDomain so an
+	// in-place domain rename (GH #1579) keeps the TLS-RPT dashboard's history
+	// instead of orphaning it under the old name (the dashboard reads by domain
+	// name). Sole UPDATE path on an otherwise append-only table; returns the
+	// rows moved. Mirrors the DMARC sibling.
+	ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error)
 }
 
 type tlsRptRepo struct{ db *gorm.DB }
@@ -45,6 +52,19 @@ func (r *tlsRptRepo) InsertMany(ctx context.Context, rows []models.TLSRPTAggrega
 		return 0, translate(err)
 	}
 	return len(rows), nil
+}
+
+func (r *tlsRptRepo) ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error) {
+	// No unique key spans `domain`, so moving rows onto an existing name never
+	// collides; ingest still dedupes app-side via ExistsForReport. A no-match
+	// (domain never received a TLS-RPT report) updates zero rows — a clean no-op.
+	res := r.db.WithContext(ctx).Model(&models.TLSRPTAggregate{}).
+		Where("domain = ?", oldDomain).
+		Update("domain", newDomain)
+	if res.Error != nil {
+		return 0, translate(res.Error)
+	}
+	return res.RowsAffected, nil
 }
 
 func (r *tlsRptRepo) ExistsForReport(ctx context.Context, reporter string, windowStart, windowEnd time.Time) (bool, error) {

--- a/panel-api/internal/repository/tlsrpt_aggregate_repository_test.go
+++ b/panel-api/internal/repository/tlsrpt_aggregate_repository_test.go
@@ -1,0 +1,52 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ReKeyDomain (GH #1579) moves every TLS-RPT aggregate row from the old domain
+// name to the new one and returns the rows moved. The SQL is pinned so the WHERE
+// stays scoped to the old name.
+func TestTLSRPT_ReKeyDomain_MovesRowsToNewName(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewTLSRPTAggregateRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .tlsrpt_aggregate. SET .domain.=.?.*WHERE domain = .?`).
+		WithArgs("new.com", "old.com").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	n, err := repo.ReKeyDomain(context.Background(), "old.com", "new.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A domain that never received a TLS-RPT report moves nothing: zero rows, no error.
+func TestTLSRPT_ReKeyDomain_NoMatchIsZero(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewTLSRPTAggregateRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .tlsrpt_aggregate. SET .domain.=.?.*WHERE domain = .?`).
+		WithArgs("new.com", "notlsrpt.com").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	n, err := repo.ReKeyDomain(context.Background(), "notlsrpt.com", "new.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -41,6 +41,14 @@ type DMARCReKeyer interface {
 	ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error)
 }
 
+// TLSRPTReKeyer moves a domain's stored TLS-RPT aggregate history from the old
+// name to the new one on a rename (GH #1579) — same orphan-on-rename as the
+// DMARC dashboard. Satisfied by repository.TLSRPTAggregateRepository. Optional on
+// Deps: nil skips the re-key (the rename still succeeds).
+type TLSRPTReKeyer interface {
+	ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error)
+}
+
 // FtpDocrootLister lists a tenant's FTP/SFTP subaccounts so a rename can refuse
 // when one is homed at (or under) the docroot the rename is about to move
 // (GH #1579). Satisfied by repository.FtpAccountRepository. Optional on Deps:
@@ -106,9 +114,10 @@ func renameErr(code, format string, args ...any) *RenameError {
 // domain_id-keyed (so it survives the rename), and RenameDomain flips it back to
 // pending so the reconciler reissues it for mail.<new> on its next tick instead
 // of serving mail.<old> until the 30-day renewal window (best-effort; a domain
-// with no mail cert simply skips). The domain's stored DMARC aggregate history
-// is moved to the new name too (best-effort) so the DMARC dashboard, which reads
-// by domain name, is not orphaned. Not carried (documented limitation, non-fatal):
+// with no mail cert simply skips). The domain's stored DMARC and TLS-RPT
+// aggregate history is moved to the new name too (best-effort) so those
+// dashboards, which read by domain name, are not orphaned. Not carried
+// (documented limitation, non-fatal):
 // a webmail send-as identity created before the rename keeps the old address
 // until re-added. The catch-all address (a literal string on the Domain entity)
 // IS rewritten by the verb, best-effort.
@@ -378,6 +387,16 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	if d.DMARC != nil {
 		if _, drerr := d.DMARC.ReKeyDomain(ctx, oldName, newName); drerr != nil {
 			logRenameHeal(d.Log, "rekey DMARC history", oldName, newName, drerr)
+		}
+	}
+
+	// 4f. Same for the domain's TLS-RPT aggregate history (SMTP TLS Reporting) —
+	//     the sibling dashboard also reads by domain name, so a rename orphans it
+	//     the same way. Best-effort; a domain that never received a TLS-RPT report
+	//     moves nothing.
+	if d.TLSRPT != nil {
+		if _, trerr := d.TLSRPT.ReKeyDomain(ctx, oldName, newName); trerr != nil {
+			logRenameHeal(d.Log, "rekey TLS-RPT history", oldName, newName, trerr)
 		}
 	}
 

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -247,6 +247,24 @@ func (m *drDMARC) ReKeyDomain(_ context.Context, oldDomain, newDomain string) (i
 	return m.rekeyN, nil
 }
 
+type drTLSRPT struct {
+	rec              *drRecorder
+	rekeyErr         error
+	rekeyN           int64
+	oldSeen, newSeen string
+	called           bool
+}
+
+func (m *drTLSRPT) ReKeyDomain(_ context.Context, oldDomain, newDomain string) (int64, error) {
+	m.called = true
+	m.oldSeen, m.newSeen = oldDomain, newDomain
+	if m.rekeyErr != nil {
+		return 0, m.rekeyErr
+	}
+	m.rec.events = append(m.rec.events, "tlsrpt.rekey")
+	return m.rekeyN, nil
+}
+
 type drSched struct{ scheduled []string }
 
 func (r *drSched) Schedule(id string) { r.scheduled = append(r.scheduled, id) }
@@ -1056,6 +1074,81 @@ func TestRenameDomain_NoDMARCSkips(t *testing.T) {
 	for _, e := range rec.events {
 		if e == "dmarc.rekey" {
 			t.Fatalf("nil DMARC must not run a re-key, got %v", rec.events)
+		}
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should still be renamed, got %q", dom.Name)
+	}
+}
+
+// ---- TLS-RPT dashboard re-key (GH #1579 tlsrpt slice) ----
+
+// The domain's TLS-RPT aggregate history is moved to the new name after the
+// rename: ReKeyDomain is called with (oldName, newName), AFTER the DB rename, and
+// never fails the rename.
+func TestRenameDomain_TLSRPTReKey(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	tr := &drTLSRPT{rec: rec, rekeyN: 2}
+	d.TLSRPT = tr
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tr.called {
+		t.Fatalf("ReKeyDomain must be called on a rename")
+	}
+	if tr.oldSeen != "old.com" || tr.newSeen != "new.com" {
+		t.Fatalf("ReKeyDomain args = (%q,%q), want (old.com,new.com)", tr.oldSeen, tr.newSeen)
+	}
+	di, ri := -1, -1
+	for i, e := range rec.events {
+		switch e {
+		case "db.rename":
+			di = i
+		case "tlsrpt.rekey":
+			ri = i
+		}
+	}
+	if di == -1 || ri == -1 || ri < di {
+		t.Fatalf("tlsrpt.rekey (%d) must come after db.rename (%d): %v", ri, di, rec.events)
+	}
+}
+
+// A TLS-RPT re-key failure is a best-effort post-commit heal: logged, not
+// surfaced, never fails the already-committed rename.
+func TestRenameDomain_TLSRPTReKeyFailureStillSucceeds(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.TLSRPT = &drTLSRPT{rec: rec, rekeyErr: errors.New("tlsrpt rekey failed")}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("a TLS-RPT re-key failure must not fail the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed despite the re-key failure, got %q", dom.Name)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("a TLS-RPT re-key failure must not surface a warning, got %v", warnings)
+	}
+}
+
+// A panel without the TLS-RPT repo wired (TLSRPT nil) still renames — the re-key
+// is simply skipped.
+func TestRenameDomain_NoTLSRPTSkips(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner()) // TLSRPT left nil
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range rec.events {
+		if e == "tlsrpt.rekey" {
+			t.Fatalf("nil TLSRPT must not run a re-key, got %v", rec.events)
 		}
 	}
 	if dom.Name != "new.com" {

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -71,10 +71,11 @@ type Deps struct {
 	// at or under the docroot being moved (GH #1579) — its jail/chroot is not
 	// moved automatically. Optional: nil skips the check (the rename proceeds).
 	FtpAccounts FtpDocrootLister
-	// DMARC moves the domain's stored DMARC aggregate history onto the new name
-	// on a rename (GH #1579) so the DMARC dashboard is not orphaned. Optional:
-	// nil skips the re-key (the rename still succeeds).
+	// DMARC / TLSRPT move the domain's stored DMARC + TLS-RPT aggregate history
+	// onto the new name on a rename (GH #1579) so those dashboards are not
+	// orphaned. Optional: nil skips the re-key (the rename still succeeds).
 	DMARC        DMARCReKeyer
+	TLSRPT       TLSRPTReKeyer
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int


### PR DESCRIPTION
## Summary

Sibling of the DMARC re-key (#1590). `tlsrpt_aggregate` is the exact twin of `dmarc_aggregate`: rows key on the literal domain **name**, and the per-domain **TLS-RPT** (SMTP TLS Reporting, RFC 8460) dashboard reads them by name (`ListByDomainSince`: `WHERE domain = ?`). An in-place domain rename orphaned every stored report the same way — the TLS-RPT view went blank after a rename until fresh reports arrived under the new name.

`RenameDomain` now moves the domain's TLS-RPT aggregate history onto the new name as a best-effort post-commit heal, right alongside the DMARC re-key.

## Change

- **`TLSRPTAggregateRepository.ReKeyDomain(old, new)`** — `UPDATE tlsrpt_aggregate SET domain=new WHERE domain=old`, returning rows moved. Sole UPDATE path on an otherwise append-only table; no unique key spans `domain`, so moving rows onto an existing name never collides (ingest still dedupes via `ExistsForReport`); a domain that never received a report moves nothing.
- **`userops.RenameDomain`** — new `TLSRPTReKeyer` interface + optional `Deps.TLSRPT`; step 4f re-keys with `(oldName, newName)` after the DB rename. Best-effort: logged on failure, never fails the committed rename; nil skips.
- Wired `DomainHandlerConfig` → `domains_rename.go` → `app.go`; `deps.TLSRPTAggregate` is assigned unconditionally in `serve.go`, so the heal is always active in production.

## Testing

- **Unit** — repo `ReKeyDomain` (SQL-pinned; `WHERE domain = ?` scoped to the old name; no-match returns 0). Rename: re-key called with `(old, new)` after `db.rename`; failure-still-succeeds; nil skips. Full suite green (repository, userops, api, app); `go vet` clean.
- **Box (.60, full end-to-end via the real `POST /domains/:id/rename` with an owner API token)** — seeded 2 `tlsrpt_aggregate` rows under `testing44.net`; rename → both moved to `testing45.net` (success/failure counts + result_type preserved), 0 orphaned; rename back → both returned to `testing44.net`. Fixtures + `linux_uid` repair reverted, tombstones cleared, `testing44.net` left live + intact.

GH #1579
