### PR TITLE
feat(databases): reassign a database's owner to another tenant (GH #1609)

### DIFF
--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dbops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -39,6 +41,16 @@ type DatabaseHandlerConfig struct {
 	Packages          repository.PackageRepository
 	ServerSettings    repository.ServerSettingsRepository
 	Agent             agent.AgentInterface
+	// Installs (GH #1609 chown) backs the change-owner refusal: a database that
+	// backs an application install must not move (its config holds the old
+	// owner's credentials). The chown handler 503s when nil rather than fail
+	// open. Optional for the non-chown routes.
+	Installs repository.ApplicationInstallRepository
+	// AuditEvents records the admin change-owner (GH #1609). Optional — nil skips.
+	AuditEvents repository.AuditEventRepository
+	// KratosClient gates the change-owner route behind the JAB-380 recent-auth
+	// step-up. Optional for the non-chown routes.
+	KratosClient *kratosclient.Client
 }
 
 const (
@@ -67,6 +79,11 @@ func RegisterDatabaseRoutes(g *gin.RouterGroup, cfg DatabaseHandlerConfig) {
 	databases.POST("/:id/restore-chunk", h.restoreChunk)
 	databases.GET("/:id/restore-chunk-status", h.restoreChunkStatus)
 	databases.GET("/:id/restore-status", h.restoreStatus)
+
+	// GH #1609: reassign a database (+ the DB users bound only to it) to a new
+	// tenant. Admin-only AND behind the JAB-380 recent-auth step-up (enforced in
+	// the handler), same posture as domain chown.
+	g.POST("/admin/databases/:id/chown", middleware.RequireAdmin(), h.chown)
 }
 
 type databaseHandler struct{ cfg DatabaseHandlerConfig }

--- a/panel-api/internal/api/databases_chown.go
+++ b/panel-api/internal/api/databases_chown.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dbops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// databases_chown.go — admin action to reassign a database (and the DB users
+// bound only to it) to a new tenant in place (GH #1609).
+//
+// The heavy lifting lives in dbops.ReassignDatabaseOwner (shared, so a CLI
+// subcommand can reuse it): the agent renames the database + its users onto the
+// new owner's prefix (db.rename_db / db.rename_user) and re-points their grants,
+// then the panel repoints the rows' owner + name. Like domain chown this is a
+// data-moving, cross-tenant operation, so it's admin-only AND behind the
+// JAB-380 recent-auth step-up.
+//
+// v1 refuses a database backing an app install (its config holds the old owner's
+// credentials → cross-tenant leak), a shared DB user, a postgres database, and
+// off-convention names — see dbops_chown.go. The app-install refusal depends on
+// Installs being wired; this handler 503s when it isn't rather than fail open.
+
+type chownDatabaseRequest struct {
+	NewOwnerID string `json:"new_owner_id"`
+}
+
+// chown handles POST /admin/databases/:id/chown { new_owner_id }.
+func (h *databaseHandler) chown(c *gin.Context) {
+	// Root-privileged, cross-tenant surface: require a recently-authenticated
+	// session (JAB-380). A stale session gets a 403 the SPA turns into re-auth.
+	if !requireRecentAuth(c, h.cfg.KratosClient, stepUpWindow) {
+		return
+	}
+
+	// Fail closed: the cross-tenant-credential (app-install) refusal in dbops is
+	// only armed when Installs is wired. Never let a missing dep disable it.
+	if h.cfg.Installs == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "chown_unavailable", "detail": "app-install repository not wired"})
+		return
+	}
+
+	databaseID := c.Param("id")
+	if databaseID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "database id required"})
+		return
+	}
+	var req chownDatabaseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	if req.NewOwnerID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "new_owner_id required"})
+		return
+	}
+
+	// The rename + regrant go through the agent; bound it so a wedged agent can't
+	// pin the request forever (same ceiling domain chown uses).
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Minute)
+	defer cancel()
+
+	// Capture the pre-change owner for the audit before dbops mutates the row.
+	var oldOwnerID string
+	if db, err := h.cfg.Databases.FindByID(ctx, databaseID); err == nil && db != nil {
+		oldOwnerID = db.UserID
+	}
+
+	d := dbops.Deps{
+		Users:          h.cfg.Users,
+		Packages:       h.cfg.Packages,
+		Databases:      h.cfg.Databases,
+		ServerSettings: h.cfg.ServerSettings,
+		DatabaseGrants: h.cfg.DatabaseGrants,
+		DatabaseUsers:  h.cfg.DatabaseUsers,
+		Installs:       h.cfg.Installs,
+		Agent:          h.cfg.Agent,
+		Log:            slog.Default(),
+	}
+	res, err := dbops.ReassignDatabaseOwner(ctx, d, dbops.ReassignInput{
+		DatabaseID: databaseID,
+		NewOwnerID: req.NewOwnerID,
+	})
+	if err != nil {
+		h.auditDBChown(c, databaseID, oldOwnerID, req.NewOwnerID, "", models.AuditResultError)
+		status, body := dbChownErrorResponse(err)
+		c.JSON(status, body)
+		return
+	}
+
+	h.auditDBChown(c, databaseID, oldOwnerID, req.NewOwnerID, res.NewName, models.AuditResultOK)
+	c.JSON(http.StatusOK, gin.H{
+		"id":            databaseID,
+		"user_id":       res.Database.UserID,
+		"name":          res.NewName,
+		"renamed_users": res.RenamedUsers,
+	})
+}
+
+// dbChownErrorResponse maps dbops sentinels to an HTTP status + body.
+func dbChownErrorResponse(err error) (int, gin.H) {
+	switch {
+	case errors.Is(err, dbops.ErrDeps):
+		return http.StatusServiceUnavailable, gin.H{"error": "chown_unavailable", "detail": err.Error()}
+	case errors.Is(err, dbops.ErrNotFound):
+		return http.StatusNotFound, gin.H{"error": "not_found", "detail": "database not found"}
+	case errors.Is(err, dbops.ErrUserNotFound):
+		return http.StatusNotFound, gin.H{"error": "not_found", "detail": "new owner not found"}
+	case errors.Is(err, dbops.ErrAttached):
+		// Same shape the delete path uses for an app-install-backed DB.
+		var ae *dbops.AttachedError
+		installID := ""
+		if errors.As(err, &ae) {
+			installID = ae.InstallID
+		}
+		return http.StatusConflict, gin.H{"error": "in_use_by_app", "detail": "this database backs an application install — detach or migrate it to the new owner first", "install_id": installID}
+	case errors.Is(err, dbops.ErrAgentFailed), errors.Is(err, dbops.ErrInternal):
+		return http.StatusInternalServerError, gin.H{"error": "chown_failed", "detail": err.Error()}
+	default:
+		// User-actionable refusals: same-owner, invalid owner, engine, prefix,
+		// shared user, collision, quota, invalid input.
+		return http.StatusUnprocessableEntity, gin.H{"error": "chown_failed", "detail": err.Error()}
+	}
+}
+
+// auditDBChown records the admin change-of-owner. Subject = OLD owner (their
+// asset moved away). No-op when the audit repo isn't wired.
+func (h *databaseHandler) auditDBChown(c *gin.Context, databaseID, oldOwnerID, newOwnerID, newName, result string) {
+	if h.cfg.AuditEvents == nil {
+		return
+	}
+	meta, _ := json.Marshal(map[string]string{
+		"new_owner_id": newOwnerID,
+		"new_name":     newName,
+	})
+	ev := &models.AuditEvent{
+		ID:         ids.NewULID(),
+		TS:         time.Now().UTC(),
+		ActorKind:  models.AuditActorAdmin,
+		Action:     "admin.database.chown",
+		TargetType: "database",
+		TargetID:   databaseID,
+		Result:     result,
+		Meta:       meta,
+	}
+	if oldOwnerID != "" {
+		subject := oldOwnerID
+		ev.SubjectUserID = &subject
+	}
+	if claims := ginctx.Claims(c); claims != nil && claims.UserID != "" {
+		actor := claims.UserID
+		ev.ActorUserID = &actor
+	}
+	if ip := c.ClientIP(); ip != "" {
+		ev.SourceIP = &ip
+	}
+	if reqID := ginctx.RequestID(c); reqID != "" {
+		ev.RequestID = &reqID
+	}
+	_ = h.cfg.AuditEvents.Create(c.Request.Context(), ev)
+}

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -863,10 +863,14 @@ func (m *mockUserRepo) UpdateShadowDBUsernames(context.Context, string, *string,
 	return nil
 }
 
