### PR TITLE
feat(domains): SSL tab + Overview cert actions, mobile-responsive tabs (GH #1543)

### DIFF
--- a/panel-ui/src/components/domains/types.ts
+++ b/panel-ui/src/components/domains/types.ts
@@ -45,6 +45,9 @@ export type Domain = {
   is_panel_primary?: boolean;
   is_quota_suspended?: boolean;
   ssl_enabled?: boolean;
+  // Certificate mode (le/self/custom/shared/none) — the detail/list handlers
+  // send it; shown read-only on the tenant SSL tab (GH #1543).
+  ssl_mode?: string;
   mail_provider?: string;
   m365_onmicrosoft?: string;
   google_dkim?: string;

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -2,6 +2,7 @@
 // the active pane, an unknown/absent tab falls back to Overview, the breadcrumb
 // trail ends at the domain name, a tab click navigates to that tab's URL, and a
 // domain the caller can't load surfaces an error (never a blank scoped view).
+import { Grid } from "antd";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
@@ -58,6 +59,9 @@ vi.mock("../../dns/DNSRecordsPage", () => ({
 }));
 vi.mock("../../../components/logs/DomainLogsPanel", () => ({
   DomainLogsPanel: ({ domainId }: { domainId: string }) => <div>logs-pane:{domainId}</div>,
+}));
+vi.mock("./tabs/SSLTab", () => ({
+  SSLTab: ({ domain }: { domain: { id: string } }) => <div>ssl-pane:{domain.id}</div>,
 }));
 vi.mock("../../../components/domains/DomainPHPSettingsPanel", () => ({
   DomainPHPSettingsPanel: ({ domainId }: { domainId: string }) => <div>php-pane:{domainId}</div>,
@@ -168,6 +172,11 @@ describe("WebDomainPage (GH #1543)", () => {
     expect(screen.queryByText("dns-pane:d1")).not.toBeInTheDocument();
   });
 
+  it("renders the SSL pane when :tab=ssl (GH #1543, lxsdevcode)", async () => {
+    renderAt("/jabali-panel/domains/d1/ssl");
+    expect(await screen.findByText("ssl-pane:d1")).toBeInTheDocument();
+  });
+
   it("renders the Logs pane when :tab=logs (GH #1543)", async () => {
     renderAt("/jabali-panel/domains/d1/logs");
     expect(await screen.findByText("logs-pane:d1")).toBeInTheDocument();
@@ -241,5 +250,24 @@ describe("WebDomainPage (GH #1543)", () => {
     domainQ.value = { data: undefined, isLoading: false, isError: true };
     renderAt("/jabali-panel/domains/d1");
     expect(await screen.findByText("Domain not available")).toBeInTheDocument();
+  });
+
+  it("collapses the tab strip to a Select on a narrow screen and navigates on change (GH #1543)", async () => {
+    // `md === false` is the mobile branch; the desktop tests exercise the
+    // default (unknown breakpoint) path.
+    const bp = vi.spyOn(Grid, "useBreakpoint").mockReturnValue({ md: false });
+    try {
+      renderAt("/jabali-panel/domains/d1");
+      // The Overview pane still renders under the Select.
+      const combo = await screen.findByRole("combobox");
+      expect(screen.getByText("Preview URL")).toBeInTheDocument();
+      // Opening the Select and choosing another section navigates to its URL —
+      // the same URL-per-tab contract the desktop strip uses.
+      fireEvent.mouseDown(combo);
+      fireEvent.click(await screen.findByText("Caching"));
+      expect(navigate).toHaveBeenCalledWith("/jabali-panel/domains/d1/caching");
+    } finally {
+      bp.mockRestore();
+    }
   });
 });

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -4,15 +4,19 @@
 // modal launchers. The tab lives in the URL (:tab), so a tab is linkable and
 // the browser Back button walks the tabs.
 //
-// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles), DNS
-// (gated on dns_enabled), Redirects, Index Files, Caching and Directory
-// Privacy, plus three tabs gated on the same caps as the old row menu — Domain
-// options and Rewrite rules (tenant_domain_options_enabled) and Document root
-// (tenant_docroot_editable). The tenant row menu is now just Enable/Delete; the
-// DNS records manager (DNSRecordsPanel) renders here embedded and standalone on
-// the admin route.
+// Tabs here: Overview (facts + the preview-URL / bot-challenge toggles), Logs,
+// SSL, DNS (gated on dns_enabled), PHP Settings, Redirects, Index Files, Caching
+// and Directory Privacy, plus three tabs gated on the same caps as the old row
+// menu — Domain options and Rewrite rules (tenant_domain_options_enabled) and
+// Document root (tenant_docroot_editable). The tenant row menu is now just
+// Enable/Delete; the DNS records manager (DNSRecordsPanel) renders here embedded
+// and standalone on the admin route.
+//
+// The tab bar stays horizontal on desktop (johnnyq's call over a vertical
+// sidebar) but collapses to a Select on narrow screens so it doesn't force
+// horizontal scrolling on mobile (lxsdevcode).
 import type { ReactNode } from "react";
-import { Alert, Button, Card, Skeleton, Space, Typography } from "antd";
+import { Alert, Button, Card, Grid, Select, Skeleton, Space, Typography } from "antd";
 import { GlobalOutlined } from "@icons";
 import { useNavigate, useParams } from "react-router";
 
@@ -33,6 +37,7 @@ import { DomainPHPSettingsPanel } from "../../../components/domains/DomainPHPSet
 import { RenameDomainButton } from "../../../components/domains/RenameDomainButton";
 import { DomainEnvVarsCard } from "../php-settings/DomainEnvVarsCard";
 import { OverviewTab } from "./tabs/OverviewTab";
+import { SSLTab } from "./tabs/SSLTab";
 
 const DEFAULT_TAB = "overview";
 const LIST_PATH = "/jabali-panel/domains";
@@ -43,6 +48,12 @@ export const WebDomainPage = () => {
 
   const domainQ = useOneQuery<Domain>({ resource: "domains", id });
   const { data: caps } = useServerCapabilities();
+  // Horizontal tabs stay on desktop; on a narrow screen the strip collapses to
+  // a Select so the tabs don't force horizontal scrolling (GH #1543). `md ===
+  // false` (never just falsy) keeps SSR / first paint / jsdom on the desktop
+  // strip — an unknown breakpoint must not flip to the mobile control.
+  const screens = Grid.useBreakpoint();
+  const mobile = screens.md === false;
 
   // The shell already renders ONE breadcrumb (RouteBreadcrumb, GH #455). Override
   // it with the entity trail so the last crumb is the domain name, not the raw
@@ -88,8 +99,10 @@ export const WebDomainPage = () => {
   // sees neither the menu item nor the tab (never a disabled stub).
   const optionsOn = caps?.tenant_domain_options_enabled === true;
   const docrootOn = caps?.tenant_docroot_editable === true;
-  // DNS folds in here as a tab (GH #1543). Gate on the same dns_enabled signal
+  // DNS renders here as a tab (GH #1543). Gate on the same dns_enabled signal
   // the sidebar and the old row-menu item used — default-on while caps load.
+  // The tenant DNS Zones overview page links straight into this tab to manage a
+  // zone's records, so this is the tenant's per-domain DNS records manager.
   const dnsOn = caps?.dns_enabled !== false;
 
   const tabs: { key: string; label: string; node: ReactNode }[] = [
@@ -98,6 +111,10 @@ export const WebDomainPage = () => {
     // "is the site up" — so it sits second, before the editors. It exists for
     // every web domain, so it is not cap-gated.
     { key: "logs", label: "Logs", node: <DomainLogsPanel domainId={domain.id} /> },
+    // SSL — this domain's certificate: status / expiry, view the issued cert,
+    // renew or retry issuance (GH #1543, lxsdevcode). Certificate mode is shown
+    // read-only; switching mode is an admin action.
+    { key: "ssl", label: "SSL", node: <SSLTab domain={domain} /> },
     ...(dnsOn
       ? [{ key: "dns", label: "DNS", node: <DNSRecordsPanel domainId={domain.id} embedded /> }]
       : []),
@@ -173,13 +190,28 @@ export const WebDomainPage = () => {
         />
       </Space>
 
-      <Card
-        tabList={tabs.map((tdef) => ({ key: tdef.key, tab: tdef.label }))}
-        activeTabKey={activeKey}
-        onTabChange={(k) => navigate(`${LIST_PATH}/${domain.id}/${k}`)}
-      >
-        {active.node}
-      </Card>
+      {mobile ? (
+        // Narrow screens: a full-width Select replaces the tab strip so tabs
+        // don't scroll horizontally. Same URL-per-tab contract.
+        <Card>
+          <Select
+            value={activeKey}
+            onChange={(k) => navigate(`${LIST_PATH}/${domain.id}/${k}`)}
+            options={tabs.map((tdef) => ({ value: tdef.key, label: tdef.label }))}
+            style={{ width: "100%", marginBottom: 16 }}
+            aria-label="Domain section"
+          />
+          {active.node}
+        </Card>
+      ) : (
+        <Card
+          tabList={tabs.map((tdef) => ({ key: tdef.key, tab: tdef.label }))}
+          activeTabKey={activeKey}
+          onTabChange={(k) => navigate(`${LIST_PATH}/${domain.id}/${k}`)}
+        >
+          {active.node}
+        </Card>
+      )}
     </div>
   );
 };

--- a/panel-ui/src/shells/user/domains/tabs/OverviewTab.test.tsx
+++ b/panel-ui/src/shells/user/domains/tabs/OverviewTab.test.tsx
@@ -1,0 +1,77 @@
+// OverviewTab.test — GH #1543. The SSL row on the tenant Web Domain Overview:
+// the badge, and — only for an issued cert — the expiry and a View Certificate
+// action, plus an always-present "SSL settings" link to the SSL tab.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return { ...actual, useNavigate: () => navigate };
+});
+vi.mock("../../../../apiClient", () => ({ apiClient: { patch: vi.fn().mockResolvedValue({}) } }));
+vi.mock("../../../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn() } },
+}));
+// Isolate from the cert-fetch modal — assert the wiring, not the network.
+vi.mock("../../../../components/ssl/SSLCertViewModal", () => ({
+  SSLCertViewModal: ({ domainId }: { domainId: string | null }) =>
+    domainId ? <div>cert-modal:{domainId}</div> : null,
+}));
+
+import { OverviewTab } from "./OverviewTab";
+import type { Domain } from "../../../../components/domains/types";
+
+const base: Domain = {
+  id: "d1",
+  name: "site.tld",
+  doc_root: "/home/alice/site.tld/public_html",
+  is_enabled: true,
+} as Domain;
+
+const inDays = (n: number) => new Date(Date.now() + n * 86_400_000).toISOString();
+
+function renderTab(domain: Domain) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <OverviewTab domain={domain} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => navigate.mockReset());
+
+describe("OverviewTab SSL row (GH #1543)", () => {
+  it("shows expiry and View Certificate for an issued cert, and opens the cert modal", () => {
+    renderTab({
+      ...base,
+      ssl_state: "active_le",
+      ssl: { status: "issued", issuer: "Let's Encrypt", expires_at: inDays(60) },
+    } as Domain);
+    expect(screen.getByText(/expires in 60 days/)).toBeInTheDocument();
+    const view = screen.getByRole("button", { name: /View Certificate/ });
+    fireEvent.click(view);
+    expect(screen.getByText("cert-modal:d1")).toBeInTheDocument();
+  });
+
+  it("hides View Certificate and expiry for a not-yet-issued cert but keeps the SSL settings link", () => {
+    renderTab({
+      ...base,
+      ssl_state: "pending",
+      // A parked cert's nested expires_at is the self-signed fallback date — it
+      // must NOT surface as the certificate's expiry.
+      ssl: { status: "pending_acme_retry", expires_at: inDays(300) },
+    } as Domain);
+    expect(screen.queryByText(/expires in/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View Certificate/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "SSL settings" })).toBeInTheDocument();
+  });
+
+  it("navigates to the SSL tab when SSL settings is clicked", () => {
+    renderTab({ ...base, ssl_state: "off" } as Domain);
+    fireEvent.click(screen.getByRole("button", { name: "SSL settings" }));
+    expect(navigate).toHaveBeenCalledWith("/jabali-panel/domains/d1/ssl");
+  });
+});

--- a/panel-ui/src/shells/user/domains/tabs/OverviewTab.tsx
+++ b/panel-ui/src/shells/user/domains/tabs/OverviewTab.tsx
@@ -5,12 +5,16 @@
 // caches so the badge and the list stay in step, mirroring the DomainInventory
 // row handlers.
 import { useState } from "react";
-import { Descriptions, Space, Switch, Tag, Typography } from "antd";
+import { Button, Descriptions, Space, Switch, Tag, Typography } from "antd";
+import { SafetyCertificateOutlined } from "@icons";
+import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../../apiClient";
 import { feedback } from "../../../../lib/feedback";
 import { getSSLTag } from "../../../../utils/sslState";
+import { daysUntil } from "../../../../components/ssl/sslHealth";
+import { SSLCertViewModal } from "../../../../components/ssl/SSLCertViewModal";
 import type { Domain } from "../../../../components/domains/types";
 
 const stripHomePrefix = (path: string): string => {
@@ -23,7 +27,9 @@ const stripHomePrefix = (path: string): string => {
 
 export const OverviewTab = ({ domain }: { domain: Domain }) => {
   const qc = useQueryClient();
+  const navigate = useNavigate();
   const [busy, setBusy] = useState<null | "preview" | "bot">(null);
+  const [viewCert, setViewCert] = useState(false);
 
   const patch = async (
     field: "preview" | "bot",
@@ -69,6 +75,12 @@ export const OverviewTab = ({ domain }: { domain: Domain }) => {
     );
 
   const ssl = getSSLTag(domain.ssl_state);
+  // An on-disk certificate to view/date exists only once issued — for a parked
+  // (pending_acme_retry) cert the nested expires_at is the self-signed
+  // fallback's date, so never show it as the cert's expiry (GH #1543).
+  const sslIssued = domain.ssl?.status === "issued";
+  const sslExpiryDays = sslIssued ? daysUntil(domain.ssl?.expires_at ?? null) : null;
+  const goToSSL = () => navigate(`/jabali-panel/domains/${domain.id}/ssl`);
 
   return (
     <Space direction="vertical" size="large" style={{ width: "100%" }}>
@@ -77,7 +89,22 @@ export const OverviewTab = ({ domain }: { domain: Domain }) => {
           {domain.is_enabled ? <Tag color="green">Enabled</Tag> : <Tag color="red">Disabled</Tag>}
         </Descriptions.Item>
         <Descriptions.Item label="SSL">
-          <Tag color={ssl.color}>{ssl.label}</Tag>
+          <Space wrap size="small">
+            <Tag color={ssl.color}>{ssl.label}</Tag>
+            {sslIssued && sslExpiryDays !== null ? (
+              <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+                expires in {sslExpiryDays} day{sslExpiryDays === 1 ? "" : "s"}
+              </Typography.Text>
+            ) : null}
+            {sslIssued ? (
+              <Button size="small" icon={<SafetyCertificateOutlined />} onClick={() => setViewCert(true)}>
+                View Certificate
+              </Button>
+            ) : null}
+            <Button size="small" type="link" style={{ padding: 0 }} onClick={goToSSL}>
+              SSL settings
+            </Button>
+          </Space>
         </Descriptions.Item>
         <Descriptions.Item label="Document root">
           <Typography.Text code>{stripHomePrefix(domain.doc_root)}</Typography.Text>
@@ -127,6 +154,12 @@ export const OverviewTab = ({ domain }: { domain: Domain }) => {
           </div>
         </Space>
       </Space>
+
+      <SSLCertViewModal
+        domainId={viewCert ? domain.id : null}
+        domainName={domain.name}
+        onClose={() => setViewCert(false)}
+      />
     </Space>
   );
 };

--- a/panel-ui/src/shells/user/domains/tabs/SSLTab.test.tsx
+++ b/panel-ui/src/shells/user/domains/tabs/SSLTab.test.tsx
@@ -1,0 +1,86 @@
+// SSLTab.test — GH #1543. The tenant per-domain SSL tab: it reads the
+// owner-scoped GET /domains/:id/ssl, gates View Certificate / Renew to an
+// issued cert and Retry to a failed / parked one, and POSTs to the tenant
+// renew/retry endpoints. It never offers a certificate-mode switch (admin-only).
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const get = vi.hoisted(() => vi.fn());
+const post = vi.hoisted(() => vi.fn());
+vi.mock("../../../../apiClient", () => ({ apiClient: { get, post } }));
+vi.mock("../../../../lib/feedback", () => ({
+  feedback: { message: { success: vi.fn(), error: vi.fn(), info: vi.fn() } },
+}));
+vi.mock("../../../../components/ssl/SSLCertViewModal", () => ({
+  SSLCertViewModal: ({ domainId }: { domainId: string | null }) =>
+    domainId ? <div>cert-modal:{domainId}</div> : null,
+}));
+
+import { SSLTab } from "./SSLTab";
+import type { Domain } from "../../../../components/domains/types";
+
+const domain = { id: "d1", name: "site.tld", ssl_state: "active_le", ssl_mode: "le" } as Domain;
+const inDays = (n: number) => new Date(Date.now() + n * 86_400_000).toISOString();
+
+function renderTab() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SSLTab domain={domain} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  get.mockReset();
+  post.mockReset();
+  post.mockResolvedValue({});
+});
+
+describe("SSLTab (GH #1543)", () => {
+  it("issued: shows View Certificate + Renew, hides Retry, and renews via the tenant endpoint", async () => {
+    get.mockResolvedValue({ data: { ssl: { status: "issued", issued_at: inDays(-5), expires_at: inDays(80) } } });
+    renderTab();
+    expect(await screen.findByRole("button", { name: /View Certificate/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Retry now/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Renew now/ }));
+    await waitFor(() => expect(post).toHaveBeenCalledWith("/domains/d1/ssl/renew"));
+  });
+
+  it("failed: shows the error alert + Retry, hides Renew, and retries via the tenant endpoint", async () => {
+    get.mockResolvedValue({ data: { ssl: { status: "failed", last_error: "DNS not resolving" } } });
+    renderTab();
+    expect(await screen.findByText("DNS not resolving")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Renew now/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Retry now/ }));
+    await waitFor(() => expect(post).toHaveBeenCalledWith("/domains/d1/ssl/retry"));
+  });
+
+  it("pending_acme_retry: offers a manual Retry", async () => {
+    get.mockResolvedValue({ data: { ssl: { status: "pending_acme_retry", last_error: "waiting on DNS" } } });
+    renderTab();
+    expect(await screen.findByRole("button", { name: /Retry now/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Renew now/ })).not.toBeInTheDocument();
+  });
+
+  it("self_signed: explains the self-signed cert and offers no actions (inspect 409s for non-issued)", async () => {
+    get.mockResolvedValue({ data: { ssl: { status: "self_signed" } } });
+    renderTab();
+    expect(await screen.findByText(/served with a self-signed certificate/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View Certificate/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Renew now/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Retry now/ })).not.toBeInTheDocument();
+  });
+
+  it("no cert (404): renders without View/Renew/Retry actions", async () => {
+    get.mockRejectedValue({ response: { status: 404 } });
+    renderTab();
+    // The read settles to 'no certificate' — none of the action buttons appear.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /Renew now/ })).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /Retry now/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View Certificate/ })).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/domains/tabs/SSLTab.tsx
+++ b/panel-ui/src/shells/user/domains/tabs/SSLTab.tsx
@@ -1,0 +1,195 @@
+// SSLTab — the SSL pane of the tenant Web Domain page (GH #1543, lxsdevcode).
+// The Overview badge only tells you the state; this tab is where a tenant acts
+// on the certificate for THIS domain: see its status / issuer / expiry, view
+// the issued certificate, and renew or retry issuance. It reads the same
+// owner-scoped endpoints the tenant SSL Manager table already uses
+// (GET/POST /domains/:id/ssl*), scoped to one domain.
+//
+// Deliberately NOT a certificate-mode switcher: choosing Let's Encrypt /
+// self-signed / custom-upload / shared is an admin capability (DomainSSLSection
+// hits /admin/*), so the mode is shown read-only here — same as the tenant SSL
+// Manager, which lists the mode but never lets a tenant change it.
+import { Alert, Button, Descriptions, Skeleton, Space, Tag, Typography } from "antd";
+import { ReloadOutlined, RedoOutlined, SafetyCertificateOutlined } from "@icons";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../../../apiClient";
+import { feedback } from "../../../../lib/feedback";
+import { getSSLTag } from "../../../../utils/sslState";
+import { daysUntil, modeTag } from "../../../../components/ssl/sslHealth";
+import { SSLCertViewModal } from "../../../../components/ssl/SSLCertViewModal";
+import type { Domain } from "../../../../components/domains/types";
+
+// The owner-scoped GET /domains/:id/ssl payload (mirrors the admin section's
+// read — the API wraps the certificate in `.ssl`, and 404 means none issued).
+type CertStatus = {
+  status: string;
+  issued_at?: string;
+  expires_at?: string;
+  last_error?: string;
+  staging?: boolean;
+};
+
+export const SSLTab = ({ domain }: { domain: Domain }) => {
+  const qc = useQueryClient();
+  const [viewOpen, setViewOpen] = useState(false);
+
+  const certQ = useQuery<CertStatus | null>({
+    queryKey: ["domain-ssl", domain.id],
+    queryFn: async () => {
+      try {
+        const res = await apiClient.get<{ ssl: CertStatus }>(`/domains/${domain.id}/ssl`);
+        return res.data.ssl;
+      } catch (err) {
+        // No certificate row yet (pre-issuance) reads as 404 — not an error.
+        if ((err as { response?: { status?: number } }).response?.status === 404) return null;
+        throw err;
+      }
+    },
+  });
+
+  // Renew/retry both change the served cert, so refresh this tab, the domain
+  // row + list (the Overview badge), and the SSL Manager page in one go —
+  // the same fan-out the Overview toggles use.
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ["domain-ssl", domain.id] });
+    qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
+    qc.invalidateQueries({ queryKey: ["list", "domains"] });
+    qc.invalidateQueries({ queryKey: ["ssl-manager"] });
+  };
+
+  const renew = useMutation({
+    mutationFn: () => apiClient.post(`/domains/${domain.id}/ssl/renew`),
+    onSuccess: () => {
+      feedback.message.success("Renewal scheduled");
+      invalidate();
+    },
+    onError: () => feedback.message.error("Failed to schedule renewal"),
+  });
+
+  const retry = useMutation({
+    mutationFn: () => apiClient.post(`/domains/${domain.id}/ssl/retry`),
+    onSuccess: () => {
+      feedback.message.success("Retry queued");
+      invalidate();
+    },
+    onError: (err) => {
+      // A cert that isn't in a retryable state comes back 409 with a reason —
+      // surface it as info, not a blanket failure (mirrors DomainSSLSection).
+      const e = err as { response?: { status?: number; data?: { detail?: string } } };
+      if (e.response?.status === 409) {
+        feedback.message.info(e.response.data?.detail ?? "This certificate isn't retryable right now.");
+      } else {
+        feedback.message.error(e.response?.data?.detail ?? "Failed to queue retry");
+      }
+      invalidate();
+    },
+  });
+
+  if (certQ.isLoading) return <Skeleton active paragraph={{ rows: 3 }} />;
+
+  const cert = certQ.data;
+  const status = cert?.status;
+  const ssl = getSSLTag(domain.ssl_state);
+  const mode = modeTag(domain.ssl_mode);
+  const isIssued = status === "issued";
+  // A parked (pending_acme_retry) or failed cert is serving the self-signed
+  // fallback; offer a manual retry so a tenant who just fixed DNS can re-attempt
+  // now instead of waiting for the daily recheck.
+  const isRetryable = status === "failed" || status === "pending_acme_retry";
+  const days = isIssued ? daysUntil(cert?.expires_at ?? null) : null;
+  // When there's no actionable cert (not issued, not retryable), explain the
+  // state without implying "no certificate" — a self_signed domain IS served.
+  // View Certificate stays issued-only because the API's inspect endpoint
+  // returns a 409 for any non-issued status.
+  const note =
+    status === "self_signed"
+      ? "This domain is served with a self-signed certificate. The certificate mode is set by the server administrator."
+      : status === "revoked"
+        ? "The certificate was revoked. The certificate mode is set by the server administrator."
+        : status === "pending" || status === "issuing" || status === "renewing"
+          ? "A certificate is being issued — its details and renewal actions appear here once it's ready."
+          : "SSL is managed by the server administrator. When a certificate is issued, its details and renewal actions appear here.";
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: "100%" }}>
+      {status === "failed" && cert?.last_error ? (
+        <Alert type="error" showIcon message="Certificate issuance failed" description={cert.last_error} />
+      ) : null}
+      {status === "pending_acme_retry" && cert?.last_error ? (
+        <Alert
+          type="warning"
+          showIcon
+          message="Serving a self-signed certificate while issuance retries"
+          description={cert.last_error}
+        />
+      ) : null}
+
+      <Descriptions column={1} size="small" bordered>
+        <Descriptions.Item label="SSL">
+          <Space>
+            <Tag color={ssl.color}>{ssl.label}</Tag>
+            {cert?.staging ? <Tag color="purple">staging</Tag> : null}
+          </Space>
+        </Descriptions.Item>
+        {mode ? (
+          <Descriptions.Item label="Certificate mode">
+            <Tag color={mode.color}>{mode.label}</Tag>
+          </Descriptions.Item>
+        ) : null}
+        {domain.ssl?.issuer ? (
+          <Descriptions.Item label="Issuer">{domain.ssl.issuer}</Descriptions.Item>
+        ) : null}
+        {isIssued && cert?.issued_at ? (
+          <Descriptions.Item label="Issued">{new Date(cert.issued_at).toLocaleString()}</Descriptions.Item>
+        ) : null}
+        {isIssued && cert?.expires_at ? (
+          <Descriptions.Item label="Expires">
+            {new Date(cert.expires_at).toLocaleString()}
+            {days !== null ? (
+              <Tag color={days < 15 ? "orange" : "default"} style={{ marginLeft: 8 }}>
+                in {days} day{days === 1 ? "" : "s"}
+              </Tag>
+            ) : null}
+          </Descriptions.Item>
+        ) : null}
+      </Descriptions>
+
+      <Space wrap>
+        {isIssued ? (
+          <>
+            <Button icon={<SafetyCertificateOutlined />} onClick={() => setViewOpen(true)}>
+              View Certificate
+            </Button>
+            <Button icon={<ReloadOutlined />} loading={renew.isPending} onClick={() => renew.mutate()}>
+              Renew now
+            </Button>
+          </>
+        ) : null}
+        {isRetryable ? (
+          <Button
+            type="primary"
+            icon={<RedoOutlined />}
+            loading={retry.isPending}
+            onClick={() => retry.mutate()}
+          >
+            Retry now
+          </Button>
+        ) : null}
+      </Space>
+
+      {!isIssued && !isRetryable ? (
+        <Typography.Paragraph type="secondary" style={{ margin: 0 }}>
+          {note}
+        </Typography.Paragraph>
+      ) : null}
+
+      <SSLCertViewModal
+        domainId={viewOpen ? domain.id : null}
+        domainName={domain.name}
+        onClose={() => setViewOpen(false)}
+      />
+    </Space>
+  );
+};


