### PR TITLE
feat(domains): show the real inherited value in the per-domain PHP dropdowns (GH #1543)

### DIFF
--- a/panel-agent/internal/commands/php_ini_defaults.go
+++ b/panel-agent/internal/commands/php_ini_defaults.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// php.ini_defaults (GH #1543, johnnyq) returns the effective baseline php.ini
+// values a domain INHERITS on a given PHP version when it sets no per-domain
+// override — so the panel's per-domain PHP Settings dropdowns can label the
+// inherit option with the real value (e.g. "256M (Default)") instead of a
+// generic "Pool default". The panel overlays the pool's own ini overrides
+// (which it holds in the DB) on top of this baseline; here we report only what
+// the box's FPM master config + conf.d resolve to, read straight from PHP so a
+// distro/operator-tuned php.ini is reflected truthfully rather than guessed.
+
+// phpIniDefaultDirectives is the fixed set the per-domain panel exposes. Kept in
+// lockstep with the panel's DomainPHPSettingsPanel selects.
+var phpIniDefaultDirectives = []string{
+	"memory_limit",
+	"upload_max_filesize",
+	"post_max_size",
+	"max_input_vars",
+	"max_execution_time",
+	"max_input_time",
+}
+
+// phpVersionRE bounds the version to <major>.<minor> before it is spliced into a
+// binary name / ini path — no shell is involved (exec.Command, not sh -c), but
+// this keeps a mangled version from probing arbitrary paths.
+var phpVersionRE = regexp.MustCompile(`^\d+\.\d+$`)
+
+type phpIniDefaultsParams struct {
+	PHPVersion string `json:"php_version"`
+}
+
+type phpIniDefaultsResponse struct {
+	PHPVersion string            `json:"php_version"`
+	Defaults   map[string]string `json:"defaults"`
+}
+
+func phpIniDefaultsHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p phpIniDefaultsParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if !phpVersionRE.MatchString(p.PHPVersion) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "php_version must be <major>.<minor>"}
+	}
+
+	// Read the values PHP itself resolves for the FPM SAPI's config: the master
+	// php.ini plus its conf.d scan dir — the same layering the FPM pool starts
+	// from before per-pool php_admin_value. Executed through the version's own
+	// CLI binary so the answer matches that version's build.
+	bin := "php" + p.PHPVersion // e.g. php8.3, resolved via PATH
+	iniFile := "/etc/php/" + p.PHPVersion + "/fpm/php.ini"
+	scanDir := "/etc/php/" + p.PHPVersion + "/fpm/conf.d"
+
+	script := "$d=[];foreach(['" +
+		joinQuoted(phpIniDefaultDirectives) +
+		"] as $k){$d[$k]=(string)ini_get($k);}echo json_encode($d);"
+
+	cmd := execCommandContext(ctx, bin, "-c", iniFile, "-r", script)
+	// Layer conf.d exactly as FPM does. -n would drop it; instead point the scan
+	// dir at the FPM conf.d so extension/tuning .ini files are honoured.
+	cmd.Env = append(cmd.Environ(), "PHP_INI_SCAN_DIR="+scanDir)
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("php %s ini read failed: %v", p.PHPVersion, err)}
+	}
+	var defaults map[string]string
+	if uerr := json.Unmarshal(out, &defaults); uerr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("php ini output parse failed: %v", uerr)}
+	}
+
+	return phpIniDefaultsResponse{PHPVersion: p.PHPVersion, Defaults: defaults}, nil
+}
+
+// joinQuoted renders directive names as a PHP single-quoted, comma-separated
+// list body. The names are a fixed internal allowlist (phpIniDefaultDirectives),
+// never caller input, so there is nothing to escape.
+func joinQuoted(names []string) string {
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += "','"
+		}
+		out += n
+	}
+	return out
+}
+
+func init() {
+	Default.Register("php.ini_defaults", phpIniDefaultsHandler)
+}

