### PR TITLE
feat(dns): delete a DNS zone while keeping web + mail (GH #1611)

### DIFF
--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
@@ -33,6 +34,9 @@ type DNSHandlerConfig struct {
 	// wire as the fallback (mirrors the domains list).
 	Users      repository.UserRepository
 	Reconciler DNSScheduler
+	// Agent tears down the PowerDNS zone on a DNS-facet delete (GH #1611).
+	// Optional: nil makes DELETE /domains/:id/dns/zone return 503.
+	Agent agent.AgentInterface
 }
 
 func RegisterDNSRoutes(g *gin.RouterGroup, cfg DNSHandlerConfig) {
@@ -42,6 +46,8 @@ func RegisterDNSRoutes(g *gin.RouterGroup, cfg DNSHandlerConfig) {
 	d := g.Group("/domains/:id/dns")
 	d.GET("/zone", h.getZone)
 	d.PATCH("/zone", h.updateZone)
+	// GH #1611: drop the DNS facet (keep web + mail) — "host DNS elsewhere".
+	d.DELETE("/zone", h.deleteZone)
 	d.GET("/records", h.listRecords)
 	d.POST("/records", h.createRecord)
 	// SOA + NS are auto-generated at compile time (never stored in

--- a/panel-api/internal/api/dns_zone_delete.go
+++ b/panel-api/internal/api/dns_zone_delete.go
@@ -1,0 +1,172 @@
+// DNS-zone delete — drop the DNS facet of a domain while keeping web + mail
+// (GH #1611, johnnyq). "Host DNS elsewhere": the panel stops hosting the zone,
+// but the Web Domain and Mail Domain keep working.
+//
+// A jabali "domain" is one row carrying web + mail + DNS facets. This is the
+// mirror image of the GH #1603 facet-preserving WEB delete: there the web facet
+// goes and mail/DNS may stay; here the DNS facet goes and web/mail stay. Both
+// share tearDownDNSFacet so the two paths can never drift on how a zone is torn
+// down.
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// tearDownDNSFacet drops the DNS facet of dom: flip dns_disabled=true, delete the
+// PowerDNS zone on the box, and remove the panel's dns_zones + dns_records rows so
+// the end-state is indistinguishable from a domain created with ManageDNS=false
+// (dns_disabled=1, no zone row — the reconciler never auto-creates one while
+// disabled). Shared by the GH #1603 web-facet delete and the GH #1611 DNS-zone
+// delete.
+//
+// Ordering is fail-closed: the flip runs FIRST and, if it fails, the function
+// returns immediately WITHOUT deleting anything on the box — dns_disabled is
+// still 0, so the reconciler still owns the zone and would resurrect whatever we
+// removed. flipErr is that (hard) failure; a zone-delete or row-cleanup problem
+// is non-fatal residue returned in warnings (the flag is already set, so a retry
+// of the same delete converges).
+func tearDownDNSFacet(
+	ctx context.Context,
+	domains repository.DomainRepository,
+	zones repository.DNSZoneRepository,
+	records repository.DNSRecordRepository,
+	ag agent.AgentInterface,
+	dom *models.Domain,
+) (warnings []string, flipErr error) {
+	// 1. dns_disabled=true BEFORE any teardown so the reconciler stops pushing
+	//    the zone. On failure the reconciler still owns it → do NOT delete it.
+	if err := domains.UpdateDNSDisabled(ctx, dom.ID, true); err != nil {
+		return nil, err
+	}
+
+	// 2. Delete the PowerDNS zone on the box. A box without the DNS module has no
+	//    PowerDNS backend; that is permanent, not a failure.
+	zctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	_, zerr := ag.Call(zctx, "dns.zone.delete", map[string]string{"zone": dom.Name})
+	cancel()
+	if zerr != nil && !strings.Contains(zerr.Error(), "powerdns backend not available") {
+		warnings = append(warnings, "DNS zone not removed on the server; remove it manually if it lingers")
+	}
+
+	// 3. Remove the panel's zone + records rows so the domain matches the
+	//    ManageDNS=false shape (no zone row). FindByDomainID → ErrNotFound simply
+	//    means there was never a row (created disabled) — nothing to clean. The
+	//    repos are optional (nil in a dev binary without DNS wired); a missing one
+	//    just leaves the rows in place, non-fatally.
+	if zones == nil || records == nil {
+		return warnings, nil
+	}
+	if z, err := zones.FindByDomainID(ctx, dom.ID); err == nil && z != nil {
+		if err := records.DeleteByZoneID(ctx, z.ID); err != nil {
+			warnings = append(warnings, "DNS records not cleared from the panel database")
+		}
+		if err := zones.Delete(ctx, z.ID); err != nil {
+			warnings = append(warnings, "DNS zone row not cleared from the panel database")
+		}
+	}
+	return warnings, nil
+}
+
+// tenantMayDeleteZone reports whether a non-admin tenant may delete an entire
+// zone under the server's per-type DNS record policy (GH #466). A zone delete
+// removes EVERY record, so the conservative rule is: permit it only if the
+// policy allows `delete` on every user-manageable record type. If an admin has
+// locked delete on even one type (say MX), a tenant cannot drop the whole zone
+// out from under that restriction — they delete records within their allowance
+// instead. Mirrors the per-record delete gate in deleteRecord so the zone path
+// can't be used to bypass it wholesale.
+func tenantMayDeleteZone(pol models.DNSUserRecordPolicy) bool {
+	for _, t := range models.UserManageableDNSTypes {
+		if !pol.Allows(t, "delete") {
+			return false
+		}
+	}
+	return true
+}
+
+// deleteZone serves DELETE /domains/:id/dns/zone — drop the DNS facet, keep web
+// + mail. Admin or the domain's owner. Refuses (v1) rather than surprise:
+//   - the panel's own primary domain (its DNS underpins the panel);
+//   - a DNSSEC-signed zone (deleting it makes the domain bogus for validating
+//     resolvers while the DS still sits at the registrar);
+//   - the domain's LAST facet (web off + mail off): deleting DNS would leave an
+//     empty row — the caller should delete the whole domain instead.
+func (h *dnsHandler) deleteZone(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	if h.cfg.Agent == nil {
+		// Dev binary without an agent wired: the teardown can't run.
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dns_teardown_unavailable"})
+		return
+	}
+
+	// FindByID + owner-or-admin authorization (401/403/404/500 handled inside).
+	dom := h.loadDomainOwned(c, c.Param("id"))
+	if dom == nil {
+		return
+	}
+	claims := ginctx.Claims(c) // non-nil: loadDomainOwned already gated it.
+
+	if dom.IsPanelPrimary {
+		c.JSON(http.StatusForbidden, gin.H{"error": "panel_primary_protected"})
+		return
+	}
+
+	// Per-type DNS policy gate for non-admin tenants (GH #466). A zone delete is a
+	// delete of every record, so a tenant may drop the zone only if the policy
+	// permits delete on every user-manageable type; admins bypass. Same 403 shape
+	// as the per-record delete gate so a restricted tenant can't bypass it here.
+	if !claims.IsAdmin && !tenantMayDeleteZone(h.userRecordPolicy(ctx)) {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":  "record_type_forbidden",
+			"detail": "Your administrator does not allow deleting one or more DNS record types, so you cannot delete the whole zone.",
+		})
+		return
+	}
+
+	// Transition guards only fire when DNS is currently managed. If it's already
+	// disabled the call is an idempotent cleanup (a retry after a partial run),
+	// so let tearDownDNSFacet mop up any lingering zone/rows and return 200.
+	if !dom.DNSDisabled {
+		if dom.DNSSECEnabled {
+			c.JSON(http.StatusConflict, gin.H{
+				"error":  "dnssec_enabled",
+				"detail": "Disable DNSSEC and remove the DS record at your registrar before deleting the zone.",
+			})
+			return
+		}
+		if dom.WebDisabled && !dom.EmailEnabled {
+			c.JSON(http.StatusConflict, gin.H{
+				"error":  "last_facet",
+				"detail": "This domain has only DNS (no web, no mail). Delete the whole domain instead.",
+			})
+			return
+		}
+	}
+
+	// The teardown must complete even if the client hangs up.
+	ctx = context.WithoutCancel(ctx)
+	warnings, flipErr := tearDownDNSFacet(ctx, h.cfg.Domains, h.cfg.Zones, h.cfg.Records, h.cfg.Agent, dom)
+	if flipErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if h.cfg.Reconciler != nil {
+		h.cfg.Reconciler.Schedule(dom.ID)
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"kept":     gin.H{"web": !dom.WebDisabled, "mail": dom.EmailEnabled},
+		"warnings": warnings,
+	})
+}

