### PR TITLE
fix(migrations): preserve source resource types on a Hestia domain import (GH #1606)

### DIFF
--- a/docs/site/migrations.md
+++ b/docs/site/migrations.md
@@ -46,6 +46,7 @@ own read-only CLI, then rebuilds destination-side).
 
 - BIND zones translated to PowerDNS schema rows — A/AAAA/CNAME/MX/TXT/**SRV** (priority in the pdns prio column) / **CAA** all import; the source SOA is dropped (pdns generates its own).
 - Hestia's `web/<domain>/public_html` docroot layout is handled for both the file split and the app-config scan (differs from the native `domains/<domain>/public_html`).
+- Resource types are preserved per source facet (GH #1606): Hestia lists web dirs and DNS zones independently, so a web dir with no source zone imports as a **Web Domain only** (`dns_disabled`, no managed PowerDNS zone), a DNS zone with no web dir imports as a **DNS Zone only** (`web_disabled`, no nginx vhost/PHP), and a domain in both imports full-facet. Other importers (cPanel, DirectAdmin, Plesk, CloudPanel, CyberPanel) create every domain full-facet unchanged.
 - The account **Contact Name** (`user.conf` FNAME/LNAME) carries onto the created jabali user's name.
 - Exim → Stalwart routing rules: forwards + autoresponders ported; complex Exim ACL rules need manual re-implementation.
 

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -567,14 +567,20 @@ failed stage. Already-done stages are skipped.`,
 				if h, herr := hestiacp.ParseHestiaTarball(hTarPath, extractDir); herr == nil {
 					// GH #327 diag: make an empty import self-explaining.
 					fmt.Fprintf(cmd.ErrOrStderr(),
-						"hestia import: parsed %d web domain(s), %d db dump(s); tar top-level=%v\n",
-						len(h.DomainDirs), len(h.MySQLDumps), h.TopLevel)
+						"hestia import: parsed %d web domain(s), %d DNS zone(s), %d db dump(s); tar top-level=%v\n",
+						len(h.DomainDirs), len(h.ZoneFiles), len(h.MySQLDumps), h.TopLevel)
 					parsed = &cpanel.ParsedTarball{
 						ExtractDir: extractDir,
 						SourceUser: job.SourceUser,
 						HomeDir:    h.WebRoot,  // Hestia rsync target = web/<dom>/public_html/...
 						MailRoot:   h.MailRoot, // Hestia stores at mail/<dom>/<local>/Maildir
 						MySQLDumps: h.MySQLDumps,
+						// GH #1606: Hestia enumerates web dirs (DomainNames) and DNS
+						// zones (ZoneFiles) INDEPENDENTLY, so a web dir without a
+						// zone is a web-only domain and a zone without a web dir is a
+						// DNS-only zone. Tell ImportDomains to honour that split
+						// instead of creating every domain full-facet.
+						SeparateWebDNSLists: true,
 					}
 					if h.SSHKeys != "" {
 						parsed.SSHAuthorized = []string{h.SSHKeys}

--- a/panel-api/internal/migrate/cpanel/restore_domains.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains.go
@@ -126,6 +126,13 @@ func ImportDomains(
 	// Zone-derived entries come first because they carry createWWW from the
 	// source zone; a web-only domain has no zone to read, so it stays apex-only
 	// (createWWW=false), matching the old DomainNames-branch default.
+	// webNames / zoneNames record which source list each name came from, so an
+	// importer that enumerates web and DNS separately (parsed.SeparateWebDNSLists,
+	// e.g. Hestia) can be created with the right facets: a name only in the web
+	// list is web-only (dns_disabled), a name only in the zone list is DNS-only
+	// (web_disabled), a name in both is full-facet. GH #1606.
+	zoneNames := map[string]bool{}
+	webNames := map[string]bool{}
 	var entries []domainEntry
 	seen := map[string]bool{}
 	for _, zonePath := range parsed.ZoneFiles {
@@ -134,6 +141,7 @@ func ImportDomains(
 			res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:empty_name_from_%s", zonePath))
 			continue
 		}
+		zoneNames[domainName] = true
 		if seen[domainName] {
 			continue
 		}
@@ -145,7 +153,11 @@ func ImportDomains(
 		})
 	}
 	for _, name := range parsed.DomainNames {
-		if name == "" || seen[name] {
+		if name == "" {
+			continue
+		}
+		webNames[name] = true
+		if seen[name] {
 			continue
 		}
 		seen[name] = true
@@ -159,19 +171,37 @@ func ImportDomains(
 			continue
 		}
 
+		// Facets (GH #1606): only an importer that lists web and DNS separately
+		// (parsed.SeparateWebDNSLists) downgrades a single-list name; otherwise
+		// every domain is full-facet (web + DNS), the historical behavior for
+		// cpanel/DA/CloudPanel/Plesk.
+		isWeb, isDNS := true, true
+		if parsed.SeparateWebDNSLists {
+			isWeb, isDNS = webNames[domainName], zoneNames[domainName]
+		}
+
 		domainID := ids.NewULID()
 		docRoot := e.docRoot
+		if !isWeb {
+			// A DNS-only zone is docroot-less — no vhost, no PHP, no web SSL.
+			docRoot = ""
+		}
 
-		if _, err := agentCli.Call(ctx, "domain.create", map[string]any{
-			"domain_id":      domainID,
-			"domain":         domainName,
-			"username":       targetUsername,
-			"doc_root":       docRoot,
-			"index_priority": "html_first",
-		}); err != nil {
-			res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:agent_create_failed:%s:%v", domainName, err))
-			res.Failed = append(res.Failed, fmt.Sprintf("%s (%v)", domainName, err))
-			continue
+		// Build the web vhost ONLY for a web facet. A DNS-only zone gets no
+		// vhost; its zone is created by the ImportDNS stage and the reconciler
+		// serves DNS alone (web_disabled row).
+		if isWeb {
+			if _, err := agentCli.Call(ctx, "domain.create", map[string]any{
+				"domain_id":      domainID,
+				"domain":         domainName,
+				"username":       targetUsername,
+				"doc_root":       docRoot,
+				"index_priority": "html_first",
+			}); err != nil {
+				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:agent_create_failed:%s:%v", domainName, err))
+				res.Failed = append(res.Failed, fmt.Sprintf("%s (%v)", domainName, err))
+				continue
+			}
 		}
 
 		now := time.Now()
@@ -183,11 +213,18 @@ func ImportDomains(
 			IsEnabled:     true,
 			IndexPriority: "html_first",
 			GhostState:    "unchecked",
+			// GH #1606: honour the source's facets so a migration recreates the
+			// right resource TYPES — a web-only domain gets no managed DNS zone,
+			// a DNS-only zone gets no web vhost. Full-facet when both (or when the
+			// importer doesn't separate the lists).
+			WebDisabled: !isWeb,
+			DNSDisabled: !isDNS,
 			// JAB-249: carry the source's www presence so the issued LE cert
 			// covers www.<domain> (the #1069 SAN-drift reconciler adds the SAN
 			// on its next reachable-gated pass). Domains whose source has no
-			// www record stay apex-only (unchanged default).
-			CreateWWW: e.createWWW,
+			// www record stay apex-only (unchanged default). Web-off rows have no
+			// web cert, so www is moot there.
+			CreateWWW: e.createWWW && isWeb,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -209,23 +246,32 @@ func ImportDomains(
 		// into the vhost on its next tick — nginx -t gated). An absent
 		// .htaccess is the common case and is a silent no-op; unconverted
 		// lines surface as per-domain manifest warnings, never dropped quietly.
-		applyMigratedHtaccess(filepath.Join(docRoot, ".htaccess"), domainName, d, res)
+		// .htaccess conversion only applies to a web facet (a DNS-only zone has
+		// no docroot to read).
+		if isWeb {
+			applyMigratedHtaccess(filepath.Join(docRoot, ".htaccess"), domainName, d, res)
+		}
 
 		if err := domainsRepo.Create(ctx, d); err != nil {
-			// JAB-57: domain.create already built the nginx vhost (+ enabled
-			// symlink) but the panel row failed to land — an unmanaged vhost
-			// that serves traffic and collides with a retry (whose collision
-			// check keys on the domains row, now absent). Roll it back:
-			// domain.delete removes the vhost + reloads nginx. The docroot
-			// under /home is left (harmless; overwritten by the home-split
-			// rsync on retry) — only the serving/system state is reverted.
-			delCtx, dcancel := context.WithTimeout(ctx, 60*time.Second)
-			_, delErr := agentCli.Call(delCtx, "domain.delete", map[string]string{"domain": domainName})
-			dcancel()
-			if delErr != nil {
-				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed_AND_vhost_rollback_failed:%s:row=%v:delete=%v", domainName, err, delErr))
+			// JAB-57: for a web facet, domain.create already built the nginx
+			// vhost (+ enabled symlink) but the panel row failed to land — an
+			// unmanaged vhost that serves traffic and collides with a retry
+			// (whose collision check keys on the domains row, now absent). Roll
+			// it back: domain.delete removes the vhost + reloads nginx. The
+			// docroot under /home is left (harmless; overwritten by the
+			// home-split rsync on retry). A DNS-only entry built no vhost, so
+			// there is nothing to roll back.
+			if isWeb {
+				delCtx, dcancel := context.WithTimeout(ctx, 60*time.Second)
+				_, delErr := agentCli.Call(delCtx, "domain.delete", map[string]string{"domain": domainName})
+				dcancel()
+				if delErr != nil {
+					res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed_AND_vhost_rollback_failed:%s:row=%v:delete=%v", domainName, err, delErr))
+				} else {
+					res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed_vhost_rolled_back:%s:%v", domainName, err))
+				}
 			} else {
-				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed_vhost_rolled_back:%s:%v", domainName, err))
+				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed:%s:%v", domainName, err))
 			}
 			continue
 		}

--- a/panel-api/internal/migrate/cpanel/restore_domains_facets_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains_facets_test.go
@@ -1,0 +1,172 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// recordingDomainRepo captures every row ImportDomains creates so a test can
+// assert the facet flags (WebDisabled / DNSDisabled) on each.
+type recordingDomainRepo struct {
+	repository.DomainRepository
+	created []*models.Domain
+}
+
+func (recordingDomainRepo) FindByName(context.Context, string) (*models.Domain, error) {
+	return nil, repository.ErrNotFound
+}
+func (r *recordingDomainRepo) Create(_ context.Context, d *models.Domain) error {
+	r.created = append(r.created, d)
+	return nil
+}
+
+func rowByName(rows []*models.Domain, name string) *models.Domain {
+	for _, d := range rows {
+		if d.Name == name {
+			return d
+		}
+	}
+	return nil
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// GH #1606 (follow-up): an importer that enumerates web dirs and DNS zones
+// separately (Hestia, parsed.SeparateWebDNSLists) must recreate the source's
+// resource TYPES, not blanket web+DNS. johnnyq's Hestia account migrated a web
+// domain (DNS hosted off-box) and a DNS-only zone (parked, no web); the union
+// fix carried both over but as full-facet domains, so the web domain grew a
+// stray managed zone and the parked zone grew a stray web vhost. This asserts
+// each source facet lands as its own type.
+func TestImportDomains_HestiaSeparateFacets(t *testing.T) {
+	dir := t.TempDir()
+	// A DNS-only zone on the source (present in ZoneFiles, absent from web dirs).
+	dnsOnly := filepath.Join(dir, "parked.example.db")
+	if err := os.WriteFile(dnsOnly, []byte("@ IN SOA ns admin ( 1 2 3 4 5 )\n@ IN A 192.0.2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A full-facet domain: it has BOTH a source zone and a web dir.
+	both := filepath.Join(dir, "full.example.db")
+	if err := os.WriteFile(both, []byte("@ IN SOA ns admin ( 1 2 3 4 5 )\n@ IN A 192.0.2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &createRecordingAgent{}
+	repo := &recordingDomainRepo{}
+	parsed := &ParsedTarball{
+		ExtractDir:          dir,
+		SourceUser:          "carol",
+		SeparateWebDNSLists: true,
+		ZoneFiles:           []string{dnsOnly, both},
+		// Web dirs: a web-only domain (no zone on the source) + the full-facet one.
+		DomainNames: []string{"web.example", "full.example"},
+	}
+
+	res, err := ImportDomains(context.Background(), repo, ag,
+		parsed, "01USERULID0000000000000000", "carol")
+	if err != nil {
+		t.Fatalf("ImportDomains hard error: %v", err)
+	}
+	if res.Created != 3 {
+		t.Fatalf("res.Created = %d, want 3", res.Created)
+	}
+
+	// web-only: web facet on, DNS facet off, docroot present, vhost built.
+	if d := rowByName(repo.created, "web.example"); d == nil {
+		t.Fatal("web.example row missing")
+	} else {
+		if d.WebDisabled {
+			t.Error("web.example: WebDisabled=true, want false (has web dir)")
+		}
+		if !d.DNSDisabled {
+			t.Error("web.example: DNSDisabled=false, want true (no source zone)")
+		}
+		if d.DocRoot == "" {
+			t.Error("web.example: empty DocRoot, want a docroot for a web domain")
+		}
+		if !contains(ag.created, "web.example") {
+			t.Error("web.example: no domain.create call, want vhost built for a web domain")
+		}
+	}
+
+	// DNS-only: web facet off, DNS facet on, no docroot, NO vhost built.
+	if d := rowByName(repo.created, "parked.example"); d == nil {
+		t.Fatal("parked.example row missing")
+	} else {
+		if !d.WebDisabled {
+			t.Error("parked.example: WebDisabled=false, want true (no web dir)")
+		}
+		if d.DNSDisabled {
+			t.Error("parked.example: DNSDisabled=true, want false (has source zone)")
+		}
+		if d.DocRoot != "" {
+			t.Errorf("parked.example: DocRoot=%q, want empty for a DNS-only zone", d.DocRoot)
+		}
+		if contains(ag.created, "parked.example") {
+			t.Error("parked.example: domain.create was called, want NO vhost for a DNS-only zone")
+		}
+	}
+
+	// both: full-facet.
+	if d := rowByName(repo.created, "full.example"); d == nil {
+		t.Fatal("full.example row missing")
+	} else {
+		if d.WebDisabled || d.DNSDisabled {
+			t.Errorf("full.example: WebDisabled=%v DNSDisabled=%v, want both false", d.WebDisabled, d.DNSDisabled)
+		}
+		if !contains(ag.created, "full.example") {
+			t.Error("full.example: no domain.create call, want vhost built")
+		}
+	}
+}
+
+// Regression guard: an importer that does NOT separate the lists (cpanel, DA,
+// Plesk, CloudPanel — SeparateWebDNSLists=false) keeps the historical
+// full-facet behavior even for a name that appears in only one source list. The
+// union fix must not silently downgrade those to web-only/DNS-only.
+func TestImportDomains_NonSeparateStaysFullFacet(t *testing.T) {
+	dir := t.TempDir()
+	zoned := filepath.Join(dir, "site.example.db")
+	if err := os.WriteFile(zoned, []byte("@ IN SOA ns admin ( 1 2 3 4 5 )\n@ IN A 192.0.2.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ag := &createRecordingAgent{}
+	repo := &recordingDomainRepo{}
+	parsed := &ParsedTarball{
+		ExtractDir: dir,
+		SourceUser: "dave",
+		// SeparateWebDNSLists left false. A web-only name (DomainNames, no zone).
+		ZoneFiles:   []string{zoned},
+		DomainNames: []string{"webonly.example"},
+	}
+
+	if _, err := ImportDomains(context.Background(), repo, ag,
+		parsed, "01USERULID0000000000000000", "dave"); err != nil {
+		t.Fatalf("ImportDomains hard error: %v", err)
+	}
+
+	for _, name := range []string{"site.example", "webonly.example"} {
+		d := rowByName(repo.created, name)
+		if d == nil {
+			t.Fatalf("%s row missing", name)
+		}
+		if d.WebDisabled || d.DNSDisabled {
+			t.Errorf("%s: WebDisabled=%v DNSDisabled=%v, want both false (importer does not separate lists)", name, d.WebDisabled, d.DNSDisabled)
+		}
+		if !contains(ag.created, name) {
+			t.Errorf("%s: no domain.create call, want vhost built (full-facet)", name)
+		}
+	}
+}

--- a/panel-api/internal/migrate/cpanel/tarball.go
+++ b/panel-api/internal/migrate/cpanel/tarball.go
@@ -47,6 +47,15 @@ type ParsedTarball struct {
 	// default zone. Populated by per-importer adapters (DA scans
 	// <HomeDir>/domains/*; Hestia scans <HomeDir>/web/*).
 	DomainNames []string
+	// SeparateWebDNSLists tells ImportDomains that ZoneFiles and DomainNames are
+	// INDEPENDENT facet lists (web dirs vs DNS zones), not two views of the same
+	// domain set. Set by importers that enumerate web and DNS separately (Hestia:
+	// web/<d> dirs vs dns/<d>/conf/<d>.db). When true, a name only in DomainNames
+	// is created web-only (dns_disabled) and a name only in ZoneFiles is created
+	// DNS-only (web_disabled) — GH #1606. When false (cpanel/DA/CloudPanel/Plesk,
+	// where ZoneFiles or DomainNames is the authoritative domain list), every
+	// imported domain is full-facet (web + DNS), the historical behavior.
+	SeparateWebDNSLists bool
 	// DocRoots optionally overrides the default docroot for a name in
 	// DomainNames. DA: <HomeDir>/domains/<dom>/public_html on source
 	// → /home/<target>/domains/<dom>/public_html in dest. Empty map


### PR DESCRIPTION
## Problem

The union fix (PR #1608) stopped web domains and DNS-only zones from being dropped on a Hestia import, but carried every source domain over as **full-facet** (web + DNS). On johnnyq's account this produced the wrong resource *types*:

- the **2 web domains** (DNS hosted off-box) each grew a stray managed PowerDNS zone;
- the **2 parked DNS-only zones** each grew a stray nginx Web Domain.

The migration was carrying everything over, just as the wrong type.

## Fix

Hestia enumerates web dirs (`web/<d>`) and DNS zones (`dns/<d>/conf/<d>.db`) **independently**, so the source already records which facet each domain has. `ImportDomains` now records which source list each name came from and — only for importers that separate the lists — sets the row facets accordingly:

| source | row |
|--------|-----|
| web dir, no source zone | **Web Domain only** — `dns_disabled`, no managed zone |
| source zone, no web dir | **DNS Zone only** — `web_disabled`, no vhost / PHP |
| present in both | full-facet |

A DNS-only entry gets no docroot, no `domain.create` (no nginx vhost), no `.htaccess` conversion, and no vhost rollback on a row-insert failure.

The reconciler's existing **GH #1449** facet gates finish the job — no new reconciler logic needed:

- `reconcileDNSZone` returns early on `DNSDisabled` (`reconciler.go:2454`) → a web-only row never gets a stray PowerDNS zone;
- the web-off branch (`reconciler.go:3832`) skips `createDomainOnAgent` + PHP binding → a DNS-only row never gets a stray vhost.

## Scope

Gated behind a new `ParsedTarball.SeparateWebDNSLists` flag, set **only** by the Hestia branch (`migrate_run_cmd.go`). cPanel, DirectAdmin, Plesk, CloudPanel and CyberPanel keep their historical full-facet behavior — proven by `TestImportDomains_NonSeparateStaysFullFacet`.

Later Hestia stages (`ImportSSL`, `ImportExtras` PHP/subdomains/forwarders) iterate `parsed.DomainNames`/`DocRoots` or cpanel-userdata sets, so a DNS-only zone (ZoneFiles-only, empty `DocRoot`) never reaches a cert install or FPM-pool step.

## Test plan

- [x] `go build ./panel-api/...`
- [x] `go vet ./panel-api/internal/migrate/... ./panel-api/cmd/server/...`
- [x] `go test ./panel-api/internal/migrate/...` — all green
- [x] New `TestImportDomains_HestiaSeparateFacets` — web-only → vhost + `dns_disabled` + no `domain.create` for the zone; DNS-only → no vhost + `web_disabled` + empty docroot; both → full-facet
- [x] New `TestImportDomains_NonSeparateStaysFullFacet` — regression guard for the non-separating importers
- [x] Existing union + rollback tests still pass (default `SeparateWebDNSLists=false` → full-facet)

GH #1606
