### PR TITLE
fix(disk-usage): auto-measure on open for hour-old snapshots + log the nightly sweep (GH #1439)

### DIFF
--- a/install/systemd/disk-maintenance
+++ b/install/systemd/disk-maintenance
@@ -42,7 +42,11 @@ fi
 # jabali-maintenance.slice (MemoryMax=50%, IOSchedulingClass=idle, Nice=19) via
 # the service unit. Keep it serial; do not add a parallel flag.
 if command -v jabali >/dev/null 2>&1; then
-  jabali disk-usage refresh-all >/dev/null 2>&1 || true
+  # Let the "refreshed=N skipped=N failed=N" summary reach the journal (2>&1),
+  # so "did the nightly sweep run?" is answerable from the service logs — it
+  # wasn't while this was >/dev/null. `|| true` still keeps a hard failure from
+  # aborting the rest of the timer (this is an optional, idempotent step).
+  jabali disk-usage refresh-all 2>&1 || true
 fi
 
 exit 0

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.test.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.test.tsx
@@ -129,4 +129,17 @@ describe("DiskUsagePage auto-measure on open (GH #1439, lxsdevcode)", () => {
     renderPage();
     await waitFor(() => expect(postRefresh).toHaveBeenCalledTimes(1));
   });
+
+  // Regression guard for lxsdevcode's exact report: the nightly refresh-all
+  // keeps snapshots just under a day old ("Computed 22 h ago"), and the earlier
+  // 24h gate treated that as fresh, so the page never auto-measured on open. A
+  // snapshot a couple of hours old must now trigger a measure (threshold is 1h).
+  it("auto-measures when the snapshot is a few hours old (GH #1439 nightly-kept case)", async () => {
+    getState.resp = {
+      ...diskUsage,
+      computed_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    };
+    renderPage();
+    await waitFor(() => expect(postRefresh).toHaveBeenCalledTimes(1));
+  });
 });

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
@@ -166,12 +166,20 @@ const COLORS = {
 } as const;
 
 // GH #1439 (lxsdevcode): a snapshot older than this (or missing) triggers an
-// automatic measure on page open, so a tenant sees the real figure without
-// having to know to click Refresh. 24h sits just above the nightly refresh-all
-// cadence (--max-age 20h), so a fleet whose daily job is running never
-// auto-measures redundantly on every visit — only when the job hasn't kept the
-// snapshot fresh (job disabled, missed, or a brand-new account).
-const AUTO_MEASURE_STALE_MS = 24 * 60 * 60 * 1000;
+// automatic measure on page open, so a tenant sees a current figure without
+// having to know to click Refresh.
+//
+// An earlier 24h window sat just ABOVE the nightly refresh-all cadence
+// (--max-age 20h) to avoid re-measuring on every visit — but that backfired:
+// the nightly job keeps every snapshot just under 24h old, so opening the page
+// never crossed the gate and the tenant always saw yesterday's number until
+// they clicked Refresh (lxsdevcode's report: "Computed 22 h ago", unchanged).
+// 1h instead means opening the page reflects near-current usage. The recompute
+// is one serial home `du` (~seconds), fires AT MOST ONCE per mount, and is
+// driven by a human opening the page (not a poll), so it can't stampede. The
+// nightly job still keeps the dashboard card — which never opens this page —
+// fresh on its own.
+const AUTO_MEASURE_STALE_MS = 60 * 60 * 1000;
 
 function isSnapshotStale(computedAt?: string | null): boolean {
   if (!computedAt) return true; // never computed


### PR DESCRIPTION
## What

lxsdevcode reported the tenant **Disk Usage** page still showed a stale figure ("Computed 22 h ago") and didn't measure on open until Refresh was clicked, and that the scheduled sweep didn't look like it had run (GH #1439). Both are addressed here.

## Auto-measure on open — the 1h fix

#1598 added an auto-measure-on-open that fires when the snapshot is missing or **older than 24h**. That threshold was chosen to sit just *above* the nightly `refresh-all` cadence (`--max-age 20h`) so the page wouldn't re-measure on every visit — but it backfired: the nightly job keeps every snapshot **just under 24h old**, so opening the page never crossed the gate and the tenant always saw the previous day's number.

Lowering the gate to **1h**: opening the page now reflects near-current usage. The recompute is one serial home `du` (~seconds), fires **at most once per mount**, and is driven by a human opening the page (not a poll), so it can't stampede. The nightly job still keeps the dashboard card — which never opens this page — fresh on its own.

## "Did the nightly sweep run?" — observability

The `jabali-disk-maintenance` script ran `jabali disk-usage refresh-all >/dev/null 2>&1`, so the sweep's own `refreshed=N skipped=N failed=N` summary went to `/dev/null` and the answer to lxsdevcode's second question was unavailable from the service logs. It now sends that summary to the journal (`2>&1`); `|| true` still keeps a hard failure from aborting the rest of the timer (it's an optional, idempotent step).

## What was NOT wrong (verified on the test host, not guessed)

- `GET /me/disk-usage` with **no snapshot row** returns HTTP 200 with `computed_at: null` (auto-measure fires, no error Alert) — the brand-new-tenant path.
- `POST /me/disk-usage/refresh` recomputes and returns a fresh snapshot.
- The nightly unit, run under systemd (not a root shell), **refreshed an aged snapshot and recreated a deleted one**, `Result=success`.
- After deploying this build: the journal now shows `disk-usage refresh-all: refreshed=2 skipped=0 failed=0 (of 2 tenants)`; served SPA and services healthy.

So #1598's code was correct — the only defects were the threshold value and the swallowed log.

## The "22 h ago" timeline (for context)

lxsdevcode's screenshot (comment at 15:52Z, 09-08) reads "Computed 22 h ago" → ≈17:52Z on 09-07, which is when the dashboard-fix Refresh was done. The nightly sweep (00:07) correctly *skipped* that snapshot (it was ~6h old, under the 20h `--max-age`), and by page-open it was 22h old — under the old 24h gate — so **neither** mechanism re-measured it. That's exactly the hole this closes.

## Tests
Adds a frontend regression test for the nightly-kept case (a few-hours-old snapshot must now auto-measure). `tsc`, eslint, `go vet`, and the disk-usage vitest suite (6/6) are green.

GH #1439
