### PR TITLE
fix(domains): rename works without the mail module + expose it in Admin (GH #1579)

### DIFF
--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -91,7 +91,11 @@ func (h *domainHandler) rename(c *gin.Context) {
 		TLSRPT: h.cfg.TLSRPTAggregate,
 		// Forwarders rewrites alias forwarder targets to the new name.
 		Forwarders: h.cfg.Forwarders,
-		Log:        slog.Default(),
+		// Settings gates the mail-carry verb on ServerSettings.MailEnabled so a
+		// rename on a server without the mail module installed skips the Stalwart
+		// call instead of failing on the absent admin token (GH #1579).
+		Settings: h.cfg.ServerSettings,
+		Log:      slog.Default(),
 	}, rec, domain, newName)
 	if err != nil {
 		var re *userops.RenameError

--- a/panel-api/internal/userops/domain_rename.go
+++ b/panel-api/internal/userops/domain_rename.go
@@ -263,16 +263,32 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 		return nil, renameErr("name_taken", "%q already exists", newName)
 	}
 
+	// Is the mail module installed on this box? The mail.domain.rename verb reads
+	// the Stalwart admin token, which does not exist on a server without mail, so
+	// calling it there fails the whole rename (GH #1579). Skip the mail carry when
+	// mail is off — the same ServerSettings.MailEnabled flag middleware.ModuleMail
+	// gates every mail route on. FAIL-CLOSED: only a positive "mail disabled"
+	// reading skips it; nil Settings, a read error, or MailEnabled=true keep the
+	// verb in the flow, so a domain that has mail never renames without carrying it.
+	mailInstalled := true
+	if d.Settings != nil {
+		if s, serr := d.Settings.Get(ctx); serr == nil && s != nil {
+			mailInstalled = s.MailEnabled
+		}
+	}
+
 	// Dry-run the mail-domain rename BEFORE moving any files, so a genuine
 	// conflict (the new name already carries mail in Stalwart) fails the rename
 	// while nothing is committed. Fail-closed: an agent error here refuses.
