### PR TITLE
fix(domains): show real SSL state on Web Domain Overview (GH #1543)

### DIFF
--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -99,6 +99,12 @@ func (m *mockDomainRepo) ListByUserID(ctx context.Context, userID string, opts r
 	return m.listByUserResult, int64(len(m.listByUserResult)), nil
 }
 
+// ComputeSSLState delegates to the real canonical computation so handler tests
+// exercise the actual ssl_state logic, not a stubbed copy (GH #1543).
+func (m *mockDomainRepo) ComputeSSLState(d *models.Domain, cert *models.SSLCertificate) string {
+	return repository.ComputeSSLState(d, cert)
+}
+
 func (m *mockDomainRepo) ListForRegistrarRefresh(ctx context.Context, staleBefore time.Time, limit int) ([]models.Domain, error) {
 	return nil, nil
 }

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -687,6 +687,12 @@ func (h *domainHandler) enrichDomainResponse(ctx context.Context, d models.Domai
 				}
 			}
 			row.SSL = sslBadgeForDomain(&d, cert)
+			// GH #1543: FindByID returns the raw row with an empty ssl_state
+			// (omitempty → the field vanishes), so the Web Domain Overview read
+			// "Off" even with a live cert. Fill the flat state from the cert we
+			// just fetched, using the same computation the list endpoints use —
+			// no extra query.
+			row.Domain.SSLState = h.cfg.Domains.ComputeSSLState(&d, cert)
 		}
 	}
 	if h.cfg.ManagedIPs != nil {

--- a/panel-api/internal/api/domains_ssl_badge_test.go
+++ b/panel-api/internal/api/domains_ssl_badge_test.go
@@ -169,6 +169,63 @@ func TestDomainList_EmbedsSSLBadge(t *testing.T) {
 	}
 }
 
