### PR TITLE
feat(domains): facet-preserving Web Domain delete — backend (GH #1603)

### DIFF
--- a/panel-agent/internal/commands/domain_web_teardown.go
+++ b/panel-agent/internal/commands/domain_web_teardown.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// domain.web_teardown removes ONLY the WEB facet of a domain — the nginx web
+// vhost (sites-available + sites-enabled) and the web TLS lineage — while
+// leaving the MAIL facet (the per-domain mail vhost, its relay credential, the
+// mail.<domain> certificate) and the DNS zone intact (GH #1603, johnnyq).
+//
+// It is the primitive the panel uses for a facet-preserving delete: "delete the
+// Web Domain, keep the Mail Domain and/or DNS Zone". Neither of the existing
+// verbs fits — domain.disable only unlinks the enabled symlink (a reversible
+// pause), and domain.delete reaps the mail vhost, the relay cred, and BOTH the
+// web AND mail cert lineages (a full teardown). This one is scoped strictly to
+// the web parts.
+//
+// Idempotent: a missing file is a no-op, so a retry after a mid-run failure
+// converges. The domain row survives web-off; the reconciler already skips the
+// web render for a WebDisabled row, so it never re-creates what this removed.
+type domainWebTeardownParams struct {
+	Domain string `json:"domain"`
+}
+
+type domainWebTeardownResponse struct {
+	Domain   string `json:"domain"`
+	TornDown bool   `json:"torn_down"`
+}
+
+func domainWebTeardownHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p domainWebTeardownParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	if !domainRegex.MatchString(p.Domain) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid domain %q: must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$", p.Domain),
+		}
+	}
+
+	// JAB-71: serialize the unlink→reload against every other nginx op.
+	nginxOpMu.Lock()
+	defer nginxOpMu.Unlock()
+
+	// Remove the WEB vhost only (sites-enabled symlink + sites-available conf).
+	// The per-domain MAIL vhost (<domain>-mail.conf) is deliberately left alone —
+	// that is the difference from domain.delete.
+	os.Remove(filepath.Join("/etc/nginx/sites-enabled", p.Domain+".conf"))
+	os.Remove(filepath.Join("/etc/nginx/sites-available", p.Domain+".conf"))
+
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
+	var reloadOutput bytes.Buffer
+	reloadCmd.Stdout = &reloadOutput
+	reloadCmd.Stderr = &reloadOutput
+	if err := reloadCmd.Run(); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("systemctl reload nginx failed: %s", reloadOutput.String()),
+		}
+	}
+
+	// #432: reap the per-domain nginx WEB logs (current + rotated).
+	for _, suffix := range []string{"-access.log", "-error.log"} {
+		matches, _ := filepath.Glob("/var/log/nginx/" + p.Domain + suffix + "*")
+		for _, m := range matches {
+			_ = os.Remove(m)
+		}
+	}
+
+	// Remove the WEB TLS artifacts for the exact name only — the self-signed dir
+	// and the web certbot/LE lineage. The mail.<domain> lineage is NOT touched
+	// (removeDomainCertArtifacts reaps both; here we keep mail). Best-effort +
+	// name-scoped (domainRegex-validated), so a shared/wildcard cert is untouched.
+	_ = os.RemoveAll(filepath.Join(baseSelfSignDir, p.Domain))
+	cleanupCertbotLineage(ctx, sslLERoot, p.Domain)
+
+	return domainWebTeardownResponse{Domain: p.Domain, TornDown: true}, nil
+}
+
+func init() {
+	Default.Register("domain.web_teardown", domainWebTeardownHandler)
+}