--- a/panel-api/internal/api/dns_zone_delete_test.go
+++ b/panel-api/internal/api/dns_zone_delete_test.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Fakes for the GH #1611 DNS-zone delete. Each embeds its repository interface so
+// only the methods deleteZone/tearDownDNSFacet touch are implemented; any other
+// call panics (guards against silent scope creep).
+
+type dzDomainRepo struct {
+	repository.DomainRepository
+	dom       *models.Domain
+	flipCalls int
+	flipErr   error
+	flippedTo bool
+	notFound  bool
+}
+
+func (r *dzDomainRepo) FindByID(_ context.Context, id string) (*models.Domain, error) {
+	if r.notFound || r.dom == nil || r.dom.ID != id {
+		return nil, repository.ErrNotFound
+	}
+	return r.dom, nil
+}
+func (r *dzDomainRepo) UpdateDNSDisabled(_ context.Context, _ string, disabled bool) error {
+	r.flipCalls++
+	if r.flipErr != nil {
+		return r.flipErr
+	}
+	r.flippedTo = disabled
+	return nil
+}
+
+type dzZoneRepo struct {
+	repository.DNSZoneRepository
+	zone        *models.DNSZone
+	deletedZone string
+}
+
+func (r *dzZoneRepo) FindByDomainID(_ context.Context, domainID string) (*models.DNSZone, error) {
+	if r.zone == nil || r.zone.DomainID != domainID {
+		return nil, repository.ErrNotFound
+	}
+	return r.zone, nil
+}
+func (r *dzZoneRepo) Delete(_ context.Context, id string) error {
+	r.deletedZone = id
+	return nil
+}
+
+type dzRecordRepo struct {
+	repository.DNSRecordRepository
+	deletedByZone string
+}
+
+func (r *dzRecordRepo) DeleteByZoneID(_ context.Context, zoneID string) error {
+	r.deletedByZone = zoneID
+	return nil
+}
+
+func dzDo(h *dnsHandler, id, userID string, isAdmin bool) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/domains/"+id+"/dns/zone", nil)
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: isAdmin})
+	h.deleteZone(c)
+	return w
+}
+
+func dzHandler(dom *models.Domain, zone *models.DNSZone) (*dnsHandler, *dzDomainRepo, *dzZoneRepo, *dzRecordRepo, *mockAgent) {
+	dr := &dzDomainRepo{dom: dom}
+	zr := &dzZoneRepo{zone: zone}
+	rr := &dzRecordRepo{}
+	ag := &mockAgent{}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr, Zones: zr, Records: rr, Agent: ag}}
+	return h, dr, zr, rr, ag
+}
+
+func TestDeleteZone_HappyPath_KeepsWebMail(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true}
+	zone := &models.DNSZone{ID: "z1", DomainID: "d1"}
+	h, dr, zr, rr, ag := dzHandler(dom, zone)
+
+	w := dzDo(h, "d1", "u1", false)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Kept struct {
+			Web  bool `json:"web"`
+			Mail bool `json:"mail"`
+		} `json:"kept"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Kept.Web, "web kept")
+	assert.True(t, resp.Kept.Mail, "mail kept")
+
+	assert.Equal(t, 1, dr.flipCalls, "dns_disabled flipped once")
+	assert.True(t, dr.flippedTo, "flipped to disabled")
+	assert.Equal(t, "dns.zone.delete", ag.lastCommand, "pdns zone deleted")
+	assert.Equal(t, 1, ag.callCount)
+	assert.Equal(t, "z1", rr.deletedByZone, "records cleared")
+	assert.Equal(t, "z1", zr.deletedZone, "zone row cleared")
+}
+
+func TestDeleteZone_PanelPrimary_Refused(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "panel.example", UserID: "u1", IsPanelPrimary: true}
+	h, dr, _, _, ag := dzHandler(dom, nil)
+	w := dzDo(h, "d1", "u1", true)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "panel_primary_protected")
+	assert.Equal(t, 0, dr.flipCalls, "no flip on refusal")
+	assert.Equal(t, 0, ag.callCount, "no teardown on refusal")
+}
+
+func TestDeleteZone_DNSSEC_Refused(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true, DNSSECEnabled: true}
+	h, dr, _, _, ag := dzHandler(dom, nil)
+	w := dzDo(h, "d1", "u1", false)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "dnssec_enabled")
+	assert.Equal(t, 0, dr.flipCalls)
+	assert.Equal(t, 0, ag.callCount)
+}
+
+func TestDeleteZone_LastFacet_Refused(t *testing.T) {
+	// web off + mail off → DNS is the only facet → refuse (delete the domain).
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", WebDisabled: true, EmailEnabled: false}
+	h, dr, _, _, ag := dzHandler(dom, nil)
+	w := dzDo(h, "d1", "u1", false)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "last_facet")
+	assert.Equal(t, 0, dr.flipCalls)
+	assert.Equal(t, 0, ag.callCount)
+}
+
+func TestDeleteZone_NonOwnerTenant_Forbidden(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "owner", EmailEnabled: true}
+	h, dr, _, _, ag := dzHandler(dom, nil)
+	w := dzDo(h, "d1", "someone-else", false)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "forbidden")
+	assert.Equal(t, 0, dr.flipCalls)
+	assert.Equal(t, 0, ag.callCount)
+}
+
+func TestDeleteZone_NotFound(t *testing.T) {
+	h, _, _, _, ag := dzHandler(nil, nil)
+	w := dzDo(h, "nope", "u1", true)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, 0, ag.callCount)
+}
+
+func TestDeleteZone_FlipFail_500_NoTeardown(t *testing.T) {
+	// The flip failing means dns_disabled is still 0 → the reconciler still owns
+	// the zone; tearDownDNSFacet must NOT delete it, and the caller returns 500.
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true}
+	zone := &models.DNSZone{ID: "z1", DomainID: "d1"}
+	h, dr, zr, rr, ag := dzHandler(dom, zone)
+	dr.flipErr = assert.AnError
+	w := dzDo(h, "d1", "u1", false)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, 1, dr.flipCalls, "flip attempted")
+	assert.Equal(t, 0, ag.callCount, "no pdns delete after a failed flip")
+	assert.Empty(t, zr.deletedZone, "zone row untouched")
+	assert.Empty(t, rr.deletedByZone, "records untouched")
+}
+
+func TestDeleteZone_AgentNil_503(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: &dzDomainRepo{dom: dom}}}
+	w := dzDo(h, "d1", "u1", false)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "dns_teardown_unavailable")
+}
+
+func TestDeleteZone_TenantRestrictedByPolicy(t *testing.T) {
+	// GH #466: an admin has locked tenant record deletes (locked-down denies
+	// delete on MX/TXT/SRV/CAA). A non-admin owner must not drop the whole zone —
+	// that would delete the very records they're barred from deleting — but an
+	// admin still bypasses the matrix.
+	locked, _ := models.DNSPolicyPreset("locked-down")
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{ID: 1, DNSUserRecordPolicy: locked}}
+
+	newH := func() (*dnsHandler, *dzDomainRepo, *mockAgent) {
+		dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true}
+		dr := &dzDomainRepo{dom: dom}
+		ag := &mockAgent{}
+		h := &dnsHandler{cfg: DNSHandlerConfig{
+			Domains: dr, Zones: &dzZoneRepo{}, Records: &dzRecordRepo{}, Agent: ag, ServerSettings: settings,
+		}}
+		return h, dr, ag
+	}
+
+	t.Run("non-admin owner forbidden", func(t *testing.T) {
+		h, dr, ag := newH()
+		w := dzDo(h, "d1", "u1", false)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), "record_type_forbidden")
+		assert.Equal(t, 0, dr.flipCalls, "no flip when policy forbids")
+		assert.Equal(t, 0, ag.callCount, "no teardown when policy forbids")
+	})
+
+	t.Run("admin bypasses the matrix", func(t *testing.T) {
+		h, dr, ag := newH()
+		w := dzDo(h, "d1", "admin", true)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 1, dr.flipCalls, "admin tears down despite the locked policy")
+		assert.Equal(t, 1, ag.callCount)
+	})
+}
+
+func TestDeleteZone_AlreadyDisabled_Idempotent(t *testing.T) {
+	// A retry after a partial run: dns_disabled is already true and no zone row
+	// remains. The transition guards are skipped; tearDownDNSFacet re-flips
+	// (idempotent), still calls the agent, finds no row to clean, returns 200.
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true, DNSDisabled: true}
+	h, dr, _, _, ag := dzHandler(dom, nil) // nil zone → FindByDomainID ErrNotFound
+	w := dzDo(h, "d1", "u1", false)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, dr.flipCalls, "re-flip is idempotent")
+	assert.Equal(t, 1, ag.callCount, "pdns delete still attempted")
+}

--- a/panel-api/internal/api/domain_facet_delete.go
+++ b/panel-api/internal/api/domain_facet_delete.go
@@ -11,7 +11,6 @@ package api
 import (
 	"context"
 	"log/slog"
-	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -73,19 +72,16 @@ func (h *domainHandler) facetPreservingWebDelete(
 		warnings = append(warnings, mailWarnings...)
 	}
 
-	// 4. Delete the DNS Zone (optional) — flip dns_disabled so the reconciler
-	//    stops pushing the zone, then delete the PowerDNS zone. A box without the
-	//    DNS module has no PowerDNS backend; that is permanent, not a failure.
+	// 4. Delete the DNS Zone (optional) — shared with the GH #1611 DNS-zone
+	//    delete so the two paths tear a zone down identically: flip dns_disabled,
+	//    delete the PowerDNS zone, and clear the panel's zone + records rows so
+	//    the domain matches the ManageDNS=false shape.
 	if deleteDNS {
-		if err := h.cfg.Domains.UpdateDNSDisabled(ctx, dom.ID, true); err != nil {
+		w, flipErr := tearDownDNSFacet(ctx, h.cfg.Domains, h.cfg.DNSZones, h.cfg.DNSRecords, h.cfg.Agent, dom)
+		if flipErr != nil {
 			warnings = append(warnings, "DNS management flag not cleared in the database")
 		}
-		zctx, zcancel := context.WithTimeout(ctx, 30*time.Second)
-		_, zerr := h.cfg.Agent.Call(zctx, "dns.zone.delete", map[string]string{"zone": dom.Name})
-		zcancel()
-		if zerr != nil && !strings.Contains(zerr.Error(), "powerdns backend not available") {
-			warnings = append(warnings, "DNS zone not removed; remove it manually if it lingers")
-		}
+		warnings = append(warnings, w...)
 	}
 
 	// 5. Delete the files (optional) — same async, tenant-uid removal the full

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3069,6 +3069,17 @@ paths:
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
+    delete:
+      tags: [Dns]
+      summary: Delete the DNS zone (drop DNS, keep web + mail — GH #1611)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "200": { description: DNS facet removed; web + mail kept }
+        "403": { description: Forbidden or panel-primary protected }
+        "404": { description: Domain not found }
+        "409": { description: DNSSEC signed, or DNS is the domain's only facet }
+        "503": { description: DNS teardown unavailable (agent not wired) }
 
 
   # --- Dnssec (auto) ---

--- a/panel-api/internal/api/user_token_scopes_test.go
+++ b/panel-api/internal/api/user_token_scopes_test.go
@@ -28,6 +28,7 @@ func scopeTestRouter(tok *models.UserAPIToken) *gin.Engine {
 	v1.GET("/domains/:id/dns/records", ok)
 	v1.POST("/domains/:id/dns/records", ok)
 	v1.PATCH("/dns/records/:recordId", ok)
+	v1.DELETE("/domains/:id/dns/zone", ok)    // GH #1611 destructive DNS-zone delete
 	v1.GET("/domains/:id/mail/mailboxes", ok) // unmapped
 	return r
 }
@@ -58,6 +59,8 @@ func TestEnforceUserTokenScopes(t *testing.T) {
 		{"read:dns cannot write dns", readDNS, "POST", "/api/v1/domains/d1/dns/records", http.StatusForbidden},
 		{"write:dns writes dns", writeDNS, "POST", "/api/v1/domains/d1/dns/records", http.StatusOK},
 		{"write:dns on record route", writeDNS, "PATCH", "/api/v1/dns/records/r1", http.StatusOK},
+		{"read:dns cannot delete zone", readDNS, "DELETE", "/api/v1/domains/d1/dns/zone", http.StatusForbidden},
+		{"write:dns deletes zone", writeDNS, "DELETE", "/api/v1/domains/d1/dns/zone", http.StatusOK},
 		{"dns token denied on unmapped mail", writeDNS, "GET", "/api/v1/domains/d1/mail/mailboxes", http.StatusForbidden},
 		{"ddns token denied on dns REST", ddns, "GET", "/api/v1/domains/d1/dns/records", http.StatusForbidden},
 		{"ddns token denied on unmapped", ddns, "GET", "/api/v1/domains/d1/mail/mailboxes", http.StatusForbidden},

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -986,6 +986,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				ServerSettings: deps.ServerSettings,
 				Users:          deps.Users,
 				Reconciler:     deps.Reconciler,
+				Agent:          deps.Agent, // GH #1611: DNS-zone delete teardown
 			})
 		}
 		if deps.Domains != nil && deps.SSLCerts != nil {

--- a/panel-ui/src/components/dns/DNSZoneDeleteAction.tsx
+++ b/panel-ui/src/components/dns/DNSZoneDeleteAction.tsx
@@ -1,0 +1,78 @@
+// DNSZoneDeleteAction — controlled confirm modal that deletes a domain's DNS
+// zone while keeping the Web Domain and Mail Domain (GH #1611, johnnyq). The
+// panel stops hosting DNS for the domain ("host DNS elsewhere"); web + mail are
+// untouched.
+//
+// DELETE /domains/:id/dns/zone is admin-or-owner. The backend refuses (4xx with
+// a `detail`) a DNSSEC-signed zone, the panel's own primary domain, and a domain
+// whose only remaining facet is DNS (delete the whole domain instead); those
+// messages are surfaced verbatim.
+import { useState } from "react";
+import { Alert, Modal, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+import type { DnsZoneRow } from "./DNSZoneInventory";
+
+interface DNSZoneDeleteActionProps {
+  zone: DnsZoneRow;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const DNSZoneDeleteAction = ({ zone, open, onClose }: DNSZoneDeleteActionProps) => {
+  const qc = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleDelete = async () => {
+    setIsLoading(true);
+    try {
+      await apiClient.delete(`/domains/${encodeURIComponent(zone.id)}/dns/zone`);
+      feedback.message.success(
+        `Deleted the DNS zone for "${zone.name}". Web and mail are unchanged.`,
+      );
+      qc.invalidateQueries({ queryKey: ["list", "dns/zones"] });
+      onClose();
+    } catch (err: unknown) {
+      const errMsg =
+        (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data
+          ?.detail ??
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        (err instanceof Error ? err.message : "Delete DNS zone failed");
+      feedback.message.error(errMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Delete DNS zone"
+      open={open}
+      onCancel={onClose}
+      onOk={handleDelete}
+      okText="Delete DNS zone"
+      okButtonProps={{ danger: true }}
+      confirmLoading={isLoading}
+      destroyOnHidden
+    >
+      <Typography.Paragraph>
+        This removes the panel-hosted DNS zone for <b>{zone.name}</b>. The Web Domain and
+        Mail Domain keep working — only DNS hosting moves off the panel.
+      </Typography.Paragraph>
+      <Alert
+        type="warning"
+        showIcon
+        message="Copy your records first — this can't be undone"
+        description={
+          <>
+            The zone and all {zone.record_count} of its records are deleted. If this domain
+            sends or receives mail, copy its <b>MX, SPF, DKIM and DMARC</b> records (Manage
+            Records) and publish them at your new DNS host first, or mail will break.
+          </>
+        }
+      />
+    </Modal>
+  );
+};

--- a/panel-ui/src/components/dns/DNSZoneInventory.test.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.test.tsx
@@ -131,6 +131,18 @@ describe("DnsZoneInventory audience policy (JAB-299)", () => {
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 
+  it("shows a DNS-zone delete action gated by provisioning + DNSSEC (GH #1611)", () => {
+    renderPage(adminAudience);
+
+    // Only the provisioned row carries a delete action; the not-provisioned row
+    // (nothing to tear down) has none.
+    const del = screen.getAllByText("dnszonesoverviewpage.delete_zone");
+    expect(del.length).toBe(1);
+    // The provisioned fixture is DNSSEC-signed, so the button is disabled
+    // (unsign first) — the same refusal the backend enforces.
+    expect(del[0].closest("button")).toBeDisabled();
+  });
+
   it("DNSSEC tab receives showOwner=true for the admin audience (AC5)", () => {
     renderPage(adminAudience);
     fireEvent.click(screen.getByText("DNSSEC"));

--- a/panel-ui/src/components/dns/DNSZoneInventory.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.tsx
@@ -11,13 +11,15 @@
 // action, the DNSSEC owner-visibility + copy, and the page header. Everything
 // else — query state (URL-backed search/sort/page), the whole-list error
 // branch, and the common columns — is shared so the two screens cannot drift.
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Card, Spin, Table, Tag, Tooltip, Typography } from "antd";
+import { Alert, Button, Card, Space, Spin, Table, Tag, Tooltip, Typography } from "antd";
 import { useNavigate } from "react-router";
 
 import { useTabParam } from "../../hooks/useTabParam";
 import { columnSearchProps } from "../columnSearch";
 import { DNSSECTable } from "../dnssec/DNSSECTable";
+import { DNSZoneDeleteAction } from "./DNSZoneDeleteAction";
 import { SearchableTableStringQ } from "../SearchableTable";
 import { useTableURL } from "../../hooks/useTableURL";
 import { sorterToParams } from "../../utils/tableSorter";
@@ -72,6 +74,9 @@ export interface DnsZoneInventoryAudience {
 const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  // GH #1611: the row whose DNS zone is being deleted (null = closed). Admin +
+  // tenant both get the action; the backend enforces admin-or-owner.
+  const [deleteTarget, setDeleteTarget] = useState<DnsZoneRow | null>(null);
 
   // One batched request (JAB-377): the endpoint returns provisioning state +
   // record count + effective TTL per row, so there is no per-domain zone fetch
@@ -198,12 +203,36 @@ const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
           <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.actions")}
             render={(_, record) => (
-              <Button type="primary" onClick={() => navigate(audience.manageRoute(record.id))}>
-                Manage Records
-              </Button>
+              <Space>
+                <Button type="primary" onClick={() => navigate(audience.manageRoute(record.id))}>
+                  Manage Records
+                </Button>
+                {/* GH #1611: delete the DNS zone (keep web + mail). Only for a
+                    panel-hosted zone; a DNSSEC-signed zone must be unsigned
+                    first (the backend refuses it too). */}
+                {record.provisioned &&
+                  (record.dnssec_enabled ? (
+                    <Tooltip title={t("dnszonesoverviewpage.delete_disabled_dnssec")}>
+                      <Button danger disabled>
+                        {t("dnszonesoverviewpage.delete_zone")}
+                      </Button>
+                    </Tooltip>
+                  ) : (
+                    <Button danger onClick={() => setDeleteTarget(record)}>
+                      {t("dnszonesoverviewpage.delete_zone")}
+                    </Button>
+                  ))}
+              </Space>
             )}
           />
         </SearchableTableStringQ>
+      )}
+      {deleteTarget && (
+        <DNSZoneDeleteAction
+          zone={deleteTarget}
+          open={deleteTarget != null}
+          onClose={() => setDeleteTarget(null)}
+        />
       )}
     </>
   );

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -369,6 +369,8 @@
   },
   "dnszonesoverviewpage": {
     "actions": "Actions",
+    "delete_zone": "Delete zone",
+    "delete_disabled_dnssec": "Disable DNSSEC before deleting this zone",
     "dns_zones_are_provisioned_automatically_when": "DNS zones are provisioned automatically when a domain is created. Nameservers are configured in Server Settings.",
     "dnssec": "DNSSEC",
     "domain_name": "Domain Name",


### PR DESCRIPTION
## What

johnnyq (GH #1611): add a **Delete zone** action to the DNS Zone List that drops a domain's **DNS facet** while leaving the **Web Domain** and **Mail Domain** intact — "this allows someone to host DNS elsewhere". Available to admins and to a domain's owner.

Mirror image of the GH #1603 facet-preserving *web* delete: there the web facet goes and mail/DNS may stay; here the DNS facet goes and web/mail stay. Both paths now share one teardown helper.

## How

- **`tearDownDNSFacet`** (new, shared by #1603 and #1611): flip `dns_disabled=true` **first** (fail-closed — if the flip fails the reconciler still owns the zone, so nothing on the box is touched and the caller returns 500), delete the PowerDNS zone, then clear the panel's `dns_zones` + `dns_records` rows so the end-state is indistinguishable from a domain created with `ManageDNS=false` (dns_disabled=1, no zone row — the reconciler never re-creates one while disabled).
- **`DELETE /domains/:id/dns/zone`** — admin-or-owner via `loadDomainOwned`; for API tokens it sits under the existing `write:dns` scope (a `read:dns` token is refused — covered by `user_token_scopes_test.go`).
- Refactored `domain_facet_delete.go` step 4 to call the shared helper.

## Refusals (v1, deliberate)

| Condition | Response |
|---|---|
| Panel's own primary domain | 403 `panel_primary_protected` |
| DNSSEC-signed zone | 409 `dnssec_enabled` (unsign + remove DS at registrar first) |
| DNS is the domain's only remaining facet (web off + mail off) | 409 `last_facet` (delete the whole domain instead) |
| Non-admin tenant + a per-type delete lock (GH #466) | 403 `record_type_forbidden` |
| Already `dns_disabled` | 200 — idempotent cleanup (safe retry after a partial run) |

## Hardening — GH #466 policy gate

A zone delete removes **every** record, so it must not become a way around the per-type DNS record policy. A non-admin tenant may drop the zone only if the policy permits `delete` on **every** user-manageable type; if an admin has locked delete on even one type (say MX), the tenant is refused and must delete records within their allowance instead. Admins bypass the matrix, exactly as with per-record deletes. The tenant Delete button stays visible and surfaces the 403 detail — the server is authoritative (same posture as the per-record delete gate).

## Bug fixed in passing (GH #1603)

The web-facet delete previously removed the PowerDNS zone but left the panel's `dns_zones`/`dns_records` rows behind, and could delete the pdns zone even after a failed `dns_disabled` flip (the reconciler would then resurrect it). Routing both paths through `tearDownDNSFacet` fixes both halves.

## UI

`DNSZoneInventory` gains a Delete action (shared admin + tenant component). Hidden for a not-provisioned row; disabled with a tooltip for a DNSSEC-signed one. The confirm modal warns that MX/SPF/DKIM/DMARC must be re-published at the new DNS host or mail breaks, and that the action can't be undone.

## Tests

- `dns_zone_delete_test.go` (10): happy path keeps web+mail, panel-primary / DNSSEC / last-facet refusals, non-owner 403, not-found, failed-flip → 500 with no teardown, agent-nil → 503, **#466 tenant-restricted → 403 + admin bypass**, **already-disabled → idempotent 200**.
- `user_token_scopes_test.go`: `read:dns` refused, `write:dns` allowed on the new route.
- `openapi.yaml`: DELETE stanza added; `TestOpenAPICoverage` (app pkg) green.
- Backend `api`/`app`/`models` packages green; UI `tsc`/dns vitest green.

## Product notes / follow-ups (not in this PR)

- **One-way in v1.** There is no re-enable-DNS path (`domain update` carries no `ManageDNS`); re-hosting DNS here later is an admin DB flip. "Re-enable DNS" is the natural follow-up. The modal's "can't be undone" wording is honest about this.
- **The row stays.** The zone list is domain-driven, so after delete the domain remains as a **not-provisioned** row with no Delete button (not a disappearing row). A small UX follow-up could label this end-state "External DNS" (add `dns_disabled` to the inventory row) to distinguish it from a reconcile-pending zone.
- **CLI parity** (`jabali dns zone delete`) is a follow-up.
- **DNS-only domains** still need the full-delete surface (the `last_facet` refusal points there).
- **No audit event** — matches the un-audited `DELETE /domains/:id` sibling; align both later.
- Browser smoke of the two DNS routes not run.

GH #1611