### PR TITLE
feat(mail): show external-DNS records for a mail domain with no panel zone (GH #1612)

### DIFF
--- a/panel-api/internal/api/domain_email.go
+++ b/panel-api/internal/api/domain_email.go
@@ -316,7 +316,17 @@ func (h *domainEmailHandler) disable(c *gin.Context) {
 // bare hint list with empty `Status` — the UI falls back to showing
 // them as static instructions.
 func (h *domainEmailHandler) buildHintsWithStatus(ctx context.Context, domainID, domainName, selector, pubKey string) ([]domainEmailDNSHint, []string) {
-	hints := staticEmailHints(domainName, selector, pubKey)
+	// The mail host's public IP (server_settings) leads the record set so an
+	// external-DNS operator (GH #1612) can publish mail.<domain> — every MX/SRV/
+	// autodiscover record points at it. Best-effort: an unwired/unreadable
+	// ServerSettings just omits the A/AAAA rows.
+	ip4, ip6 := "", ""
+	if h.cfg.ServerSettings != nil {
+		if s, err := h.cfg.ServerSettings.Get(ctx); err == nil && s != nil {
+			ip4, ip6 = s.PublicIPv4, s.PublicIPv6
+		}
+	}
+	hints := staticEmailHints(domainName, selector, pubKey, ip4, ip6)
 
 	if h.cfg.DNSZones == nil || h.cfg.DNSRecords == nil {
 		return hints, nil
@@ -365,8 +375,29 @@ func (h *domainEmailHandler) buildHintsWithStatus(ctx context.Context, domainID,
 // records the operator should see regardless of whether live state
 // can be read. When DKIM isn't set yet (pre-enable) the DKIM entry
 // still appears with an empty Value so the UI shows it as "pending".
-func staticEmailHints(domainName, selector, pubKey string) []domainEmailDNSHint {
-	hints := []domainEmailDNSHint{
+//
+// ip4/ip6 are the server's public addresses (server_settings). When known, the
+// mail host's own A/AAAA records lead the list: MX, every SRV, and the
+// autoconfig/autodiscover CNAMEs all point at mail.<domain>, so on EXTERNAL DNS
+// (GH #1612) this is the record without which none of the others resolve. On a
+// panel-hosted zone the M4 bootstrap already publishes it (status shows "ok"),
+// so listing it universally is honest, not redundant. Empty ip4/ip6 (server IP
+// unknown, or ServerSettings not wired) simply omits the row.
+func staticEmailHints(domainName, selector, pubKey, ip4, ip6 string) []domainEmailDNSHint {
+	hints := make([]domainEmailDNSHint, 0, 16)
+	if ip4 != "" {
+		hints = append(hints, domainEmailDNSHint{
+			Purpose: "A — the mail host itself; MX, SRV and autodiscover all point here",
+			Name:    "mail." + domainName + ".", Type: "A", Value: ip4,
+		})
+	}
+	if ip6 != "" {
+		hints = append(hints, domainEmailDNSHint{
+			Purpose: "AAAA — the mail host over IPv6",
+			Name:    "mail." + domainName + ".", Type: "AAAA", Value: ip6,
+		})
+	}
+	hints = append(hints, []domainEmailDNSHint{
 		{Purpose: "MX — delivers incoming mail to this host", Name: domainName + ".", Type: "MX", Value: "10 mail." + domainName + "."},
 		{Purpose: "SPF — authorises this host to send mail for the domain", Name: domainName + ".", Type: "TXT", Value: `v=spf1 mx ~all`},
 		{Purpose: "DMARC — tells receivers to reject unauthenticated mail", Name: "_dmarc." + domainName + ".", Type: "TXT", Value: "v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"},
@@ -380,7 +411,7 @@ func staticEmailHints(domainName, selector, pubKey string) []domainEmailDNSHint 
 		{Purpose: "TLS-RPT — receives aggregate TLS-failure reports (RFC 8460)", Name: "_smtp._tls." + domainName + ".", Type: "TXT", Value: "v=TLSRPTv1; rua=mailto:postmaster@" + domainName},
 		{Purpose: "CAA — restricts cert issuance to Let's Encrypt", Name: domainName + ".", Type: "CAA", Value: `0 issue "letsencrypt.org"`},
 		{Purpose: "CAA — incident-reporting address for cert issues", Name: domainName + ".", Type: "CAA", Value: `0 iodef "mailto:postmaster@` + domainName + `"`},
-	}
+	}...)
 	if selector != "" && pubKey != "" {
 		hints = append(hints, domainEmailDNSHint{
 			Purpose: "DKIM — signs outbound mail so receivers can verify it",

--- a/panel-api/internal/api/domain_email_test.go
+++ b/panel-api/internal/api/domain_email_test.go
@@ -248,6 +248,61 @@ func TestDomainEmail_Get_NotFound(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+// TestDomainEmail_Get_IncludesMailHostAWhenServerIPKnown — GH #1612: when the
+// server's public IP is known, the mail host's A/AAAA records lead the hint
+// list. On external DNS these are the records every MX/SRV/autodiscover entry
+// points at, so without them nothing resolves. Also asserts the DKIM Value is
+// the full TXT content (v=DKIM1; …), copy-pasteable as-is.
+func TestDomainEmail_Get_IncludesMailHostAWhenServerIPKnown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "user1", IsAdmin: false})
+		c.Next()
+	})
+	domains := newMockDomainRepo()
+	// Production stores the agent's DKIM value verbatim and UNQUOTED (the zone
+	// publisher adds the quotes at wire time — email_records.go). The hint's Value
+	// is that raw string, copy-pasteable into a provider's TXT field as-is.
+	sel, key := "jabali", "v=DKIM1;k=ed25519;p=AAAA"
+	domains.domains["dom1"] = &models.Domain{
+		ID: "dom1", UserID: "user1", Name: "example.com",
+		EmailEnabled: true, DkimSelector: &sel, DkimPublicKey: &key,
+	}
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		ID: 1, PublicIPv4: "203.0.113.9", PublicIPv6: "2001:db8::9",
+	}}
+	RegisterDomainEmailRoutes(v1, DomainEmailHandlerConfig{
+		Domains: domains, Agent: &mockAgent{}, ServerSettings: settings,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/domains/dom1/email", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var resp domainEmailResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	require.GreaterOrEqual(t, len(resp.Records), 2)
+	require.Equal(t, "A", resp.Records[0].Type, "mail-host A leads the list")
+	require.Equal(t, "mail.example.com.", resp.Records[0].Name)
+	require.Equal(t, "203.0.113.9", resp.Records[0].Value)
+	require.Equal(t, "AAAA", resp.Records[1].Type)
+	require.Equal(t, "mail.example.com.", resp.Records[1].Name)
+	require.Equal(t, "2001:db8::9", resp.Records[1].Value)
+
+	byKey := map[string]domainEmailDNSHint{}
+	for _, h := range resp.Records {
+		byKey[h.Type+":"+h.Name] = h
+	}
+	dkim, ok := byKey["TXT:jabali._domainkey.example.com."]
+	require.True(t, ok, "DKIM hint present when enabled")
+	require.Equal(t, "v=DKIM1;k=ed25519;p=AAAA", dkim.Value,
+		"DKIM Value is the raw TXT content (unquoted), copy-pasteable as-is")
+}
+
 // ---- M6 Step 6: DNS autoconfig sync ---------------------------------
 
 // Enable with DNS repos wired must insert the three M6 records

--- a/panel-api/internal/api/me_mail_domains.go
+++ b/panel-api/internal/api/me_mail_domains.go
@@ -68,6 +68,11 @@ type mailDomainRow struct {
 	// recipient). nil = unknown (agent unavailable) — omitted from JSON so the
 	// UI shows "—" instead of a misleading 0.
 	Queue *int64 `json:"queue,omitempty"`
+	// DNSDisabled marks a mail domain whose DNS the panel does NOT host (external
+	// DNS — GH #1449 create-with-DNS-off, or GH #1611 zone delete). The UI badges
+	// it "External DNS" and offers the "DNS records" action (GH #1612) so the
+	// operator can publish MX/SPF/DKIM/… at their own provider.
+	DNSDisabled bool `json:"dns_disabled"`
 }
 
 func (h *meMailDomainsHandler) list(c *gin.Context) {
@@ -143,6 +148,7 @@ func (h *meMailDomainsHandler) list(c *gin.Context) {
 			EmailEnabled:     d.EmailEnabled,
 			SSLState:         d.SSLState,
 			IsQuotaSuspended: d.IsQuotaSuspended,
+			DNSDisabled:      d.DNSDisabled,
 		})
 	}
 

--- a/panel-api/internal/api/me_mail_domains_test.go
+++ b/panel-api/internal/api/me_mail_domains_test.go
@@ -89,7 +89,7 @@ func TestMailDomains_AggregatesAndScopes(t *testing.T) {
 	cfg := MeMailDomainsConfig{
 		Domains: mdDomainRepo{ds: []models.Domain{
 			{ID: "da", UserID: "u1", Name: "a.test", EmailEnabled: true, SSLState: "active_le"},
-			{ID: "db", UserID: "u1", Name: "b.test", EmailEnabled: true, IsQuotaSuspended: true},
+			{ID: "db", UserID: "u1", Name: "b.test", EmailEnabled: true, IsQuotaSuspended: true, DNSDisabled: true},
 			{ID: "dd", UserID: "u1", Name: "off.test", EmailEnabled: false},
 			{ID: "dc", UserID: "u2", Name: "c.test", EmailEnabled: true},
 		}},
@@ -159,6 +159,14 @@ func TestMailDomains_AggregatesAndScopes(t *testing.T) {
 	}
 	if !b.IsQuotaSuspended {
 		t.Fatalf("b.test is_quota_suspended = false, want true (suspended active domain still surfaces its state)")
+	}
+	// GH #1612: dns_disabled must reach the wire so the UI can badge "External
+	// DNS" and offer the DNS-records action. b.test has DNS off; a.test does not.
+	if !b.DNSDisabled {
+		t.Fatalf("b.test dns_disabled = false, want true (external DNS)")
+	}
+	if a.DNSDisabled {
+		t.Fatalf("a.test dns_disabled = true, want false (panel-hosted DNS)")
 	}
 	if _, listed := byName["off.test"]; listed {
 		t.Fatalf("off.test (mail off) must be EXCLUDED from the mail-active list: %+v", resp.Data)

--- a/panel-ui/src/components/mail/MailDNSRecordsModal.tsx
+++ b/panel-ui/src/components/mail/MailDNSRecordsModal.tsx
@@ -1,0 +1,125 @@
+// MailDNSRecordsModal — GH #1612 (johnnyq). When a mail domain's DNS is hosted
+// externally (no panel-managed zone), the panel can't publish the mail records
+// itself. This modal shows exactly what the operator must add at their own DNS
+// provider — the mail host A/AAAA, MX, SPF, DKIM, DMARC, autodiscover/SRV,
+// TLS-RPT and CAA — each with a copy button, plus a "Copy all" that emits
+// zone-file lines for bulk import.
+//
+// The record set is the same one GET /domains/:id/email already returns (the
+// panel's authoritative mail-record list), so this can never drift from what a
+// panel-hosted zone would publish. The live "status" column is dropped here on
+// purpose: with no panel zone there's nothing to compare against.
+import { Alert, Button, Modal, Space, Table, Typography, type TableColumnsType } from "antd";
+import { CopyOutlined } from "@icons";
+import { feedback } from "../../lib/feedback";
+import { useDomainEmail, type DomainEmailDNSHint } from "../../hooks/useMailboxes";
+
+interface Props {
+  domainId?: string;
+  domainName?: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+async function copyText(text: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+    feedback.message.success("Copied to clipboard");
+  } catch {
+    feedback.message.error("Copy failed — select the value and copy manually");
+  }
+}
+
+// zoneFileLine renders one hint as a bulk-import-friendly zone-file line. The
+// value already carries record-data form (MX/SRV priorities inlined), so it
+// drops in after "<name> IN <type> ". TXT rdata MUST be quoted for zone-file
+// syntax — an unquoted "v=DMARC1; p=…" is truncated at the first ";" (a comment
+// marker), silently corrupting DMARC/DKIM/TLS-RPT/SPF. Per-value copy stays bare
+// (provider UIs want the raw string); only the zone-file form quotes.
+function zoneFileLine(h: DomainEmailDNSHint): string {
+  const rdata = h.type === "TXT" && !h.value.startsWith('"') ? `"${h.value}"` : h.value;
+  return `${h.name}\tIN\t${h.type}\t${rdata}`;
+}
+
+export function MailDNSRecordsModal({ domainId, domainName, open, onClose }: Props) {
+  // Only fetch while open — passing undefined disables the query.
+  const { data, isLoading } = useDomainEmail(open ? domainId : undefined);
+  const records = (data?.records ?? []).filter((r) => r.value !== "");
+
+  const copyAll = () => {
+    if (records.length === 0) return;
+    void copyText(records.map(zoneFileLine).join("\n"));
+  };
+
+  const columns: TableColumnsType<DomainEmailDNSHint> = [
+    { title: "Name", dataIndex: "name", width: 240, render: (v: string) => <Typography.Text code>{v}</Typography.Text> },
+    { title: "Type", dataIndex: "type", width: 64 },
+    {
+      title: "Value",
+      dataIndex: "value",
+      render: (value: string) => (
+        <Space size="small">
+          <Typography.Text code style={{ wordBreak: "break-all", fontSize: 12 }}>
+            {value}
+          </Typography.Text>
+          <Button
+            size="small"
+            icon={<CopyOutlined />}
+            onClick={() => void copyText(value)}
+            aria-label={`Copy ${value}`}
+          />
+        </Space>
+      ),
+    },
+    {
+      title: "Purpose",
+      dataIndex: "purpose",
+      width: 300,
+      render: (v: string) => <Typography.Text type="secondary">{v}</Typography.Text>,
+    },
+  ];
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      title={domainName ? `DNS records for ${domainName}` : "DNS records"}
+      width={860}
+      footer={[
+        <Button key="copy-all" icon={<CopyOutlined />} onClick={copyAll} disabled={records.length === 0}>
+          Copy all (zone file)
+        </Button>,
+        <Button key="close" type="primary" onClick={onClose}>
+          Close
+        </Button>,
+      ]}
+      destroyOnClose
+    >
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 12 }}
+        message="This domain's DNS is hosted elsewhere"
+        description={
+          <>
+            The panel does not manage this domain's DNS, so it can't publish these
+            records for you. Add them at your DNS provider so mail delivers and
+            authenticates (SPF/DKIM/DMARC) and mail clients auto-configure. Until
+            the <Typography.Text code>MX</Typography.Text> and{" "}
+            <Typography.Text code>mail</Typography.Text> host records exist, incoming
+            mail will not arrive.
+          </>
+        }
+      />
+      <Table<DomainEmailDNSHint>
+        size="small"
+        loading={isLoading}
+        pagination={false}
+        dataSource={records}
+        scroll={{ x: "max-content" }}
+        rowKey={(r) => `${r.type}:${r.name}`}
+        columns={columns}
+      />
+    </Modal>
+  );
+}

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.test.tsx
@@ -202,6 +202,106 @@ describe("GH #1387 — MailDomainsPage (mail-active only)", () => {
     expect(screen.queryByRole("button", { name: /Create Mail Domain/i })).not.toBeInTheDocument();
   });
 
+  // GH #1612 (johnnyq): a mail domain whose DNS is hosted externally
+  // (dns_disabled) gets an "External DNS" tag and a "DNS records" ⋯ action; a
+  // panel-hosted domain gets neither (the panel publishes the records itself).
+  const ROWS_DNS = [
+    { ...ROWS[0], id: "d-int", name: "int.test", dns_disabled: false },
+    { ...ROWS[0], id: "d-ext", name: "ext.test", dns_disabled: true },
+  ];
+
+  function mockDnsList() {
+    mocked.get
+      .mockReset()
+      .mockResolvedValue({ data: { data: ROWS_DNS, total: 2, page: 1, page_size: 2 } });
+  }
+
+  it("GH #1612: external-DNS row is tagged and offers a DNS records action", async () => {
+    mockDnsList();
+    renderPage();
+    const extRow = (await screen.findByText("ext.test")).closest("tr") as HTMLElement;
+    const intRow = (await screen.findByText("int.test")).closest("tr") as HTMLElement;
+
+    // Tag only on the external-DNS row.
+    expect(within(extRow).getByText("External DNS")).toBeInTheDocument();
+    expect(within(intRow).queryByText("External DNS")).not.toBeInTheDocument();
+
+    // ⋯ menu offers "DNS records" on the external row.
+    fireEvent.click(within(extRow).getByRole("button", { name: /Actions for/i }));
+    expect(await screen.findByRole("menuitem", { name: "DNS records" })).toBeInTheDocument();
+  });
+
+  it("GH #1612: panel-hosted-DNS row has no DNS records action", async () => {
+    mockDnsList();
+    renderPage();
+    const intRow = (await screen.findByText("int.test")).closest("tr") as HTMLElement;
+    fireEvent.click(within(intRow).getByRole("button", { name: /Actions for/i }));
+    // Menu opened (Disable present) but no DNS-records item.
+    await screen.findByRole("menuitem", { name: "Disable" });
+    expect(screen.queryByRole("menuitem", { name: "DNS records" })).not.toBeInTheDocument();
+  });
+
+  // DKIM/SPF are stored unquoted (raw provider form); the zone-file "Copy all"
+  // must quote TXT rdata or a ";" truncates DMARC/DKIM/TLS-RPT on bulk import.
+  const EMAIL_STATE = {
+    domain_id: "d-ext",
+    domain_name: "ext.test",
+    email_enabled: true,
+    records: [
+      { purpose: "A — the mail host itself", name: "mail.ext.test.", type: "A", value: "203.0.113.9" },
+      { purpose: "MX — delivers incoming mail", name: "ext.test.", type: "MX", value: "10 mail.ext.test." },
+      { purpose: "SPF — authorises this host", name: "ext.test.", type: "TXT", value: "v=spf1 mx ~all" },
+      { purpose: "DKIM — signs outbound mail", name: "jabali._domainkey.ext.test.", type: "TXT", value: "v=DKIM1;k=ed25519;p=AAAA" },
+    ],
+    warnings: [],
+  };
+
+  function mockDnsListAndEmail() {
+    mocked.get.mockReset().mockImplementation((url: string) => {
+      if (url === "/me/mail-domains") {
+        return Promise.resolve({ data: { data: ROWS_DNS, total: 2, page: 1, page_size: 2 } });
+      }
+      if (url === "/domains/d-ext/email") return Promise.resolve({ data: EMAIL_STATE });
+      return Promise.resolve({ data: {} });
+    });
+  }
+
+  it("GH #1612: DNS records action opens a modal listing records with copy buttons", async () => {
+    mockDnsListAndEmail();
+    renderPage();
+
+    const extRow = (await screen.findByText("ext.test")).closest("tr") as HTMLElement;
+    await openRowMenu(extRow, "DNS records");
+
+    // Modal opens, titled for the domain, listing the records + a copy-all.
+    expect(await screen.findByText("DNS records for ext.test")).toBeInTheDocument();
+    // Records load async after the email GET resolves.
+    expect(await screen.findByText("203.0.113.9")).toBeInTheDocument();
+    expect(screen.getByText("10 mail.ext.test.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy all/i })).toBeInTheDocument();
+    // A per-value copy button exists (aria-labelled with the value).
+    expect(screen.getByRole("button", { name: "Copy 203.0.113.9" })).toBeInTheDocument();
+  });
+
+  it("GH #1612: Copy all quotes TXT rdata so DKIM/SPF survive a zone import", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    mockDnsListAndEmail();
+    renderPage();
+
+    const extRow = (await screen.findByText("ext.test")).closest("tr") as HTMLElement;
+    await openRowMenu(extRow, "DNS records");
+    await screen.findByText("203.0.113.9");
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy all/i }));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    const copied = writeText.mock.calls[0][0] as string;
+    // TXT values are quoted; non-TXT (MX) is not.
+    expect(copied).toContain('\tTXT\t"v=DKIM1;k=ed25519;p=AAAA"');
+    expect(copied).toContain('\tTXT\t"v=spf1 mx ~all"');
+    expect(copied).toContain("\tMX\t10 mail.ext.test.");
+  });
+
   // GH #1479: the mail-mode create posts the right domain shape (web off, mail on
   // Jabali, ssl le, DNS on), and webmail-OFF fires a follow-up PATCH.
   it("submits a mail domain: POST /domains (web off, jabali mail) + webmail-off PATCH", async () => {

--- a/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailDomainsPage.tsx
@@ -17,13 +17,21 @@ import {
   Empty,
   Input,
   Modal,
+  Space,
   Spin,
   Table,
   Tag,
   Typography,
   type TableColumnsType,
 } from "antd";
-import { DeleteOutlined, MoreOutlined, PlusOutlined, PoweroffOutlined } from "@icons";
+import {
+  DeleteOutlined,
+  FileTextOutlined,
+  GlobalOutlined,
+  MoreOutlined,
+  PlusOutlined,
+  PoweroffOutlined,
+} from "@icons";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useListQuery } from "../../../hooks/useQueries";
@@ -33,6 +41,7 @@ import { apiClient } from "../../../apiClient";
 import { feedback } from "../../../lib/feedback";
 import { useServerCapabilities } from "../../../hooks/useServerCapabilities";
 import { UserDomainDrawer } from "../domains/UserDomainDrawer";
+import { MailDNSRecordsModal } from "../../../components/mail/MailDNSRecordsModal";
 
 interface MailDomainRow {
   id: string;
@@ -47,6 +56,9 @@ interface MailDomainRow {
   email_enabled: boolean;
   ssl_state?: string;
   is_quota_suspended?: boolean;
+  // GH #1612: true when the panel does NOT host this domain's DNS (external DNS).
+  // Drives the "External DNS" tag + the "DNS records" action.
+  dns_disabled?: boolean;
 }
 
 const num = (n: number | null | undefined): string => (n ?? 0).toLocaleString();
@@ -69,6 +81,12 @@ export function MailDomainsPage() {
   // mail-enabled server never flashes the button away. Mirrors the sidebar gate.
   const { data: caps } = useServerCapabilities();
   const mailEnabled = caps?.mail_enabled !== false;
+  // DNS is "external" for a domain when the panel doesn't host its zone
+  // (dns_disabled) OR the server has no DNS module at all (GH #1612).
+  const dnsEnabled = caps?.dns_enabled !== false;
+  const isExternalDNS = (row: MailDomainRow) => !!row.dns_disabled || !dnsEnabled;
+  // GH #1612: the domain whose external-DNS records modal is open.
+  const [dnsRecordsRow, setDnsRecordsRow] = useState<MailDomainRow | null>(null);
   const query = useListQuery<MailDomainRow>({ resource: "me/mail-domains" });
   const rows = query.items;
 
@@ -133,7 +151,14 @@ export function MailDomainsPage() {
       sorter: (a, b) => a.name.localeCompare(b.name),
       defaultSortOrder: "ascend",
       render: (name: string, row) => (
-        <a onClick={() => navigate(`/jabali-panel/mail-domains/${row.id}`)}>{name}</a>
+        <Space size="small">
+          <a onClick={() => navigate(`/jabali-panel/mail-domains/${row.id}`)}>{name}</a>
+          {isExternalDNS(row) && (
+            <Tag icon={<GlobalOutlined />} color="blue">
+              External DNS
+            </Tag>
+          )}
+        </Space>
       ),
     },
     {
@@ -198,6 +223,18 @@ export function MailDomainsPage() {
           trigger={["click"]}
           menu={{
             items: [
+              // GH #1612: only when DNS is hosted externally — a panel-hosted
+              // zone publishes these records itself, so there's nothing to copy.
+              ...(isExternalDNS(row)
+                ? [
+                    {
+                      key: "dns-records",
+                      icon: <FileTextOutlined />,
+                      label: "DNS records",
+                      onClick: () => setDnsRecordsRow(row),
+                    },
+                  ]
+                : []),
               {
                 key: "disable",
                 icon: <PoweroffOutlined />,
@@ -315,6 +352,13 @@ export function MailDomainsPage() {
           }}
         />
       </Modal>
+
+      <MailDNSRecordsModal
+        open={!!dnsRecordsRow}
+        domainId={dnsRecordsRow?.id}
+        domainName={dnsRecordsRow?.name}
+        onClose={() => setDnsRecordsRow(null)}
+      />
 
       <UserDomainDrawer
         open={createOpen}


### PR DESCRIPTION
## What

johnnyq (GH #1612): when a **Mail domain exists but the panel doesn't host its DNS** — created with DNS off (GH #1449) or its zone deleted (GH #1611) — surface the DNS records the operator must publish at their **external** DNS provider, with a copy button per value.

The tenant **Mail Domains** list now:
- tags such a domain **`External DNS`**,
- adds a **DNS records** action to the row `⋯` menu (only when DNS is external),
- which opens a modal listing the full record set — **mail host A/AAAA, MX, SPF, DKIM, DMARC, autoconfig/autodiscover, the client SRVs, TLS-RPT, CAA** — each with a copy button, plus **Copy all** that emits zone-file lines for bulk import.

## How

- **No new endpoint.** The record set is the one `GET /domains/:id/email` already computes (the panel's authoritative mail-record list), so the external view can't drift from what a panel-hosted zone would publish. The modal reuses the existing `useDomainEmail` hook; the live "status" column is dropped (with no panel zone there's nothing to compare against).
- **`domain_email.go`** — the mail host's own **A/AAAA lead the hint list** when the server's public IP is known (`server_settings`). MX, every SRV, and the autodiscover/autoconfig CNAMEs all point at `mail.<domain>`, so on external DNS this is the record without which *none of the others resolve* — pasting the list without it leaves mail dead. Added universally: on a panel-hosted zone the M4 bootstrap already publishes it, so it just shows status `ok`.
- **`me_mail_domains.go`** — expose `dns_disabled` on each row so the UI can gate the tag + action.
- **Gate:** the action shows when `row.dns_disabled || !caps.dns_enabled` (a domain with DNS off, or a server with no DNS module at all — external in practice).
- **`Copy all` quotes TXT rdata** (`"v=DKIM1;…"`, `"v=spf1 …"`). Unquoted, a `;` is a zone-file comment marker and would silently truncate DMARC/DKIM/TLS-RPT at the first `;` on import. Per-value copy stays **bare** — provider UIs want the raw string.

Admin is unchanged: the records table already lives on the Domain-edit page (`DomainEmailSection`), which now also gains the mail A/AAAA rows.

## Behavior change to note (on upgrade)

The mail `A`/`AAAA` hints now flow through `buildHintsWithStatus`. A tenant who has deliberately re-pointed `mail.<domain>` at another host (an unmanaged, hand-edited row) will now see that row surfaced as `conflict` + the existing "remove it to let the panel manage this slot" warning in the admin `DomainEmailSection`. This is the pre-existing pattern for MX/SPF/DMARC extended to one more row — honest, but new noise on some installs.

## Tests

- Backend: `TestMailDomains_AggregatesAndScopes` asserts `dns_disabled` reaches the wire; new `TestDomainEmail_Get_IncludesMailHostAWhenServerIPKnown` asserts the mail A/AAAA lead the list and that the DKIM Value is the raw (unquoted) TXT content, copy-pasteable as-is. `go test ./...` green.
- UI: `MailDomainsPage.test.tsx` — external row tagged + offers the action, panel-hosted row does not, the action opens the modal listing records with copy buttons, and **Copy all quotes TXT rdata** (DKIM/SPF) while leaving MX bare. `tsc`/`eslint` clean; vitest green.

## Follow-ups (not in this PR)

- **MTA-STS**: a domain with `mta_sts_enabled` also needs `_mta-sts.<domain>` TXT + an `mta-sts.<domain>` host on external DNS — not included here (separate flag + policy id).
- **SPF**: the hint is the literal `v=spf1 mx ~all`; the panel's own zone publishes `dnscompile.BuildSPFString(srv)`. Functionally equivalent on external DNS (the `mx` mechanism resolves via the published MX→A), but matching it exactly is a small follow-up.
- **RSA DKIM > 255 chars** would need zone-file string splitting in Copy all; the default ed25519 key fits in one string, so not handled here.
- Browser smoke of the modal not run (covered by vitest).

GH #1612