-func (m *mockDatabaseRepo) UpdateName(context.Context, string, string) error { return nil }
+func (m *mockDatabaseRepo) UpdateName(context.Context, string, string) error            { return nil }
+func (m *mockDatabaseRepo) TransferOwner(context.Context, string, string, string) error { return nil }
 func (m *mockDatabaseRepo) ListAllMariaDB(context.Context) ([]models.Database, error) {
 	return nil, nil
 }
 func (m *mockDatabaseRepo) UpdateSize(context.Context, string, uint64, time.Time) error { return nil }
 
 func (m *mockDatabaseUserRepo) UpdateUsername(context.Context, string, string) error { return nil }
+func (m *mockDatabaseUserRepo) TransferOwner(context.Context, string, string, string) error {
+	return nil
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5965,6 +5965,28 @@ paths:
         "422": { description: Change refused — new owner is not a tenant, is already the owner, the domain has an app install, or the docroot is outside the owner's home, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "503": { description: Change-owner not available (app-install repository not wired), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
 
+  /admin/databases/{id}/chown:
+    post:
+      tags: [Databases]
+      summary: Reassign a database to a new tenant in place (admin, JAB-380 step-up, GH #1609)
+      description: |
+        Renames the database and the DB users bound only to it onto the new
+        owner's prefix (db.rename_db / db.rename_user), re-points their grants,
+        and repoints the panel rows' owner. v1 (MariaDB) refuses a postgres
+        database, a database backing an app install (its config holds the current
+        owner's credentials), a DB user shared with another database, and
+        off-convention names.
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { new_owner_id: { type: string } }, required: [new_owner_id] } } } }
+      responses:
+        "200": { description: Reassigned, content: { application/json: { schema: { type: object, properties: { id: { type: string }, user_id: { type: string }, name: { type: string }, renamed_users: { type: array, items: { type: string } } } } } } }
+        "403": { description: Recent-auth step-up required (JAB-380), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "404": { description: Database or new owner not found, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "409": { description: Database backs an application install — detach it first, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "422": { description: Change refused — new owner is not a tenant/already the owner, postgres engine, a shared DB user, a name collision, or an off-convention name, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "503": { description: Change-owner not available (app-install repository not wired), content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
   /me/ssh-forwarding:
     get:
       tags: [Users]

--- a/panel-api/internal/api/sso_phpmyadmin_validate_test.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate_test.go
@@ -307,7 +307,9 @@ func (m *mockUserRepoValidate) Update(ctx context.Context, u *models.User) error
 	return nil
 }
 
-func (m *mockUserRepoValidate) UpdateComposerChannel(ctx context.Context, id string, channel *string) error { return nil }
+func (m *mockUserRepoValidate) UpdateComposerChannel(ctx context.Context, id string, channel *string) error {
+	return nil
+}
 
 func (m *mockUserRepoValidate) UpdateCLIPHPVersion(context.Context, string, *string) error {
 	return nil
@@ -440,3 +442,6 @@ func (m *mockUserRepoValidate) UpdateShadowDBUsernames(context.Context, string, 
 }
 
 func (m *mockDatabaseRepoValidate) UpdateName(context.Context, string, string) error { return nil }
+func (m *mockDatabaseRepoValidate) TransferOwner(context.Context, string, string, string) error {
+	return nil
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -799,6 +799,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Packages:          deps.Packages,
 				ServerSettings:    deps.ServerSettings,
 				Agent:             deps.Agent,
+				// GH #1609 admin database chown deps.
+				Installs:     deps.WordPressInstalls,
+				AuditEvents:  repository.NewAuditEventRepository(deps.DB),
+				KratosClient: deps.KratosClient,
 			})
 		}
 		if deps.DatabaseUsers != nil && deps.DatabaseUserGrants != nil {

--- a/panel-api/internal/dbops/dbops.go
+++ b/panel-api/internal/dbops/dbops.go
@@ -66,6 +66,15 @@ func logWarn(d Deps, msg string, args ...any) {
 	}
 }
 
+// logInfo guards the optional logger. Used by the reassign path to record each
+// completed row write so an operator can finish a rare mid-flight failure by
+// hand (GH #1609).
+func logInfo(d Deps, msg string, args ...any) {
+	if d.Log != nil {
+		d.Log.Info(msg, args...)
+	}
+}
+
 // CreateInput is the shared input shape. Both callers (REST + CLI)
 // build this from their own argument parsing.
 //

--- a/panel-api/internal/dbops/dbops_chown.go
+++ b/panel-api/internal/dbops/dbops_chown.go
@@ -1,0 +1,318 @@
+package dbops
+
+// dbops_chown.go — reassign a single database (and the DB users bound only to
+// it) from one tenant to another (GH #1609).
+//
+// This reuses the GH #1238 re-prefix primitives that user-rename is built on
+// (agent db.rename_db / db.rename_user / db_user.grant / db_user.revoke), but
+// scoped to ONE database instead of a whole account, and crossing an owner
+// boundary instead of a username change. Because the panel names every DB and
+// DB user `<owner-username>_*` and the tenant list filters on that prefix, a
+// reassign is NOT a user_id repoint — the database and its users are renamed
+// onto the NEW owner's prefix so they stay visible and the new owner's
+// `<newowner>_%.*` mysqladmin wildcard grant covers them, while the old owner's
+// wildcard no longer matches.
+//
+// Order (fail-closed, mirrors renameUserDBArtifacts): run ALL the idempotent
+// agent verbs first — rename the database, then each bound DB user, then
+// re-point their grants onto the new names and revoke the stale ones — and only
+// after the box is fully moved repoint the panel rows. Because every agent verb
+// is a re-runnable no-op once done (old gone / new present), an agent-side
+// failure leaves every panel row untouched, so a re-run resumes cleanly from the
+// top. Each row write is a single atomic name+owner UPDATE (TransferOwner), so
+// the only non-resumable window is between two local UPDATEs (no network); every
+// completed row write is logged so a rare failure there can be finished by hand.
+//
+// v1 is deliberately conservative and REFUSES rather than half-move:
+//   - postgres databases (the rename+regrant path is MariaDB-only here, same as
+//     user-rename; a PG slice is a follow-up);
+//   - a database that backs an application install (its config holds the old
+//     owner's credentials — a cross-tenant leak, same hazard as domain chown);
+//   - a DB user that also has grants on another database, or is owned by someone
+//     other than the current owner (renaming it would break that other database);
+//   - a database or DB user whose name isn't under the current owner's prefix
+//     (admin-created off-convention — needs manual review);
+//   - a name collision under the new owner.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Reassign-specific sentinels (create/delete sentinels like ErrDeps,
+// ErrUserNotFound, ErrNotFound, ErrQuotaExceeded and ErrAttached are reused).
+var (
+	ErrReassignSameOwner    = errors.New("dbops: database is already owned by that user")
+	ErrReassignOwnerInvalid = errors.New("dbops: new owner must be a fully-provisioned tenant")
+	ErrReassignEngine       = errors.New("dbops: reassigning a postgres database isn't supported yet")
+	ErrReassignPrefix       = errors.New("dbops: a name is not under the current owner's prefix (needs manual review)")
+	ErrReassignSharedUser   = errors.New("dbops: a database user is shared with another database or owner")
+	ErrReassignCollision    = errors.New("dbops: a name already exists under the new owner")
+)
+
+// ReassignInput is the shared input for both callers (REST now; CLI can follow).
+type ReassignInput struct {
+	DatabaseID string
+	NewOwnerID string
+}
+
+// ReassignResult reports what moved, for the caller's response/audit.
+type ReassignResult struct {
+	Database     *models.Database
+	NewName      string
+	RenamedUsers []string // new (post-move) usernames
+}
+
+// ReassignDatabaseOwner moves one database + its exclusively-bound DB users to a
+// new tenant, renaming them onto the new owner's prefix. See the file header for
+// the ordering and refusal rules.
+func ReassignDatabaseOwner(ctx context.Context, d Deps, in ReassignInput) (*ReassignResult, error) {
+	if d.Users == nil || d.Databases == nil || d.DatabaseUsers == nil ||
+		d.DatabaseGrants == nil || d.Installs == nil || d.Packages == nil || d.Agent == nil {
+		return nil, ErrDeps
+	}
+	if in.DatabaseID == "" || in.NewOwnerID == "" {
+		return nil, fmt.Errorf("%w: database id and new owner id required", ErrNameInvalid)
+	}
+
+	db, err := d.Databases.FindByID(ctx, in.DatabaseID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("%w: load database: %v", ErrInternal, err)
+	}
+	if db.Engine != "mariadb" {
+		return nil, fmt.Errorf("%w: %q is a %s database", ErrReassignEngine, db.Name, db.Engine)
+	}
+
+	newOwner, err := d.Users.FindByID(ctx, in.NewOwnerID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("%w: load new owner: %v", ErrInternal, err)
+	}
+	if newOwner.IsAdmin || newOwner.Username == nil || *newOwner.Username == "" || newOwner.LinuxUID == nil {
+		return nil, fmt.Errorf("%w: %s", ErrReassignOwnerInvalid, in.NewOwnerID)
+	}
+	if db.UserID == newOwner.ID {
+		return nil, fmt.Errorf("%w: %q", ErrReassignSameOwner, db.Name)
+	}
+
+	oldOwner, err := d.Users.FindByID(ctx, db.UserID)
+	if err != nil || oldOwner == nil || oldOwner.Username == nil || *oldOwner.Username == "" {
+		return nil, fmt.Errorf("%w: resolve current owner of %q: %v", ErrInternal, db.Name, err)
+	}
+	oldPrefix := *oldOwner.Username + "_"
+	newPrefix := *newOwner.Username + "_"
+	if !strings.HasPrefix(db.Name, oldPrefix) {
+		return nil, fmt.Errorf("%w: database %q", ErrReassignPrefix, db.Name)
+	}
+	newDBName := newPrefix + strings.TrimPrefix(db.Name, oldPrefix)
+
+	// Precise app-install refusal (application_installs.db_id — GH #1609/#1238):
+	// the install's config carries the OLD owner's DB credentials.
+	if inst, err := d.Installs.FindByDBID(ctx, db.ID); err == nil && inst != nil {
+		return nil, &AttachedError{InstallID: inst.ID}
+	} else if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		// Fail closed: never move a database while the leak check is unavailable.
+		return nil, fmt.Errorf("%w: app-install check: %v", ErrInternal, err)
+	}
+
+	// Package clamps on the NEW owner (#282: never fail-open a clamp). Load the
+	// package once here; the DB clamp is checked now, the DB-user clamp after the
+	// bound users are resolved (below).
+	var newOwnerPkg *models.HostingPackage
+	if newOwner.PackageID != nil && *newOwner.PackageID != "" {
+		newOwnerPkg, err = d.Packages.FindByID(ctx, *newOwner.PackageID)
+		if err != nil {
+			return nil, fmt.Errorf("%w: load new owner package: %v", ErrInternal, err)
+		}
+		if newOwnerPkg.MaxDatabases > 0 {
+			count, err := d.Databases.CountByUserID(ctx, newOwner.ID)
+			if err != nil {
+				return nil, fmt.Errorf("%w: count new owner databases: %v", ErrInternal, err)
+			}
+			if count >= int64(newOwnerPkg.MaxDatabases) {
+				return nil, fmt.Errorf("%w: %d/%d databases", ErrQuotaExceeded, count, newOwnerPkg.MaxDatabases)
+			}
+		}
+	}
+
+	// Resolve the DB users bound to this database (via grants), and refuse any
+	// that are shared with another database/owner or off-convention.
+	type moveUser struct {
+		id      string
+		oldName string
+		newName string
+	}
+	grants, err := d.DatabaseGrants.ListByDatabaseID(ctx, db.ID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: list grants for database: %v", ErrInternal, err)
+	}
+	seen := map[string]bool{}
+	var users []moveUser
+	for i := range grants {
+		duID := grants[i].DatabaseUserID
+		if seen[duID] {
+			continue
+		}
+		seen[duID] = true
+
+		du, err := d.DatabaseUsers.FindByID(ctx, duID)
+		if err != nil || du == nil {
+			return nil, fmt.Errorf("%w: load database user %s: %v", ErrInternal, duID, err)
+		}
+		if du.UserID != db.UserID {
+			return nil, fmt.Errorf("%w: user %q is owned by another tenant", ErrReassignSharedUser, du.Username)
+		}
+		if du.Engine != "mariadb" {
+			return nil, fmt.Errorf("%w: user %q is a %s user", ErrReassignEngine, du.Username, du.Engine)
+		}
+		if !strings.HasPrefix(du.Username, oldPrefix) {
+			return nil, fmt.Errorf("%w: database user %q", ErrReassignPrefix, du.Username)
+		}
+		// Shared-user refusal: any grant of this user on a DIFFERENT database.
+		duGrants, err := d.DatabaseGrants.ListByDatabaseUserID(ctx, duID)
+		if err != nil {
+			return nil, fmt.Errorf("%w: list grants for user %q: %v", ErrInternal, du.Username, err)
+		}
+		for j := range duGrants {
+			if duGrants[j].DatabaseID != db.ID {
+				return nil, fmt.Errorf("%w: user %q also has access to another database", ErrReassignSharedUser, du.Username)
+			}
+		}
+		users = append(users, moveUser{
+			id:      du.ID,
+			oldName: du.Username,
+			newName: newPrefix + strings.TrimPrefix(du.Username, oldPrefix),
+		})
+	}
+
+	// Package DB-user clamp on the NEW owner (#282): the move brings len(users)
+	// DB users across, so the new owner's total must not breach MaxDatabaseUsers.
+	if newOwnerPkg != nil && newOwnerPkg.MaxDatabaseUsers > 0 && len(users) > 0 {
+		count, err := d.DatabaseUsers.CountByUserID(ctx, newOwner.ID)
+		if err != nil {
+			return nil, fmt.Errorf("%w: count new owner database users: %v", ErrInternal, err)
+		}
+		if count+int64(len(users)) > int64(newOwnerPkg.MaxDatabaseUsers) {
+			return nil, fmt.Errorf("%w: %d/%d database users", ErrQuotaExceeded, count+int64(len(users)), newOwnerPkg.MaxDatabaseUsers)
+		}
+	}
+
+	// Collision check under the new owner (database + each user), before any move.
+	if exists, err := d.Databases.ExistsByUserAndName(ctx, newOwner.ID, newDBName); err != nil {
+		return nil, fmt.Errorf("%w: collision check database: %v", ErrInternal, err)
+	} else if exists {
+		return nil, fmt.Errorf("%w: database %q", ErrReassignCollision, newDBName)
+	}
+	for _, u := range users {
+		if exists, err := d.DatabaseUsers.ExistsByUserAndUsername(ctx, newOwner.ID, u.newName); err != nil {
+			return nil, fmt.Errorf("%w: collision check user: %v", ErrInternal, err)
+		} else if exists {
+			return nil, fmt.Errorf("%w: database user %q", ErrReassignCollision, u.newName)
+		}
+	}
+
+	// ---- mutate: ALL idempotent agent verbs first, THEN the panel rows ----
+	//
+	// Every agent verb below is a re-runnable no-op once done (db.rename_db /
+	// db.rename_user succeed when old is gone and new is present; grant/revoke
+	// tolerate an already-applied state). Running the whole box-side move before
+	// touching any row means an agent-side failure leaves every panel row on the
+	// OLD names/owner, so a re-run resumes cleanly from the top. Only the row
+	// writes at the end are non-idempotent — and each is a single atomic UPDATE.
+
+	// 1. Rename the database on the box. db.rename_db refuses
+	//    views/triggers/routines/events, so a DB carrying those is rejected here
+	//    before anything moves.
+	if _, err := d.Agent.Call(ctx, "db.rename_db", map[string]any{"old_db": db.Name, "new_db": newDBName}); err != nil {
+		return nil, fmt.Errorf("%w: rename database %q → %q: %v", ErrAgentFailed, db.Name, newDBName, err)
+	}
+
+	// 2. Rename each bound DB user (RENAME USER carries its grants onto the new
+	//    account, still on the OLD db name).
+	for _, u := range users {
+		if _, err := d.Agent.Call(ctx, "db.rename_user", map[string]any{"old_name": u.oldName, "new_name": u.newName}); err != nil {
+			return nil, fmt.Errorf("%w: rename database user %q → %q: %v", ErrAgentFailed, u.oldName, u.newName, err)
+		}
+	}
+
+	// 3. Re-point each grant onto the new db + user, then revoke the stale grant
+	//    the RENAME USER carried over on the OLD db name.
+	for i := range grants {
+		g := &grants[i]
+		var nu string
+		for _, u := range users {
+			if u.id == g.DatabaseUserID {
+				nu = u.newName
+				break
+			}
+		}
+		if nu == "" {
+			continue
+		}
+		privs := splitPrivileges(g.Privileges)
+		if _, err := d.Agent.Call(ctx, "db_user.grant", map[string]any{
+			"db_name": newDBName, "db_user_name": nu, "privileges": privs,
+		}); err != nil {
+			return nil, fmt.Errorf("%w: re-grant %q on %q: %v", ErrAgentFailed, nu, newDBName, err)
+		}
+		if _, err := d.Agent.Call(ctx, "db_user.revoke", map[string]any{
+			"db_name": db.Name, "db_user_name": nu, "privileges": privs,
+		}); err != nil {
+			return nil, fmt.Errorf("%w: revoke stale grant on %q: %v", ErrAgentFailed, db.Name, err)
+		}
+	}
+
+	// 4. Box fully moved. Repoint the panel rows — each an atomic name+owner
+	//    UPDATE. A failure past this point is the one non-resumable window (the
+	//    box is on the new names but a row still claims the old owner); log every
+	//    completed step so an operator can finish the reassign by hand.
+	if err := d.Databases.TransferOwner(ctx, db.ID, newOwner.ID, newDBName); err != nil {
+		return nil, fmt.Errorf("%w: repoint database row to %q owner %s (box already moved — manual resync needed): %v", ErrInternal, newDBName, newOwner.ID, err)
+	}
+	logInfo(d, "dbops.reassign: database row repointed", "database_id", db.ID, "new_name", newDBName, "new_owner", newOwner.ID)
+	for _, u := range users {
+		if err := d.DatabaseUsers.TransferOwner(ctx, u.id, newOwner.ID, u.newName); err != nil {
+			return nil, fmt.Errorf("%w: repoint database-user row to %q owner %s (box already moved — manual resync needed): %v", ErrInternal, u.newName, newOwner.ID, err)
+		}
+		logInfo(d, "dbops.reassign: database-user row repointed", "database_user_id", u.id, "new_name", u.newName, "new_owner", newOwner.ID)
+	}
+
+	db.Name = newDBName
+	db.UserID = newOwner.ID
+	res := &ReassignResult{Database: db, NewName: newDBName}
+	for _, u := range users {
+		res.RenamedUsers = append(res.RenamedUsers, u.newName)
+	}
+	return res, nil
+}
+
+// splitPrivileges turns a stored "ALL" / "SELECT,INSERT" grant string into the
+// list db_user.grant/revoke expect. Empty → ["ALL"] (the row default). Mirrors
+// the userops helper of the same name (GH #1238).
+func splitPrivileges(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{"ALL"}
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return []string{"ALL"}
+	}
+	return out
+}

--- a/panel-api/internal/dbops/dbops_chown_test.go
+++ b/panel-api/internal/dbops/dbops_chown_test.go
@@ -1,0 +1,270 @@
+package dbops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes for the reassign (GH #1609) path ---
+
+type caUsers struct {
+	repository.UserRepository
+	byID map[string]*models.User
+}
+
+func (r *caUsers) FindByID(_ context.Context, id string) (*models.User, error) {
+	if u, ok := r.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type caPackages struct {
+	repository.PackageRepository
+	byID map[string]*models.HostingPackage
+}
+
+func (r *caPackages) FindByID(_ context.Context, id string) (*models.HostingPackage, error) {
+	if p, ok := r.byID[id]; ok {
+		return p, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type caDatabases struct {
+	repository.DatabaseRepository
+	row         *models.Database
+	count       int64
+	existsNames map[string]bool // "<userID>|<name>" → taken
+	newName     string
+	newOwner    string
+}
+
+func (r *caDatabases) FindByID(_ context.Context, id string) (*models.Database, error) {
+	if r.row == nil || r.row.ID != id {
+		return nil, repository.ErrNotFound
+	}
+	return r.row, nil
+}
+func (r *caDatabases) CountByUserID(_ context.Context, _ string) (int64, error) { return r.count, nil }
+func (r *caDatabases) ExistsByUserAndName(_ context.Context, userID, name string) (bool, error) {
+	return r.existsNames[userID+"|"+name], nil
+}
+func (r *caDatabases) UpdateName(_ context.Context, _, name string) error {
+	r.newName = name
+	return nil
+}
+func (r *caDatabases) TransferOwner(_ context.Context, _, uid, name string) error {
+	r.newName = name
+	r.newOwner = uid
+	return nil
+}
+
+type caDBUsers struct {
+	repository.DatabaseUserRepository
+	byID        map[string]*models.DatabaseUser
+	existsUsers map[string]bool // "<userID>|<username>" → taken
+	count       int64           // CountByUserID → for the DB-user cap clamp
+	renamed     map[string]string
+	reowned     map[string]string
+}
+
+func (r *caDBUsers) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
+	if u, ok := r.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (r *caDBUsers) ExistsByUserAndUsername(_ context.Context, userID, username string) (bool, error) {
+	return r.existsUsers[userID+"|"+username], nil
+}
+func (r *caDBUsers) CountByUserID(_ context.Context, _ string) (int64, error) { return r.count, nil }
+func (r *caDBUsers) UpdateUsername(_ context.Context, id, name string) error {
+	if r.renamed == nil {
+		r.renamed = map[string]string{}
+	}
+	r.renamed[id] = name
+	return nil
+}
+func (r *caDBUsers) TransferOwner(_ context.Context, id, uid, name string) error {
+	if r.renamed == nil {
+		r.renamed = map[string]string{}
+	}
+	if r.reowned == nil {
+		r.reowned = map[string]string{}
+	}
+	r.renamed[id] = name
+	r.reowned[id] = uid
+	return nil
+}
+
+type caGrants struct {
+	repository.DatabaseUserGrantRepository
+	byDB   map[string][]models.DatabaseUserGrant
+	byUser map[string][]models.DatabaseUserGrant
+}
+
+func (r *caGrants) ListByDatabaseID(_ context.Context, dbID string) ([]models.DatabaseUserGrant, error) {
+	return r.byDB[dbID], nil
+}
+func (r *caGrants) ListByDatabaseUserID(_ context.Context, duID string) ([]models.DatabaseUserGrant, error) {
+	return r.byUser[duID], nil
+}
+
+func uidPtr(v uint32) *uint32 { return &v }
+func strPtr(s string) *string { return &s }
+
+// caFixture builds a stock scenario: database alice_blog (owner alice) with one
+// DB user alice_web granted rw, reassigning to bob.
+type caFixture struct {
+	ag     *recAgent
+	dbs    *caDatabases
+	dus    *caDBUsers
+	grants *caGrants
+	users  *caUsers
+	pkgs   *caPackages
+	deps   Deps
+}
+
+func newCAFixture() *caFixture {
+	alice := &models.User{ID: "alice", Username: strPtr("alice"), LinuxUID: uidPtr(1001)}
+	bob := &models.User{ID: "bob", Username: strPtr("bob"), LinuxUID: uidPtr(1002)}
+	db := &models.Database{ID: "db1", UserID: "alice", Name: "alice_blog", Engine: "mariadb"}
+	du := &models.DatabaseUser{ID: "du1", UserID: "alice", Username: "alice_web", Engine: "mariadb"}
+	grant := models.DatabaseUserGrant{ID: "g1", DatabaseID: "db1", DatabaseUserID: "du1", GrantLevel: "rw", Privileges: "ALL"}
+
+	f := &caFixture{
+		ag:     &recAgent{},
+		dbs:    &caDatabases{row: db, existsNames: map[string]bool{}},
+		dus:    &caDBUsers{byID: map[string]*models.DatabaseUser{"du1": du}, existsUsers: map[string]bool{}},
+		grants: &caGrants{byDB: map[string][]models.DatabaseUserGrant{"db1": {grant}}, byUser: map[string][]models.DatabaseUserGrant{"du1": {grant}}},
+		users:  &caUsers{byID: map[string]*models.User{"alice": alice, "bob": bob}},
+		pkgs:   &caPackages{byID: map[string]*models.HostingPackage{}},
+	}
+	f.deps = Deps{
+		Users:          f.users,
+		Packages:       f.pkgs,
+		Databases:      f.dbs,
+		DatabaseUsers:  f.dus,
+		DatabaseGrants: f.grants,
+		Installs:       &recInstalls{},
+		Agent:          f.ag,
+	}
+	return f
+}
+
+func TestReassign_HappyPath_RenamesAndReowns(t *testing.T) {
+	f := newCAFixture()
+	res, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.NewName != "bob_blog" {
+		t.Errorf("new db name = %q, want bob_blog", res.NewName)
+	}
+	if f.dbs.newName != "bob_blog" || f.dbs.newOwner != "bob" {
+		t.Errorf("db row not repointed: name=%q owner=%q", f.dbs.newName, f.dbs.newOwner)
+	}
+	if f.dus.renamed["du1"] != "bob_web" || f.dus.reowned["du1"] != "bob" {
+		t.Errorf("db-user row not repointed: name=%q owner=%q", f.dus.renamed["du1"], f.dus.reowned["du1"])
+	}
+	// Transcript: engine rename first (db then user), then re-grant + revoke stale.
+	want := []string{"db.rename_db", "db.rename_user", "db_user.grant", "db_user.revoke"}
+	if strings.Join(f.ag.calls, ",") != strings.Join(want, ",") {
+		t.Errorf("agent transcript = %v, want %v", f.ag.calls, want)
+	}
+}
+
+func TestReassign_Postgres_Refused(t *testing.T) {
+	f := newCAFixture()
+	f.dbs.row.Engine = "postgres"
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err == nil || !contains(err, ErrReassignEngine) {
+		t.Fatalf("want ErrReassignEngine, got %v", err)
+	}
+	if len(f.ag.calls) != 0 {
+		t.Errorf("expected zero mutation, got %v", f.ag.calls)
+	}
+}
+
+func TestReassign_SameOwner_Refused(t *testing.T) {
+	f := newCAFixture()
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "alice"})
+	if err == nil || !contains(err, ErrReassignSameOwner) {
+		t.Fatalf("want ErrReassignSameOwner, got %v", err)
+	}
+}
+
+func TestReassign_AppInstall_Refused_ZeroMutation(t *testing.T) {
+	f := newCAFixture()
+	f.deps.Installs = &recInstalls{install: &models.ApplicationInstall{ID: "inst1"}}
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err == nil || !contains(err, ErrAttached) {
+		t.Fatalf("want ErrAttached, got %v", err)
+	}
+	if len(f.ag.calls) != 0 {
+		t.Errorf("expected zero mutation on refusal, got %v", f.ag.calls)
+	}
+}
+
+func TestReassign_SharedDBUser_Refused(t *testing.T) {
+	f := newCAFixture()
+	// The DB user also has a grant on another database → shared → refuse.
+	f.grants.byUser["du1"] = append(f.grants.byUser["du1"],
+		models.DatabaseUserGrant{ID: "g2", DatabaseID: "other", DatabaseUserID: "du1", Privileges: "ALL"})
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err == nil || !contains(err, ErrReassignSharedUser) {
+		t.Fatalf("want ErrReassignSharedUser, got %v", err)
+	}
+	if len(f.ag.calls) != 0 {
+		t.Errorf("expected zero mutation on refusal, got %v", f.ag.calls)
+	}
+}
+
+func TestReassign_QuotaClamp_Refused(t *testing.T) {
+	f := newCAFixture()
+	bob := f.users.byID["bob"]
+	bob.PackageID = strPtr("pkg1")
+	f.pkgs.byID["pkg1"] = &models.HostingPackage{MaxDatabases: 2}
+	f.dbs.count = 2 // bob already at cap
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err == nil || !contains(err, ErrQuotaExceeded) {
+		t.Fatalf("want ErrQuotaExceeded, got %v", err)
+	}
+}
+
+func TestReassign_DBUserQuotaClamp_Refused(t *testing.T) {
+	f := newCAFixture()
+	bob := f.users.byID["bob"]
+	bob.PackageID = strPtr("pkg1")
+	// DB cap has room; DB-USER cap is the binding one: bob at 2/2, move brings 1 more.
+	f.pkgs.byID["pkg1"] = &models.HostingPackage{MaxDatabases: 10, MaxDatabaseUsers: 2}
+	f.dus.count = 2
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err == nil || !contains(err, ErrQuotaExceeded) {
+		t.Fatalf("want ErrQuotaExceeded (db-user cap), got %v", err)
+	}
+	if len(f.ag.calls) != 0 {
+		t.Errorf("expected zero mutation on refusal, got %v", f.ag.calls)
+	}
+}
+
+func TestReassign_Collision_Refused(t *testing.T) {
+	f := newCAFixture()
+	f.dbs.existsNames["bob|bob_blog"] = true // target name already owned by bob
+	_, err := ReassignDatabaseOwner(context.Background(), f.deps, ReassignInput{DatabaseID: "db1", NewOwnerID: "bob"})
+	if err == nil || !contains(err, ErrReassignCollision) {
+		t.Fatalf("want ErrReassignCollision, got %v", err)
+	}
+	if len(f.ag.calls) != 0 {
+		t.Errorf("expected zero mutation on refusal, got %v", f.ag.calls)
+	}
+}
+
+// contains is errors.Is with a friendlier name for the tables above.
+func contains(err, target error) bool { return errors.Is(err, target) }

--- a/panel-api/internal/repository/database_repository.go
+++ b/panel-api/internal/repository/database_repository.go
@@ -22,6 +22,11 @@ type DatabaseRepository interface {
 	// UpdateName renames the database row in place (GH #1238 DB re-prefix). The
 	// on-disk rename is done by the agent; this repoints the panel row.
 	UpdateName(ctx context.Context, id, name string) error
+	// TransferOwner repoints the database row to a new tenant AND renames it onto
+	// that owner's prefix in a single UPDATE (GH #1609 reassign). Done as one
+	// statement so a reassign never leaves a row half-moved (new name / old
+	// owner, or vice-versa). The engine-level rename is done by the agent first.
+	TransferOwner(ctx context.Context, id, newUserID, newName string) error
 	// ListAllMariaDB returns every MariaDB-engine database (id + name) for the
 	// DB-usage sweeper to map schema sizes back to rows (GH #1242).
 	ListAllMariaDB(ctx context.Context) ([]models.Database, error)
@@ -127,6 +132,12 @@ func (r *databaseRepo) Delete(ctx context.Context, id string) error {
 func (r *databaseRepo) UpdateName(ctx context.Context, id, name string) error {
 	return translate(r.db.WithContext(ctx).
 		Model(&models.Database{}).Where("id = ?", id).Update("name", name).Error)
+}
+
+func (r *databaseRepo) TransferOwner(ctx context.Context, id, newUserID, newName string) error {
+	return translate(r.db.WithContext(ctx).
+		Model(&models.Database{}).Where("id = ?", id).
+		Updates(map[string]any{"user_id": newUserID, "name": newName}).Error)
 }
 
 func (r *databaseRepo) ListAllMariaDB(ctx context.Context) ([]models.Database, error) {

--- a/panel-api/internal/repository/database_user_repository.go
+++ b/panel-api/internal/repository/database_user_repository.go
@@ -20,6 +20,10 @@ type DatabaseUserRepository interface {
 	UpdatePasswordHash(ctx context.Context, id string, hash string) error
 	// UpdateUsername renames the DB-user row in place (GH #1238 DB re-prefix).
 	UpdateUsername(ctx context.Context, id, username string) error
+	// TransferOwner repoints the DB-user row to a new tenant AND renames it onto
+	// that owner's prefix in a single UPDATE (GH #1609 reassign) — never a
+	// half-moved row. The engine-level RENAME USER is done by the agent first.
+	TransferOwner(ctx context.Context, id, newUserID, newUsername string) error
 	ExistsByUserAndUsername(ctx context.Context, userID string, username string) (bool, error)
 }
 
@@ -111,6 +115,11 @@ func (r *databaseUserRepo) UpdatePasswordHash(ctx context.Context, id string, ha
 
 func (r *databaseUserRepo) UpdateUsername(ctx context.Context, id, username string) error {
 	return r.db.WithContext(ctx).Model(&models.DatabaseUser{}).Where("id = ?", id).Update("username", username).Error
+}
+
+func (r *databaseUserRepo) TransferOwner(ctx context.Context, id, newUserID, newUsername string) error {
+	return r.db.WithContext(ctx).Model(&models.DatabaseUser{}).Where("id = ?", id).
+		Updates(map[string]any{"user_id": newUserID, "username": newUsername}).Error
 }
 
 func (r *databaseUserRepo) ExistsByUserAndUsername(ctx context.Context, userID string, username string) (bool, error) {

--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -79,6 +79,8 @@ const PackageList = lazy(() => import("./shells/admin/packages/PackageList").the
 const DomainCreate = lazy(() => import("./shells/admin/domains/DomainCreate").then((m) => ({ default: m.DomainCreate })));
 const DomainEdit = lazy(() => import("./shells/admin/domains/DomainEdit").then((m) => ({ default: m.DomainEdit })));
 const DomainList = lazy(() => import("./shells/admin/domains/DomainList").then((m) => ({ default: m.DomainList })));
+const AdminDatabaseList = lazy(() => import("./shells/admin/databases/DatabaseList").then((m) => ({ default: m.DatabaseList })));
+const AdminDatabaseCreate = lazy(() => import("./shells/admin/databases/DatabaseCreate").then((m) => ({ default: m.DatabaseCreate })));
 const ServerSettingsPage = lazy(() => import("./shells/admin/settings/ServerSettingsPage").then((m) => ({ default: m.ServerSettingsPage })));
 const AdminTerminal = lazy(() => import("./shells/admin/terminal/AdminTerminal").then((m) => ({ default: m.AdminTerminal })));
 const MyProfile = lazy(() => import("./shells/user/MyProfile").then((m) => ({ default: m.MyProfile })));
@@ -264,6 +266,11 @@ const ThemedApp = () => {
               <Route path="create" element={<DomainCreate />} />
               <Route path="edit/:id" element={<DomainEdit />} />
               <Route path=":id/dns" element={<DNSRecordsPage />} />
+            </Route>
+            {/* GH #1609: admin databases list — reassign a database's owner. */}
+            <Route path="databases">
+              <Route index element={<AdminDatabaseList />} />
+              <Route path="create" element={<AdminDatabaseCreate />} />
             </Route>
             <Route
               path="dns"

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -7,6 +7,8 @@
       "users_desc": "Manage panel users, sessions, and impersonation",
       "domains": "Web Domains",
       "domains_desc": "All web domains across every user",
+      "databases": "Databases",
+      "databases_desc": "Browse all databases and reassign their owner",
       "mail": "Mail",
       "mail_desc": "Mailboxes, forwarders, and webmail",
       "packages": "Hosting Packages",
@@ -360,6 +362,7 @@
   },
   "databaselist": {
     "actions": "Actions",
+    "change_owner": "Change owner",
     "charset": "Charset",
     "created": "Created",
     "database": "Database",

--- a/panel-ui/src/nav.ts
+++ b/panel-ui/src/nav.ts
@@ -105,6 +105,13 @@ export const adminNav: NavItem[] = [
     path: "/jabali-admin/domains",
   },
   {
+    key: "databases",
+    label: "nav.admin.databases",
+    description: "nav.admin.databases_desc",
+    icon: navIcon(DatabaseOutlined),
+    path: "/jabali-admin/databases",
+  },
+  {
     key: "mail",
     label: "nav.admin.mail",
     description: "nav.admin.mail_desc",

--- a/panel-ui/src/shells/admin/databases/DatabaseChownAction.tsx
+++ b/panel-ui/src/shells/admin/databases/DatabaseChownAction.tsx
@@ -1,0 +1,163 @@
+// DatabaseChownAction — controlled modal that reassigns a database (and the DB
+// users bound only to it) to a new tenant (GH #1609).
+//
+// The database and its exclusively-bound DB users are renamed onto the new
+// owner's `<username>_` prefix (so the new owner's mysqladmin wildcard grant
+// covers them and the tenant list shows them), their grants are re-pointed, and
+// the panel rows are repointed. POST /admin/databases/:id/chown is admin-only
+// AND behind the JAB-380 step-up — a stale session gets a 403 that apiClient
+// turns into a re-auth + retry.
+//
+// v1 (MariaDB) refuses a postgres database, a database that backs an app install
+// (its config holds the current owner's credentials → cross-tenant leak), a DB
+// user shared with another database, and off-convention names. The backend
+// returns those as a 4xx with a `detail` message, surfaced verbatim.
+import { useMemo, useState } from "react";
+import { Alert, Form, Modal, Select, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../../apiClient";
+import { useListQuery } from "../../../hooks/useQueries";
+import type { Database } from "./DatabaseList";
+
+// The subset of the /users list payload the picker needs.
+type PickableUser = {
+  id: string;
+  username?: string | null;
+  is_admin?: boolean;
+  linux_uid?: number | null;
+};
+
+interface DatabaseChownActionProps {
+  database: Database;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const DatabaseChownAction = ({ database, open, onClose }: DatabaseChownActionProps) => {
+  const qc = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [newOwnerId, setNewOwnerId] = useState<string | undefined>(undefined);
+
+  const isPostgres = database.engine === "postgres";
+
+  // Fetch tenants for the picker. The backend is the real gate (it refuses a
+  // non-tenant, an unprovisioned account, or the current owner); the client
+  // filter just keeps obviously-invalid choices out of the list.
+  const usersQ = useListQuery<PickableUser>({
+    resource: "users",
+    params: { pageSize: 200, is_admin: false },
+    enabled: open && !isPostgres,
+  });
+
+  const options = useMemo(
+    () =>
+      usersQ.items
+        .filter((u) => !u.is_admin && u.id !== database.user_id)
+        .map((u) => ({
+          value: u.id,
+          disabled: u.linux_uid == null,
+          label:
+            (u.username ?? u.id) + (u.linux_uid == null ? " (not provisioned yet)" : ""),
+        })),
+    [usersQ.items, database.user_id],
+  );
+
+  const okDisabled = isPostgres || !newOwnerId;
+
+  const handleClose = () => {
+    setNewOwnerId(undefined);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!newOwnerId) return;
+    setIsLoading(true);
+    try {
+      await apiClient.post(`/admin/databases/${encodeURIComponent(database.id)}/chown`, {
+        new_owner_id: newOwnerId,
+      });
+      feedback.message.success(`Reassigned "${database.name}" to its new owner.`);
+      qc.invalidateQueries({ queryKey: ["list", "databases"] });
+      handleClose();
+    } catch (err: unknown) {
+      // 403 stepup_required is handled globally (apiClient redirects to re-auth).
+      const errMsg =
+        (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data
+          ?.detail ??
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        (err instanceof Error ? err.message : "Change owner failed");
+      feedback.message.error(errMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Change owner"
+      open={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText="Change owner"
+      okButtonProps={{ danger: true, disabled: okDisabled }}
+      confirmLoading={isLoading}
+      destroyOnHidden
+    >
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        Reassigns <b>{database.name}</b> to another tenant. The database and the
+        DB users bound only to it are renamed onto the new owner's prefix and
+        their grants are re-pointed. Applications using the old name/credentials
+        will need updating.
+      </Typography.Paragraph>
+
+      {isPostgres ? (
+        <Alert
+          type="info"
+          showIcon
+          message="PostgreSQL databases can't be reassigned yet"
+          description="v1 supports MariaDB databases only. Reassigning a PostgreSQL database is a follow-up."
+        />
+      ) : (
+        <>
+          <Form layout="vertical">
+            <Form.Item label="New owner">
+              <Select
+                autoFocus
+                showSearch
+                placeholder="Select a tenant"
+                value={newOwnerId}
+                loading={usersQ.isLoading}
+                options={options}
+                optionFilterProp="label"
+                onChange={(v: string) => setNewOwnerId(v)}
+              />
+            </Form.Item>
+          </Form>
+
+          <Alert
+            type="warning"
+            showIcon
+            message="Before you change the owner"
+            description={
+              <ul style={{ margin: 0, paddingInlineStart: 18 }}>
+                <li>
+                  Refused (v1) if the database backs an <b>app install</b> (e.g.
+                  WordPress) — its config holds the current owner's credentials.
+                  Detach or migrate the app first.
+                </li>
+                <li>
+                  Refused if a DB user attached to this database also has access
+                  to another database (it can't be moved cleanly).
+                </li>
+                <li>The database and its users are renamed onto the new owner's prefix.</li>
+                <li>You'll be asked to re-authenticate the first time in a session.</li>
+              </ul>
+            }
+          />
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/panel-ui/src/shells/admin/databases/DatabaseList.tsx
+++ b/panel-ui/src/shells/admin/databases/DatabaseList.tsx
@@ -1,6 +1,7 @@
 // DatabaseList — admin view. Currently unrouted (no /jabali-admin/
 // databases mount in App.tsx) but kept Refine-free so a future route
 // wire-up doesn't have to touch this file again.
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Card, Space, Table, Tag, Typography } from "antd";
 import { shortDateTime } from "../../../utils/datetime";
@@ -13,6 +14,7 @@ import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
 import { useDeleteMutation } from "../../../hooks/useQueries";
 import { useTableURL } from "../../../hooks/useTableURL";
+import { DatabaseChownAction } from "./DatabaseChownAction";
 
 export type Database = {
   id: string;
@@ -39,6 +41,9 @@ export const DatabaseList = () => {
     defaultOrder: "asc",
   });
   const deleteMutation = useDeleteMutation({ resource: "databases" });
+  // GH #1609: admin reassign-owner modal, controlled by the row whose owner is
+  // being changed (null = closed).
+  const [chownTarget, setChownTarget] = useState<Database | null>(null);
 
   const handleTableChange: React.ComponentProps<
     typeof Table<Database>
@@ -138,6 +143,9 @@ export const DatabaseList = () => {
             dataIndex="actions"
             render={(_, r) => (
               <Space>
+                <Button size="small" onClick={() => setChownTarget(r)}>
+                  {t("databaselist.change_owner")}
+                </Button>
                 <RowDeleteButton
                   confirmTitle={`Delete database "${r.name}"?`}
                   onConfirm={async () => {
@@ -149,6 +157,14 @@ export const DatabaseList = () => {
           />
         </SearchableTableStringQ>
       </Card>
+
+      {chownTarget && (
+        <DatabaseChownAction
+          database={chownTarget}
+          open={chownTarget != null}
+          onClose={() => setChownTarget(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What

Adds admin **reassign database owner**: hand a MariaDB database — and the DB users bound only to it — from one tenant to another.

Because the panel names every database and DB user `<owner>_*` and the tenant list filters on that prefix, a reassign is **not** a bare `user_id` repoint. The database and its exclusively-bound DB users are renamed onto the **new** owner's prefix (reusing the GH #1238 `db.rename_db` / `db.rename_user` / `db_user.grant` / `db_user.revoke` agent primitives), their grants re-pointed, and only then are the panel rows moved.

## Ordering (fail-closed, resumable)

Run **all** the idempotent agent verbs first (rename db → rename each user → re-grant/revoke), **then** repoint the panel rows. Consequences:

- An agent-side failure leaves every panel row on the old names/owner → a re-run resumes cleanly from the top (the agent verbs are no-ops once done).
- Each row write is a **single atomic name+owner UPDATE** (`repository.TransferOwner` on both the database and DB-user repos), so the only non-resumable window is between two local UPDATEs (no network). Every completed row write is logged at Info so an operator can finish that rare case by hand.

## v1 refusals (MariaDB-only — refuse rather than half-move)

- **postgres** databases (the rename+regrant path is MariaDB-only, same as user-rename);
- a database that **backs an app install** (its config holds the old owner's DB credentials — a cross-tenant leak; returns `409 in_use_by_app` with the `install_id`);
- a DB user **shared** with another database or owned by another tenant;
- **off-convention** names (not under the current owner's prefix — needs manual review);
- a name **collision** under the new owner.

Package **MaxDatabases** and **MaxDatabaseUsers** clamps apply to the new owner (#282: never fail-open a clamp — the DB-user cap counts the users being moved in).

## Endpoint & UI

- `POST /admin/databases/:id/chown` — admin-only + JAB-380 step-up (`requireRecentAuth`); `503` if the app-install repo is unwired (fail closed); errors mapped `503/404/409/422/500`; audited as `admin.database.chown`.
- This PR also **routes the previously-unrouted admin Databases page** (list + `create`) and adds its **nav entry** — the page's Create button now lands somewhere. Per-row **"Change owner"** modal with a tenant picker; postgres shows an info alert with a disabled OK.
- openapi.yaml updated (coverage test enforces it).

## Tests

- `dbops`: happy path (transcript `db.rename_db,db.rename_user,db_user.grant,db_user.revoke`; `alice_blog`→`bob_blog`, `alice_web`→`bob_web`), plus zero-mutation refusals for postgres / same-owner / app-install / shared-user / DB collision, and both quota clamps (DB and DB-user).
- Backend `go build` / `go vet` / `go test` (dbops, api, repository, app) green; `gofmt` clean.
- UI `tsc` clean, eslint clean on touched files, full vitest **708/708** green.

## v1 limitations (follow-ups)

- **CLI parity** (`jabali-app` / admin CLI) not included here — REST + UI only.
- Legacy app installs with a NULL `db_id` evade the `FindByDBID` leak check (same known gap as `dbops.Delete`).
- The admin list still renders `user_id` as a ULID prefix; a human-readable owner column on this page is a sensible follow-up now that its purpose is owner reassignment.

GH #1609