### PR TITLE
feat(ui): show the panel hostname in the browser tab title (GH #1604)

### DIFF
--- a/panel-ui/src/lib/pageTitle.test.ts
+++ b/panel-ui/src/lib/pageTitle.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPageTitle } from "./pageTitle";
+
+describe("buildPageTitle (GH #1604)", () => {
+  it("prefixes the host before the product name", () => {
+    expect(buildPageTitle("panel.example.com")).toBe("panel.example.com | Jabali Panel");
+  });
+
+  it("passes a bare IP through unchanged", () => {
+    expect(buildPageTitle("192.0.2.10")).toBe("192.0.2.10 | Jabali Panel");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(buildPageTitle("  host.local  ")).toBe("host.local | Jabali Panel");
+  });
+
+  it("falls back to the bare product name for an empty host", () => {
+    expect(buildPageTitle("")).toBe("Jabali Panel");
+    expect(buildPageTitle("   ")).toBe("Jabali Panel");
+  });
+
+  it("falls back for null/undefined", () => {
+    expect(buildPageTitle(null)).toBe("Jabali Panel");
+    expect(buildPageTitle(undefined)).toBe("Jabali Panel");
+  });
+});

--- a/panel-ui/src/lib/pageTitle.ts
+++ b/panel-ui/src/lib/pageTitle.ts
@@ -1,0 +1,22 @@
+// GH #1604 (johnnyq): the browser tab title was the static "Jabali Panel" from
+// index.html, so an operator running several instances could not tell tabs
+// apart. Prefix the address-bar host — "<hostname> | Jabali Panel" — so each
+// instance's tab is identifiable at a glance. The host comes from
+// window.location, not server settings, so it is correct before login and
+// reflects exactly the address the tab was opened on (an IP shows as the IP).
+
+const SUFFIX = "Jabali Panel";
+
+/**
+ * buildPageTitle returns the document title for a given address-bar host.
+ * An empty or whitespace-only host falls back to the bare product name.
+ */
+export function buildPageTitle(hostname: string | null | undefined): string {
+  const host = (hostname ?? "").trim();
+  return host ? `${host} | ${SUFFIX}` : SUFFIX;
+}
+
+/** setPageTitle applies buildPageTitle(window.location.hostname) to the tab. */
+export function setPageTitle(): void {
+  document.title = buildPageTitle(window.location.hostname);
+}

--- a/panel-ui/src/main.tsx
+++ b/panel-ui/src/main.tsx
@@ -11,6 +11,11 @@ import "./i18n";
 import { message, notification } from "antd";
 import App from "./App";
 import { registerServiceWorker } from "./lib/registerServiceWorker";
+import { setPageTitle } from "./lib/pageTitle";
+
+// GH #1604: tab title = "<hostname> | Jabali Panel" so multiple instances are
+// distinguishable at a glance. Set before render (independent of the React tree).
+setPageTitle();
 
 // GH #970: give the STATIC message/notification methods (still used across the
 // app) the same house style as the App-scoped config in App.tsx, so every toast


### PR DESCRIPTION
## Problem

The browser tab title was the static `Jabali Panel` baked into `index.html`. An operator running several instances can't tell which tab is which instance (johnnyq's request on #1604).

## Fix

Set the tab title to **`<hostname> | Jabali Panel`**, where `hostname` is the address-bar host (`window.location.hostname`):

- correct **before login** and on every screen — no server round-trip, no dependency on server settings;
- reflects exactly the address the tab was opened on — an IP shows as the IP;
- empty/whitespace host falls back to the bare `Jabali Panel`.

Applied once at the entry point (`main.tsx`) through a small pure helper (`lib/pageTitle.ts`). The static `index.html` `<title>Jabali Panel</title>` stays as the pre-JS fallback.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` on the 3 files clean
- [x] `vitest run src/lib/pageTitle.test.ts` — 5 tests (host prefix, bare IP, whitespace trim, empty/null/undefined fallback)

GH #1604
