### PR TITLE
feat(domains): rewrite alias forwarder targets on a rename (GH #1579)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -52,6 +52,9 @@ type DomainHandlerConfig struct {
 	// orphaned. Optional — nil skips the re-key (the rename still succeeds).
 	DMARCAggregate  repository.DMARCAggregateRepository
 	TLSRPTAggregate repository.TLSRPTAggregateRepository
+	// Forwarders lets the GH #1579 rename rewrite the domain's alias forwarder
+	// targets to the new name. Optional — nil skips (the rename still succeeds).
+	Forwarders repository.EmailForwarderRepository
 	Packages    repository.PackageRepository
 	Agent       agent.AgentInterface
 	Reconciler *reconciler.Reconciler

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -89,7 +89,9 @@ func (h *domainHandler) rename(c *gin.Context) {
 		// name so those dashboards are not orphaned.
 		DMARC:  h.cfg.DMARCAggregate,
 		TLSRPT: h.cfg.TLSRPTAggregate,
-		Log:    slog.Default(),
+		// Forwarders rewrites alias forwarder targets to the new name.
+		Forwarders: h.cfg.Forwarders,
+		Log:        slog.Default(),
 	}, rec, domain, newName)
 	if err != nil {
 		var re *userops.RenameError

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -711,6 +711,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// history onto the new name so those dashboards are not orphaned.
 				DMARCAggregate:  deps.DMARCAggregate,
 				TLSRPTAggregate: deps.TLSRPTAggregate,
+				// GH #1579 rename: rewrites alias forwarder targets to the new name.
+				Forwarders: deps.Forwarders,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/repository/email_forwarder_rekey_test.go
+++ b/panel-api/internal/repository/email_forwarder_rekey_test.go
@@ -1,0 +1,52 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ReKeyAliasTargets (GH #1579) recomputes each alias forwarder's target as
+// <local_part>@<newDomain>. The SQL is pinned so it stays scoped to ALIAS rows
+// with a non-null local_part (external forwarders keep their outside target).
+func TestForwarder_ReKeyAliasTargets_RewritesAliasesOnly(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewEmailForwarderRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .email_forwarders. SET .target.=CONCAT\(local_part.*domain_id = .*type = .*local_part IS NOT NULL`).
+		WithArgs("new.com", sqlmock.AnyArg(), "dom-1", "alias").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectCommit()
+
+	n, err := repo.ReKeyAliasTargets(context.Background(), "dom-1", "new.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A domain with no alias forwarder rewrites nothing: zero rows, no error.
+func TestForwarder_ReKeyAliasTargets_NoAliasesIsZero(t *testing.T) {
+	t.Parallel()
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewEmailForwarderRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE .email_forwarders. SET .target.=CONCAT\(local_part.*domain_id = .*type = .*local_part IS NOT NULL`).
+		WithArgs("new.com", sqlmock.AnyArg(), "dom-none", "alias").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	n, err := repo.ReKeyAliasTargets(context.Background(), "dom-none", "new.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/repository/email_forwarder_repository.go
+++ b/panel-api/internal/repository/email_forwarder_repository.go
@@ -27,6 +27,15 @@ type EmailForwarderRepository interface {
 	Create(ctx context.Context, fwd *models.EmailForwarder) error
 	Update(ctx context.Context, fwd *models.EmailForwarder) error
 	Delete(ctx context.Context, id string) error
+
+	// ReKeyAliasTargets rewrites the stored `target` of this domain's ALIAS
+	// forwarders from <local_part>@<old> to <local_part>@<new> after an in-place
+	// rename (GH #1579). The alias target is the canonical AliasForwarderTarget
+	// (local_part@domain); it is unused at apply time (delivery is by local_part
+	// -> mailbox) but backs the uq_external_forward unique key and is shown in the
+	// UI, so it must track the current name. External forwarders (target = an
+	// outside address) are left untouched. Returns the rows rewritten.
+	ReKeyAliasTargets(ctx context.Context, domainID, newDomain string) (int64, error)
 }
 
 type emailForwarderRepo struct {
@@ -150,6 +159,21 @@ func (r *emailForwarderRepo) Create(ctx context.Context, fwd *models.EmailForwar
 func (r *emailForwarderRepo) Update(ctx context.Context, fwd *models.EmailForwarder) error {
 	fwd.UpdatedAt = time.Now().UTC()
 	return r.db.WithContext(ctx).Save(fwd).Error
+}
+
+func (r *emailForwarderRepo) ReKeyAliasTargets(ctx context.Context, domainID, newDomain string) (int64, error) {
+	// Recompute each alias target as <local_part>@<newDomain> in one statement —
+	// byte-identical to models.AliasForwarderTarget. Scoped to type='alias' with a
+	// non-null local_part, so external forwarders (target = an outside address) are
+	// never touched. No unique key can collide: alias local_parts are unique per
+	// domain, so the recomputed targets are unique too.
+	res := r.db.WithContext(ctx).Model(&models.EmailForwarder{}).
+		Where("domain_id = ? AND type = ? AND local_part IS NOT NULL", domainID, "alias").
+		Update("target", gorm.Expr("CONCAT(local_part, '@', ?)", newDomain))
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
 }
 
 func (r *emailForwarderRepo) Delete(ctx context.Context, id string) error {

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -49,6 +49,15 @@ type TLSRPTReKeyer interface {
 	ReKeyDomain(ctx context.Context, oldDomain, newDomain string) (int64, error)
 }
 
+// ForwarderAliasReKeyer rewrites the stored target of a domain's ALIAS forwarders
+// (target = local_part@domain) to track the new name on a rename (GH #1579).
+// Cosmetic — the target is unused at apply — but it backs the alias unique key
+// and the UI. Satisfied by repository.EmailForwarderRepository. Optional on Deps:
+// nil skips.
+type ForwarderAliasReKeyer interface {
+	ReKeyAliasTargets(ctx context.Context, domainID, newDomain string) (int64, error)
+}
+
 // FtpDocrootLister lists a tenant's FTP/SFTP subaccounts so a rename can refuse
 // when one is homed at (or under) the docroot the rename is about to move
 // (GH #1579). Satisfied by repository.FtpAccountRepository. Optional on Deps:
@@ -397,6 +406,18 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	if d.TLSRPT != nil {
 		if _, trerr := d.TLSRPT.ReKeyDomain(ctx, oldName, newName); trerr != nil {
 			logRenameHeal(d.Log, "rekey TLS-RPT history", oldName, newName, trerr)
+		}
+	}
+
+	// 4g. Rewrite the stored target of this domain's ALIAS forwarders to track the
+	//     new name (target = local_part@<domain>). Cosmetic — the target is unused
+	//     at apply (alias delivery is by local_part -> mailbox) — but it backs the
+	//     alias unique key and is shown in the UI, so keep it consistent. Keyed by
+	//     domain_id (the rows survive the rename). Best-effort; external forwarders
+	//     (an outside target address) are left untouched by the repo's scope.
+	if d.Forwarders != nil {
+		if _, ferr := d.Forwarders.ReKeyAliasTargets(ctx, domain.ID, newName); ferr != nil {
+			logRenameHeal(d.Log, "rekey alias forwarder targets", oldName, newName, ferr)
 		}
 	}
 

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -265,6 +265,24 @@ func (m *drTLSRPT) ReKeyDomain(_ context.Context, oldDomain, newDomain string) (
 	return m.rekeyN, nil
 }
 
+type drForwarders struct {
+	rec               *drRecorder
+	rekeyErr          error
+	rekeyN            int64
+	domSeen, nameSeen string
+	called            bool
+}
+
+func (m *drForwarders) ReKeyAliasTargets(_ context.Context, domainID, newDomain string) (int64, error) {
+	m.called = true
+	m.domSeen, m.nameSeen = domainID, newDomain
+	if m.rekeyErr != nil {
+		return 0, m.rekeyErr
+	}
+	m.rec.events = append(m.rec.events, "forwarder.rekey")
+	return m.rekeyN, nil
+}
+
 type drSched struct{ scheduled []string }
 
 func (r *drSched) Schedule(id string) { r.scheduled = append(r.scheduled, id) }
@@ -1149,6 +1167,82 @@ func TestRenameDomain_NoTLSRPTSkips(t *testing.T) {
 	for _, e := range rec.events {
 		if e == "tlsrpt.rekey" {
 			t.Fatalf("nil TLSRPT must not run a re-key, got %v", rec.events)
+		}
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should still be renamed, got %q", dom.Name)
+	}
+}
+
+// ---- alias forwarder target re-key (GH #1579 forwarder-target slice) ----
+
+// The domain's alias forwarder targets are rewritten to the new name after the
+// rename: ReKeyAliasTargets is called with (domain.ID, newName), AFTER the DB
+// rename, and never fails the rename.
+func TestRenameDomain_ForwarderAliasReKey(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	fw := &drForwarders{rec: rec, rekeyN: 3}
+	d.Forwarders = fw
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fw.called {
+		t.Fatalf("ReKeyAliasTargets must be called on a rename")
+	}
+	// Keyed by domain_id (the rows survive the rename), with the NEW name.
+	if fw.domSeen != "dom-1" || fw.nameSeen != "new.com" {
+		t.Fatalf("ReKeyAliasTargets args = (%q,%q), want (dom-1,new.com)", fw.domSeen, fw.nameSeen)
+	}
+	di, ri := -1, -1
+	for i, e := range rec.events {
+		switch e {
+		case "db.rename":
+			di = i
+		case "forwarder.rekey":
+			ri = i
+		}
+	}
+	if di == -1 || ri == -1 || ri < di {
+		t.Fatalf("forwarder.rekey (%d) must come after db.rename (%d): %v", ri, di, rec.events)
+	}
+}
+
+// A forwarder re-key failure is a best-effort post-commit heal: logged, not
+// surfaced, never fails the already-committed rename.
+func TestRenameDomain_ForwarderReKeyFailureStillSucceeds(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Forwarders = &drForwarders{rec: rec, rekeyErr: errors.New("forwarder rekey failed")}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("a forwarder re-key failure must not fail the rename, got %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed despite the re-key failure, got %q", dom.Name)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("a forwarder re-key failure must not surface a warning, got %v", warnings)
+	}
+}
+
+// A panel without the forwarder repo wired (Forwarders nil) still renames — the
+// re-key is simply skipped.
+func TestRenameDomain_NoForwardersSkips(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, _, _ := drNewDeps(rec, dom, drHappyOwner()) // Forwarders left nil
+
+	if _, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range rec.events {
+		if e == "forwarder.rekey" {
+			t.Fatalf("nil Forwarders must not run a re-key, got %v", rec.events)
 		}
 	}
 	if dom.Name != "new.com" {

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -74,8 +74,11 @@ type Deps struct {
 	// DMARC / TLSRPT move the domain's stored DMARC + TLS-RPT aggregate history
 	// onto the new name on a rename (GH #1579) so those dashboards are not
 	// orphaned. Optional: nil skips the re-key (the rename still succeeds).
-	DMARC        DMARCReKeyer
-	TLSRPT       TLSRPTReKeyer
+	DMARC  DMARCReKeyer
+	TLSRPT TLSRPTReKeyer
+	// Forwarders rewrites the domain's alias forwarder targets to the new name on
+	// a rename (GH #1579). Optional: nil skips (the rename still succeeds).
+	Forwarders   ForwarderAliasReKeyer
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int


### PR DESCRIPTION
## Summary

Hygiene follow-up noted in #1589: an **alias forwarder** stores its canonical target as `local_part@<domain>` (`AliasForwarderTarget`). The rows key on `domain_id` and survive an in-place rename, but the stored `target` kept the **old** name. Cosmetic — the target is unused at apply (alias delivery is by `local_part` → mailbox) — but it backs the `uq_external_forward` unique key and is shown in the UI, so it should track the current name.

`RenameDomain` now rewrites the domain's alias forwarder targets to the new name as a best-effort post-commit heal, alongside the other rename heals.

## Change

- **`EmailForwarderRepository.ReKeyAliasTargets(domainID, newDomain)`** — `UPDATE email_forwarders SET target = CONCAT(local_part, '@', newDomain) WHERE domain_id = ? AND type = 'alias' AND local_part IS NOT NULL`. One statement, byte-identical to `AliasForwarderTarget`. **External** forwarders (target = an outside address) are left untouched. Returns rows rewritten; alias `local_part`s are unique per domain, so the recomputed targets never collide on the unique key.
- **`userops.RenameDomain`** — new `ForwarderAliasReKeyer` interface + optional `Deps.Forwarders`; step 4g re-keys with `(domain.ID, newName)` after the DB rename. Best-effort: logged on failure, never fails the committed rename; nil skips.
- Wired `DomainHandlerConfig` → `domains_rename.go` → `app.go`; `deps.Forwarders` is constructed unconditionally in `serve.go`.

## Testing

- **Unit** — repo `ReKeyAliasTargets` (SQL-pinned; scoped to `type='alias'` rows with a non-null `local_part`; no-match returns 0). Rename: re-key called with `(domain.ID, new)` after `db.rename`; failure-still-succeeds; nil skips. Full suite green (repository, userops, api, app); `go vet` clean.
- **Box (.60, full end-to-end via the real `POST /domains/:id/rename` with an owner API token)** — seeded one alias (`sales@testing44.net`) and one external (`someone@external.example`) forwarder; rename → alias target rewritten to `sales@testing45.net`, external left **unchanged**; rename back → alias target returned to `sales@testing44.net`. Fixtures + `linux_uid` repair reverted, tombstones cleared, `testing44.net` left live + intact.

GH #1579
