### PR TITLE
fix(migrate): create web domains that have no source DNS zone (GH #1606)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_domains.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains.go
@@ -116,27 +116,40 @@ func ImportDomains(
 		// ERR_CERT_COMMON_NAME_INVALID on https://www.<domain>.
 		createWWW bool
 	}
+	// Build the create list from the UNION of the source's DNS zones and its web
+	// domains, deduped by name. GH #1606: ZoneFiles and DomainNames were an
+	// either/or — ZoneFiles when present, DomainNames only as a fallback when
+	// empty — so a web domain WITHOUT a matching source zone was silently dropped
+	// whenever the account had at least one zone. (Hestia's JAB-28 zone feeding
+	// made this bite: an account with some zoned domains lost every web-only
+	// domain, e.g. a subdomain served from the web with DNS hosted off-box.)
+	// Zone-derived entries come first because they carry createWWW from the
+	// source zone; a web-only domain has no zone to read, so it stays apex-only
+	// (createWWW=false), matching the old DomainNames-branch default.
 	var entries []domainEntry
-	if len(parsed.ZoneFiles) > 0 {
-		for _, zonePath := range parsed.ZoneFiles {
-			domainName := strings.TrimSuffix(filepath.Base(zonePath), ".db")
-			if domainName == "" {
-				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:empty_name_from_%s", zonePath))
-				continue
-			}
-			entries = append(entries, domainEntry{
-				name:      domainName,
-				docRoot:   docRootFor(domainName),
-				createWWW: zoneHasWWWRecord(zonePath, domainName),
-			})
+	seen := map[string]bool{}
+	for _, zonePath := range parsed.ZoneFiles {
+		domainName := strings.TrimSuffix(filepath.Base(zonePath), ".db")
+		if domainName == "" {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:empty_name_from_%s", zonePath))
+			continue
 		}
-	} else {
-		for _, name := range parsed.DomainNames {
-			if name == "" {
-				continue
-			}
-			entries = append(entries, domainEntry{name: name, docRoot: docRootFor(name)})
+		if seen[domainName] {
+			continue
 		}
+		seen[domainName] = true
+		entries = append(entries, domainEntry{
+			name:      domainName,
+			docRoot:   docRootFor(domainName),
+			createWWW: zoneHasWWWRecord(zonePath, domainName),
+		})
+	}
+	for _, name := range parsed.DomainNames {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		entries = append(entries, domainEntry{name: name, docRoot: docRootFor(name)})
 	}
 
 	for _, e := range entries {

--- a/panel-api/internal/migrate/cpanel/restore_domains_union_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains_union_test.go
@@ -1,0 +1,104 @@
+package cpanel
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// createRecordingAgent records the domain name of every domain.create it
+// receives, always succeeding, so ImportDomains reaches the row insert.
+type createRecordingAgent struct{ created []string }
+
+func (a *createRecordingAgent) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	if command == "domain.create" {
+		if m, ok := params.(map[string]any); ok {
+			if v, ok := m["domain"].(string); ok {
+				a.created = append(a.created, v)
+			}
+		}
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// newDomainRepo: nothing exists yet, every Create succeeds.
+type newDomainRepo struct{ repository.DomainRepository }
+
+func (newDomainRepo) FindByName(context.Context, string) (*models.Domain, error) {
+	return nil, repository.ErrNotFound
+}
+func (newDomainRepo) Create(context.Context, *models.Domain) error { return nil }
+
+// GH #1606: a web domain WITHOUT a source DNS zone must still be created. The
+// bug: ImportDomains iterated ZoneFiles OR DomainNames (DomainNames only as a
+// fallback when ZoneFiles was empty), so any web-only domain was dropped once
+// the account had at least one zone — johnnyq's Hestia user had zoned domains
+// plus web-only subdomains whose DNS was hosted off-box, and the latter never
+// migrated. The fix creates the UNION of both.
+func TestImportDomains_UnionOfZonesAndWebDomains(t *testing.T) {
+	dir := t.TempDir()
+	// One source zone (a domain with DNS configured on the source box)…
+	zoned := filepath.Join(dir, "domain.org.db")
+	if err := os.WriteFile(zoned, []byte("@ IN SOA ns admin ( 1 2 3 4 5 )\n@ IN A 192.0.2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ag := &createRecordingAgent{}
+	parsed := &ParsedTarball{
+		ExtractDir: dir,
+		SourceUser: "alice",
+		ZoneFiles:  []string{zoned},
+		// …plus a web-only domain (no zone on the source) — must still migrate.
+		DomainNames: []string{"sub.domain.co.uk"},
+	}
+
+	res, err := ImportDomains(context.Background(), newDomainRepo{}, ag,
+		parsed, "01USERULID0000000000000000", "alice")
+	if err != nil {
+		t.Fatalf("ImportDomains hard error: %v", err)
+	}
+
+	sort.Strings(ag.created)
+	got := ag.created
+	want := []string{"domain.org", "sub.domain.co.uk"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("domain.create for %v, want %v (web-only domain must not be dropped)", ag.created, want)
+	}
+	if res.Created != 2 {
+		t.Fatalf("res.Created = %d, want 2", res.Created)
+	}
+}
+
+// A domain present in BOTH the zone list and the web list is created once, not
+// twice (the union dedupes by name).
+func TestImportDomains_UnionDedupes(t *testing.T) {
+	dir := t.TempDir()
+	zoned := filepath.Join(dir, "example.com.db")
+	if err := os.WriteFile(zoned, []byte("@ IN SOA ns admin ( 1 2 3 4 5 )\n@ IN A 192.0.2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ag := &createRecordingAgent{}
+	parsed := &ParsedTarball{
+		ExtractDir:  dir,
+		SourceUser:  "bob",
+		ZoneFiles:   []string{zoned},
+		DomainNames: []string{"example.com"},
+	}
+
+	res, err := ImportDomains(context.Background(), newDomainRepo{}, ag,
+		parsed, "01USERULID0000000000000000", "bob")
+	if err != nil {
+		t.Fatalf("ImportDomains hard error: %v", err)
+	}
+	if len(ag.created) != 1 || ag.created[0] != "example.com" {
+		t.Fatalf("domain.create = %v, want exactly [example.com]", ag.created)
+	}
+	if res.Created != 1 {
+		t.Fatalf("res.Created = %d, want 1", res.Created)
+	}
+}


### PR DESCRIPTION
## Problem

During a Hestia → Jabali migration, web domains that had **no DNS zone on the source** were not migrated. johnnyq saw two `sub.domain.co.uk` domains skipped while `sub.domain.org` migrated; the difference turned out to be **zone presence, not the TLD** — the `.co.uk` sites had Web Domains but no DNS Zone in Hestia (DNS hosted off-box).

## Root cause

`cpanel.ImportDomains` — the shared domain-creation writer for **every** importer (cPanel, Hestia, DirectAdmin, Plesk, CloudPanel, CyberPanel) — built its create list as an either/or:

```go
if len(parsed.ZoneFiles) > 0 {
    // iterate ZoneFiles only
} else {
    // iterate DomainNames only (fallback)
}
```

So `DomainNames` (the web-domain list) was used **only when there were no zones at all**. Once the account had a single DNS zone, the writer iterated zones exclusively and every web domain without a matching zone was dropped.

This was latent until Hestia's JAB-28 change started feeding `dns/<dom>/conf/<dom>.db` into `ZoneFiles`. `migrate_run_cmd.go` populates **both** `ZoneFiles` (zoned domains) and `DomainNames` (all web dirs) for Hestia — so a user with any zoned domain silently lost their web-only domains. The stale comment in that adapter ("no BIND zones in Hestia tarball") captures the assumption that broke.

## Fix

Build the create list from the **union** of `ZoneFiles` and `DomainNames`, deduped by name. Zone-derived entries keep their source-zone `createWWW`; a web-only domain has no zone to read and stays apex-only (`createWWW=false`), exactly the prior `DomainNames`-branch default. Purely additive — no domain that used to be created stops being created, and a name in both lists is created once.

## Tests

- `TestImportDomains_UnionOfZonesAndWebDomains` — one zoned domain + one web-only domain → **both** get `domain.create` (the web-only one no longer dropped).
- `TestImportDomains_UnionDedupes` — a name in both lists is created once.
- Full `./panel-api/internal/migrate/...` suite green (cpanel, hestiacp, directadmin, plesk, cloudpanel, cyberpanel, …) — no regressions.

## Test plan

- [ ] Hestia user with a mix of zoned domains and web-only domains → all web domains migrate.
- [ ] cPanel/DA migration unchanged (zoned domains still created, www SAN preserved).
- [ ] A domain present as both a zone and a web dir is created once.

GH #1606
