### PR TITLE
fix(dns): delete pdns child rows on zone teardown, not just the domains row

### DIFF
--- a/panel-agent/internal/pdns/client.go
+++ b/panel-agent/internal/pdns/client.go
@@ -230,9 +230,91 @@ func (c *Client) UpsertZoneWithMeta(name string, records []Record, opts UpsertZo
 	return zoneID, nil
 }
 
-// DeleteZone removes the zone and all its records. Idempotent — no
-// error if the zone isn't there.
+// zoneDeleteStep is one statement in the ordered teardown of a PowerDNS zone.
+// Child tables (records, domainmetadata, comments, cryptokeys) all key on
+// domain_id and MUST be cleared before the parent `domains` row, since the
+// gmysql backend does not necessarily cascade the delete (GH #1620).
+type zoneDeleteStep struct {
+	table string
+	sql   string
+}
+
+// zoneDeletePlan returns the ordered DELETE statements for tearing down a zone
+// by name. present says which OPTIONAL child tables exist; records and
+// domainmetadata are mandatory in every gmysql schema so they always lead.
+// Every statement binds exactly one arg — the zone name. Children resolve their
+// domain_id through a subquery (defensive: sweeps every same-name `domains` row,
+// though the standard schema keeps `name` unique), and the parent `domains`
+// delete is always last since the children reference it.
+func zoneDeletePlan(present map[string]bool) []zoneDeleteStep {
+	const childWhere = ` WHERE domain_id IN (SELECT id FROM domains WHERE name = ?)`
+	steps := []zoneDeleteStep{
+		{"records", `DELETE FROM records` + childWhere},
+		{"domainmetadata", `DELETE FROM domainmetadata` + childWhere},
+	}
+	if present["comments"] {
+		steps = append(steps, zoneDeleteStep{"comments", `DELETE FROM comments` + childWhere})
+	}
+	if present["cryptokeys"] {
+		steps = append(steps, zoneDeleteStep{"cryptokeys", `DELETE FROM cryptokeys` + childWhere})
+	}
+	steps = append(steps, zoneDeleteStep{"domains", `DELETE FROM domains WHERE name = ?`})
+	return steps
+}
+
+// presentOptionalTables reports which optional PowerDNS child tables exist in
+// the connected schema. records + domainmetadata are mandatory in every gmysql
+// schema, so they are not probed. Probing up front (rather than tolerating a
+// mid-transaction "table doesn't exist") keeps DeleteZone's transaction free of
+// conditional error handling and portable to strict SQL modes.
+func (c *Client) presentOptionalTables() (map[string]bool, error) {
+	present := map[string]bool{}
+	rows, err := c.db.Query(
+		`SELECT table_name FROM information_schema.tables
+		 WHERE table_schema = DATABASE() AND table_name IN ('comments','cryptokeys')`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		present[t] = true
+	}
+	return present, rows.Err()
+}
+
+// DeleteZone removes a zone and every child row that keys on its domain_id —
+// records, domainmetadata, and (when present) comments and cryptokeys — then
+// the `domains` row itself, all in one transaction. The old "delete only
+// domains" left records + domainmetadata orphaned when the backend didn't
+// cascade the delete: duplicate records on re-add and continued resolution off
+// the stale rows (GH #1620). Explicit child deletes make teardown independent
+// of whether the schema enforces ON DELETE CASCADE. Idempotent — a missing zone
+// deletes nothing and returns nil.
+//
+// cryptokeys is normally managed by `pdnsutil` (see dnssec.go), not raw SQL; we
+// still sweep it here because the zone is being destroyed outright, so
+// pdnsutil's view of it is moot.
 func (c *Client) DeleteZone(name string) error {
-	_, err := c.db.Exec(`DELETE FROM domains WHERE name = ?`, name)
-	return err
+	present, err := c.presentOptionalTables()
+	if err != nil {
+		return fmt.Errorf("probe pdns tables: %w", err)
+	}
+	tx, err := c.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once committed
+	for _, s := range zoneDeletePlan(present) {
+		if _, err := tx.Exec(s.sql, name); err != nil {
+			return fmt.Errorf("delete %s: %w", s.table, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
 }

--- a/panel-agent/internal/pdns/client_test.go
+++ b/panel-agent/internal/pdns/client_test.go
@@ -1,0 +1,76 @@
+package pdns
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestZoneDeletePlan_OrderAndShape pins the invariant that broke GH #1620:
+// child rows (records, domainmetadata, ...) are deleted BEFORE the parent
+// `domains` row, each scoped by a domain_id subquery, and the parent delete is
+// last. No DB — this asserts the statement plan, not a live schema.
+func TestZoneDeletePlan_OrderAndShape(t *testing.T) {
+	all := zoneDeletePlan(map[string]bool{"comments": true, "cryptokeys": true})
+	wantTables := []string{"records", "domainmetadata", "comments", "cryptokeys", "domains"}
+	if len(all) != len(wantTables) {
+		t.Fatalf("plan len = %d, want %d: %+v", len(all), len(wantTables), all)
+	}
+	for i, w := range wantTables {
+		if all[i].table != w {
+			t.Fatalf("step %d table = %q, want %q", i, all[i].table, w)
+		}
+	}
+
+	// Every child (all but the last) scopes by the domain_id subquery and never
+	// deletes the parent `domains` row at its head — otherwise a same-name
+	// duplicate would strand children, or the parent would vanish first.
+	for _, s := range all[:len(all)-1] {
+		if !strings.Contains(s.sql, "domain_id IN (SELECT id FROM domains WHERE name = ?)") {
+			t.Fatalf("child %s must scope by domain_id subquery, got %q", s.table, s.sql)
+		}
+		if strings.HasPrefix(s.sql, "DELETE FROM domains ") {
+			t.Fatalf("child %s must not delete the parent domains row: %q", s.table, s.sql)
+		}
+	}
+
+	// Parent is last and is exactly the domains-by-name delete.
+	last := all[len(all)-1]
+	if last.table != "domains" || last.sql != "DELETE FROM domains WHERE name = ?" {
+		t.Fatalf("last step = %+v, want the domains-by-name delete", last)
+	}
+
+	// Every statement binds exactly one placeholder — the zone name.
+	for _, s := range all {
+		if n := strings.Count(s.sql, "?"); n != 1 {
+			t.Fatalf("step %s must bind exactly one arg, got %d: %q", s.table, n, s.sql)
+		}
+	}
+}
+
+// TestZoneDeletePlan_OptionalTablesSkipped verifies that a schema lacking the
+// optional tables produces a plan touching only the mandatory ones — the
+// probe-then-plan design never emits a DELETE for a table that isn't there.
+func TestZoneDeletePlan_OptionalTablesSkipped(t *testing.T) {
+	min := zoneDeletePlan(map[string]bool{})
+	wantTables := []string{"records", "domainmetadata", "domains"}
+	if len(min) != len(wantTables) {
+		t.Fatalf("minimal plan len = %d, want %d: %+v", len(min), len(wantTables), min)
+	}
+	for i, w := range wantTables {
+		if min[i].table != w {
+			t.Fatalf("minimal step %d = %q, want %q", i, min[i].table, w)
+		}
+	}
+
+	// comments present, cryptokeys absent → comments in, cryptokeys out, order held.
+	one := zoneDeletePlan(map[string]bool{"comments": true})
+	wantOne := []string{"records", "domainmetadata", "comments", "domains"}
+	if len(one) != len(wantOne) {
+		t.Fatalf("plan len = %d, want %d: %+v", len(one), len(wantOne), one)
+	}
+	for i, w := range wantOne {
+		if one[i].table != w {
+			t.Fatalf("step %d = %q, want %q", i, one[i].table, w)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (GH #1620, johnnyq)

Deleting a domain (or a user, or a DNS zone via #1611's tenant action) left rows behind in the `jabali_pdns` database. `DeleteZone` ran only:

```sql
DELETE FROM domains WHERE name = ?
```

When the PowerDNS backend does not cascade the delete, every child row keyed on `domain_id` was orphaned — `records` and `domainmetadata` (johnnyq called out `domainmetadata` specifically), plus `comments`/`cryptokeys` where present. Symptoms:

- **Duplicate records** on re-adding the same domain (old rows still there).
- **Continued DNS resolution** off the stale `records` even though the panel treats the domain as gone.

## Fix

`DeleteZone` now runs an **ordered, transactional teardown**: clear the child tables *before* the parent `domains` row, in one transaction.

- Children are scoped by `domain_id IN (SELECT id FROM domains WHERE name = ?)`, so the parent row still exists when children resolve their `domain_id`; the parent delete is last.
- Explicit child deletes make teardown **independent of whether the schema enforces `ON DELETE CASCADE`** — it cleans up either way.
- `comments`/`cryptokeys` are optional across schema variants, so `DeleteZone` **probes `information_schema` up front** and includes only tables that exist. No mid-transaction "table doesn't exist" tolerance; portable to strict SQL modes.
- `cryptokeys` is normally `pdnsutil`-managed, but the zone is destroyed outright, so a raw sweep is safe.

This is the single funnel for all pdns zone deletes → fixes both the full domain/user-delete path and **#1611's tenant Delete Zone** action. Cache invalidation was never the gap: the `dns.zone.delete` handler already runs `pdns_control purge` / `rec_control wipe-cache`.

## Tests

The ordering is the crux, so it's pinned by a **DB-free unit test** on the extracted pure `zoneDeletePlan`:

- children before parent, correct order;
- each child scoped by the `domain_id` subquery, never the parent-by-name form;
- `domains` delete last;
- every statement binds exactly one arg;
- optional tables absent → plan touches only the mandatory ones.

`go build` / `go vet` / `gofmt` / `go test -race ./internal/pdns/` all green; full `panel-agent` suite green.

## Existing orphans (one-time manual sweep on affected boxes)

This fix prevents **new** orphans; it does not heal rows already stranded (their `domains` row is gone, so nothing keys them). On an affected box, clean up once against `jabali_pdns`:

```sql
DELETE FROM records        WHERE domain_id NOT IN (SELECT id FROM domains);
DELETE FROM domainmetadata WHERE domain_id NOT IN (SELECT id FROM domains);
DELETE FROM comments       WHERE domain_id NOT IN (SELECT id FROM domains);
DELETE FROM cryptokeys     WHERE domain_id NOT IN (SELECT id FROM domains);
```

Then `pdns_control purge` (the manual DELETE doesn't purge the packet cache the way the handler does; stale answers otherwise linger until TTL).

GH #1620