### PR DESCRIPTION
Closes the shippable remaining Web Domain page feedback on #1543 (after the SSL-badge fix in #1596).

## 1. SSL tab (lxsdevcode)

A new per-domain **SSL** tab: certificate status / mode / issuer / expiry, plus **View Certificate**, **Renew**, and **Retry**. It reads the owner-scoped `GET /domains/:id/ssl` (authorized via `loadDomainOwned`, the same guard the renew/retry endpoints use) and posts to the tenant renew/retry endpoints — the same capabilities the tenant SSL Manager table already exposes, scoped to one domain.

- Named **"SSL"**, not "SSL Settings": nothing on it is settable by a tenant, and a shorter label keeps the tab bar compact.
- Certificate **mode** is shown **read-only**. Switching mode (LE / self-signed / custom / shared) stays an admin action (`DomainSSLSection` hits `/admin/*`), so tenants gain no new capability.
- **View Certificate** and **Renew** are gated to `status == issued` — `inspectSSL` returns 409 for any non-issued status, and renewing a self-signed cert is meaningless. **Retry** is offered for `failed` / `pending_acme_retry`. A `self_signed` domain gets an explanatory note (it *is* served), not a "no certificate" message.
- The `404 → null` in the cert query is intentional (a domain with no cert row yet, pre-issuance), not a swallowed error.