+// TestDomainGet_PopulatesSSLState is the GH #1543 fix: the single-domain detail
+// endpoint (GET /domains/:id, which feeds the Web Domain Overview) must return a
+// flat ssl_state that matches the list/SSL page. FindByID returns the raw row
+// with an empty ssl_state (omitempty → absent → the Overview showed "Off" even
+// with a live cert); enrichDomainResponse now fills it from the cert it fetches.
+func TestDomainGet_PopulatesSSLState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	lePath := "/etc/letsencrypt/live/x/fullchain.pem"
+	now := time.Now()
+
+	cases := []struct {
+		name     string
+		mode     string
+		cert     *models.SSLCertificate
+		wantSSL  string // expected flat ssl_state on the detail response
+		wantHTTP int
+	}{
+		{"active LE cert", models.SSLModeLE, &models.SSLCertificate{ID: "c", DomainID: "d1", Status: models.SSLStatusIssued, CertPath: &lePath, IssuedAt: &now}, "active_le", 200},
+		{"issued non-LE cert", models.SSLModeLE, &models.SSLCertificate{ID: "c", DomainID: "d1", Status: models.SSLStatusIssued, IssuedAt: &now}, "self_signed", 200},
+		{"LE mode, no cert yet", models.SSLModeLE, nil, "pending", 200},
+		{"None mode ignores cert", models.SSLModeNone, &models.SSLCertificate{ID: "c", DomainID: "d1", Status: models.SSLStatusIssued, CertPath: &lePath, IssuedAt: &now}, "off", 200},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := gin.New()
+			v1 := r.Group("/api/v1")
+			v1.Use(func(c *gin.Context) {
+				ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: true})
+				c.Next()
+			})
+			base := newMockDomainRepo()
+			base.Create(context.Background(), &models.Domain{ID: "d1", UserID: "u1", Name: "x.com", SSLMode: tc.mode, SSLEnabled: true})
+			certMap := map[string]*models.SSLCertificate{}
+			if tc.cert != nil {
+				certMap["d1"] = tc.cert
+			}
+			RegisterDomainRoutes(v1, DomainHandlerConfig{Domains: base, SSLCerts: &mockSSLCertsForBadge{byDomainID: certMap}})
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/domains/d1", nil))
+			if w.Code != tc.wantHTTP {
+				t.Fatalf("status: got %d want %d, body=%s", w.Code, tc.wantHTTP, w.Body.String())
+			}
+			var resp struct {
+				SSLState string `json:"ssl_state"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp.SSLState != tc.wantSSL {
+				t.Errorf("ssl_state: got %q want %q (body=%s)", resp.SSLState, tc.wantSSL, w.Body.String())
+			}
+		})
+	}
+}
+
 // GH #246 follow-up: the badge must reflect ssl_mode, not just the cert row —
 // a None-mode domain keeps a revoked cert; a Self/None domain with no usable
 // cert must not read as "pending".

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -168,6 +168,10 @@ func (m *MockDomainRepository) Rename(ctx context.Context, id, newName, newDocRo
 	return args.Error(0)
 }
 
+func (m *MockDomainRepository) ComputeSSLState(d *models.Domain, cert *models.SSLCertificate) string {
+	return repository.ComputeSSLState(d, cert)
+}
+
 func (m *MockDomainRepository) ListByUserID(ctx context.Context, userID string, opts repository.ListOptions) ([]models.Domain, int64, error) {
 	args := m.Called(ctx, userID, opts.Offset, opts.Limit)
 	if args.Get(0) == nil {

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -113,6 +113,10 @@ func (f *fakeDomainRepo) List(ctx context.Context, opts repository.ListOptions) 
 	return result, int64(len(result)), nil
 }
 
+func (f *fakeDomainRepo) ComputeSSLState(d *models.Domain, cert *models.SSLCertificate) string {
+	return repository.ComputeSSLState(d, cert)
+}
+
 func (f *fakeDomainRepo) ListByUserID(ctx context.Context, userID string, opts repository.ListOptions) ([]models.Domain, int64, error) {
 	var result []models.Domain
 	for _, d := range f.domains {

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -21,6 +21,10 @@ type DomainRepository interface {
 	FindByName(ctx context.Context, name string) (*models.Domain, error)
 	List(ctx context.Context, opts ListOptions) ([]models.Domain, int64, error)
 	ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.Domain, int64, error)
+	// ComputeSSLState resolves a domain's flat ssl_state from its cert row (the
+	// same value the list endpoints populate). Lets the single-domain detail
+	// handler fill ssl_state, which FindByID leaves empty (GH #1543).
+	ComputeSSLState(domain *models.Domain, cert *models.SSLCertificate) string
 	Update(ctx context.Context, d *models.Domain) error
 	// RewriteDocRootPrefix rewrites the leading /home/<old> of every doc_root
 	// owned by userID to /home/<new> when a user is renamed (GH #1238).
@@ -972,14 +976,23 @@ func (r *domainRepo) populateSSLStates(ctx context.Context, domains *[]models.Do
 
 	// Compute SSL state for each domain
 	for i := range *domains {
-		(*domains)[i].SSLState = r.computeSSLState(&(*domains)[i], certsByDomain[(*domains)[i].ID])
+		(*domains)[i].SSLState = ComputeSSLState(&(*domains)[i], certsByDomain[(*domains)[i].ID])
 	}
 
 	return nil
 }
 
-// computeSSLState determines the SSL certificate state for a domain
-func (r *domainRepo) computeSSLState(domain *models.Domain, cert *models.SSLCertificate) string {
+// ComputeSSLState is the interface-level wrapper so a single-domain handler
+// (the Web Domain detail / Overview, GH #1543) can set the flat ssl_state from
+// a cert it already has — matching what the list endpoints render.
+func (r *domainRepo) ComputeSSLState(domain *models.Domain, cert *models.SSLCertificate) string {
+	return ComputeSSLState(domain, cert)
+}
+
+// ComputeSSLState determines the SSL certificate state for a domain. Package
+// func (no receiver) so callers outside the repo — including test mocks — can
+// reuse the exact same canonical computation instead of duplicating it.
+func ComputeSSLState(domain *models.Domain, cert *models.SSLCertificate) string {
 	// None mode never serves TLS regardless of any lingering cert row (GH #246).
 	if domain.SSLMode == models.SSLModeNone || !domain.SSLEnabled {
 		return "off"

--- a/panel-api/internal/repository/domain_ssl_state_test.go
+++ b/panel-api/internal/repository/domain_ssl_state_test.go
@@ -35,7 +35,7 @@ func TestComputeSSLState(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := r.computeSSLState(tc.d, tc.c); got != tc.want {
+			if got := r.ComputeSSLState(tc.d, tc.c); got != tc.want {
 				t.Errorf("computeSSLState = %q, want %q", got, tc.want)
 			}
 		})


### PR DESCRIPTION
## Problem

The Web Domain **Overview** tab renders the SSL status as **"Off"** even when the domain has a live certificate. The reporter sees an active LE cert but the badge reads Off.

## Root cause

`Domain.ssl_state` is a computed, non-persisted field (`gorm:"-" json:"ssl_state,omitempty"`). The **list** endpoints populate it via `populateSSLStates`, but the **single-domain detail** path (`GET /api/v1/domains/:id` → `FindByID` → `enrichDomainResponse`) never set it. With `omitempty`, the key is simply absent from the detail JSON, so the frontend's `getSSLTag(domain.ssl_state)` receives `undefined` and falls through to **"Off"**.

Reproduced live on the test box (same domain, pre-fix binary):
- `GET /api/v1/domains` → `"ssl_state":"active_le"` (and `"pending"` etc.) present.
- `GET /api/v1/domains/:id` → **no `ssl_state` key**, though the nested `ssl` badge object is present.

The Overview tab reads the flat `ssl_state`, hence the wrong badge.

## Fix

- Expose the previously-private `computeSSLState` as a package function `repository.ComputeSSLState(domain, cert)` and add it to the `DomainRepository` interface (the `domainRepo` method now delegates to it).
- In `enrichDomainResponse`, set `row.Domain.SSLState = ComputeSSLState(&d, cert)` from the certificate the handler **already fetches** for the nested badge — **no extra query**.

Now the detail response carries the same `ssl_state` the list endpoints do, and the Overview badge reflects the real state (active / self-signed / issuing / off).

## Tests

- `TestDomainGet_PopulatesSSLState` — drives `GET /domains/:id` through the real route and `ComputeSSLState` across four states (active_le / self_signed / pending / off).
- Three test fakes (`api` MockDomainRepository, `dns_test` mock, `reconciler` fakeDomainRepo) gained a delegating `ComputeSSLState` method; the repository unit test was renamed to the exported call. All delegate to the real func so coverage stays honest.
- `go build ./...`, `go vet ./...`, and the repository / api / reconciler suites are green.

## Not in scope (deferred)

The reporter also asked for **"View Certificate"** and **"SSL Settings"** actions on the Overview tab — those are enhancements, not part of this correctness fix, and are left for a follow-up. This PR only makes the existing badge show the truth.

GH #1543
