### PR TITLE
feat(nginx): admin custom directives use a relaxed denylist, not the tenant allowlist (GH #1580)

### DIFF
--- a/panel-api/cmd/server/domain_advanced_cmd.go
+++ b/panel-api/cmd/server/domain_advanced_cmd.go
@@ -163,17 +163,19 @@ func newDomainIPACLDeleteCmd() *cobra.Command {
 
 // validateDomainSetInput enforces on the CLI `domain set` path the SAME field
 // validation the HTTP PATCH handler applies (JAB-318 parity): the admin nginx
-// directive allowlist (api.ValidateNginxDirectives), the redirect destination
-// scheme/host check (api.ValidateRedirectURL) and the index-priority enum
-// (api.IsValidIndexPriority). It also normalises the redirect type to the
-// numeric nginx return code the renderer emits — redirects.Compile writes
-// `return <type> <url>;` verbatim, so only 301|302|307|308 (or the friendly
-// aliases permanent=301 / temporary=302) produce valid nginx. Each pointer is
-// nil when its flag was not set, so an unchanged field is never validated.
-// Pure (no DB, no cobra) so it is unit-testable directly.
+// directive validator (api.ValidateNginxDirectivesAdmin — the relaxed denylist,
+// since `jabali domain set` is an operator/admin surface, matching the panel
+// admin path per GH #1580), the redirect destination scheme/host check
+// (api.ValidateRedirectURL) and the index-priority enum (api.IsValidIndexPriority).
+// It also normalises the redirect type to the numeric nginx return code the
+// renderer emits — redirects.Compile writes `return <type> <url>;` verbatim, so
+// only 301|302|307|308 (or the friendly aliases permanent=301 / temporary=302)
+// produce valid nginx. Each pointer is nil when its flag was not set, so an
+// unchanged field is never validated. Pure (no DB, no cobra) so it is
+// unit-testable directly.
 func validateDomainSetInput(nginxDirs, redirectTo, redirectType, indexPriority *string) (normRedirectType string, err error) {
 	if nginxDirs != nil {
-		if msg := api.ValidateNginxDirectives(*nginxDirs); msg != "" {
+		if msg := api.ValidateNginxDirectivesAdmin(*nginxDirs); msg != "" {
 			return "", fmt.Errorf("--nginx-directives: %s", msg)
 		}
 	}

--- a/panel-api/cmd/server/domain_advanced_cmd_validation_test.go
+++ b/panel-api/cmd/server/domain_advanced_cmd_validation_test.go
@@ -24,12 +24,15 @@ func TestValidateDomainSetInput(t *testing.T) {
 		errSub      string // substring the error must contain (when wantErr)
 		wantNormTyp string // expected normalised redirect type (when no error)
 	}{
-		// nginx directives — the admin allowlist / brace / null-byte checks.
-		{name: "nginx disallowed directive", nginx: sp("root /etc/jabali-panel;"), wantErr: true, errSub: "--nginx-directives"},
+		// nginx directives — the admin denylist / brace / null-byte checks (GH
+		// #1580: `domain set` is an operator surface, so it gets the relaxed
+		// admin validator — proxy_pass is allowed, the footguns stay blocked).
+		{name: "nginx footgun root blocked", nginx: sp("root /etc/jabali-panel;"), wantErr: true, errSub: "--nginx-directives"},
 		{name: "nginx access_log off forbidden", nginx: sp("access_log off;"), wantErr: true, errSub: "--nginx-directives"},
 		{name: "nginx unbalanced brace", nginx: sp("location / {"), wantErr: true, errSub: "--nginx-directives"},
 		{name: "nginx null byte", nginx: sp("add_header X \x00;"), wantErr: true, errSub: "--nginx-directives"},
 		{name: "nginx allowed directive ok", nginx: sp("proxy_set_header X-Test 1;")},
+		{name: "nginx proxy_pass now allowed for admin", nginx: sp("proxy_pass http://127.0.0.1:9000;")},
 		{name: "nginx empty ok", nginx: sp("")},
 
 		// redirect destination — scheme + host.

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -55,8 +55,8 @@ type DomainHandlerConfig struct {
 	// Forwarders lets the GH #1579 rename rewrite the domain's alias forwarder
 	// targets to the new name. Optional — nil skips (the rename still succeeds).
 	Forwarders repository.EmailForwarderRepository
-	Packages    repository.PackageRepository
-	Agent       agent.AgentInterface
+	Packages   repository.PackageRepository
+	Agent      agent.AgentInterface
 	Reconciler *reconciler.Reconciler
 	// PortAllocations (GH #1175): shared loopback-port pool for reverse-proxy domains.
 	PortAllocations repository.PortAllocationRepository
@@ -955,7 +955,11 @@ func (h *domainHandler) update(c *gin.Context) {
 	// is_enabled. Admin role bypasses the gate.
 	if claims.IsAdmin {
 		if req.NginxCustomDirectives != nil {
-			if msg := ValidateNginxDirectives(*req.NginxCustomDirectives); msg != "" {
+			// GH #1580: this field is already admin-only (the gate above), so an
+			// admin gets the relaxed validator — the full directive range minus a
+			// small denylist — instead of the tenant safe-allowlist. nginx -t at
+			// apply time is the syntactic guard.
+			if msg := ValidateNginxDirectivesAdmin(*req.NginxCustomDirectives); msg != "" {
 				c.JSON(http.StatusBadRequest, gin.H{"error": msg})
 				return
 			}
@@ -1515,7 +1519,76 @@ var allowedNginxDirectives = map[string]struct{}{
 	"open_file_cache_errors":   {},
 }
 
+// ValidateNginxDirectives is the STRICT, allowlist-based validator used for the
+// tenant/default path: only directives on allowedNginxDirectives pass. proxy_pass
+// and other raw-target directives are intentionally absent (JAB-66); tenants get
+// reverse proxying only through the SSRF-validated Rule Builder.
 func ValidateNginxDirectives(directives string) string {
+	return scanNginxDirectives(directives, func(directive, _ string) string {
+		if _, allowed := allowedNginxDirectives[directive]; !allowed {
+			return "forbidden directive: " + directive
+		}
+		return ""
+	})
+}
+
+// adminDeniedNginxDirectives is the DENYLIST for the admin path (GH #1580): an
+// administrator may use the full range of nginx directives the panel renders
+// into the server block — including proxy_pass and the rest of the reverse-proxy
+// family, which the Rule Builder's RootOverridden flow already anticipates — with
+// nginx -t as the syntactic guard at apply time. Only these few remain blocked,
+// because nginx -t does NOT catch them and they have no legitimate use in a
+// per-domain custom block:
+//
+//   - root / alias: serve arbitrary paths (e.g. `root /etc/jabali-panel/`) over
+//     HTTP — file disclosure. Admins set a custom docroot via the DocRoot field,
+//     which confines it to the owner's home.
+//   - include: pulls arbitrary files into this server block as nginx config —
+//     could splice another tenant's config or leak secrets. The panel's own
+//     per-CMS include is already in the template.
+//   - auth_basic_user_file: an arbitrary-file read / existence oracle (point it
+//     at /etc/shadow). Directory Privacy manages the htpasswd file safely.
+//   - load_module: main-context only; a paste here is a nonsense footgun.
+var adminDeniedNginxDirectives = map[string]struct{}{
+	"root":                 {},
+	"alias":                {},
+	"include":              {},
+	"auth_basic_user_file": {},
+	"load_module":          {},
+}
+
+// ValidateNginxDirectivesAdmin is the RELAXED validator for admin-authored custom
+// directives (GH #1580). It keeps every structural guard ValidateNginxDirectives
+// applies (null bytes, nesting depth, balanced braces — which also stops a paste
+// from closing the server block early and escaping into the main context), but
+// replaces the safe-directive allowlist with a small denylist of the few
+// directives nginx -t can't catch and that have no legitimate per-domain use.
+func ValidateNginxDirectivesAdmin(directives string) string {
+	return scanNginxDirectives(directives, func(directive, cleaned string) string {
+		if _, denied := adminDeniedNginxDirectives[directive]; denied {
+			return "forbidden directive: " + directive
+		}
+		// Value-blocked footguns: the "off" form suppresses security logging /
+		// strips inherited auth — neither is a syntax error, so nginx -t won't
+		// stop them. A custom log PATH or an auth realm string is fine.
+		switch directive {
+		case "access_log", "auth_basic":
+			for _, arg := range nginxDirectiveArgs(cleaned) {
+				if arg == "off" {
+					return "forbidden directive: " + directive + " off"
+				}
+			}
+		}
+		return ""
+	})
+}
+
+// scanNginxDirectives runs the structural safety checks shared by both nginx
+// validators (null-byte rejection, comment stripping, brace balance + nesting
+// cap) and calls check(directive, cleaned) for every directive line — directive
+// lowercased, cleaned = the comment-stripped, trimmed line. A non-empty return
+// from check rejects the whole input with that message.
+func scanNginxDirectives(directives string, check func(directive, cleaned string) string) string {
 	// Reject if input contains null bytes (binary/injection attempt).
 	if strings.ContainsRune(directives, '\x00') {
 		return "forbidden directive: null byte detected"
@@ -1567,10 +1640,9 @@ func ValidateNginxDirectives(directives string) string {
 			continue
 		}
 
-		// Normalize to lowercase and check against allowlist.
 		directive = strings.ToLower(directive)
-		if _, allowed := allowedNginxDirectives[directive]; !allowed {
-			return "forbidden directive: " + directive
+		if msg := check(directive, cleaned); msg != "" {
+			return msg
 		}
 	}
 
@@ -1580,6 +1652,24 @@ func ValidateNginxDirectives(directives string) string {
 	}
 
 	return ""
+}
+
+// nginxDirectiveArgs returns the lowercased argument tokens of a directive line
+// (everything after the directive name), stripped of a trailing ';' and
+// surrounding quotes — enough to spot the `off` value form of access_log /
+// auth_basic. `access_log off;` -> ["off"]; `auth_basic "realm";` -> ["realm"].
+func nginxDirectiveArgs(cleaned string) []string {
+	fields := strings.FieldsFunc(cleaned, func(r rune) bool { return r == ' ' || r == '\t' })
+	if len(fields) <= 1 {
+		return nil
+	}
+	args := make([]string, 0, len(fields)-1)
+	for _, f := range fields[1:] {
+		f = strings.TrimRight(f, ";")
+		f = strings.Trim(f, `"'`)
+		args = append(args, strings.ToLower(f))
+	}
+	return args
 }
 
 // countBraces counts opening and closing braces in a line, respecting quoted strings.

--- a/panel-api/internal/api/domains_nginx_admin_validator_test.go
+++ b/panel-api/internal/api/domains_nginx_admin_validator_test.go
@@ -1,0 +1,78 @@
+package api
+
+import "testing"
+
+// GH #1580: an admin authoring nginx_custom_directives gets the relaxed
+// denylist validator (ValidateNginxDirectivesAdmin) — the full directive range,
+// including proxy_pass and the reverse-proxy family the reporter needs, minus a
+// small set of directives nginx -t can't catch. The strict allowlist validator
+// (ValidateNginxDirectives) is unchanged for the tenant/default path.
+
+func TestValidateNginxDirectivesAdmin_AllowsReverseProxy(t *testing.T) {
+	// The reporter's exact reverse-proxy block — every line must pass now.
+	ok := []string{
+		"proxy_pass $arg_url;",
+		"proxy_http_version 1.1;",
+		`proxy_set_header Connection "";`,
+		"proxy_buffering off;",
+		"proxy_request_buffering off;",
+		"proxy_ignore_client_abort on;",
+		"proxy_redirect off;",
+		"proxy_pass_request_headers on;",
+		"proxy_set_header Host $proxy_host;",
+		"proxy_read_timeout 3600s;",
+		"proxy_connect_timeout 5s;",
+		// A whole reverse-proxy location block (the RootOverridden flow).
+		"location / {\n  proxy_pass http://127.0.0.1:9000;\n  proxy_set_header Host $host;\n}",
+		// access_log / auth_basic with a real value (NOT the off form) are fine.
+		"access_log /var/log/nginx/custom.log;",
+		`auth_basic "Members Only";`,
+	}
+	for _, in := range ok {
+		if msg := ValidateNginxDirectivesAdmin(in); msg != "" {
+			t.Errorf("admin validator rejected a legitimate directive %q: %s", in, msg)
+		}
+	}
+	// And these were exactly what the strict tenant validator blocked — proving
+	// the two paths now differ (the whole point of #1580).
+	if msg := ValidateNginxDirectives("proxy_pass http://x;"); msg == "" {
+		t.Error("strict validator must STILL reject proxy_pass (tenant path unchanged)")
+	}
+}
+
+func TestValidateNginxDirectivesAdmin_BlocksFootguns(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		// File disclosure — serve arbitrary paths over HTTP.
+		{"root", "root /etc/jabali-panel;"},
+		{"alias", "alias /etc/;"},
+		// Arbitrary config/file inclusion.
+		{"include", "include /etc/nginx/other-tenant.conf;"},
+		// Arbitrary-file read / existence oracle.
+		{"auth_basic_user_file", "auth_basic_user_file /etc/shadow;"},
+		// Main-context-only footgun.
+		{"load_module", "load_module modules/ngx_http_x.so;"},
+		// The "off" value forms — nginx -t accepts them; they suppress security
+		// logging / strip inherited auth.
+		{"access_log off", "access_log off;"},
+		{"auth_basic off", "auth_basic off;"},
+		// Case + whitespace must not slip a footgun past the check.
+		{"ROOT upper", "ROOT /etc;"},
+		{"access_log   off tabs", "access_log\toff;"},
+		// Structural guards still apply for admin.
+		{"null byte", "add_header X \x00;"},
+		{"unbalanced open", "location / {"},
+		// Break-out attempt: a leading } would close the server block early.
+		{"server-block escape", "}\nserver { listen 80; }\nlocation / {"},
+		{"nesting too deep", "a { b { c { d { deny all; } } } }"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if msg := ValidateNginxDirectivesAdmin(tc.in); msg == "" {
+				t.Errorf("admin validator accepted a footgun it must block: %q", tc.in)
+			}
+		})
+	}
+}

--- a/panel-ui/src/shells/DomainSettingsButton.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.tsx
@@ -189,8 +189,16 @@ add_header X-Frame-Options "DENY" always;`}
         type="secondary"
         style={{ display: "block", marginTop: 8 }}
       >
-        Restricted to safe directives (rewrite, add_header, proxy_pass, etc.).
-        Dangerous directives are blocked.
+        Admin: the full range of nginx directives is available — including{" "}
+        <Typography.Text code>proxy_pass</Typography.Text> and the rest of the
+        reverse-proxy family — and is validated with{" "}
+        <Typography.Text code>nginx -t</Typography.Text> before reload. A few
+        directives stay blocked for safety:{" "}
+        <Typography.Text code>root</Typography.Text>,{" "}
+        <Typography.Text code>alias</Typography.Text>,{" "}
+        <Typography.Text code>include</Typography.Text>,{" "}
+        <Typography.Text code>auth_basic_user_file</Typography.Text>, and{" "}
+        <Typography.Text code>access_log off</Typography.Text>.
       </Typography.Text>
     </div>
   );


### PR DESCRIPTION
Lets an **admin** use the full range of nginx directives (including `proxy_pass`) in a domain's Custom Nginx Directives, while the tenant path keeps its safe allowlist (GH #1580).

## What was wrong

`nginx_custom_directives` is **already admin-only** — a tenant can only reach the SSRF-validated Rule Builder; the raw field is silently dropped for non-admins. But the raw field was validated with the **same strict safe-directive allowlist** as everything else, so an admin couldn't use `proxy_pass` and the rest of the reverse-proxy family — even though the vhost template's `RootOverridden` flow ("reverse proxy this domain to upstream X" via a custom `location /`) was built for exactly that. And the UI claimed `proxy_pass` was allowed while the backend returned `forbidden directive: proxy_pass` — the mismatch the reporter hit.

## Change

Admin now gets **`ValidateNginxDirectivesAdmin`** — a **denylist** instead of an allowlist. It keeps every **structural** guard the strict validator applies:
- null-byte rejection, nesting-depth cap, and **brace balance** — which also makes a server-block break-out impossible: the directives render at depth ≥1 inside `server { … }`, and the validator (counting from 0) rejects any net-negative close, so a paste can't close the block early and escape into the main context (falsified with balanced multi-`server{}` / `upstream{}` escape attempts — all rejected).

…and replaces the allowlist with a small denylist of the few footguns `nginx -t` **can't** catch and that have no legitimate per-domain use:

| Blocked | Why |
|---|---|
| `root`, `alias` | serve arbitrary paths over HTTP (file disclosure); admins use the confined DocRoot field |
| `include` | splice arbitrary files into the server block as config |
| `auth_basic_user_file` | arbitrary-file read / existence oracle (e.g. `/etc/shadow`) |
| `load_module` | main-context-only footgun |
| `access_log off`, `auth_basic off` | the *`off` value form* suppresses security logging / strips inherited auth — a custom log path or realm string is fine |

`nginx -t` remains the syntactic guard at apply time — `writeVhost` already tests the rendered config and rolls back (removes the vhost, skips reload) on failure, so a bad admin paste can never brick nginx.

## Scope + surfaces

- The strict allowlist validator is **unchanged** for the tenant/default path.
- The CLI `jabali domain set` (an operator surface) is switched to the admin validator for parity.
- The admin editor's helper text now states the **real per-role policy** instead of the false "proxy_pass allowed" claim.

## Why this posture

`root`-equivalent admins can already SSH and edit the generated config; the goal (per the issue) is to stop the **panel** from needlessly blocking legitimate nginx config, not to hand tenants new power. The denylist keeps the specific non-syntax guards the original threat model documented (file disclosure / auth strip / log suppression) while granting the reverse-proxy directives the reporter needs.

## Tests
- The reporter's full reverse-proxy block passes; a whole `location / { proxy_pass … }` block passes.
- Every denylisted footgun — incl. case (`ROOT`) and tab-separated (`access_log\toff`) variants and a server-block-escape attempt — is blocked.
- The strict validator **still** rejects `proxy_pass` (tenant path unchanged); the CLI gains a `proxy_pass`-allowed case.
- `go build/vet`, `gofmt`, the api + cmd/server suites, `tsc`, and eslint are green.

GH #1580
