### PR TITLE
fix(backups): trim restore Actions labels + drop the broken direct-IP notice (GH #1408)

### DIFF
--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.actions.test.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.actions.test.tsx
@@ -1,7 +1,7 @@
 // JAB-332: the admin backups page drives its per-job actions from the same
 // shared eligibility matrix as the tenant card, and hits the /admin resource
 // paths. These cover the admin side of the consolidation:
-//   - the run grouping (RunRow → "Expand to manage") is unchanged            (AC3)
+//   - the run grouping (RunRow → "Expand") is unchanged            (AC3)
 //   - a standalone job's Delete is gated by the shared canDelete (running hidden)
 //   - Delete calls DELETE /admin/backups/:id                                 (AC2)
 import { App } from "antd";
@@ -111,13 +111,13 @@ describe("AdminBackupsPage per-job actions (JAB-332)", () => {
     mockData([job("m1", "succeeded")]);
     renderPage();
     // AC3: the scheduler run still rolls up under one expandable parent row.
-    expect(await screen.findByText("Expand to manage")).toBeTruthy();
+    expect(await screen.findByText("Expand")).toBeTruthy();
   });
 
   it("shows Delete for a finished standalone job but hides it while running", async () => {
     mockData([job("m1", "succeeded"), job("m2", "running")]);
     renderPage();
-    await screen.findByText("Expand to manage");
+    await screen.findByText("Expand");
     // m1 (succeeded) shows a Delete; m2 (running) hides it → exactly one exact
     // "Delete" button in the collapsed table.
     await waitFor(() => expect(screen.getAllByText("Delete")).toHaveLength(1));

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -670,7 +670,7 @@ export const AdminBackupsPage = () => {
                   row.isRun ? (
                     <Space>
                       <Typography.Link style={{ fontSize: 12 }} onClick={() => toggleRowExpand(row)}>
-                        {expandedKeys.includes(row.rowKey) ? "Collapse" : "Expand to manage"}
+                        {expandedKeys.includes(row.rowKey) ? "Collapse" : "Expand"}
                       </Typography.Link>
                       <RowActions
                         actions={[
@@ -678,14 +678,14 @@ export const AdminBackupsPage = () => {
                           // packaged into ONE downloadable container.
                           {
                             key: "package-full",
-                            label: "Package & download",
+                            label: "Download",
                             icon: <DownloadOutlined />,
                             hidden: !row.run.has_accounts,
                             onClick: () => setPackageRunId(row.run.run_id),
                           },
                           {
                             key: "delete-all",
-                            label: "Delete all jobs",
+                            label: "Delete",
                             icon: <DeleteOutlined />,
                             danger: true,
                             onClick: () => handleDeleteRun(row.run.run_id),

--- a/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFromUploadDrawer.tsx
@@ -165,12 +165,9 @@ export function RestoreFromUploadDrawer({ open, onClose, ownerMode }: Props) {
           )}
         </Typography.Paragraph>
 
-        <Alert
-          type="info"
-          showIcon
-          message="Large archives: upload directly to the server"
-          description="For very large backups, open the panel by the server's IP address rather than through a proxied domain (e.g. Cloudflare) to avoid upload-size limits."
-        />
+        {/* GH #1408: the "upload via the server's direct IP" notice was removed —
+            direct-IP panel access/login is currently broken, so the advice was
+            misleading. Restore it once direct-IP access works again. */}
 
         {(phase === "pick" || phase === "uploading") && (
           <>

--- a/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/RestoreFullServerDrawer.tsx
@@ -121,8 +121,9 @@ export function RestoreFullServerDrawer({ open, onClose }: Props) {
     >
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-          Upload a Full Server backup archive (from “Package &amp; download”) and
-          restore the accounts it contains. Each user is restored just like a
+          Upload a Full Server backup archive (from a Full Server run&apos;s{" "}
+          <strong>Download</strong> action) and restore the accounts it contains.
+          Each user is restored just like a
           normal account restore. Accounts that don&apos;t exist yet can be
           created for you.
         </Typography.Paragraph>


### PR DESCRIPTION
## Summary

UI polish from lxsdevcode's testing on #1408 (the backup upload/restore epic — core already shipped). Two remaining items from the thread:

**1. Trim the backups Actions column (09-06 feedback).** Expanding a run row shifted the layout because "Expand to manage" is much wider than "Collapse", and a couple of action labels were wider than needed. Shortened:

| Before | After |
| --- | --- |
| Expand to manage | **Expand** |
| Package & download | **Download** |
| Delete all jobs | **Delete** |

Collapse is unchanged. The destructive intent stays explicit in each confirm modal — the "Delete all N job(s) of this run?" title + description are untouched — per lxsdevcode's "let the modal provide the context" point.

**2. Remove the broken direct-IP upload notice (09-04 feedback).** *Restore from Upload* showed:

> Large archives: upload directly to the server — open the panel by the server's IP…

Direct-IP panel access/login is currently broken (separate Kratos issue), so this pointed users at a flow that fails. Removed the `Alert` (a comment marks where to restore it once direct IP works). The drawer is shared by the admin page **and** the tenant *My backups* card (`MyProfileBackupCard`), so this clears the misleading notice in both.

Also updated the *Restore Full Server* blurb that referenced the old "Package & download" name to the new "Download".

## Testing

- **vitest**: `AdminBackupsPage.actions` (updated for "Expand"; the run-row "Delete" is a dropdown action, so the collapsed-table Delete-count assertions still hold) + `MyProfileBackupCard.actions`/`.download` — 11/11.
- **tsc -b**: clean.
- UI-only, no behavior change. CI runs `tsc -b && vite build` + vitest.

GH #1408