-	if dryRaw, aerr := d.Agent.Call(ctx, "mail.domain.rename", map[string]any{
-		"old": oldName, "new": newName, "dry_run": true,
-	}); aerr != nil {
-		return nil, renameErr("unavailable", "could not check mail before renaming %q: %v", oldName, aerr)
-	} else if st, _ := mailRenameStatus(dryRaw); st == mailRenameConflict {
-		return nil, renameErr("mail_domain_conflict",
-			"%q already has mail configured in Stalwart — delete or migrate it before renaming %q into it", newName, oldName)
+	if mailInstalled {
+		if dryRaw, aerr := d.Agent.Call(ctx, "mail.domain.rename", map[string]any{
+			"old": oldName, "new": newName, "dry_run": true,
+		}); aerr != nil {
+			return nil, renameErr("unavailable", "could not check mail before renaming %q: %v", oldName, aerr)
+		} else if st, _ := mailRenameStatus(dryRaw); st == mailRenameConflict {
+			return nil, renameErr("mail_domain_conflict",
+				"%q already has mail configured in Stalwart — delete or migrate it before renaming %q into it", newName, oldName)
+		}
 	}
 
 	// ---- orchestrate ----
@@ -304,15 +320,17 @@ func RenameDomain(ctx context.Context, d Deps, rec RenameReconciler, domain *mod
 	//     is fully re-runnable. Statuses renamed | already | not_in_registry all
 	//     proceed; a conflict (racing another rename since the dry-run) refuses.
 	var mailWarnings []string
-	if mailRaw, aerr := d.Agent.Call(ctx, "mail.domain.rename", map[string]any{
-		"old": oldName, "new": newName,
-	}); aerr != nil {
-		return nil, renameErr("mail_rename_failed", "could not carry mail to the new name for %q: %v", oldName, aerr)
-	} else if st, w := mailRenameStatus(mailRaw); st == mailRenameConflict {
-		return nil, renameErr("mail_domain_conflict",
-			"%q already has mail configured in Stalwart — delete or migrate it before renaming %q into it", newName, oldName)
-	} else {
-		mailWarnings = w
+	if mailInstalled {
+		if mailRaw, aerr := d.Agent.Call(ctx, "mail.domain.rename", map[string]any{
+			"old": oldName, "new": newName,
+		}); aerr != nil {
+			return nil, renameErr("mail_rename_failed", "could not carry mail to the new name for %q: %v", oldName, aerr)
+		} else if st, w := mailRenameStatus(mailRaw); st == mailRenameConflict {
+			return nil, renameErr("mail_domain_conflict",
+				"%q already has mail configured in Stalwart — delete or migrate it before renaming %q into it", newName, oldName)
+		} else {
+			mailWarnings = w
+		}
 	}
 
 	// 2. Rename the row (name + doc_root as a unit) — the authoritative flip.

--- a/panel-api/internal/userops/domain_rename_test.go
+++ b/panel-api/internal/userops/domain_rename_test.go
@@ -132,6 +132,22 @@ func (a *drAppInstalls) ListByDomainIDs(_ context.Context, _ []string) ([]models
 	return a.installs, a.err
 }
 
+// drSettings is a minimal ServerSettingsRepository whose Get returns a settings
+// row with a chosen MailEnabled (or a forced error), to drive the GH #1579
+// mail-module gate on the rename's mail carry.
+type drSettings struct {
+	repository.ServerSettingsRepository
+	mailEnabled bool
+	getErr      error
+}
+
+func (s *drSettings) Get(_ context.Context) (*models.ServerSettings, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return &models.ServerSettings{MailEnabled: s.mailEnabled}, nil
+}
+
 type drTeardowns struct {
 	rec     *drRecorder
 	ensured []string
@@ -445,6 +461,53 @@ func TestRenameDomain_MailDryRunErrorFailsClosed(t *testing.T) {
 	}
 	if ag.reownLast != nil {
 		t.Fatalf("a dry-run agent error must refuse before the file move")
+	}
+}
+
+// GH #1579: on a server without the mail module installed, the mail.domain.rename
+// verb reads an absent Stalwart admin token and errors — which used to fail the
+// whole rename. With Settings reporting MailEnabled=false the rename skips the
+// mail carry entirely (never calls the verb) and succeeds, even when the agent
+// would error on it.
+func TestRenameDomain_MailModuleDisabledSkipsMailCarry(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Settings = &drSettings{mailEnabled: false}
+	// Would fail the rename if the verb were called — proving it is skipped.
+	ag.errByMethod = map[string]error{"mail.domain.rename": errors.New("stalwart not installed")}
+
+	warnings, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if err != nil {
+		t.Fatalf("mail-disabled rename must succeed, got: %v", err)
+	}
+	if dom.Name != "new.com" {
+		t.Fatalf("row should be renamed, got %q", dom.Name)
+	}
+	if len(ag.mailRenameCalls) != 0 {
+		t.Fatalf("mail.domain.rename must not be called when mail is disabled, got %d calls", len(ag.mailRenameCalls))
+	}
+	for _, e := range rec.events {
+		if e == evDryMail {
+			t.Fatalf("no mail verb event expected when mail disabled, got %v", rec.events)
+		}
+	}
+	_ = warnings
+}
+
+// A Settings read error is FAIL-CLOSED: the mail carry still runs (a box that
+// actually has mail must never rename without carrying it), so the same agent
+// error that TestRenameDomain_MailDryRunErrorFailsClosed asserts still refuses.
+func TestRenameDomain_MailSettingsReadErrorFailsClosed(t *testing.T) {
+	rec := &drRecorder{}
+	dom := drWebDomain()
+	d, ag, _ := drNewDeps(rec, dom, drHappyOwner())
+	d.Settings = &drSettings{getErr: errors.New("db down")}
+	ag.errByMethod = map[string]error{"mail.domain.rename": errors.New("stalwart down")}
+
+	_, err := RenameDomain(context.Background(), d, &drSched{}, dom, "new.com")
+	if got := drCodeOf(t, err); got != "unavailable" {
+		t.Fatalf("code = %q, want unavailable (a settings read error must not skip the mail carry)", got)
 	}
 }
 

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -78,7 +78,17 @@ type Deps struct {
 	TLSRPT TLSRPTReKeyer
 	// Forwarders rewrites the domain's alias forwarder targets to the new name on
 	// a rename (GH #1579). Optional: nil skips (the rename still succeeds).
-	Forwarders   ForwarderAliasReKeyer
+	Forwarders ForwarderAliasReKeyer
+	// Settings lets RenameDomain skip the mail-carry agent verb on a server where
+	// the mail module is not installed (GH #1579): the mail.domain.rename verb
+	// reads the Stalwart admin token, which is absent on a mail-less box, so it
+	// would fail the whole rename. Gated on the same ServerSettings.MailEnabled
+	// flag that middleware.ModuleMail uses, so the rename honours the optional
+	// module exactly like every other mail surface. Optional and FAIL-CLOSED:
+	// nil, a read error, or MailEnabled=true all keep the mail verb in the flow
+	// (a domain that has mail must never rename without carrying it), so only a
+	// positive "mail module disabled" reading skips it.
+	Settings     repository.ServerSettingsRepository
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int

--- a/panel-ui/src/components/domains/DomainInventory.tsx
+++ b/panel-ui/src/components/domains/DomainInventory.tsx
@@ -29,6 +29,7 @@ import { DomainIndexButton } from "../../shells/DomainIndexButton";
 import { DomainInfoButton } from "../../shells/DomainInfoButton";
 import { DomainSettingsButton } from "../../shells/DomainSettingsButton";
 import { DomainChownAction } from "../../shells/admin/domains/DomainChownAction";
+import { RenameDomainDialog } from "./RenameDomainDialog";
 
 import { buildDomainDataColumns, type DomainInventoryAudience } from "./domainColumns";
 import { buildDomainMenuItems, type DomainModalType } from "./domainActions";
@@ -248,6 +249,19 @@ export const DomainInventory = ({ audience }: { audience: DomainInventoryAudienc
           )}
           {activeModal?.domainId === r.id && activeModal.type === "chown" && (
             <DomainChownAction domain={r} open={true} onClose={() => setActiveModal(null)} />
+          )}
+          {activeModal?.domainId === r.id && activeModal.type === "rename" && (
+            <RenameDomainDialog
+              domain={r}
+              open={true}
+              onClose={() => setActiveModal(null)}
+              onRenamed={() => {
+                // Same-id rename: refresh both the list and the single-row cache
+                // so the new name shows without a manual reload (GH #1579).
+                qc.invalidateQueries({ queryKey: ["list", "domains"] });
+                qc.invalidateQueries({ queryKey: ["one", "domains", r.id] });
+              }}
+            />
           )}
         </Space>
       ),

--- a/panel-ui/src/components/domains/RenameDomainButton.tsx
+++ b/panel-ui/src/components/domains/RenameDomainButton.tsx
@@ -1,22 +1,11 @@
-// RenameDomainButton — GH #1579. Renames an existing web domain in place
-// (POST /domains/:id/rename) instead of the create-new-and-move workaround.
-//
-// Experimental: the backend refuses when the new name already carries mail in
-// Stalwart (mail_domain_conflict), when the domain is the panel's own primary,
-// or when it has no website. It moves the docroot, tears down the old name's
-// nginx vhost + DNS zone, and re-provisions the new name (SSL is reissued by the
-// reconciler). Mail is CARRIED to the new name — the Stalwart registry domain is
-// renamed in place, so mailboxes, stored messages, and DKIM follow; users just
-// reconfigure their mail clients to mail.<newname>. For a WordPress install it
-// rewrites the stored site URL to the new name (best-effort, via wp
-// search-replace); any install it could not rewrite — and a catch-all it could
-// not re-point — is returned in `warnings` and surfaced here. Other apps'
-// internal configuration is not changed — the modal notes that.
+// RenameDomainButton — GH #1579. The tenant Web Domain page's trigger for the
+// in-place rename: a Button that opens the shared RenameDomainDialog. The dialog
+// (and all its flow/validation) lives in RenameDomainDialog so the admin domain
+// inventory can open the identical modal from its Actions menu.
 import { useState } from "react";
-import { Alert, Button, Checkbox, Input, Modal, Typography } from "antd";
+import { Button } from "antd";
 import { EditOutlined } from "@icons";
-import { apiClient } from "../../apiClient";
-import { feedback } from "../../lib/feedback";
+import { RenameDomainDialog } from "./RenameDomainDialog";
 
 interface RenameDomainButtonProps {
   domain: { id: string; name: string };
@@ -25,113 +14,20 @@ interface RenameDomainButtonProps {
   onRenamed: () => void;
 }
 
-// A light client-side FQDN shape check to disable the button early; the server
-// runs the authoritative validateDomainName.
-const looksLikeFQDN = (s: string): boolean =>
-  /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/.test(s);
-
 export function RenameDomainButton({ domain, onRenamed }: RenameDomainButtonProps) {
   const [open, setOpen] = useState(false);
-  const [newName, setNewName] = useState("");
-  const [ack, setAck] = useState(false);
-  const [busy, setBusy] = useState(false);
-
-  const normalized = newName.trim().toLowerCase();
-  const canSubmit =
-    ack &&
-    !busy &&
-    looksLikeFQDN(normalized) &&
-    normalized !== domain.name.toLowerCase();
-
-  const close = () => {
-    setOpen(false);
-    setNewName("");
-    setAck(false);
-  };
-
-  const submit = async () => {
-    if (!canSubmit) return;
-    setBusy(true);
-    try {
-      const resp = await apiClient.post<{ warnings?: string[] }>(
-        `/domains/${domain.id}/rename`,
-        { name: normalized },
-      );
-      feedback.message.success(`Renamed to ${normalized}`);
-      // Best-effort app-URL rewrites that did not complete (e.g. a WordPress
-      // site URL that must be updated by hand) come back as warnings.
-      (resp.data?.warnings ?? []).forEach((w) => feedback.message.warning(w));
-      close();
-      onRenamed();
-    } catch (err) {
-      feedback.message.error(
-        err instanceof Error ? err.message : "Could not rename the domain",
-      );
-    } finally {
-      setBusy(false);
-    }
-  };
 
   return (
     <>
       <Button icon={<EditOutlined />} onClick={() => setOpen(true)}>
         Rename domain
       </Button>
-
-      <Modal
+      <RenameDomainDialog
+        domain={domain}
         open={open}
-        title={`Rename ${domain.name}`}
-        okText="Rename domain"
-        okButtonProps={{ disabled: !canSubmit, loading: busy }}
-        onOk={submit}
-        onCancel={close}
-        destroyOnClose
-      >
-        <Alert
-          type="warning"
-          showIcon
-          style={{ marginBottom: 12 }}
-          message="Experimental feature"
-          description="Renaming a domain is new. If anything looks wrong afterwards, please file a bug report."
-        />
-        <Alert
-          type="info"
-          showIcon
-          style={{ marginBottom: 12 }}
-          message="WordPress site URL is updated automatically"
-          description="For a WordPress install, the site URL is rewritten to the new name automatically (via wp search-replace). Other apps' internal settings are not changed — update those in the app itself. If the automatic rewrite can't run, you'll see a warning to update it by hand."
-        />
-        <Typography.Paragraph style={{ marginBottom: 4 }}>
-          Renaming <Typography.Text code>{domain.name}</Typography.Text> will:
-        </Typography.Paragraph>
-        <ul style={{ margin: "0 0 12px", paddingLeft: 18 }}>
-          <li>Move the website files to the new domain's document root</li>
-          <li>Rebuild the web server (nginx) configuration for the new name</li>
-          <li>Reissue the SSL certificate for the new name</li>
-          <li>Recreate the managed DNS zone under the new name and remove the old one</li>
-          <li>Carry mail to the new name — mailboxes, stored messages, and DKIM move automatically</li>
-          <li>Rewrite a WordPress install's site URL to the new name (other apps unchanged)</li>
-        </ul>
-        <Typography.Paragraph type="secondary" style={{ marginBottom: 4 }}>
-          Mail is carried to the new name automatically. Each mailbox keeps its
-          messages and password; after the rename, reconfigure mail clients to
-          use <Typography.Text code>mail.{normalized || "new-domain.com"}</Typography.Text> for
-          IMAP/SMTP. The per-domain mail certificate is reissued separately.
-        </Typography.Paragraph>
-        <Input
-          autoFocus
-          placeholder="new-domain.com"
-          value={newName}
-          onChange={(e) => setNewName(e.target.value)}
-          onPressEnter={submit}
-          style={{ marginBottom: 12 }}
-        />
-        <Checkbox checked={ack} onChange={(e) => setAck(e.target.checked)}>
-          I understand this is experimental. Mail is carried to the new name and
-          mail clients must be reconfigured to the new mail host. A WordPress
-          site URL is updated automatically; other apps' internal settings are not.
-        </Checkbox>
-      </Modal>
+        onClose={() => setOpen(false)}
+        onRenamed={onRenamed}
+      />
     </>
   );
 }

--- a/panel-ui/src/components/domains/RenameDomainDialog.tsx
+++ b/panel-ui/src/components/domains/RenameDomainDialog.tsx
@@ -1,0 +1,133 @@
+// RenameDomainDialog — GH #1579. The controlled Rename-domain modal (open +
+// onClose), shared by the tenant Web Domain page (via RenameDomainButton) and
+// the admin domain inventory's Actions menu, so both surfaces run the exact
+// same flow and validation (lxsdevcode's consistency ask on GH #1579).
+//
+// Experimental: the backend refuses when the new name already carries mail in
+// Stalwart (mail_domain_conflict), when the domain is the panel's own primary,
+// or when it has no website. It moves the docroot, tears down the old name's
+// nginx vhost + DNS zone, and re-provisions the new name (SSL is reissued by the
+// reconciler). Mail is CARRIED to the new name — the Stalwart registry domain is
+// renamed in place, so mailboxes, stored messages, and DKIM follow; users just
+// reconfigure their mail clients to mail.<newname>. For a WordPress install it
+// rewrites the stored site URL to the new name (best-effort, via wp
+// search-replace); any install it could not rewrite — and a catch-all it could
+// not re-point — is returned in `warnings` and surfaced here. Other apps'
+// internal configuration is not changed — the modal notes that.
+import { useState } from "react";
+import { Alert, Checkbox, Input, Modal, Typography } from "antd";
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback";
+
+interface RenameDomainDialogProps {
+  domain: { id: string; name: string };
+  open: boolean;
+  onClose: () => void;
+  // Called after a successful rename so the parent can refetch the (same-id)
+  // domain (or its list row) and show the new name.
+  onRenamed?: () => void;
+}
+
+// A light client-side FQDN shape check to disable the button early; the server
+// runs the authoritative validateDomainName.
+const looksLikeFQDN = (s: string): boolean =>
+  /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/.test(s);
+
+export function RenameDomainDialog({ domain, open, onClose, onRenamed }: RenameDomainDialogProps) {
+  const [newName, setNewName] = useState("");
+  const [ack, setAck] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const normalized = newName.trim().toLowerCase();
+  const canSubmit =
+    ack &&
+    !busy &&
+    looksLikeFQDN(normalized) &&
+    normalized !== domain.name.toLowerCase();
+
+  const close = () => {
+    setNewName("");
+    setAck(false);
+    onClose();
+  };
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setBusy(true);
+    try {
+      const resp = await apiClient.post<{ warnings?: string[] }>(
+        `/domains/${domain.id}/rename`,
+        { name: normalized },
+      );
+      feedback.message.success(`Renamed to ${normalized}`);
+      // Best-effort app-URL rewrites that did not complete (e.g. a WordPress
+      // site URL that must be updated by hand) come back as warnings.
+      (resp.data?.warnings ?? []).forEach((w) => feedback.message.warning(w));
+      close();
+      onRenamed?.();
+    } catch (err) {
+      feedback.message.error(
+        err instanceof Error ? err.message : "Could not rename the domain",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={`Rename ${domain.name}`}
+      okText="Rename domain"
+      okButtonProps={{ disabled: !canSubmit, loading: busy }}
+      onOk={submit}
+      onCancel={close}
+      destroyOnClose
+    >
+      <Alert
+        type="warning"
+        showIcon
+        style={{ marginBottom: 12 }}
+        message="Experimental feature"
+        description="Renaming a domain is new. If anything looks wrong afterwards, please file a bug report."
+      />
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 12 }}
+        message="WordPress site URL is updated automatically"
+        description="For a WordPress install, the site URL is rewritten to the new name automatically (via wp search-replace). Other apps' internal settings are not changed — update those in the app itself. If the automatic rewrite can't run, you'll see a warning to update it by hand."
+      />
+      <Typography.Paragraph style={{ marginBottom: 4 }}>
+        Renaming <Typography.Text code>{domain.name}</Typography.Text> will:
+      </Typography.Paragraph>
+      <ul style={{ margin: "0 0 12px", paddingLeft: 18 }}>
+        <li>Move the website files to the new domain's document root</li>
+        <li>Rebuild the web server (nginx) configuration for the new name</li>
+        <li>Reissue the SSL certificate for the new name</li>
+        <li>Recreate the managed DNS zone under the new name and remove the old one</li>
+        <li>Carry mail to the new name — mailboxes, stored messages, and DKIM move automatically</li>
+        <li>Rewrite a WordPress install's site URL to the new name (other apps unchanged)</li>
+      </ul>
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 4 }}>
+        Mail is carried to the new name automatically. Each mailbox keeps its
+        messages and password; after the rename, reconfigure mail clients to
+        use <Typography.Text code>mail.{normalized || "new-domain.com"}</Typography.Text> for
+        IMAP/SMTP. The per-domain mail certificate is reissued separately.
+      </Typography.Paragraph>
+      <Input
+        autoFocus
+        placeholder="new-domain.com"
+        value={newName}
+        onChange={(e) => setNewName(e.target.value)}
+        onPressEnter={submit}
+        style={{ marginBottom: 12 }}
+      />
+      <Checkbox checked={ack} onChange={(e) => setAck(e.target.checked)}>
+        I understand this is experimental. Mail is carried to the new name and
+        mail clients must be reconfigured to the new mail host. A WordPress
+        site URL is updated automatically; other apps' internal settings are not.
+      </Checkbox>
+    </Modal>
+  );
+}

--- a/panel-ui/src/components/domains/domainActions.test.tsx
+++ b/panel-ui/src/components/domains/domainActions.test.tsx
@@ -49,7 +49,7 @@ describe("buildDomainMenuItems — admin audience", () => {
 
   it("offers the admin item set and none of the tenant-only actions", () => {
     const k = keys(buildDomainMenuItems(row(), ctx({ audience: admin, caps: { dns_enabled: true } })));
-    expect(k).toEqual(["edit", "dns", "info", "redirects", "index", "settings", "caching", "chown", "toggle", "delete"]);
+    expect(k).toEqual(["edit", "dns", "info", "redirects", "index", "settings", "caching", "chown", "rename", "toggle", "delete"]);
     // tenant-only actions never appear on the admin list
     for (const t of ["directory-privacy", "nginx-options", "rewrite-rules", "document-root", "preview-url", "bot-challenge"]) {
       expect(k).not.toContain(t);
@@ -65,6 +65,19 @@ describe("buildDomainMenuItems — admin audience", () => {
   it("hides Delete for the System domain (is_panel_primary guard)", () => {
     const k = keys(buildDomainMenuItems(row({ is_panel_primary: true }), ctx({ audience: admin })));
     expect(k).not.toContain("delete");
+  });
+
+  it("offers Rename and opens the rename modal (GH #1579)", () => {
+    const onOpenModal = vi.fn();
+    const items = buildDomainMenuItems(row(), ctx({ audience: admin, onOpenModal }));
+    expect(keys(items)).toContain("rename");
+    byKey(items, "rename")?.onClick?.();
+    expect(onOpenModal).toHaveBeenCalledWith("d1", "rename");
+  });
+
+  it("hides Rename for the System domain (backend refuses panel_primary, GH #1579)", () => {
+    const k = keys(buildDomainMenuItems(row({ is_panel_primary: true }), ctx({ audience: admin })));
+    expect(k).not.toContain("rename");
   });
 
   it("Edit and DNS navigate to the admin route prefix", () => {

--- a/panel-ui/src/components/domains/domainActions.tsx
+++ b/panel-ui/src/components/domains/domainActions.tsx
@@ -33,7 +33,8 @@ export type DomainModalType =
   | "settings"
   | "info"
   | "caching"
-  | "chown";
+  | "chown"
+  | "rename";
 
 export type DomainMenuCaps =
   | {
@@ -146,6 +147,19 @@ export function buildDomainMenuItems(r: Domain, ctx: DomainMenuCtx): MenuProps["
         label: "Change owner",
         onClick: () => onOpenModal(r.id, "chown"),
       },
+      // GH #1579: in-place rename, the same modal the tenant Web Domain page
+      // uses. Admins may rename any domain (the API is owner-scoped: admin any).
+      // Hidden for the panel's own primary domain, which the backend refuses.
+      ...(r.is_panel_primary
+        ? []
+        : [
+            {
+              key: "rename",
+              icon: <EditOutlined />,
+              label: "Rename domain",
+              onClick: () => onOpenModal(r.id, "rename"),
+            },
+          ]),
       toggleItem,
       ...deleteItems,
     ];


### PR DESCRIPTION
Two follow-ups to the experimental in-place domain rename, from lxsdevcode's testing on #1579.

## 1. Rename failed on a server without the mail module

`RenameDomain` called the `mail.domain.rename` agent verb as a pre-check even when Stalwart mail was not installed. That verb reads the Stalwart admin token, so on a mail-less box it errored and failed the whole rename:

```json
{ "error": "unavailable",
  "message": "could not check mail before renaming \"test.com\": agent: internal: admin token: read /etc/jabali-panel/stalwart-admin.token: no such file or directory" }
```

**Fix.** Gate the mail carry (both the dry-run and the real call) on `ServerSettings.MailEnabled` — the same flag `middleware.ModuleMail` uses to gate every mail route — via a new optional `Settings` dependency on `userops.Deps`. **Fail-closed:** nil `Settings`, a settings read error, or `MailEnabled == true` all keep the verb in the flow, so a domain that actually has mail never renames without carrying it. Only a positive "mail module disabled" reading skips it. On a mail-less box the rename now completes with no Stalwart call.

## 2. Rename was missing from the Admin UI

The tenant Web Domain page had a **Rename domain** button; the admin domain inventory did not, even though the API is owner-scoped (an admin can rename any domain).

**Fix.** Extract the modal into a shared, controlled `RenameDomainDialog` (open/onClose). `RenameDomainButton` (tenant page) now wraps it, and the admin inventory's **Actions** menu gets a **Rename domain** entry that opens the identical modal and validation. Hidden for the panel's own primary domain, which the backend refuses.

## Tests

- `userops`: `TestRenameDomain_MailModuleDisabledSkipsMailCarry` (mail off → rename succeeds, verb never called even though it would error) and `TestRenameDomain_MailSettingsReadErrorFailsClosed` (settings read error → still fails closed). Existing fail-closed tests unchanged.
- `panel-ui`: `domainActions.test` gains rename-present / opens-modal / hidden-for-panel-primary cases; `RenameDomainButton.test` unchanged and green against the refactor.
- `go build`/`vet`/`test`, `tsc`, `vitest`, `eslint` all clean; rebased onto latest `origin/main` and re-run post-rebase.

## Test plan

- [ ] Rename a domain on a server with **no** mail module → succeeds, no mail error.
- [ ] Rename a domain **with** mailboxes (mail installed) → mail is still carried (unchanged).
- [ ] Admin domain list → Actions → **Rename domain** opens the same modal as the tenant page; renaming updates the list.
- [ ] Rename is absent for the panel's primary domain in Admin.

GH #1579