--- a/panel-agent/internal/commands/domain_web_teardown_test.go
+++ b/panel-agent/internal/commands/domain_web_teardown_test.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+func TestDomainWebTeardown_InvalidDomain(t *testing.T) {
+	t.Parallel()
+	for _, d := range []string{"Example.COM", "-example.com", "example-.com", "localhost", "example", ""} {
+		params, _ := json.Marshal(domainWebTeardownParams{Domain: d})
+		_, err := domainWebTeardownHandler(context.Background(), params)
+		require.NotNil(t, err, "domain %q must be rejected", d)
+		var aerr *agentwire.AgentError
+		require.ErrorAs(t, err, &aerr)
+		assert.Equal(t, agentwire.CodeInvalidArgument, aerr.Code)
+	}
+}
+
+// The web teardown removes the WEB TLS material for the exact name while leaving
+// the mail.<domain> lineage intact — that facet separation is the whole point of
+// GH #1603 (delete the Web Domain, keep the Mail Domain). Assert on the
+// self-signed dirs, which are removed by a deterministic os.RemoveAll (the
+// certbot lineage path depends on certbot being on PATH, so it is not asserted).
+func TestDomainWebTeardown_RemovesWebCertKeepsMail(t *testing.T) {
+	selfDir := t.TempDir()
+	leRoot := t.TempDir()
+	prevSelf, prevLE := baseSelfSignDir, sslLERoot
+	baseSelfSignDir, sslLERoot = selfDir, leRoot
+	t.Cleanup(func() { baseSelfSignDir, sslLERoot = prevSelf, prevLE })
+
+	const dom = "example.com"
+	webCert := filepath.Join(selfDir, dom)
+	mailCert := filepath.Join(selfDir, "mail."+dom)
+	require.NoError(t, os.MkdirAll(webCert, 0o755))
+	require.NoError(t, os.MkdirAll(mailCert, 0o755))
+
+	params, _ := json.Marshal(domainWebTeardownParams{Domain: dom})
+	out, err := domainWebTeardownHandler(context.Background(), params)
+	require.NoError(t, err)
+	resp, ok := out.(domainWebTeardownResponse)
+	require.True(t, ok)
+	assert.True(t, resp.TornDown)
+	assert.Equal(t, dom, resp.Domain)
+
+	assert.NoDirExists(t, webCert, "web self-signed cert must be removed")
+	assert.DirExists(t, mailCert, "mail self-signed cert must be KEPT (facet-preserving)")
+}

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -260,6 +260,24 @@ func (m *mockDomainRepo) UpdateDNSSECEnabled(ctx context.Context, id string, ena
 	return nil
 }
 
