### PR TITLE
fix(domains): rename the Web Domains list page heading + admin breadcrumb (GH #1582)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -32,7 +32,7 @@ export const DomainList = () => {
 
   useSetBreadcrumbs(
     ownerId
-      ? ownerResourceCrumbs({ id: ownerId, username: ownerQ.data?.username }, { key: "domains", label: "Domains" })
+      ? ownerResourceCrumbs({ id: ownerId, username: ownerQ.data?.username }, { key: "domains", label: "Web Domains" })
       : null,
   );
 
@@ -47,7 +47,7 @@ export const DomainList = () => {
       >
         <Space wrap align="center">
           <Typography.Title level={3} style={{ margin: 0 }}>
-            <GlobalOutlined /> Domains
+            <GlobalOutlined /> Web Domains
           </Typography.Title>
           {ownerRef && (
             <Tag closable onClose={clearOwner} color="blue">

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -30,7 +30,7 @@ export const UserDomainList = () => {
         }}
       >
         <Typography.Title level={3} style={{ margin: 0 }}>
-          <GlobalOutlined /> Domains
+          <GlobalOutlined /> Web Domains
         </Typography.Title>
         <Button
           type="primary"


### PR DESCRIPTION
## Problem

Follow-up to #1610. That PR renamed the web-domain chrome to **Web Domain(s)** across the nav, dashboards and breadcrumbs — but the list page's own `<h1>` still read plain **"Domains"**, ambiguous next to *Mail Domains* and inconsistent with its own *Dashboard / Web Domains* breadcrumb.

johnnyq's screenshot on #1582:

> breadcrumb `Dashboard / Web Domains`, heading `🌐 Domains`

## Fix

- **tenant list** (`UserDomainList.tsx`) — H1 `Domains` → `Web Domains`
- **admin list** (`DomainList.tsx`) — H1 `Domains` → `Web Domains`, and the owner-scoped breadcrumb leaf label likewise (parity with the tenant breadcrumb, already "Web Domains")

These are the shells' plain-literal headings — the same style as the sibling *Add Web Domain* button — not i18n keys, so no locale files change.

Left unchanged (correct as-is): the generic **"Domain" name-column** header, the DNS/Mail **domain pickers**, the **Mail Domains** / **DNS Zones** page headings, and the package **"Max Domains"** limit.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` on both files clean
- [x] `vitest run` — UserDomainList, WebDomainPage, AdminBreadcrumb (23 tests) pass; `AdminBreadcrumb.test.tsx` builds its own fixture label so it is unaffected by the admin breadcrumb-label change

GH #1582