--- a/panel-agent/internal/commands/php_ini_defaults_test.go
+++ b/panel-agent/internal/commands/php_ini_defaults_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// GH #1543: php.ini_defaults reports the box php.ini baseline per PHP version so
+// the panel can label the per-domain PHP dropdowns with the real inherited
+// value. These pin the input guards (the php exec itself needs a real box, so
+// it's covered by the live smoke, not here).
+
+func TestPHPIniDefaults_RejectsBadVersion(t *testing.T) {
+	for _, v := range []string{"", "8", "8.x", "../8.3", "8.3; rm -rf", "8.3\n"} {
+		params, _ := json.Marshal(phpIniDefaultsParams{PHPVersion: v})
+		_, err := phpIniDefaultsHandler(context.Background(), params)
+		ae, ok := err.(*agentwire.AgentError)
+		if !ok || ae.Code != agentwire.CodeInvalidArgument {
+			t.Errorf("version %q: want CodeInvalidArgument, got %v", v, err)
+		}
+	}
+}
+
+func TestPHPIniDefaults_RejectsBadParams(t *testing.T) {
+	_, err := phpIniDefaultsHandler(context.Background(), json.RawMessage(`not json`))
+	if ae, ok := err.(*agentwire.AgentError); !ok || ae.Code != agentwire.CodeInvalidArgument {
+		t.Errorf("want CodeInvalidArgument on unparseable params, got %v", err)
+	}
+}
+
+// The PHP script body must be a well-formed single-quoted list of exactly the
+// directives the panel exposes — a drift here would read the wrong ini keys.
+func TestPHPIniDefaults_ScriptListsAllDirectives(t *testing.T) {
+	body := joinQuoted(phpIniDefaultDirectives)
+	for _, d := range phpIniDefaultDirectives {
+		if !strings.Contains(body, d) {
+			t.Errorf("directive %q missing from the ini-read script list", d)
+		}
+	}
+	if strings.Contains(body, `"`) {
+		t.Error("directive list must use single quotes only (PHP -r string)")
+	}
+}

