### PR TITLE
fix(dashboard): source tenant disk usage from the du snapshot, not POSIX quota (GH #1439)

### DIFF
--- a/panel-api/internal/api/user_limits.go
+++ b/panel-api/internal/api/user_limits.go
@@ -68,6 +68,14 @@ type UserLimitsHandlerConfig struct {
 	// call. Empty string disables the disk half of the report (CI,
 	// dev box without quota).
 	QuotaMount string
+	// DiskSnapshots reads the last computed per-user disk-usage breakdown
+	// (the same snapshot the tenant Disk Usage page persists). Optional:
+	// nil leaves the response unchanged. When present, the usage endpoint
+	// surfaces the snapshot's home-directory `du` figure as `disk_used` so
+	// the dashboard shows the SAME number as the Disk Usage page instead of
+	// the POSIX quota, which is absent when quota isn't tracking (shown as
+	// 0 B) and over-reports the home dir when it is (GH #1439).
+	DiskSnapshots repository.DiskUsageSnapshotRepository
 }
 
 // RegisterUserLimitsRoutes mounts /users/:id/usage and /limit-overrides
@@ -116,6 +124,21 @@ type usageResponse struct {
 	Package  *limitFieldsView          `json:"package,omitempty"`
 	Override *models.UserLimitOverride `json:"override,omitempty"`
 	Current  json.RawMessage           `json:"current,omitempty"`
+	// DiskUsed is the authoritative home-directory usage sourced from the
+	// persisted Disk Usage snapshot (an actual `du`), not the POSIX quota in
+	// `current`. Present only when a snapshot exists; the UI prefers it over
+	// `current.disk.used_kb` so the dashboard matches the Disk Usage page
+	// (GH #1439). Absent (nil) → the client falls back to the quota figure.
+	DiskUsed *diskUsedView `json:"disk_used,omitempty"`
+}
+
+// diskUsedView is the snapshot-derived disk figure the dashboard prefers.
+// Source is "du" today (the only snapshot source); ComputedAt lets the UI
+// show how fresh the measurement is.
+type diskUsedView struct {
+	Bytes      uint64     `json:"bytes"`
+	Source     string     `json:"source"`
+	ComputedAt *time.Time `json:"computed_at,omitempty"`
 }
 
 func (h *userLimitsHandler) usage(c *gin.Context) {
@@ -166,6 +189,28 @@ func (h *userLimitsHandler) usage(c *gin.Context) {
 			if err == nil {
 				resp.Current = raw
 				usageReportCachePut(cacheKey, raw)
+			}
+		}
+	}
+
+	// Prefer the persisted Disk Usage snapshot's home `du` figure for the
+	// disk metric. It is the same number the Disk Usage page shows and is
+	// correct where the POSIX quota in `current` is not: quota is ABSENT
+	// (omitted → dashboard reads 0 B) when the mount has no aquota.user, and
+	// OVER-reports the home dir (every block the UID owns device-wide) when
+	// it is tracking. Read outside the 60s agent cache — snapshot freshness
+	// is its own clock. Best-effort: any miss leaves `disk_used` nil and the
+	// client falls back to the quota figure (GH #1439).
+	if h.cfg.DiskSnapshots != nil {
+		if snap, serr := h.cfg.DiskSnapshots.Get(c.Request.Context(), userID); serr == nil && snap != nil {
+			var du diskUsageResponse
+			if json.Unmarshal([]byte(snap.Payload), &du) == nil {
+				ca := snap.ComputedAt
+				resp.DiskUsed = &diskUsedView{
+					Bytes:      du.Files.Bytes,
+					Source:     "du",
+					ComputedAt: &ca,
+				}
 			}
 		}
 	}

--- a/panel-api/internal/api/user_limits_disk_test.go
+++ b/panel-api/internal/api/user_limits_disk_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ulFakeAgent returns a canned user.limits.report payload so a test can assert
+// the handler passes `current` through untouched independently of disk_used.
+type ulFakeAgent struct{ raw string }
+
+func (a ulFakeAgent) Call(context.Context, string, any) (json.RawMessage, error) {
+	return json.RawMessage(a.raw), nil
+}
+
+// GH #1439: the tenant dashboard's Disk metric used to read the POSIX quota in
+// `current`, which the agent omits when quota isn't tracking — the card then
+// showed 0 B. The usage endpoint now surfaces the persisted Disk Usage
+// snapshot's home `du` figure as `disk_used` so the dashboard matches the Disk
+// Usage page. These tests pin that contract.
+
+type ulSnapshotRepo struct {
+	repository.DiskUsageSnapshotRepository
+	snap *models.DiskUsageSnapshot
+}
+
+func (r *ulSnapshotRepo) Get(context.Context, string) (*models.DiskUsageSnapshot, error) {
+	if r.snap == nil {
+		return nil, repository.ErrNotFound
+	}
+	return r.snap, nil
+}
+
+func snapshotPayload(t *testing.T, filesBytes, emailBytes, dbBytes uint64) string {
+	t.Helper()
+	b, err := json.Marshal(diskUsageResponse{
+		TotalBytes: filesBytes + emailBytes + dbBytes,
+		Files:      diskUsageCategory{Bytes: filesBytes},
+		Email:      diskUsageCategory{Bytes: emailBytes},
+		Databases:  diskUsageCategory{Bytes: dbBytes},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return string(b)
+}
+
+func baseUsageCfg(snap repository.DiskUsageSnapshotRepository) UserLimitsHandlerConfig {
+	uname := "alice"
+	return UserLimitsHandlerConfig{
+		Users:          &ulUserRepo{u: &models.User{ID: "u1", Username: &uname}},
+		Packages:       &ulPackageRepo{},
+		LimitOverrides: &ulOverrideRepo{},
+		// No Agent: reproduces the reported case (quota absent → `current` nil).
+		DiskSnapshots: snap,
+	}
+}
+
+// With a snapshot present and NO agent (the exact 0-B scenario), the endpoint
+// reports disk_used from the snapshot's Files bytes — not email/db, so it stays
+// apples-to-apples with the home quota the card renders — and leaves `current`
+// nil. This is the whole point: the disk number no longer depends on quota.
+func TestUsage_DiskUsedFromSnapshot(t *testing.T) {
+	const files = uint64(5 * 1024 * 1024 * 1024) // 5 GiB home
+	computed := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	cfg := baseUsageCfg(&ulSnapshotRepo{snap: &models.DiskUsageSnapshot{
+		UserID:     "u1",
+		Payload:    snapshotPayload(t, files, 900*1024*1024, 300*1024*1024),
+		ComputedAt: computed,
+	}})
+
+	resp := serveUsage(t, cfg)
+
+	if resp.DiskUsed == nil {
+		t.Fatal("disk_used must be present when a snapshot exists")
+	}
+	if resp.DiskUsed.Bytes != files {
+		t.Errorf("disk_used.bytes: want home files %d (not total), got %d", files, resp.DiskUsed.Bytes)
+	}
+	if resp.DiskUsed.Source != "du" {
+		t.Errorf("disk_used.source: want %q, got %q", "du", resp.DiskUsed.Source)
+	}
+	if resp.DiskUsed.ComputedAt == nil || !resp.DiskUsed.ComputedAt.Equal(computed) {
+		t.Errorf("disk_used.computed_at: want %v, got %v", computed, resp.DiskUsed.ComputedAt)
+	}
+	if resp.Current != nil {
+		t.Errorf("no agent → current must stay nil, got %s", string(resp.Current))
+	}
+}
+
+// Agent AND snapshot both present: `current` passes through unchanged (the
+// agent's quota disk figure is preserved for the admin views that read it),
+// while disk_used independently carries the snapshot's home `du`. The two
+// sources coexist; disk_used never mutates current.
+func TestUsage_AgentAndSnapshotCoexist(t *testing.T) {
+	uname := "agentsnapuser" // unique key so the 60s usage cache can't cross-contaminate
+	cfg := UserLimitsHandlerConfig{
+		Users:          &ulUserRepo{u: &models.User{ID: "u1", Username: &uname}},
+		Packages:       &ulPackageRepo{},
+		LimitOverrides: &ulOverrideRepo{},
+		Agent:          ulFakeAgent{raw: `{"username":"agentsnapuser","disk":{"used_kb":7,"limit_kb":0}}`},
+		DiskSnapshots:  &ulSnapshotRepo{snap: &models.DiskUsageSnapshot{UserID: "u1", Payload: snapshotPayload(t, 999, 0, 0), ComputedAt: time.Now()}},
+	}
+
+	resp := serveUsage(t, cfg)
+
+	if resp.Current == nil {
+		t.Fatal("current must pass through when the agent answered")
+	}
+	var cur struct {
+		Disk struct {
+			UsedKB uint64 `json:"used_kb"`
+		} `json:"disk"`
+	}
+	if err := json.Unmarshal(resp.Current, &cur); err != nil {
+		t.Fatalf("decode current: %v", err)
+	}
+	if cur.Disk.UsedKB != 7 {
+		t.Errorf("current.disk.used_kb must be the agent's 7 (untouched), got %d", cur.Disk.UsedKB)
+	}
+	if resp.DiskUsed == nil || resp.DiskUsed.Bytes != 999 {
+		t.Fatalf("disk_used must carry the snapshot's 999 bytes independently, got %+v", resp.DiskUsed)
+	}
+}
+
+// No snapshot yet (tenant never opened the Disk Usage page): disk_used is
+// omitted and the client falls back to the quota figure — today's behavior.
+func TestUsage_NoSnapshotOmitsDiskUsed(t *testing.T) {
+	resp := serveUsage(t, baseUsageCfg(&ulSnapshotRepo{snap: nil}))
+	if resp.DiskUsed != nil {
+		t.Errorf("no snapshot → disk_used must be nil, got %+v", resp.DiskUsed)
+	}
+}
+
+// A nil DiskSnapshots repo (a deployment that hasn't wired it) leaves the
+// response exactly as before — disk_used absent.
+func TestUsage_NilSnapshotRepoIsBackwardCompatible(t *testing.T) {
+	resp := serveUsage(t, baseUsageCfg(nil))
+	if resp.DiskUsed != nil {
+		t.Errorf("nil snapshot repo → disk_used must be nil, got %+v", resp.DiskUsed)
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -688,6 +688,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				LimitOverrides: deps.LimitOverrides,
 				Agent:          deps.Agent,
 				QuotaMount:     deps.QuotaMount,
+				// Lets the dashboard usage card prefer the Disk Usage page's
+				// `du` figure over the POSIX quota for the disk metric (GH #1439).
+				DiskSnapshots: repository.NewDiskUsageSnapshotRepository(deps.DB),
 			})
 		}
 		if deps.Domains != nil {

--- a/panel-ui/src/shells/user/MyProfileUsageCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileUsageCard.tsx
@@ -39,6 +39,10 @@ type UsageResponse = {
   user_id: string;
   effective: Effective;
   current?: Current;
+  // Home-directory usage from the Disk Usage snapshot (an actual `du`).
+  // Present only once a snapshot exists; preferred over current.disk.used_kb
+  // because the POSIX quota is absent (0 B) or over-reports the home dir.
+  disk_used?: { bytes: number; source: string; computed_at?: string };
 };
 
 function MetricCard({
@@ -47,12 +51,14 @@ function MetricCard({
   label,
   value,
   pct,
+  hint,
 }: {
   icon: ReactNode;
   color: string;
   label: string;
   value: string;
   pct?: number;
+  hint?: string;
 }) {
   return (
     <div>
@@ -75,7 +81,9 @@ function MetricCard({
         </div>
         <div style={{ minWidth: 0 }}>
           <div style={{ color, fontSize: 12, fontWeight: 600 }}>{label}</div>
-          <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.2 }}>{value}</div>
+          <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.2 }} title={hint}>
+            {value}
+          </div>
         </div>
       </div>
       {pct != null && (
@@ -130,7 +138,13 @@ export function MyProfileUsageCard({ userId }: { userId: string }) {
 
   const { effective, current } = data;
 
-  const diskUsed = (current?.disk?.used_kb ?? 0) * 1024;
+  // Prefer the Disk Usage snapshot's `du` bytes (consistent with the Disk
+  // Usage page); fall back to the live POSIX quota when no snapshot exists.
+  const diskUsed = data.disk_used ? data.disk_used.bytes : (current?.disk?.used_kb ?? 0) * 1024;
+  // The snapshot figure is as-of the last Disk Usage refresh, not live — say so.
+  const diskHint = data.disk_used?.computed_at
+    ? `Home usage measured ${new Date(data.disk_used.computed_at).toLocaleString()}`
+    : undefined;
   const diskLimitKB =
     (current?.disk?.limit_kb ?? 0) > 0 ? (current?.disk?.limit_kb ?? 0) : effective.DiskQuotaMB * 1024;
   const diskLimit = diskLimitKB * 1024;
@@ -155,7 +169,7 @@ export function MyProfileUsageCard({ userId }: { userId: string }) {
   const ioWriteValue = effective.IOWriteMbps > 0 ? `${effective.IOWriteMbps} MB/s` : "Unlimited";
 
   const metrics = [
-    { icon: <HddOutlined />, color: "#1677ff", label: "Disk", value: usedOf(diskUsed, diskLimit), pct: pctOf(diskUsed, diskLimit) },
+    { icon: <HddOutlined />, color: "#1677ff", label: "Disk", value: usedOf(diskUsed, diskLimit), pct: pctOf(diskUsed, diskLimit), hint: diskHint },
     { icon: <DatabaseOutlined />, color: "#9254de", label: "Memory", value: usedOf(memUsed, memLimit), pct: pctOf(memUsed, memLimit) },
     { icon: <ThunderboltOutlined />, color: "#52c41a", label: "CPU quota", value: cpuValue },
     { icon: <AppstoreLayoutOutlined />, color: "#fa8c16", label: "Processes", value: procValue },


### PR DESCRIPTION
## Summary

The tenant main dashboard's **Disk** metric showed `0 B` even when the tenant had real files (reported on #1439). The card reads the live POSIX quota via `GET /users/:id/usage` → `current.disk.used_kb`. The agent omits the `disk` block from `user.limits.report` whenever `quota` has no answer for the user (no `aquota.user` on the mount, quota disabled, or a mount mismatch), so the card's `used_kb ?? 0` rendered **`0 B`**. Where quota *is* tracking, it also **over-reports** the home dir (it counts every block the UID owns device-wide) — the exact reason the Disk Usage page already switched to an actual `du` of the home dir (the original #1439 fix, see the header of `me_disk_usage.go`). The dashboard never got that treatment.

## Change

The `du` result is already persisted per-user as a `disk_usage_snapshots` row (written by the Disk Usage page's Refresh, the CLI, and billing). This PR surfaces that same figure on the dashboard:

- **`UserLimitsHandlerConfig`** gains an optional `DiskSnapshots` repo (nil → response byte-identical to before). `GET /users/:id/usage` now reads the snapshot — a cheap DB read, **outside** the 60s agent-report cache (snapshot freshness is its own clock) — and exposes a new top-level field:
  ```json
  "disk_used": { "bytes": 85..., "source": "du", "computed_at": "2026-..." }
  ```
  sourced from the snapshot's **home `files.bytes`** (not total) so it stays apples-to-apples with the home quota the card renders. `current` is passed through **unchanged**.
- **Tenant card (`MyProfileUsageCard`)** prefers `disk_used.bytes`, falling back to `current.disk.used_kb` when no snapshot exists. A `title` tooltip on the Disk tile discloses the measured-at time (the snapshot is as-of the last Disk Usage refresh, not live).
- **Admin views are intentionally left reading `current.disk.used_kb`.** Their per-user **Measure** button posts `/usage/measure-disk`, which refreshes the *quota cache*, not the snapshot — so switching them to `disk_used` would make Measure look like a no-op. This PR only changes the tenant card (the sole tenant-side reader of the field).

### Residual (out of scope)
A tenant who has **never** opened the Disk Usage page has no snapshot, so the dashboard still shows the quota fallback (i.e. `0 B` where quota is absent) until the first Refresh — consistent with the Disk Usage page, which is likewise empty until first measured. Triggering a `du` from the dashboard's 10s poll is deliberately avoided (it is the IO-starvation regression the on-demand Measure design already fixed).

## Testing

- **Unit** (`user_limits_disk_test.go`): snapshot present → `disk_used.bytes == files.bytes`, `source == "du"`, `computed_at` set, `current` untouched; **agent + snapshot coexist** → `current.disk.used_kb` passes through unchanged *and* `disk_used` carries the snapshot bytes; no snapshot → `disk_used` omitted; nil repo → response unchanged. Full `panel-api/internal/api` + `internal/app` suites green; `go vet` clean.
- **Box (.60, full end-to-end via the real socket + an owner/admin API token):**
  - `testing44` (has a snapshot, `files.bytes = 81920`): the agent report **had no `disk` block** — i.e. the exact `0 B` bug reproduced — and the response now returns `disk_used = {bytes: 81920, source: "du", computed_at: 2026-09-03T04:33:22.974091Z}`, identical to the Disk Usage page.
  - admin user with **no** snapshot: `disk_used` **absent** → card falls back to quota, no regression.
  - Fixtures reverted: test token deleted, original binary restored (`63946345`), panel healthy, `testing44` snapshot untouched.
- **UI typecheck** is deferred to CI's `tsc -b && vite build` (the fresh worktree has no `node_modules`; the change is an optional field on a type plus a truthy-narrowed ternary). The existing `UserDashboard`/`MyProfile` vitest suites that render this card run in CI.

GH #1439