## 2. Overview SSL row (lxsdevcode)

Now that the detail response carries `ssl_state` (#1596), the badge reads correctly. This adds, for an **issued** cert, the **expiry** and a **View Certificate** action, plus an always-present **"SSL settings"** link to the new tab. Expiry/View are gated on `status == issued` so a parked cert's self-signed fallback date never shows as the certificate's expiry.

## 3. Responsive tabs (lxsdevcode raised, johnnyq's call)

The tab strip stays **horizontal on desktop** (johnnyq preferred this over a vertical sidebar) but collapses to a full-width **Select on screens narrower than `md`**, so tabs no longer force horizontal scrolling on mobile. `Grid.useBreakpoint()` returns `{}` on SSR / first paint / jsdom, so the check is `md === false` (never a bare falsy) — an unknown breakpoint stays on the desktop strip.

## Not in this PR — DNS-tab removal (johnnyq)

johnnyq asked to remove the DNS tab as "redundant with DNS Zones". It is **not** redundant in the current architecture: the tenant **DNS Zones** overview page's *Manage* action deep-links straight into this tab (`UserDNSZonesOverviewPage` `manageRoute` → `/jabali-panel/domains/:id/dns`), so the per-domain records manager lives **only** here. Removing the tab would orphan all tenant DNS record editing (and breaks `dns-record-permissions.spec.ts`). It needs the records manager relocated to a standalone tenant route first — deferred to a separate change so this SSL/mobile work can land cleanly.

## Notes

- **Single commit**: the SSL tab and responsive change share `WebDomainPage.tsx`, so they revert together.
- Adds `Domain.ssl_mode` (already on the wire) to the type.
- **Deferred**: `SSLResponse` doesn't carry `next_retry_at`, so Retry is offered for any parked cert rather than time-gated (matches admin `DomainSSLSection`).

## Tests

- New `SSLTab.test.tsx` (issued → View+Renew; failed → error+Retry; pending_acme_retry → Retry; self_signed → note, no actions; 404 → no actions) and `OverviewTab.test.tsx` (expiry+View gated on issued; SSL-settings link navigates).
- `WebDomainPage.test.tsx`: SSL tab renders, the DNS tab still works (kept), and the mobile Select navigates on change.
- `tsc -b`, eslint, and the domains + ssl suites are green.

GH #1543
