### PR TITLE
feat(disk-usage): automatic tenant snapshot measurement — daily sweep + auto-measure on open (GH #1439)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1457,6 +1457,20 @@ Recompute a tenant's disk usage live and store the snapshot
 jabali disk-usage refresh <user-email|username|id>
 ```
 
+#### `jabali disk-usage refresh-all`
+
+Recompute the disk-usage snapshot for every tenant (serial; skips accounts refreshed within --max-age)
+
+```
+jabali disk-usage refresh-all [flags]
+```
+
+**Flags:**
+
+- `--max-age` — skip a tenant whose snapshot is younger than this (0 = always refresh) (default `20h0m0s`)
+- `--per-user-timeout` — per-tenant deadline for the live compute (default `1m30s`)
+- `--sleep` — pause between tenants to keep the sweep gentle (default `2s`)
+
 #### `jabali disk-usage show`
 
 Show a tenant's last stored disk-usage snapshot

--- a/install.sh
+++ b/install.sh
@@ -5839,6 +5839,17 @@ ensure_maintenance_isolation() {
       install -m 0644 -o root -g root "$src" "/etc/systemd/system/${u}.service"
     fi
   done
+  # GH #1439: the disk-maintenance SCRIPT gained a step (refresh every tenant's
+  # disk-usage snapshot). Re-copy it here too, or an updated box keeps the old
+  # script and the daily sweep never ships — the same main()-only gap this
+  # converger exists to close. Gate on the unit already existing so we never
+  # resurrect a helper for a deliberately-removed job.
+  if [[ -f /etc/systemd/system/jabali-disk-maintenance.service \
+        && -f "${REPO_DIR}/install/systemd/disk-maintenance" ]]; then
+    install -m 0755 -o root -g root \
+      "${REPO_DIR}/install/systemd/disk-maintenance" \
+      /usr/local/libexec/jabali/disk-maintenance
+  fi
   systemctl daemon-reload 2>/dev/null || true
 }
 

--- a/install/systemd/disk-maintenance
+++ b/install/systemd/disk-maintenance
@@ -29,4 +29,20 @@ if command -v jabali >/dev/null 2>&1 && [ -d /var/lib/jabali-nspawn/images ]; th
   jabali nspawn prune --yes >/dev/null 2>&1 || true
 fi
 
+# ---- GH #1439: refresh every tenant's disk-usage snapshot --------------
+# So the tenant dashboard + Disk Usage page carry a recent figure without the
+# user having to click Refresh. This recomputes each tenant's home `du` (+ mail
+# + db sizes) SERIALLY and stores the snapshot the panel reads.
+#
+# JAB-273: this is the daily du sweep whose *concurrent* ancestor wedged a
+# swapless box into a kswapd death-spiral. It is safe here precisely because it
+# is serial (one home at a time — `refresh-all` never fans out), skips accounts
+# already refreshed within --max-age (default 20h, so a tenant's own evening
+# Refresh isn't redone), pauses between tenants, and — critically — runs inside
+# jabali-maintenance.slice (MemoryMax=50%, IOSchedulingClass=idle, Nice=19) via
+# the service unit. Keep it serial; do not add a parallel flag.
+if command -v jabali >/dev/null 2>&1; then
+  jabali disk-usage refresh-all >/dev/null 2>&1 || true
+fi
+
 exit 0

--- a/install/systemd/jabali-disk-maintenance.service
+++ b/install/systemd/jabali-disk-maintenance.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Jabali disk maintenance (prune dated Stalwart logs + stale nspawn images)
+Description=Jabali disk maintenance (prune dated Stalwart logs + stale nspawn images; refresh tenant disk-usage snapshots)
 Documentation=https://github.com/shukiv/jabali-panel/blob/main/install/systemd/disk-maintenance
 # No hard Requires=: the sweep is best-effort and each step no-ops when its
 # target is absent, so it must never fail the boot or wedge on a missing unit.

--- a/panel-api/cmd/server/disk_usage_cmd.go
+++ b/panel-api/cmd/server/disk_usage_cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/limits"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -53,7 +54,7 @@ func newDiskUsageCmd() *cobra.Command {
 		Use:   "disk-usage",
 		Short: "Inspect / refresh a tenant's disk-usage breakdown (files / email / databases)",
 	}
-	cmd.AddCommand(newDiskUsageShowCmd(), newDiskUsageRefreshCmd())
+	cmd.AddCommand(newDiskUsageShowCmd(), newDiskUsageRefreshCmd(), newDiskUsageRefreshAllCmd())
 	return cmd
 }
 
@@ -133,4 +134,151 @@ func newDiskUsageRefreshCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// newDiskUsageRefreshAllCmd recomputes the disk-usage snapshot for every tenant,
+// SERIALLY, so the tenant dashboard + Disk Usage page carry a reasonably fresh
+// figure without the user having to click Refresh (GH #1439, lxsdevcode). It is
+// the daily-job half of that request; the nightly jabali-disk-maintenance timer
+// runs it inside jabali-maintenance.slice (MemoryMax=50%, idle IO, Nice=19).
+//
+// JAB-273 is the load-bearing constraint here: the fleet outage was a nightly
+// `du` fan-out running CONCURRENTLY across ~100 homes, which filled RAM on a
+// swapless box into a kswapd death-spiral. This command is deliberately the
+// opposite — one tenant's du at a time (never a goroutine fan-out), a fresh-skip
+// gate so an account measured within --max-age is not re-du'd, an inter-user
+// pause, and it runs only inside the resource-capped maintenance slice. Do NOT
+// parallelise it.
+func newDiskUsageRefreshAllCmd() *cobra.Command {
+	var (
+		maxAge         time.Duration
+		perUserTimeout time.Duration
+		betweenUsers   time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "refresh-all",
+		Short: "Recompute the disk-usage snapshot for every tenant (serial; skips accounts refreshed within --max-age)",
+		Args:  cobra.NoArgs,
+		// Same deps as `refresh`: the live compute path needs the agent.
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// The command context (cancellable on signal) bounds the whole run;
+			// each tenant gets its OWN short timeout so one slow home cannot
+			// starve the rest, and a run over many tenants is not held to any
+			// single fixed deadline.
+			ctx := cmd.Context()
+			snaps := diskUsageSnapshotRepoFromDB()
+			cfg := diskUsageCfg()
+
+			// Only non-admin users have a Linux home to measure; admins have no
+			// username (compute skips them, but filtering keeps the loop honest).
+			notAdmin := false
+			users, _, err := userRepo().List(ctx, repository.ListOptions{
+				IsAdmin: &notAdmin,
+				Limit:   100000, // effectively all tenants; a box never has this many
+			})
+			if err != nil {
+				return fmt.Errorf("list tenants: %w", err)
+			}
+
+			// refreshOne is the live compute+persist for a single tenant — the
+			// exact path `refresh <user>` runs, under a per-tenant timeout.
+			refreshOne := func(c context.Context, userID string) error {
+				uctx, cancel := context.WithTimeout(c, perUserTimeout)
+				defer cancel()
+				res, cerr := api.ComputeDiskUsage(uctx, cfg, userID)
+				if cerr != nil {
+					return cerr
+				}
+				now := time.Now()
+				res.ComputedAt = &now
+				payload, merr := json.Marshal(res)
+				if merr != nil {
+					return merr
+				}
+				return snaps.Upsert(uctx, userID, string(payload), now)
+			}
+
+			r, rerr := runDiskUsageRefreshAll(ctx, users, snaps, refreshAllOpts{
+				maxAge:       maxAge,
+				betweenUsers: betweenUsers,
+			}, refreshOne)
+			fmt.Printf("disk-usage refresh-all: refreshed=%d skipped=%d failed=%d (of %d tenants)\n",
+				r.refreshed, r.skipped, r.failed, len(users))
+			return rerr
+		},
+	}
+	cmd.Flags().DurationVar(&maxAge, "max-age", 20*time.Hour,
+		"skip a tenant whose snapshot is younger than this (0 = always refresh)")
+	cmd.Flags().DurationVar(&perUserTimeout, "per-user-timeout", 90*time.Second,
+		"per-tenant deadline for the live compute")
+	cmd.Flags().DurationVar(&betweenUsers, "sleep", 2*time.Second,
+		"pause between tenants to keep the sweep gentle")
+	return cmd
+}
+
+type refreshAllOpts struct {
+	maxAge       time.Duration
+	betweenUsers time.Duration
+}
+
+type refreshAllResult struct {
+	refreshed int
+	skipped   int
+	failed    int
+}
+
+// runDiskUsageRefreshAll walks the tenants SERIALLY, applying the fresh-skip
+// gate and per-user error tolerance, and calls refreshOne for each tenant that
+// needs a new snapshot. It is factored out of the cobra RunE so the sweep logic
+// (skip-fresh, one-bad-home-doesn't-abort, honour ctx cancellation) is testable
+// without a live agent. Callers MUST keep this serial — it is the JAB-273-safe
+// property (see newDiskUsageRefreshAllCmd).
+func runDiskUsageRefreshAll(
+	ctx context.Context,
+	users []models.User,
+	snaps repository.DiskUsageSnapshotRepository,
+	opts refreshAllOpts,
+	refreshOne func(ctx context.Context, userID string) error,
+) (refreshAllResult, error) {
+	var r refreshAllResult
+	for i := range users {
+		if ctx.Err() != nil {
+			return r, ctx.Err() // operator Ctrl-C / shutdown
+		}
+		u := users[i]
+		if u.Username == nil || *u.Username == "" {
+			continue // no Linux account → nothing to du
+		}
+
+		// Fresh-skip: a snapshot younger than maxAge (e.g. the tenant clicked
+		// Refresh this evening) is left alone — this bounds the nightly du work
+		// and keeps the sweep from re-measuring the whole fleet every run.
+		if opts.maxAge > 0 {
+			if snap, serr := snaps.Get(ctx, u.ID); serr == nil && snap != nil &&
+				time.Since(snap.ComputedAt) < opts.maxAge {
+				r.skipped++
+				continue
+			}
+		}
+
+		if err := refreshOne(ctx, u.ID); err != nil {
+			// Per-user tolerance: one bad home never aborts the sweep.
+			r.failed++
+			fmt.Fprintf(os.Stderr, "disk-usage refresh-all: %s: %v\n", *u.Username, err)
+			continue
+		}
+		r.refreshed++
+
+		// Yield between tenants so the sweep stays gentle even inside the capped
+		// slice; skip the pause after the last user.
+		if opts.betweenUsers > 0 && i < len(users)-1 {
+			select {
+			case <-ctx.Done():
+				return r, ctx.Err()
+			case <-time.After(opts.betweenUsers):
+			}
+		}
+	}
+	return r, nil
 }

--- a/panel-api/cmd/server/disk_usage_refresh_all_test.go
+++ b/panel-api/cmd/server/disk_usage_refresh_all_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #1439: `jabali disk-usage refresh-all` is the daily snapshot sweep. Its
+// safety rests on being SERIAL and on the fresh-skip gate (JAB-273 — a
+// concurrent nightly du fan-out wedged a swapless box). These pin that the sweep
+// skips fresh snapshots, tolerates a single failing tenant, skips accounts with
+// no Linux username, and calls each tenant exactly once in order.
+
+type raSnapshotRepo struct {
+	repository.DiskUsageSnapshotRepository
+	byUser map[string]*models.DiskUsageSnapshot
+}
+
+func (r *raSnapshotRepo) Get(_ context.Context, userID string) (*models.DiskUsageSnapshot, error) {
+	if s, ok := r.byUser[userID]; ok && s != nil {
+		return s, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func uname(s string) *string { return &s }
+
+func tenants(names ...*string) []models.User {
+	out := make([]models.User, len(names))
+	for i, n := range names {
+		id := "u" + string(rune('0'+i))
+		out[i] = models.User{ID: id, Username: n}
+	}
+	return out
+}
+
+func TestRefreshAll_SkipsFreshTolerantSerial(t *testing.T) {
+	fresh := &models.DiskUsageSnapshot{ComputedAt: time.Now().Add(-1 * time.Hour)}  // within max-age
+	stale := &models.DiskUsageSnapshot{ComputedAt: time.Now().Add(-48 * time.Hour)} // older than max-age
+	snaps := &raSnapshotRepo{byUser: map[string]*models.DiskUsageSnapshot{
+		"u0": fresh, // skip (fresh)
+		"u2": stale, // refresh (stale)
+		// u1 has no snapshot → refresh; u3 fails; u4 has no username → skipped silently
+	}}
+	users := tenants(uname("alice"), uname("bob"), uname("carol"), uname("dave"), nil)
+
+	var calls []string
+	refreshOne := func(_ context.Context, userID string) error {
+		calls = append(calls, userID)
+		if userID == "u3" { // dave: one bad home must not abort the sweep
+			return errors.New("du timed out")
+		}
+		return nil
+	}
+
+	r, err := runDiskUsageRefreshAll(context.Background(), users, snaps,
+		refreshAllOpts{maxAge: 20 * time.Hour, betweenUsers: 0}, refreshOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// bob (no snap) + carol (stale) refreshed; dave failed; alice fresh-skipped;
+	// the username-less tenant is not counted as a skip (it has nothing to du).
+	if r.refreshed != 2 || r.skipped != 1 || r.failed != 1 {
+		t.Fatalf("got refreshed=%d skipped=%d failed=%d; want 2/1/1", r.refreshed, r.skipped, r.failed)
+	}
+	// refreshOne is called only for the tenants that need it, in list order, and
+	// NEVER for the fresh one — the fresh-skip gate must short-circuit before it.
+	want := []string{"u1", "u2", "u3"}
+	if len(calls) != len(want) {
+		t.Fatalf("refreshOne calls = %v; want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("refreshOne calls = %v; want %v (order matters — serial)", calls, want)
+		}
+	}
+}
+
+// maxAge=0 disables the fresh-skip gate: every tenant with a home is refreshed,
+// even one measured seconds ago.
+func TestRefreshAll_MaxAgeZeroAlwaysRefreshes(t *testing.T) {
+	snaps := &raSnapshotRepo{byUser: map[string]*models.DiskUsageSnapshot{
+		"u0": {ComputedAt: time.Now()}, // brand new — still refreshed when maxAge=0
+	}}
+	users := tenants(uname("alice"), uname("bob"))
+
+	n := 0
+	refreshOne := func(_ context.Context, _ string) error { n++; return nil }
+
+	r, err := runDiskUsageRefreshAll(context.Background(), users, snaps,
+		refreshAllOpts{maxAge: 0, betweenUsers: 0}, refreshOne)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.refreshed != 2 || r.skipped != 0 || n != 2 {
+		t.Fatalf("got refreshed=%d skipped=%d calls=%d; want 2/0/2", r.refreshed, r.skipped, n)
+	}
+}
+
+// A cancelled context stops the sweep promptly instead of grinding the whole
+// fleet (operator Ctrl-C / shutdown).
+func TestRefreshAll_ContextCancelStops(t *testing.T) {
+	snaps := &raSnapshotRepo{byUser: map[string]*models.DiskUsageSnapshot{}}
+	users := tenants(uname("alice"), uname("bob"), uname("carol"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	n := 0
+	refreshOne := func(_ context.Context, _ string) error { n++; return nil }
+	_, err := runDiskUsageRefreshAll(ctx, users, snaps,
+		refreshAllOpts{maxAge: 20 * time.Hour, betweenUsers: 0}, refreshOne)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v; want context.Canceled", err)
+	}
+	if n != 0 {
+		t.Fatalf("refreshOne called %d times after cancel; want 0", n)
+	}
+}

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.test.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.test.tsx
@@ -4,7 +4,7 @@
 // (which would redirect to a page the tenant can't reach). Gated on the shared
 // server-capabilities mail flag, the same signal the sidebar uses.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,14 +17,27 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
 
+// A FRESH snapshot (computed just now) so the mail-gating tests below don't
+// trip the GH #1439 auto-measure-on-stale path — those tests are about which
+// cards render, not about measuring.
+const fresh = () => new Date().toISOString();
 const diskUsage = {
-  computed_at: "2026-09-04T00:00:00Z",
+  computed_at: fresh(),
   total_bytes: 1000,
   quota_bytes: 0,
   files: { bytes: 100, items: [] },
   email: { bytes: 50, items: [{ name: "noreply@site.tld", bytes: 50 }] },
   databases: { bytes: 200, items: [] },
 };
+
+// getState lets a test control what GET /me/disk-usage returns (e.g. a stale or
+// never-computed snapshot); postRefresh records the auto/manual refresh call.
+// Hoisted so the vi.mock factory (itself hoisted above module init) can close
+// over them without a TDZ error.
+const { getState, postRefresh } = vi.hoisted(() => ({
+  getState: { resp: null as unknown },
+  postRefresh: vi.fn(),
+}));
 
 vi.mock("../../../apiClient", () => ({
   apiClient: {
@@ -33,8 +46,9 @@ vi.mock("../../../apiClient", () => ({
       if (url.startsWith("/me/disk-usage/files")) {
         return { data: { path: "~", total: 0, entries: [] } };
       }
-      return { data: diskUsage };
+      return { data: getState.resp };
     }),
+    post: postRefresh,
   },
 }));
 
@@ -54,6 +68,9 @@ function renderPage() {
 describe("DiskUsagePage mail-module gating (GH #1417)", () => {
   beforeEach(() => {
     mailEnabled = true;
+    getState.resp = diskUsage;
+    postRefresh.mockReset();
+    postRefresh.mockResolvedValue({ data: { ...diskUsage, computed_at: fresh() } });
   });
 
   it("shows the Email Mailboxes section + View all mailboxes link when mail is enabled", async () => {
@@ -70,5 +87,46 @@ describe("DiskUsagePage mail-module gating (GH #1417)", () => {
     expect(await screen.findByText("Storage Quota Usage")).toBeInTheDocument();
     expect(screen.queryByText("Email Mailboxes")).not.toBeInTheDocument();
     expect(screen.queryByText("View all mailboxes")).not.toBeInTheDocument();
+  });
+
+  // A fresh snapshot must NOT auto-measure — otherwise every page open would
+  // recompute and defeat the whole point of the cached snapshot.
+  it("does not auto-refresh when the snapshot is fresh (GH #1439)", async () => {
+    renderPage();
+    expect(await screen.findByText("Storage Quota Usage")).toBeInTheDocument();
+    expect(postRefresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("DiskUsagePage auto-measure on open (GH #1439, lxsdevcode)", () => {
+  beforeEach(() => {
+    mailEnabled = true;
+    postRefresh.mockReset();
+    postRefresh.mockResolvedValue({ data: { ...diskUsage, computed_at: fresh() } });
+  });
+
+  it("auto-measures once when there is no snapshot yet", async () => {
+    getState.resp = {
+      computed_at: null,
+      total_bytes: 0,
+      quota_bytes: 0,
+      files: { bytes: 0, items: [] },
+      email: { bytes: 0, items: [] },
+      databases: { bytes: 0, items: [] },
+    };
+    renderPage();
+    // The measure fires automatically…
+    await waitFor(() => expect(postRefresh).toHaveBeenCalledTimes(1));
+    // …and its result (a fresh snapshot) renders the real page.
+    expect(await screen.findByText("Storage Quota Usage")).toBeInTheDocument();
+  });
+
+  it("auto-measures once when the snapshot is stale (older than a day)", async () => {
+    getState.resp = {
+      ...diskUsage,
+      computed_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    renderPage();
+    await waitFor(() => expect(postRefresh).toHaveBeenCalledTimes(1));
   });
 });

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { Alert, Button, Card, Col, Empty, Row, Spin, Table, Tag, Tree, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import type { DataNode } from "antd/es/tree";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 
@@ -165,6 +165,21 @@ const COLORS = {
   gold: "#faad14",
 } as const;
 
+// GH #1439 (lxsdevcode): a snapshot older than this (or missing) triggers an
+// automatic measure on page open, so a tenant sees the real figure without
+// having to know to click Refresh. 24h sits just above the nightly refresh-all
+// cadence (--max-age 20h), so a fleet whose daily job is running never
+// auto-measures redundantly on every visit — only when the job hasn't kept the
+// snapshot fresh (job disabled, missed, or a brand-new account).
+const AUTO_MEASURE_STALE_MS = 24 * 60 * 60 * 1000;
+
+function isSnapshotStale(computedAt?: string | null): boolean {
+  if (!computedAt) return true; // never computed
+  const t = Date.parse(computedAt);
+  if (Number.isNaN(t)) return true;
+  return Date.now() - t > AUTO_MEASURE_STALE_MS;
+}
+
 export function DiskUsagePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -191,6 +206,23 @@ export function DiskUsagePage() {
     },
     onSuccess: (d) => qc.setQueryData(["me-disk-usage"], d),
   });
+
+  // Auto-measure on open when the snapshot is missing or stale (GH #1439). Fire
+  // AT MOST ONCE per mount (autoMeasured guard) so a measure that fails — or
+  // returns a still-old figure — never loops; the manual Refresh button stays
+  // for an on-demand recompute. Backend GET stays a cheap snapshot read; the
+  // recompute is this one explicit POST, driven by the human opening the page
+  // (not a poll), so it can't stampede the way a per-poll du would.
+  const autoMeasured = useRef(false);
+  const refreshMutate = refresh.mutate;
+  useEffect(() => {
+    if (isLoading || !data) return;
+    if (autoMeasured.current) return;
+    if (isSnapshotStale(data.computed_at)) {
+      autoMeasured.current = true;
+      refreshMutate();
+    }
+  }, [isLoading, data, refreshMutate]);
 
   if (isLoading) {
     return (
@@ -343,7 +375,11 @@ export function DiskUsagePage() {
       </Typography.Title>
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
         <Typography.Text type="secondary">
-          {computedAt ? `Computed ${relTime(computedAt)}` : "Not computed yet"}
+          {refresh.isPending
+            ? "Calculating…"
+            : computedAt
+              ? `Computed ${relTime(computedAt)}`
+              : "Not computed yet"}
         </Typography.Text>
         <Button
           icon={<ReloadOutlined />}
@@ -360,10 +396,22 @@ export function DiskUsagePage() {
     return (
       <div>
         {header}
-        <Empty
-          description={t("diskusagepage.no_disk_usage_snapshot_yet_click_refresh_to")}
-          style={{ padding: 64 }}
-        />
+        {refresh.isPending ? (
+          // First-ever open auto-measures (or the user clicked Refresh) — show a
+          // measuring state, not the "click Refresh" prompt, so the tenant isn't
+          // told to do the thing already happening.
+          <div style={{ padding: 64, textAlign: "center" }}>
+            <Spin />
+            <Typography.Paragraph type="secondary" style={{ marginTop: 16 }}>
+              Calculating your disk usage…
+            </Typography.Paragraph>
+          </div>
+        ) : (
+          <Empty
+            description={t("diskusagepage.no_disk_usage_snapshot_yet_click_refresh_to")}
+            style={{ padding: 64 }}
+          />
+        )}
       </div>
     );
   }
@@ -489,7 +537,9 @@ export function DiskUsagePage() {
 
       <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginTop: 12 }}>
         Email usage is sampled periodically; file and database sizes (both
-        MariaDB and PostgreSQL) are recomputed when you click Refresh.
+        MariaDB and PostgreSQL) are recomputed automatically each day and when
+        you open this page with an out-of-date figure — click Refresh any time
+        for an immediate recount.
       </Typography.Text>
     </div>
   );


### PR DESCRIPTION
Makes tenant disk-usage measurement **automatic** (lxsdevcode's follow-up on #1439, after the dashboard 0 B fix in #1593). Two halves.

## 1. Daily sweep

New `jabali disk-usage refresh-all` recomputes **every tenant's** snapshot (home `du` + mail + db sizes — the exact `ComputeDiskUsage` path `refresh <user>` runs), and the nightly `jabali-disk-maintenance` job now runs it. So the tenant dashboard and Disk Usage page carry a recent figure on their own, no manual Refresh needed.

### JAB-273 is the load-bearing constraint

The fleet outage that hardened this very job was a nightly `du` fan-out running **concurrently** across ~100 homes, which filled RAM on a swapless box into a kswapd death-spiral (load ~385, operator locked out of sshd). `refresh-all` is deliberately the opposite:

- **Strictly serial** — one home at a time, never a goroutine fan-out. *Do not add a parallel flag.*
- **Fresh-skip gate** (`--max-age`, default **20h**) — a tenant already measured within the window (e.g. their own evening Refresh) is skipped, so the sweep never re-measures the whole fleet every run.
- **Inter-tenant pause** + **per-tenant timeout** + **per-tenant error tolerance** (one bad home never aborts the sweep).
- Runs **only inside `jabali-maintenance.slice`** (`MemoryMax=50%`, `IOSchedulingClass=idle`, `Nice=19`) via the existing service unit — inherits the same containment as the rest of the maintenance cohort.

The sweep loop is factored out (`runDiskUsageRefreshAll`) and unit-tested for skip-fresh, per-user tolerance, serial ordering, and ctx-cancel.

## 2. Auto-measure on page open

The tenant Disk Usage page now fires **one** measure automatically when the snapshot is **missing or older than 24h** (just above the 20h sweep cadence, so a fleet whose daily job runs never re-measures on every visit). It:
- fires **at most once per mount** (no loop if a measure fails or returns a still-old figure),
- shows a measuring state instead of the "click Refresh" prompt,
- keeps the **manual Refresh** button.

`GET /me/disk-usage` stays a cheap snapshot read; the recompute is one explicit `POST` driven by the human opening the page — **not** a per-poll `du` (the IO-starvation shape the original on-demand design deliberately avoided, and which the dashboard poll still avoids).

## Update-path gotcha (fixed)

`install_disk_maintenance_timer` is `main()`-only, so a `jabali update` would keep the **old** `disk-maintenance` script and the daily sweep would never ship to the existing fleet. The script is now also re-copied by `ensure_maintenance_isolation` (the update-reachable converger), gated on the unit already existing so it never resurrects a deliberately-removed job.

## Tests
- Go: `runDiskUsageRefreshAll` (skip-fresh / tolerance / serial order / ctx-cancel); CLI reference golden regenerated.
- Frontend: auto-measure fires on missing + stale, does **not** fire on a fresh snapshot.
- `go build/vet`, `bash -n`, the maintenance-isolation static test, `tsc`, eslint, and the disk-usage suites are green.

GH #1439