+func (m *mockDomainRepo) UpdateWebDisabled(ctx context.Context, id string, disabled bool) error {
+	d, ok := m.domains[id]
+	if !ok {
+		return repository.ErrNotFound
+	}
+	d.WebDisabled = disabled
+	return nil
+}
+
+func (m *mockDomainRepo) UpdateDNSDisabled(ctx context.Context, id string, disabled bool) error {
+	d, ok := m.domains[id]
+	if !ok {
+		return repository.ErrNotFound
+	}
+	d.DNSDisabled = disabled
+	return nil
+}
+
 func (m *mockDomainRepo) UpdateGhostState(ctx context.Context, id, state string, checkedAt time.Time, detail *string) error {
 	d, ok := m.domains[id]
 	if !ok {
@@ -1293,6 +1311,7 @@ func (r *mockDomainRepo) RewriteDocRootPrefix(context.Context, string, string, s
 }
 func (r *mockDomainRepo) TransferOwner(context.Context, string, string, string) error { return nil }
 
-
 // ListByZoneIDs added for the JAB-374 batch interface method.
-func (m *mockDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }
+func (m *mockDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) {
+	return nil, nil
+}

--- a/panel-api/internal/api/domain_facet_delete.go
+++ b/panel-api/internal/api/domain_facet_delete.go
@@ -1,0 +1,119 @@
+// Facet-preserving Web Domain delete (GH #1603, johnnyq).
+//
+// A jabali "domain" is one row carrying web + mail + DNS facets. Deleting the
+// row (userops.DeleteDomain) tears down all three. This path lets the operator
+// delete the WEB facet while KEEPING the Mail Domain and/or the DNS Zone: the
+// row survives (web-off), so mail keeps delivering and/or the zone keeps
+// answering. The delete handler routes here whenever at least one facet is kept;
+// when both are also being deleted it falls through to the full row delete.
+package api
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// facetPreservingWebDelete removes the WEB facet of dom while keeping the row,
+// then conditionally tears down the mail and/or DNS facets. Ordering is chosen
+// so a mid-run failure is safe and re-runnable:
+//
+//  1. flip web_disabled=true FIRST so the reconciler stops rendering the web
+//     vhost (otherwise it would re-create what step 2 removes);
+//  2. agent domain.web_teardown removes the existing web vhost + web cert while
+//     leaving the mail vhost / mail cert intact;
+//  3. if deleteMail, run the shared mail teardown (GH #1387 core) — its
+//     purge_accounts hard gate is the only step that returns a hard error;
+//  4. if deleteDNS, flip dns_disabled=true and delete the PowerDNS zone;
+//  5. if deleteFiles, remove the docroot as the tenant uid (async, best-effort).
+//
+// hardErr is set only for a failure that leaves the operation genuinely
+// incomplete and worth surfacing (500); every idempotent step is re-runnable, so
+// retrying the same delete converges. Non-fatal residue comes back in warnings.
+func (h *domainHandler) facetPreservingWebDelete(
+	ctx context.Context,
+	dom *models.Domain,
+	deleteMail, deleteDNS, deleteFiles bool,
+) (warnings []string, hardErr error) {
+	// The teardown must complete regardless of the client hanging up.
+	ctx = context.WithoutCancel(ctx)
+
+	// 1. web_disabled=true BEFORE the host teardown so the reconciler does not
+	//    re-render the vhost we are about to remove.
+	if err := h.cfg.Domains.UpdateWebDisabled(ctx, dom.ID, true); err != nil {
+		return nil, err
+	}
+
+	// 2. Remove the web vhost + web cert (keeps mail). Idempotent; on failure the
+	//    flag is already set, so the reconciler won't fight a retry.
+	wctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	_, werr := h.cfg.Agent.Call(wctx, "domain.web_teardown", map[string]string{"domain": dom.Name})
+	cancel()
+	if werr != nil {
+		return nil, werr
+	}
+
+	// 3. Delete the Mail Domain (optional) — the shared GH #1387 mail teardown.
+	if deleteMail {
+		_, mailWarnings, mErr := purgeDomainMailService(ctx, DomainMailPurgeHandlerConfig{
+			Domains:        h.cfg.Domains,
+			Mailboxes:      h.cfg.Mailboxes,
+			MailCerts:      h.cfg.MailCerts,
+			Agent:          h.cfg.Agent,
+			DNSZones:       h.cfg.DNSZones,
+			DNSRecords:     h.cfg.DNSRecords,
+			ServerSettings: h.cfg.ServerSettings,
+		}, dom)
+		if mErr != nil {
+			return warnings, mErr
+		}
+		warnings = append(warnings, mailWarnings...)
+	}
+
+	// 4. Delete the DNS Zone (optional) — flip dns_disabled so the reconciler
+	//    stops pushing the zone, then delete the PowerDNS zone. A box without the
+	//    DNS module has no PowerDNS backend; that is permanent, not a failure.
+	if deleteDNS {
+		if err := h.cfg.Domains.UpdateDNSDisabled(ctx, dom.ID, true); err != nil {
+			warnings = append(warnings, "DNS management flag not cleared in the database")
+		}
+		zctx, zcancel := context.WithTimeout(ctx, 30*time.Second)
+		_, zerr := h.cfg.Agent.Call(zctx, "dns.zone.delete", map[string]string{"zone": dom.Name})
+		zcancel()
+		if zerr != nil && !strings.Contains(zerr.Error(), "powerdns backend not available") {
+			warnings = append(warnings, "DNS zone not removed; remove it manually if it lingers")
+		}
+	}
+
+	// 5. Delete the files (optional) — same async, tenant-uid removal the full
+	//    delete uses (GH #1382). Best-effort; on failure the files simply remain.
+	if deleteFiles && dom.DocRoot != "" {
+		if owner, uerr := h.cfg.Users.FindByID(ctx, dom.UserID); uerr == nil &&
+			owner != nil && owner.Username != nil && *owner.Username != "" {
+			username, dname := *owner.Username, dom.Name
+			target := domainDeleteFilesTarget(username, dname, dom.DocRoot)
+			ag := h.cfg.Agent
+			go func() {
+				dctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer cancel()
+				if _, aerr := ag.Call(dctx, "domain.docroot.delete", map[string]string{
+					"username": username,
+					"docroot":  target,
+				}); aerr != nil {
+					slog.Warn("web-domain facet delete: docroot cleanup failed; files left in place",
+						"domain", dname, "error", aerr)
+				}
+			}()
+		}
+	}
+
+	// The row survives web-off; nudge the reconciler so the now mail-only / DNS-
+	// only shape converges promptly.
+	if h.cfg.Reconciler != nil {
+		h.cfg.Reconciler.Schedule(dom.ID)
+	}
+	return warnings, nil
+}

--- a/panel-api/internal/api/domain_facet_delete_test.go
+++ b/panel-api/internal/api/domain_facet_delete_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #1603: deleting a Web Domain can keep the Mail Domain and/or DNS Zone,
+// because all three are facets of one row. The facet-preserving path tears down
+// only the web facet (domain.web_teardown + web_disabled=true) and keeps the
+// row, running the mail purge / DNS-zone delete only for the facets the caller
+// chose to also delete. Reuses the mail-purge test harness (mpAgent,
+// mpMailboxRepo, newMockDomainRepo).
+
+func facetDom() *models.Domain {
+	return &models.Domain{
+		ID: "d1", UserID: "u1", Name: "foo.test",
+		EmailEnabled: true,
+		DocRoot:      "/home/u1/domains/foo.test/public_html",
+	}
+}
+
+func TestFacetDelete_KeepMailKeepDNS(t *testing.T) {
+	dr := newMockDomainRepo()
+	dom := facetDom()
+	_ = dr.Create(context.Background(), dom)
+	ag := &mpAgent{}
+	h := &domainHandler{cfg: DomainHandlerConfig{Domains: dr, Agent: ag}}
+
+	// keep mail, keep dns → only the web facet is torn down.
+	_, err := h.facetPreservingWebDelete(context.Background(), dom, false, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ag.has("domain.web_teardown") {
+		t.Fatalf("web teardown must run; calls=%v", ag.calls)
+	}
+	if ag.has("mail.domain.purge_accounts") {
+		t.Fatalf("mail must be KEPT — purge_accounts must not run; calls=%v", ag.calls)
+	}
+	if ag.has("dns.zone.delete") {
+		t.Fatalf("DNS must be KEPT — dns.zone.delete must not run; calls=%v", ag.calls)
+	}
+	got, _ := dr.FindByID(context.Background(), "d1")
+	if !got.WebDisabled {
+		t.Fatalf("web_disabled must be set")
+	}
+	if !got.EmailEnabled {
+		t.Fatalf("email must stay enabled (mail kept)")
+	}
+	if got.DNSDisabled {
+		t.Fatalf("dns must stay managed (DNS kept)")
+	}
+}
+
+func TestFacetDelete_DeleteMailKeepDNS(t *testing.T) {
+	dr := newMockDomainRepo()
+	dom := facetDom()
+	_ = dr.Create(context.Background(), dom)
+	mb := &mpMailboxRepo{byDomain: map[string][]models.Mailbox{
+		"d1": {{ID: "mb1", LocalPart: "alice"}},
+	}}
+	ag := &mpAgent{}
+	h := &domainHandler{cfg: DomainHandlerConfig{Domains: dr, Mailboxes: mb, Agent: ag}}
+
+	_, err := h.facetPreservingWebDelete(context.Background(), dom, true, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ag.has("domain.web_teardown") || !ag.has("mail.domain.purge_accounts") {
+		t.Fatalf("web teardown + mail purge must both run; calls=%v", ag.calls)
+	}
+	// The web facet must come down before the mail purge (the purge de-registers
+	// the domain in Stalwart; ordering mirrors the shared teardown).
+	if ag.indexOf("domain.web_teardown") > ag.indexOf("mail.domain.purge_accounts") {
+		t.Fatalf("web_teardown must precede purge_accounts; calls=%v", ag.calls)
+	}
+	if ag.has("dns.zone.delete") {
+		t.Fatalf("DNS kept — dns.zone.delete must not run; calls=%v", ag.calls)
+	}
+	if len(mb.deleted) != 1 || mb.deleted[0] != "mb1" {
+		t.Fatalf("mailbox row must be deleted; got %v", mb.deleted)
+	}
+	got, _ := dr.FindByID(context.Background(), "d1")
+	if !got.WebDisabled || got.EmailEnabled || got.DNSDisabled {
+		t.Fatalf("want web_disabled + email off + dns kept; got web=%v email=%v dnsDisabled=%v",
+			got.WebDisabled, got.EmailEnabled, got.DNSDisabled)
+	}
+}
+
+func TestFacetDelete_KeepMailDeleteDNS(t *testing.T) {
+	dr := newMockDomainRepo()
+	dom := facetDom()
+	_ = dr.Create(context.Background(), dom)
+	ag := &mpAgent{}
+	h := &domainHandler{cfg: DomainHandlerConfig{Domains: dr, Agent: ag}}
+
+	_, err := h.facetPreservingWebDelete(context.Background(), dom, false, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ag.has("domain.web_teardown") || !ag.has("dns.zone.delete") {
+		t.Fatalf("web teardown + dns zone delete must both run; calls=%v", ag.calls)
+	}
+	if ag.has("mail.domain.purge_accounts") {
+		t.Fatalf("mail kept — purge_accounts must not run; calls=%v", ag.calls)
+	}
+	got, _ := dr.FindByID(context.Background(), "d1")
+	if !got.WebDisabled || !got.DNSDisabled || !got.EmailEnabled {
+		t.Fatalf("want web_disabled + dns_disabled + email kept; got web=%v dns=%v email=%v",
+			got.WebDisabled, got.DNSDisabled, got.EmailEnabled)
+	}
+}
+
+// A web_teardown failure is a hard error and nothing downstream (the mail purge)
+// runs — the caller retries the idempotent op.
+func TestFacetDelete_WebTeardownFailureStopsBeforeMail(t *testing.T) {
+	dr := newMockDomainRepo()
+	dom := facetDom()
+	_ = dr.Create(context.Background(), dom)
+	ag := &mpAgent{failCmd: "domain.web_teardown"}
+	h := &domainHandler{cfg: DomainHandlerConfig{Domains: dr, Agent: ag}}
+
+	_, err := h.facetPreservingWebDelete(context.Background(), dom, true, false, false)
+	if err == nil {
+		t.Fatalf("expected a hard error when web_teardown fails")
+	}
+	if ag.has("mail.domain.purge_accounts") {
+		t.Fatalf("mail purge must not run after web_teardown fails; calls=%v", ag.calls)
+	}
+}

--- a/panel-api/internal/api/domain_mail_purge.go
+++ b/panel-api/internal/api/domain_mail_purge.go
@@ -111,6 +111,32 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 		return
 	}
 
+	deleted, warnings, hardErr := purgeDomainMailService(ctx, h.cfg, dom)
+	if hardErr != nil {
+		respondAgentErr(c, "purge_accounts_failed", hardErr)
+		return
+	}
+
+	c.JSON(http.StatusOK, domainMailPurgeResponse{
+		DomainID:         dom.ID,
+		DomainName:       dom.Name,
+		MailboxesDeleted: deleted,
+		Warnings:         warnings,
+	})
+}
+
+// purgeDomainMailService tears down the MAIL facet of a domain while keeping the
+// domain row (its web + DNS). It is the shared core of the mail-only-delete
+// endpoint (GH #1387) AND the facet-preserving Web Domain delete (GH #1603), so
+// both run the exact same ordered teardown.
+//
+// hardErr is set ONLY when the purge_accounts HARD GATE fails — at that point
+// nothing DB-side has been touched, so the caller must surface it (502/idempotent
+// retry). Every later step is best-effort and comes back as a warning; the
+// reconcilers re-converge on residue. deleted is the count of user mailbox rows
+// removed. The caller must ensure the domain is still registered in Stalwart
+// (purge_accounts is the gate that runs while it is).
+func purgeDomainMailService(ctx context.Context, cfg DomainMailPurgeHandlerConfig, dom *models.Domain) (deleted int, warnings []string, hardErr error) {
 	// Once we start the teardown it must run to completion regardless of the
 	// client hanging up: purge_accounts destroys Stalwart accounts, and a
 	// cancelled ctx aborting steps 2–6 would leave email_enabled=1, half-deleted
@@ -118,18 +144,15 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 	// from request cancellation (per-step timeouts below still bound it).
 	ctx = context.WithoutCancel(ctx)
 
-	var warnings []string
-
 	// 1. HARD GATE — destroy every Stalwart account under the domain, BY DOMAIN
 	//    (catches orphaned accounts a row-driven loop would miss), while the
 	//    domain is still registered in Stalwart. On failure nothing DB-side has
-	//    been touched: return 502 and let the operator retry (it is idempotent).
+	//    been touched: return the error and let the operator retry (idempotent).
 	pctx, cancel := context.WithTimeout(ctx, domainMailPurgeAgentTimeout)
-	_, perr := h.cfg.Agent.Call(pctx, "mail.domain.purge_accounts", map[string]any{"domain": dom.Name})
+	_, perr := cfg.Agent.Call(pctx, "mail.domain.purge_accounts", map[string]any{"domain": dom.Name})
 	cancel()
 	if perr != nil {
-		respondAgentErr(c, "purge_accounts_failed", perr)
-		return
+		return 0, nil, perr
 	}
 
 	// 2. Delete the USER mailbox rows. The domain row STAYS (web domain kept), so
@@ -139,14 +162,13 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 	//    infra ensured per-domain regardless of email_enabled by the sendmail-
 	//    cred reconciler, which re-converges its Stalwart account on its next
 	//    tick — deleting the row here would only churn it back.
-	deleted := 0
-	if h.cfg.Mailboxes != nil {
-		rows, _, lerr := h.cfg.Mailboxes.ListByDomainID(ctx, dom.ID, repository.ListOptions{ExcludeSystem: true})
+	if cfg.Mailboxes != nil {
+		rows, _, lerr := cfg.Mailboxes.ListByDomainID(ctx, dom.ID, repository.ListOptions{ExcludeSystem: true})
 		if lerr != nil {
 			warnings = append(warnings, "could not enumerate mailboxes for row cleanup")
 		}
 		for i := range rows {
-			if derr := h.cfg.Mailboxes.Delete(ctx, rows[i].ID); derr != nil {
+			if derr := cfg.Mailboxes.Delete(ctx, rows[i].ID); derr != nil {
 				warnings = append(warnings, "mailbox row "+rows[i].LocalPart+" not removed")
 				continue
 			}
@@ -158,7 +180,7 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 	//    teardown is best-effort (the reconciler re-converges), but the flag is
 	//    always cleared — the accounts are gone, so the domain no longer has mail.
 	dctx, cancel2 := context.WithTimeout(ctx, domainEmailAgentTimeout)
-	_, derr := h.cfg.Agent.Call(dctx, "domain.email_disable", map[string]any{
+	_, derr := cfg.Agent.Call(dctx, "domain.email_disable", map[string]any{
 		"domain_id":   dom.ID,
 		"domain_name": dom.Name,
 	})
@@ -166,7 +188,7 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 	if derr != nil {
 		warnings = append(warnings, "Stalwart domain de-registration reported an error; the reconciler will retry")
 	}
-	if uerr := h.cfg.Domains.UpdateEmailState(ctx, dom.ID, repository.DomainEmailState{
+	if uerr := cfg.Domains.UpdateEmailState(ctx, dom.ID, repository.DomainEmailState{
 		Enabled:        false,
 		EmailEnabledAt: nil,
 	}); uerr != nil {
@@ -178,18 +200,18 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 	// domain that no longer has mail. Clear the flag; the MTA-STS reconciler's
 	// disable branch (!enabled && applied_id != 0) tears the policy + DNS down.
 	if dom.MTASTSEnabled {
-		if _, mErr := h.cfg.Domains.UpdateMTASTSEnabled(ctx, dom.ID, false); mErr != nil {
+		if _, mErr := cfg.Domains.UpdateMTASTSEnabled(ctx, dom.ID, false); mErr != nil {
 			warnings = append(warnings, "MTA-STS not disabled; turn it off manually if it lingers")
 		}
 	}
 
 	// 4. Remove the managed mail DNS (M6 set + mail-specific bootstrap rows).
-	warnings = append(warnings, purgeMailDNS(ctx, h.cfg.DNSZones, h.cfg.DNSRecords, h.cfg.ServerSettings, dom.ID)...)
+	warnings = append(warnings, purgeMailDNS(ctx, cfg.DNSZones, cfg.DNSRecords, cfg.ServerSettings, dom.ID)...)
 
 	// 5. Remove the per-domain mail vhost so nginx stops referencing the mail
 	//    lineage BEFORE its files are deleted (cert/vhost delete-parity, #754).
 	vctx, cancel3 := context.WithTimeout(ctx, domainEmailAgentTimeout)
-	_, verr := h.cfg.Agent.Call(vctx, "webmail.vhost_remove", map[string]any{"domain_name": dom.Name})
+	_, verr := cfg.Agent.Call(vctx, "webmail.vhost_remove", map[string]any{"domain_name": dom.Name})
 	cancel3()
 	if verr != nil {
 		warnings = append(warnings, "mail vhost not removed; remove it manually if it lingers")
@@ -197,11 +219,11 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 
 	// 6. Delete the mail TLS lineage (auto-renewing on disk) + its DB row. Skips
 	//    cleanly when the domain never opted into a mail cert.
-	if h.cfg.MailCerts != nil {
-		row, cerr := h.cfg.MailCerts.GetByDomain(ctx, dom.ID)
+	if cfg.MailCerts != nil {
+		row, cerr := cfg.MailCerts.GetByDomain(ctx, dom.ID)
 		if cerr == nil && row != nil {
 			sctx, cancel4 := context.WithTimeout(ctx, domainEmailAgentTimeout)
-			_, serr := h.cfg.Agent.Call(sctx, "ssl.mail.delete", map[string]any{
+			_, serr := cfg.Agent.Call(sctx, "ssl.mail.delete", map[string]any{
 				"domain":       dom.Name,
 				"lineage_path": row.LineagePath,
 			})
@@ -209,18 +231,13 @@ func (h *domainMailPurgeHandler) purge(c *gin.Context) {
 			if serr != nil {
 				warnings = append(warnings, "mail certificate files not removed on disk; delete the lineage manually")
 			}
-			if delErr := h.cfg.MailCerts.Delete(ctx, row.ID); delErr != nil {
+			if delErr := cfg.MailCerts.Delete(ctx, row.ID); delErr != nil {
 				warnings = append(warnings, "mail certificate record not removed")
 			}
 		}
 	}
 
-	c.JSON(http.StatusOK, domainMailPurgeResponse{
-		DomainID:         dom.ID,
-		DomainName:       dom.Name,
-		MailboxesDeleted: deleted,
-		Warnings:         warnings,
-	})
+	return deleted, warnings, nil
 }
 
 // purgeMailDNS removes the managed mail records for a domain: the M6 set

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -43,6 +43,10 @@ type DomainHandlerConfig struct {
 	// the rename, but its lineage still covers mail.<old>). Optional — a panel
 	// without per-domain mail TLS simply skips that heal.
 	MailCerts repository.MailCertificateRepository
+	// Mailboxes lets the GH #1603 facet-preserving delete purge a domain's
+	// mailbox rows when the caller opts to also delete the Mail Domain. Optional —
+	// nil skips the row cleanup (Stalwart accounts are purged regardless).
+	Mailboxes repository.MailboxRepository
 	// FtpAccounts lets the GH #1579 rename refuse when an FTP/SFTP subaccount is
 	// homed at or under the docroot being moved — its jail/chroot is not moved
 	// automatically. Optional — nil skips the check (the rename proceeds).
@@ -1359,6 +1363,35 @@ func (h *domainHandler) delete(c *gin.Context) {
 	}
 	if !claims.IsAdmin && domain.UserID != claims.UserID {
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	// GH #1603 facet-preserving delete: mail + DNS are facets of this one row, so
+	// "delete the Web Domain, keep the Mail Domain / DNS Zone" cannot delete the
+	// row. When the caller opts to keep at least one facet (delete_mail=false
+	// and/or delete_dns=false, defaults true), tear down only the web facet and
+	// KEEP the row (web-off). A facet the domain doesn't have is a no-op.
+	deleteFiles := c.Query("delete_files") == "true"
+	hasMail := domain.EmailEnabled
+	hasDNS := !domain.DNSDisabled
+	deleteMail := c.Query("delete_mail") != "false"
+	deleteDNS := c.Query("delete_dns") != "false"
+	if (hasMail && !deleteMail) || (hasDNS && !deleteDNS) {
+		// The panel's own primary domain is never facet-deleted (its web is the
+		// panel). Mirror the full-delete row-layer protection.
+		if domain.IsPanelPrimary {
+			c.JSON(http.StatusForbidden, gin.H{"error": "panel_primary_protected"})
+			return
+		}
+		warnings, ferr := h.facetPreservingWebDelete(ctx, domain, hasMail && deleteMail, hasDNS && deleteDNS, deleteFiles)
+		if ferr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"kept":     gin.H{"mail": hasMail && !deleteMail, "dns": hasDNS && !deleteDNS},
+			"warnings": warnings,
+		})
 		return
 	}
 

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -299,6 +299,16 @@ func (m *MockDomainRepository) UpdateDNSSECEnabled(ctx context.Context, id strin
 	return args.Error(0)
 }
 
+func (m *MockDomainRepository) UpdateWebDisabled(ctx context.Context, id string, disabled bool) error {
+	args := m.Called(ctx, id, disabled)
+	return args.Error(0)
+}
+
+func (m *MockDomainRepository) UpdateDNSDisabled(ctx context.Context, id string, disabled bool) error {
+	args := m.Called(ctx, id, disabled)
+	return args.Error(0)
+}
+
 func (m *MockDomainRepository) UpdateGhostState(ctx context.Context, id, state string, checkedAt time.Time, detail *string) error {
 	args := m.Called(ctx, id, state, checkedAt, detail)
 	return args.Error(0)

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -707,6 +707,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				SharedCerts:     deps.SharedCerts,
 				// GH #1579 rename: re-queues the per-domain mail cert for mail.<new>.
 				MailCerts: deps.MailCerts,
+				// GH #1603 facet-preserving delete: purge mailbox rows when the
+				// caller opts to also delete the Mail Domain.
+				Mailboxes: deps.Mailboxes,
 				// GH #1579 rename: refuses when an FTP/SFTP subaccount is homed
 				// under the docroot being moved (its jail/chroot is not moved).
 				FtpAccounts: deps.FtpAccounts,

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -336,6 +336,24 @@ func (f *fakeDomainRepo) UpdateDNSSECEnabled(ctx context.Context, id string, ena
 	return nil
 }
 
+func (f *fakeDomainRepo) UpdateWebDisabled(ctx context.Context, id string, disabled bool) error {
+	d, ok := f.domains[id]
+	if !ok {
+		return &notFoundErr{}
+	}
+	d.WebDisabled = disabled
+	return nil
+}
+
+func (f *fakeDomainRepo) UpdateDNSDisabled(ctx context.Context, id string, disabled bool) error {
+	d, ok := f.domains[id]
+	if !ok {
+		return &notFoundErr{}
+	}
+	d.DNSDisabled = disabled
+	return nil
+}
+
 func (f *fakeDomainRepo) UpdateGhostState(ctx context.Context, id, state string, checkedAt time.Time, detail *string) error {
 	d, ok := f.domains[id]
 	if !ok {

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -128,6 +128,14 @@ type DomainRepository interface {
 	// allowlist; enabling without a timestamp or disabling without clearing
 	// the timestamp is a bug waiting to happen.
 	UpdateDNSSECEnabled(ctx context.Context, id string, enabled bool) error
+	// UpdateWebDisabled / UpdateDNSDisabled flip the facet flags for a
+	// facet-preserving delete (GH #1603): "delete the Web Domain, keep the
+	// Mail Domain / DNS Zone" removes the web (or DNS) facet while keeping the
+	// row. Dedicated setters because neither web_disabled nor dns_disabled is in
+	// Update()'s allowlist, and the flip must land BEFORE the host teardown so
+	// the reconciler does not re-render what the teardown just removed.
+	UpdateWebDisabled(ctx context.Context, id string, disabled bool) error
+	UpdateDNSDisabled(ctx context.Context, id string, disabled bool) error
 	// AttachDockerApp wires an existing (tenant-managed) domain to a
 	// docker app: rewrites nginx_rules + sets docker_app_id in one
 	// shot. Dedicated method because docker_app_id is not in
@@ -751,6 +759,31 @@ func (r *domainRepo) UpdateDNSSECEnabled(ctx context.Context, id string, enabled
 	res := r.db.WithContext(ctx).Model(&models.Domain{}).
 		Where("id = ?", id).
 		Updates(updates)
+	if res.Error != nil {
+		return translate(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateWebDisabled flips web_disabled (GH #1603 facet-preserving delete).
+// Dedicated setter: web_disabled is not in Update()'s allowlist, and the flip
+// must precede the host web teardown so the reconciler stops rendering the vhost.
+func (r *domainRepo) UpdateWebDisabled(ctx context.Context, id string, disabled bool) error {
+	return r.updateBoolColumn(ctx, id, "web_disabled", disabled)
+}
+
+// UpdateDNSDisabled flips dns_disabled (GH #1603 facet-preserving delete).
+func (r *domainRepo) UpdateDNSDisabled(ctx context.Context, id string, disabled bool) error {
+	return r.updateBoolColumn(ctx, id, "dns_disabled", disabled)
+}
+
+func (r *domainRepo) updateBoolColumn(ctx context.Context, id, column string, val bool) error {
+	res := r.db.WithContext(ctx).Model(&models.Domain{}).
+		Where("id = ?", id).
+		Updates(map[string]any{column: val, "updated_at": time.Now().UTC()})
 	if res.Error != nil {
 		return translate(res.Error)
 	}


### PR DESCRIPTION
Backend slice for facet-preserving Web Domain delete (GH #1603, johnnyq). **No UI yet** — the delete-modal checkboxes are a follow-up PR; this is exercisable via the API.

## Why it's not a one-line modal change

A jabali "domain" is **one row** carrying web + mail + DNS facets. Deleting the row (`userops.DeleteDomain`) tears down all three. "Delete the Web Domain, keep the Mail Domain / DNS Zone" therefore means *keep the row* (web-off), not delete it — and no existing primitive removed only the web vhost + web cert while keeping mail (`domain.disable` only unlinks the enabled symlink; `domain.delete` reaps the mail facet too).

## New agent primitive

`domain.web_teardown` — removes only the web vhost (`sites-available` + `sites-enabled`) and the web TLS lineage; leaves the mail vhost, relay credential, and `mail.<domain>` cert intact. Idempotent, name-scoped.

## panel-api

- **`purgeDomainMailService`** — extracts the GH #1387 mail-only-delete teardown (purge_accounts hard gate → mailbox rows → `email_disable` → mail DNS → mail vhost → mail cert) into a reusable function. The `/email/purge` handler and the new delete path now run the *same* ordered teardown (behavior-preserving refactor).
- **`facetPreservingWebDelete`** — flips `web_disabled=true` (so the reconciler stops rendering the vhost), runs `domain.web_teardown`, then conditionally runs the mail purge and/or `dns_disabled` + `dns.zone.delete` for whichever facets the caller also deletes. Optional file delete reuses the GH #1382 async docroot removal.
- **`DELETE /domains/:id`** now honours `delete_mail` / `delete_dns` query params (default `true`). When at least one facet is kept → the row survives web-off (200 with `{kept, warnings}`); otherwise it falls through to the existing full row delete (204, unchanged). Panel-primary is refused as before.
- **`UpdateWebDisabled` / `UpdateDNSDisabled`** dedicated repo setters (neither column is in `Update()`'s allowlist); `Mailboxes` wired into `DomainHandlerConfig`.

## Tests

- Agent verb: invalid-domain rejection; web self-signed cert removed while the `mail.<domain>` cert is kept.
- Op: all four facet combinations (keep-both / delete-mail-keep-dns / keep-mail-delete-dns) assert the exact agent calls + `web_disabled`/`email_enabled`/`dns_disabled` end state; plus web_teardown-failure-stops-before-mail.
- Existing mail-purge + domain-delete suites green (extraction is behavior-preserving). `go build ./...`, `vet`, and the api/reconciler/repository/agent/app suites all pass.

## Follow-up (PR 2)

The Web Domain delete modal gains "Also delete Mail Domain" / "Also delete DNS Zone" checkboxes (shown when the facet exists, default checked), wired to these query params.

## Test plan

- [ ] `DELETE /domains/:id?delete_mail=false` on a web+mail domain → row kept, web torn down, mailboxes intact, mail still delivers.
- [ ] `?delete_dns=false` → row kept, DNS zone still answers.
- [ ] both facets deleted (default) → full row delete, unchanged.
- [ ] panel-primary → 403.

GH #1603
