### PR TITLE
fix(domains): repair the php.ini_defaults agent script quoting (GH #1543)

### DIFF
--- a/panel-agent/internal/commands/php_ini_defaults.go
+++ b/panel-agent/internal/commands/php_ini_defaults.go
@@ -60,9 +60,7 @@ func phpIniDefaultsHandler(ctx context.Context, params json.RawMessage) (any, er
 	iniFile := "/etc/php/" + p.PHPVersion + "/fpm/php.ini"
 	scanDir := "/etc/php/" + p.PHPVersion + "/fpm/conf.d"
 
-	script := "$d=[];foreach(['" +
-		joinQuoted(phpIniDefaultDirectives) +
-		"] as $k){$d[$k]=(string)ini_get($k);}echo json_encode($d);"
+	script := phpIniReadScript()
 
 	cmd := execCommandContext(ctx, bin, "-c", iniFile, "-r", script)
 	// Layer conf.d exactly as FPM does. -n would drop it; instead point the scan
@@ -81,18 +79,17 @@ func phpIniDefaultsHandler(ctx context.Context, params json.RawMessage) (any, er
 	return phpIniDefaultsResponse{PHPVersion: p.PHPVersion, Defaults: defaults}, nil
 }
 
-// joinQuoted renders directive names as a PHP single-quoted, comma-separated
-// list body. The names are a fixed internal allowlist (phpIniDefaultDirectives),
-// never caller input, so there is nothing to escape.
-func joinQuoted(names []string) string {
-	out := ""
-	for i, n := range names {
-		if i > 0 {
-			out += "','"
-		}
-		out += n
-	}
-	return out
+// phpIniReadScript builds the PHP -r program that echoes json_encode of ini_get
+// for each exposed directive. The directive list is handed to PHP as a JSON
+// array literal that json_decode parses, rather than hand-glued single quotes —
+// the earlier hand-glued form dropped the final closing quote (a malformed
+// foreach list PHP rejects with a fatal parse error / exit 255) and the unit
+// test didn't catch it. The names are a fixed internal allowlist
+// (phpIniDefaultDirectives) with no quotes or backslashes, so the JSON literal
+// sits safely inside a single-quoted PHP string with nothing to escape.
+func phpIniReadScript() string {
+	namesJSON, _ := json.Marshal(phpIniDefaultDirectives) // ["memory_limit",...]
+	return "$d=[];foreach(json_decode('" + string(namesJSON) + "',true) as $k){$d[$k]=(string)ini_get($k);}echo json_encode($d);"
 }
 
 func init() {

--- a/panel-agent/internal/commands/php_ini_defaults_test.go
+++ b/panel-agent/internal/commands/php_ini_defaults_test.go
@@ -32,16 +32,45 @@ func TestPHPIniDefaults_RejectsBadParams(t *testing.T) {
 	}
 }
 
-// The PHP script body must be a well-formed single-quoted list of exactly the
-// directives the panel exposes — a drift here would read the wrong ini keys.
-func TestPHPIniDefaults_ScriptListsAllDirectives(t *testing.T) {
-	body := joinQuoted(phpIniDefaultDirectives)
-	for _, d := range phpIniDefaultDirectives {
-		if !strings.Contains(body, d) {
-			t.Errorf("directive %q missing from the ini-read script list", d)
+// The PHP -r program must be well-formed and read exactly the directives the
+// panel exposes. A hand-glued quote list once dropped the final closing quote,
+// yielding a malformed foreach that PHP rejected (exit 255) while this test —
+// which only checked the names were present — stayed green. So assert the real
+// property instead: the directive list embedded for PHP round-trips back to the
+// exact allowlist, and the single-quoted PHP string wrapping it is balanced.
+func TestPHPIniDefaults_ScriptIsWellFormed(t *testing.T) {
+	script := phpIniReadScript()
+
+	// The list is handed to PHP as a JSON array literal inside a single-quoted
+	// string: json_decode('[...]',true). Pull that literal back out and decode
+	// it — it must equal the allowlist exactly (order and contents).
+	start := strings.Index(script, "json_decode('")
+	if start < 0 {
+		t.Fatalf("script does not pass the directive list via json_decode: %q", script)
+	}
+	start += len("json_decode('")
+	end := strings.Index(script[start:], "'")
+	if end < 0 {
+		t.Fatalf("unterminated JSON literal in script: %q", script)
+	}
+	literal := script[start : start+end]
+
+	var got []string
+	if err := json.Unmarshal([]byte(literal), &got); err != nil {
+		t.Fatalf("embedded directive literal is not valid JSON (%v): %q", err, literal)
+	}
+	if len(got) != len(phpIniDefaultDirectives) {
+		t.Fatalf("script reads %d directives, want %d: %v", len(got), len(phpIniDefaultDirectives), got)
+	}
+	for i, d := range phpIniDefaultDirectives {
+		if got[i] != d {
+			t.Errorf("directive[%d] = %q, want %q", i, got[i], d)
 		}
 	}
-	if strings.Contains(body, `"`) {
-		t.Error("directive list must use single quotes only (PHP -r string)")
+
+	// Every single quote in the PHP -r program must be paired — an odd count is
+	// exactly the malformed-list regression this guards.
+	if q := strings.Count(script, "'"); q%2 != 0 {
+		t.Errorf("PHP -r program has unbalanced single quotes (%d): %q", q, script)
 	}
 }


### PR DESCRIPTION
## What

Repairs the `php.ini_defaults` agent command that #1600 added for the per-domain PHP dropdowns (GH #1543). As merged, that command was **broken on every call** — box-verifying it on the test host surfaced this before it reached the fleet.

## The bug

The command hand-glued the directive list into a single-quoted PHP `foreach` and **dropped the final closing quote**. The `-r` program it ran (captured with `strace` on the test host) was:

```
$d=[];foreach(['memory_limit',...,'max_input_time] as $k){...}
                                              ^ missing closing quote
```

PHP rejects that with a fatal parse error and exits 255, so the agent returned `php 8.3 ini read failed: exit status 255` for every version. The panel's `resolvePoolDefaults` degrades to `nil` on that error, so `pool_defaults` was omitted from the response and the UI **silently fell back to the generic "Use pool default" label** — the feature never actually showed the real inherited value.

The unit test only asserted the directive *names* were present in the glued string and that it used single quotes, so it stayed green through the malformed output. That's the test gap this also closes.

## The fix

Build the directive list as a **JSON array literal that PHP `json_decode()`s**, instead of hand-gluing quotes — removing the whole class of quoting bug:

```
$d=[];foreach(json_decode('["memory_limit",...,"max_input_time"]',true) as $k){$d[$k]=(string)ini_get($k);}echo json_encode($d);
```

The directive names are a fixed internal allowlist (no quotes/backslashes), so the JSON literal sits inside a single-quoted PHP string with nothing to escape.

The script test is rewritten to assert the real property: it pulls the JSON literal back out of the generated `-r` program, round-trips it, and requires it to equal the allowlist exactly — plus asserts the single quotes are balanced (the exact regression).

## Box-verified (test host, after this fix)

- `php.ini_defaults` over the agent socket now returns `ok:true` with real values for `8.3`, `8.4`, and `8.5`: `memory_limit=128M, upload_max_filesize=2M, post_max_size=8M, max_input_vars=1000, max_execution_time=0, max_input_time=-1`.
- `GET /api/v1/domains/:id/php-settings` (authenticated as the domain owner) now returns `pool_defaults` with those values, so the dropdowns render e.g. **`128M (Default)`**.
- Served SPA and both services healthy after the agent redeploy.

## Tests
`go build/vet`, `gofmt`, exec-seam lint (GH #994), and the agent + api suites are green. No frontend change (the panel already renders `pool_defaults` when present).

GH #1543