--- a/panel-api/internal/api/domain_php_settings.go
+++ b/panel-api/internal/api/domain_php_settings.go
@@ -1,16 +1,21 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -18,6 +23,12 @@ import (
 type DomainPHPSettingsHandlerConfig struct {
 	Domains  repository.DomainRepository
 	PHPPools repository.PHPPoolRepository
+	// Agent + PoolIniOverrides power the pool_defaults hint (GH #1543): the real
+	// value a domain inherits per directive, so the UI can label each dropdown's
+	// inherit option "<value> (Default)". Both optional — nil degrades the
+	// response to omit pool_defaults, and the UI falls back to a generic label.
+	Agent            agent.AgentInterface
+	PoolIniOverrides repository.PHPPoolIniOverrideRepository
 }
 
 // RegisterDomainPHPSettingsRoutes adds the PHP settings endpoints:
@@ -47,6 +58,12 @@ type getDomainPHPSettingsResponse struct {
 	PHPDisplayErrors  *bool   `json:"php_display_errors,omitempty"`
 	PHPErrorReporting *int    `json:"php_error_reporting,omitempty"`
 	PHPTimezone       *string `json:"php_timezone,omitempty"`
+	// PoolDefaults (GH #1543) is the effective value this domain INHERITS per
+	// directive when it sets no override — the pool's ini override if it has
+	// one, else the box's FPM php.ini baseline (read live via the agent). Keys
+	// are php.ini directive names (memory_limit, upload_max_filesize, …). Absent
+	// when the agent/pool can't be resolved; the UI then shows a generic label.
+	PoolDefaults map[string]string `json:"pool_defaults,omitempty"`
 }
 
 // updateDomainPHPSettingsRequest mirrors the overridable fields plus an optional
@@ -170,21 +187,106 @@ func (h *domainPHPSettingsHandler) get(c *gin.Context) {
 		PHPTimezone:          dom.PHPTimezone,
 	}
 
-	// Resolve the effective PHP version. If the domain is bound to a
-	// user pool, return that pool's version. If unbound, fall back to the
-	// user's own pool (ADR-0023: one pool per user). If neither exists,
-	// leave nil and the UI renders "Server default".
+	// Resolve the effective PHP version + the pool itself. If the domain is
+	// bound to a user pool, use that pool. If unbound, fall back to the user's
+	// own pool (ADR-0023: one pool per user). If neither exists, leave nil and
+	// the UI renders "Server default".
+	var pool *models.PHPPool
 	if dom.PHPPoolID != nil && *dom.PHPPoolID != "" {
-		if pool, perr := h.cfg.PHPPools.FindByID(ctx, *dom.PHPPoolID); perr == nil && pool != nil {
-			v := pool.PHPVersion
-			resp.PHPVersion = &v
-		}
-	} else if pool, perr := h.cfg.PHPPools.FindByUserID(ctx, dom.UserID); perr == nil && pool != nil {
+		pool, _ = h.cfg.PHPPools.FindByID(ctx, *dom.PHPPoolID)
+	} else {
+		pool, _ = h.cfg.PHPPools.FindByUserID(ctx, dom.UserID)
+	}
+	if pool != nil {
 		v := pool.PHPVersion
 		resp.PHPVersion = &v
+		// GH #1543: the value this domain inherits per directive — pool ini
+		// override if set, else the box php.ini baseline for the version. Best
+		// effort: any failure just omits pool_defaults (the UI keeps a generic
+		// "pool default" label rather than a wrong number).
+		resp.PoolDefaults = h.resolvePoolDefaults(ctx, pool)
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// poolIniDefaultCacheTTL keeps the per-version agent read rare — the box
+// php.ini baseline changes only when the operator retunes it, so a short cache
+// spares an agent round-trip on every settings-page load.
+const poolIniDefaultCacheTTL = 5 * time.Minute
+
+type cachedIniDefaults struct {
+	at   time.Time
+	vals map[string]string
+}
+
+var (
+	poolIniDefaultMu    sync.Mutex
+	poolIniDefaultCache = map[string]cachedIniDefaults{}
+)
+
+// resolvePoolDefaults returns the effective inherited value per directive for a
+// pool: the box php.ini baseline for the pool's PHP version (read via the agent,
+// cached per version) with the pool's own ini overrides layered on top. Returns
+// nil on any failure so the caller omits the hint.
+func (h *domainPHPSettingsHandler) resolvePoolDefaults(ctx context.Context, pool *models.PHPPool) map[string]string {
+	if h.cfg.Agent == nil {
+		return nil
+	}
+	base := h.phpIniDefaults(ctx, pool.PHPVersion)
+	if base == nil {
+		return nil
+	}
+	// Copy the cached baseline before mutating — the cache entry is shared.
+	out := make(map[string]string, len(base))
+	for k, v := range base {
+		out[k] = v
+	}
+	// Overlay the pool's own value-kind ini overrides (a flag-kind override —
+	// on/off — is not one of these numeric/size directives).
+	if h.cfg.PoolIniOverrides != nil {
+		if ovs, err := h.cfg.PoolIniOverrides.ListByPool(ctx, pool.ID); err == nil {
+			for i := range ovs {
+				if ovs[i].Kind == "value" {
+					if _, tracked := out[ovs[i].Directive]; tracked {
+						out[ovs[i].Directive] = ovs[i].Value
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// phpIniDefaults reads (and caches) the box FPM php.ini baseline for a PHP
+// version via the agent's php.ini_defaults command.
+func (h *domainPHPSettingsHandler) phpIniDefaults(ctx context.Context, version string) map[string]string {
+	if version == "" {
+		return nil
+	}
+	poolIniDefaultMu.Lock()
+	if c, ok := poolIniDefaultCache[version]; ok && time.Since(c.at) < poolIniDefaultCacheTTL {
+		poolIniDefaultMu.Unlock()
+		return c.vals
+	}
+	poolIniDefaultMu.Unlock()
+
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(cctx, "php.ini_defaults", map[string]any{"php_version": version})
+	if err != nil {
+		return nil
+	}
+	var resp struct {
+		Defaults map[string]string `json:"defaults"`
+	}
+	if json.Unmarshal(raw, &resp) != nil || resp.Defaults == nil {
+		return nil
+	}
+	poolIniDefaultMu.Lock()
+	poolIniDefaultCache[version] = cachedIniDefaults{at: time.Now(), vals: resp.Defaults}
+	poolIniDefaultMu.Unlock()
+	return resp.Defaults
 }
 
 func (h *domainPHPSettingsHandler) patch(c *gin.Context) {

--- a/panel-api/internal/api/domain_php_settings_pool_defaults_test.go
+++ b/panel-api/internal/api/domain_php_settings_pool_defaults_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #1543 (johnnyq): the per-domain PHP tab should show the real inherited
+// value per directive ("256M (Default)"), not a generic "Pool default". The
+// backend resolves that as the box php.ini baseline (agent) with the pool's own
+// ini overrides layered on top.
+
+type pdFakeAgent struct{ defaults map[string]string }
+
+func (f *pdFakeAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	if cmd != "php.ini_defaults" {
+		return nil, nil
+	}
+	return json.Marshal(map[string]any{"php_version": "8.3", "defaults": f.defaults})
+}
+
+type pdFakeOverrides struct {
+	repository.PHPPoolIniOverrideRepository
+	rows []models.PHPPoolIniOverride
+}
+
+func (f *pdFakeOverrides) ListByPool(_ context.Context, _ string) ([]models.PHPPoolIniOverride, error) {
+	return f.rows, nil
+}
+
+func TestResolvePoolDefaults_OverlaysPoolOverridesOnBaseline(t *testing.T) {
+	// Bust the process cache so this test isn't served a stale baseline from a
+	// sibling test / earlier run of the same version key.
+	poolIniDefaultMu.Lock()
+	delete(poolIniDefaultCache, "8.3")
+	poolIniDefaultMu.Unlock()
+
+	h := &domainPHPSettingsHandler{cfg: DomainPHPSettingsHandlerConfig{
+		Agent: &pdFakeAgent{defaults: map[string]string{
+			"memory_limit":        "128M",
+			"upload_max_filesize": "2M",
+			"post_max_size":       "8M",
+			"max_input_vars":      "1000",
+			"max_execution_time":  "30",
+			"max_input_time":      "60",
+		}},
+		PoolIniOverrides: &pdFakeOverrides{rows: []models.PHPPoolIniOverride{
+			// The pool bumps memory_limit; everything else inherits the baseline.
+			{Directive: "memory_limit", Value: "512M", Kind: "value"},
+			// A flag-kind override must NOT land in these size/int directives.
+			{Directive: "display_errors", Value: "on", Kind: "flag"},
+		}},
+	}}
+
+	got := h.resolvePoolDefaults(context.Background(), &models.PHPPool{ID: "p1", PHPVersion: "8.3"})
+	if got == nil {
+		t.Fatal("resolvePoolDefaults returned nil with a live agent + overrides")
+	}
+	if got["memory_limit"] != "512M" {
+		t.Errorf("memory_limit = %q, want 512M (pool override wins over baseline)", got["memory_limit"])
+	}
+	if got["upload_max_filesize"] != "2M" {
+		t.Errorf("upload_max_filesize = %q, want 2M (inherited baseline)", got["upload_max_filesize"])
+	}
+	if _, leaked := got["display_errors"]; leaked {
+		t.Error("a flag-kind override leaked into the size/int defaults map")
+	}
+}
+
+func TestResolvePoolDefaults_NilAgentDegrades(t *testing.T) {
+	h := &domainPHPSettingsHandler{cfg: DomainPHPSettingsHandlerConfig{}}
+	if got := h.resolvePoolDefaults(context.Background(), &models.PHPPool{ID: "p1", PHPVersion: "8.3"}); got != nil {
+		t.Errorf("no agent should omit pool_defaults, got %v", got)
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1342,8 +1342,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		}
 		if deps.Domains != nil {
 			api.RegisterDomainPHPSettingsRoutes(v1, api.DomainPHPSettingsHandlerConfig{
-				Domains:  deps.Domains,
-				PHPPools: deps.PHPPools,
+				Domains:          deps.Domains,
+				PHPPools:         deps.PHPPools,
+				Agent:            deps.Agent,
+				PoolIniOverrides: deps.PHPPoolIniOverrides,
 			})
 			// GH #1332 item 14: per-domain env vars.
 			api.RegisterDomainEnvVarsRoutes(v1, api.DomainEnvVarsHandlerConfig{

--- a/panel-ui/src/components/domains/DomainPHPSettingsPanel.test.tsx
+++ b/panel-ui/src/components/domains/DomainPHPSettingsPanel.test.tsx
@@ -81,4 +81,31 @@ describe("DomainPHPSettingsPanel (GH #1543)", () => {
       expect(mocked.delete).toHaveBeenCalledWith("/domains/d1/php-pool"),
     );
   });
+
+  // GH #1543 (johnnyq): with no per-domain override, each dropdown's inherit
+  // option shows the real inherited value labelled "(Default)", not a generic
+  // "Use pool default".
+  it("labels the inherit option with the real pool default value", async () => {
+    mocked.get.mockImplementation((url: string) => {
+      if (url === "/php/versions") return Promise.resolve({ data: { versions: ["8.3"] } });
+      if (url === "/domains/d1/php-settings")
+        return Promise.resolve({
+          data: {
+            ...SETTINGS,
+            pool_defaults: {
+              memory_limit: "256M",
+              max_execution_time: "30",
+            },
+          },
+        });
+      return Promise.resolve({ data: {} });
+    });
+    renderPanel();
+    // The memory-limit select's inherit option now reads "256M (Default)"; the
+    // execution-time one appends the unit → "30s (Default)".
+    expect(await screen.findByText("256M (Default)")).toBeInTheDocument();
+    expect(screen.getByText("30s (Default)")).toBeInTheDocument();
+    // A directive with no resolved default keeps the generic label.
+    expect(screen.getAllByText("Use pool default").length).toBeGreaterThan(0);
+  });
 });

--- a/panel-ui/src/components/domains/DomainPHPSettingsPanel.tsx
+++ b/panel-ui/src/components/domains/DomainPHPSettingsPanel.tsx
@@ -30,6 +30,11 @@ type DomainPHPSettings = {
   php_display_errors?: boolean | null;
   php_error_reporting?: number | null;
   php_timezone?: string | null;
+  // GH #1543 (johnnyq): the real value this domain inherits per directive when
+  // it sets no override (pool ini override → box php.ini baseline), keyed by
+  // php.ini directive name. Used to label each select's inherit option with the
+  // actual default, e.g. "256M (Default)". Absent → generic label.
+  pool_defaults?: Record<string, string> | null;
 };
 
 type PHPSettingsFormData = {
@@ -273,6 +278,19 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
   // GH #1332 item 6: a small tag on each field showing whether it is a custom
   // override or falls back to the pool default. Reflects the last-saved state
   // (phpSettings), refreshed after every save.
+  // GH #1543: relabel the "Use pool default" (value null) option of a select
+  // with the real inherited value — "256M (Default)" — from pool_defaults. The
+  // null option is what the Select shows while a domain has no override, so this
+  // surfaces the actual default without any extra auto-select logic. Falls back
+  // to the generic label when the backend couldn't resolve a value.
+  type Opt = { label: string; value: string | number | null };
+  const withDefault = (opts: Opt[], directive: string, suffix = ""): Opt[] => {
+    const v = phpSettings?.pool_defaults?.[directive];
+    if (!v) return opts;
+    const label = `${v}${suffix} (Default)`;
+    return opts.map((o) => (o.value === null ? { ...o, label } : o));
+  };
+
   const fieldSet = (v: unknown) => v !== null && v !== undefined;
   const overrideLabel = (text: string, overridden: boolean) => (
     <Space size={6}>
@@ -361,7 +379,7 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
                     <Select
                       placeholder={t("userphpsettingspage.use_pool_default")}
                       allowClear
-                      options={MEMORY_LIMIT_OPTIONS}
+                      options={withDefault(MEMORY_LIMIT_OPTIONS, "memory_limit")}
                     />
                   </Form.Item>
                 </Col>
@@ -376,7 +394,7 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
                     <Select
                       placeholder={t("userphpsettingspage.use_pool_default")}
                       allowClear
-                      options={UPLOAD_MAX_OPTIONS}
+                      options={withDefault(UPLOAD_MAX_OPTIONS, "upload_max_filesize")}
                     />
                   </Form.Item>
                 </Col>
@@ -391,7 +409,7 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
                     <Select
                       placeholder={t("userphpsettingspage.use_pool_default")}
                       allowClear
-                      options={POST_MAX_OPTIONS}
+                      options={withDefault(POST_MAX_OPTIONS, "post_max_size")}
                     />
                   </Form.Item>
                 </Col>
@@ -406,7 +424,7 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
                     <Select
                       placeholder={t("userphpsettingspage.use_pool_default")}
                       allowClear
-                      options={MAX_INPUT_VARS_OPTIONS}
+                      options={withDefault(MAX_INPUT_VARS_OPTIONS, "max_input_vars")}
                     />
                   </Form.Item>
                 </Col>
@@ -425,7 +443,7 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
                     <Select
                       placeholder={t("userphpsettingspage.use_pool_default")}
                       allowClear
-                      options={MAX_EXECUTION_TIME_OPTIONS}
+                      options={withDefault(MAX_EXECUTION_TIME_OPTIONS, "max_execution_time", "s")}
                     />
                   </Form.Item>
                 </Col>
@@ -440,7 +458,7 @@ export function DomainPHPSettingsPanel({ domainId }: DomainPHPSettingsPanelProps
                     <Select
                       placeholder={t("userphpsettingspage.use_pool_default")}
                       allowClear
-                      options={MAX_INPUT_TIME_OPTIONS}
+                      options={withDefault(MAX_INPUT_TIME_OPTIONS, "max_input_time", "s")}
                     />
                   </Form.Item>
                 </Col>


### PR DESCRIPTION
The per-domain **PHP Settings** tab showed a generic "Pool default" in each limit dropdown. This shows the **actual value the domain inherits** — e.g. **`256M (Default)`** for Memory Limit — so it's clear what "no override" resolves to (GH #1543, @johnnyq).

## Where the value comes from

The inherited value per directive is the pool's ini override if it has one, else the box's FPM `php.ini` baseline. The override is in the DB; the baseline is **not** — some pools are tuned by `install.sh`, so a hardcoded guess could be wrong. So it's read live and truthfully:

- **New agent command `php.ini_defaults {php_version}`** reads the six exposed directives (`memory_limit`, `upload_max_filesize`, `post_max_size`, `max_input_vars`, `max_execution_time`, `max_input_time`) straight from PHP for the **FPM** SAPI's config (master `php.ini` + its `conf.d` scan dir), so a distro/operator-tuned baseline is reflected rather than assumed. Version is regex-bounded; exec routes through the command seam (GH #994).
- **`GET /domains/:id/php-settings`** now returns `pool_defaults` = that baseline with the pool's own value-kind ini overrides layered on top, resolved via the agent and **cached per PHP version (5 min)** so it isn't a round-trip on every load. Agent + override repo are **optional deps** — nil degrades the response to omit `pool_defaults`, and the UI falls back to the generic label.
- The panel relabels each select's inherit option **`<value> (Default)`** from `pool_defaults` (time fields get an `s` suffix). That option is already what the Select shows while a domain has no override, so no extra auto-select logic is needed — it just reads truthfully now.

## Why this is accurate (verified)

The panel's pool template (`php_pool_apply`) writes `php_admin_value` **only** from the DB overrides it's handed (`p.AdminValues`) — there's no hardcoded per-pool baseline for these directives. So absent a DB override, the pool `www.conf` has no `php_admin_value[memory_limit]` and the domain inherits the FPM master `php.ini`. The chain agent-reads-`fpm/php.ini` + DB-override-overlay is therefore exactly what the domain's FPM worker resolves. Confirmed on the test box: `php8.3 -c /etc/php/8.3/fpm/php.ini -r 'ini_get(...)'` returns `128M / 2M / 8M`, matching what a no-override domain gets.

## Also in this thread

- **DNS (@johnnyq):** yes — **DNS Zones (side nav) → the domain** deep-links straight into this page's **DNS tab** (`/jabali-panel/domains/:id/dns`); they're the same manager. That's exactly why the tab was kept rather than removed (removing it would orphan that path). No change needed.

## Tests
- Backend overlay: pool override wins over baseline; flag-kind overrides don't leak into the size/int map; nil-agent degrades (omits `pool_defaults`).
- Agent guards: bad version / bad params rejected; the directive list is a well-formed single-quoted PHP list.
- Panel: the real value renders as `256M (Default)` / `30s (Default)`; a directive with no resolved default keeps the generic label.
- `go build/vet`, `gofmt`, the exec-seam lint (GH #994), `tsc`, eslint, and the api / agent / panel suites are green.

GH #1543
