### PR TITLE
feat(domains): drop the Document Root field from Add Web Domain (GH #1541)

### DIFF
--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.test.tsx
@@ -1,7 +1,8 @@
 // UserDomainDrawer — the tenant Add Web Domain flow (GH #1541), plus the mail
-// module gating (GH #1409) and the create-time document root (GH #1413), both
-// reworked by #1541: mail is now an "Add Mail Domain" checkbox and the document
-// root moved under a collapsed "Advanced" section.
+// module gating (GH #1409). #1541: mail is an "Add Mail Domain" checkbox and the
+// document root is no longer set at create time (johnnyq) — the create-time
+// docroot field (GH #1413) was dropped; only the reverse-proxy option remains
+// under "Advanced". A custom docroot is configured later from the domain page.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -86,20 +87,18 @@ describe("UserDomainDrawer Add Mail Domain (GH #1409/#1541)", () => {
   });
 });
 
-describe("UserDomainDrawer document root under Advanced (GH #1413/#1541)", () => {
-  it("keeps Document root out of the default form, shows it under Advanced, hides it for a reverse proxy", async () => {
+describe("UserDomainDrawer create form no longer sets a document root (GH #1541)", () => {
+  it("shows no Document root field, in the simple form or under Advanced", async () => {
     caps.mail = true;
     renderDrawer();
-    // Not part of the simple form.
+    // Not in the simple form.
     expect(screen.queryByLabelText("Document root")).not.toBeInTheDocument();
-    // Expand Advanced → the field registers and renders.
+    // Expand Advanced → still no Document root; the reverse-proxy option remains.
     fireEvent.click(await screen.findByText("Advanced"));
-    await waitFor(() => expect(screen.getByLabelText("Document root")).toBeInTheDocument());
-    // A reverse-proxy domain has no docroot — toggling it removes the field.
-    fireEvent.click(screen.getByRole("checkbox", { name: /set up as a reverse proxy/i }));
     await waitFor(() =>
-      expect(screen.queryByLabelText("Document root")).not.toBeInTheDocument(),
+      expect(screen.getByRole("checkbox", { name: /set up as a reverse proxy/i })).toBeInTheDocument(),
     );
+    expect(screen.queryByLabelText("Document root")).not.toBeInTheDocument();
   });
 });
 
@@ -119,6 +118,8 @@ describe("UserDomainDrawer web create payload (GH #1541)", () => {
     expect(body).not.toHaveProperty("add_mail");
     expect(body).not.toHaveProperty("enable_webmail");
     expect(body).not.toHaveProperty("temp_url_enabled");
+    // GH #1541: document root is not set at create time.
+    expect(body).not.toHaveProperty("doc_root");
   });
 
   it("Add Mail Domain unchecked (external mail None) → no Jabali mail, and a subdomain gets no www", async () => {

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -23,11 +23,10 @@ import { DnsZoneFields } from "../../../components/dns/DnsZoneFields";
 
 type UserDomainCreateInput = {
   name: string;
-  // GH #1413: optional custom document root at create time (handy for
-  // subdomains). Blank = the default …/domains/<name>/public_html. The
-  // server confines a tenant's docroot to this domain's own tree. GH #1541
-  // moved it under the drawer's "Advanced" section (out of the simple form).
-  doc_root?: string;
+  // GH #1541: document root is no longer set at create time (johnnyq: keep the
+  // Add Web Domain form to the bare minimum). Every new web domain gets the
+  // default …/domains/<name>/public_html; a custom docroot — or a redirect for
+  // a subdomain — is configured afterwards from the domain's Document Root tab.
   mail_provider?: string;
   m365_onmicrosoft?: string;
   google_dkim?: string;
@@ -138,10 +137,10 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           // www.<subdomain> record. create_www also drives the cert SAN, so it
           // stays independent of manage_dns.
           create_www: values.name.split(".").length === 2,
-          // Advanced: a reverse-proxy domain has no document root.
+          // Advanced: reverse proxy stays a create-time option (no later path to
+          // convert a plain web domain into one). Document root is not set here.
           reverse_proxy: isReverse,
           reverse_proxy_port: isReverse ? values.reverse_proxy_port : undefined,
-          doc_root: isReverse ? undefined : values.doc_root,
         };
       } else {
         // GH #1449: a web-off entry (DNS-only zone / mail-only domain) carries
@@ -350,11 +349,14 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
           </Form.Item>
         )}
 
-        {/* GH #1541: keep the create form to the bare minimum. Document Root and
-            the reverse-proxy option are real but rarely needed at create time, so
-            they live under a collapsed "Advanced" section. Preview URL is dropped
-            entirely — it's a later, per-domain toggle. antd lazily renders the
-            panel body, so these fields register only once Advanced is expanded. */}
+        {/* GH #1541: keep the create form to the bare minimum. Document Root is
+            no longer offered at create time (johnnyq) — new domains get the
+            default docroot, and a custom docroot or a subdomain redirect is set
+            afterwards from the domain's Document Root tab. Preview URL is likewise
+            a later, per-domain toggle. The reverse-proxy option stays under
+            "Advanced" because there is no later path to convert a plain web
+            domain into a reverse proxy. antd lazily renders the panel body, so
+            these fields register only once Advanced is expanded. */}
         {isWeb && (
           <Collapse
             ghost
@@ -365,19 +367,6 @@ export const UserDomainDrawer = ({ open, onClose, mode = "web" }: UserDomainDraw
                 label: "Advanced",
                 children: (
                   <>
-                    {/* GH #1413: custom document root. Hidden for reverse-proxy
-                        domains (they have no docroot). The server confines a
-                        tenant's path to this domain's own tree. */}
-                    {!reverseProxy && (
-                      <Form.Item
-                        label={t("userdomaindrawer.document_root")}
-                        name="doc_root"
-                        tooltip={t("userdomaindrawer.document_root_hint")}
-                      >
-                        <Input placeholder="Leave blank for the default (…/public_html)" />
-                      </Form.Item>
-                    )}
-
                     {/* GH #1175: reverse-proxy option. The panel reserves a
                         conflict-free loopback port and writes the proxy_pass vhost;
                         the assigned port is shown after the domain is added. */}


### PR DESCRIPTION
## Summary

Follow-up to the Web Domain rework on #1541. Per johnnyq's request there:

> yes, I think Document Root should be removed entirely from Add Web Domain. It can always be configured later if needed. For a subdomain, a 301 redirect would really be the preferred approach anyway.

The create-time **Document Root** input (which #1541 had tucked under the drawer's "Advanced" section) is now removed. Every new web domain gets the default `…/domains/<name>/public_html`; a custom document root — or a 301 redirect for a subdomain — is set afterwards from the domain's **Document Root** tab (`DomainDocRootPanel`), which is unchanged.

## Change

- **`UserDomainDrawer`** (tenant Add Web Domain): remove the `doc_root` form field, its create-payload key, and the `doc_root` member of `UserDomainCreateInput`. The field was already optional (blank = "server default"), so `POST /domains` is unchanged — it simply never receives `doc_root` now. **No backend change.**
- The **reverse-proxy** option stays under "Advanced": unlike a document root, there is no later path to convert a plain web domain into a reverse proxy, so it must remain a create-time choice.
- The unused `userdomaindrawer.document_root*` i18n keys are left in place (no runtime or lint effect) rather than churned across every locale file.

## Testing

- **vitest** (`UserDomainDrawer.test.tsx`, 13/13): the old "document root under Advanced" case becomes "no Document root field anywhere" (simple form or Advanced, with the reverse-proxy option still present); the web create-payload test now also asserts `doc_root` is never sent.
- **tsc -b**: clean.
- CI runs `tsc -b && vite build` + vitest.

GH #1541
