### PR TITLE
fix(mail): prefill Edit Mailbox via initialValues so reopen reflects the current mailbox

### DIFF
--- a/panel-ui/src/components/mail/EditMailboxModal.reopen.test.tsx
+++ b/panel-ui/src/components/mail/EditMailboxModal.reopen.test.tsx
@@ -1,0 +1,145 @@
+// EditMailboxModal.reopen.test.tsx — GH #1615.
+//
+// Guards that the Edit-mailbox drawer's Account form reflects the CURRENT
+// mailbox every time it opens — the reported bug was a blank/stale form on a
+// second open. The fix drives the prefill via the Form's initialValues +
+// clearOnDestroy (re-read on each fresh mount) instead of a
+// useEffect(setFieldsValue), which antd's FAQ warns against for a Form in a
+// lazily-rendered overlay.
+//
+// Note: jsdom mounts overlay children synchronously, so these do NOT reproduce
+// the original blank-on-reopen (that needs a real browser's lazy render). They
+// pin the fixed behavior and catch a regression to the effect-based prefill.
+//
+// Only apiClient is mocked; the real AntD Drawer/Form/Input run. The default
+// "Account" tab is under test; the other tabs are not force-rendered, so their
+// data-fetching sections never mount here.
+import { useState } from "react";
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EditMailboxModal } from "./EditMailboxModal";
+import type { Mailbox } from "../../hooks/useMailboxes";
+
+vi.mock("../../apiClient", () => ({ apiClient: { patch: vi.fn(), get: vi.fn() } }));
+
+function mailbox(overrides: Partial<Mailbox>): Mailbox {
+  return {
+    id: "mb1",
+    domain_id: "d1",
+    email: "alice@example.com",
+    display_name: "Old Name",
+    quota_bytes: 256 * 1024 * 1024,
+    is_disabled: false,
+    send_only: false,
+    last_usage_bytes: 0,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function renderModal(props: { open: boolean; mailbox: Mailbox | null }) {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <EditMailboxModal open={props.open} mailbox={props.mailbox} onClose={() => {}} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+// The display-name field is an Input; read its live value by role+name.
+function displayNameInput(): HTMLInputElement {
+  return screen.getByRole("textbox", { name: /display name/i }) as HTMLInputElement;
+}
+
+describe("EditMailboxModal reopen prefill (GH #1615)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the current display name every time it reopens (not blank/stale)", async () => {
+    const { rerender } = renderModal({ open: true, mailbox: mailbox({ display_name: "Old Name" }) });
+    await waitFor(() => expect(displayNameInput().value).toBe("Old Name"));
+
+    // Close the drawer (destroyOnHidden unmounts the form).
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <App>
+          <EditMailboxModal open={false} mailbox={null} onClose={() => {}} />
+        </App>
+      </QueryClientProvider>,
+    );
+
+    // Reopen with the UPDATED mailbox — the field must reflect the new value.
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <App>
+          <EditMailboxModal
+            open
+            mailbox={mailbox({ display_name: "New Name" })}
+            onClose={() => {}}
+          />
+        </App>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(displayNameInput().value).toBe("New Name"));
+  });
+
+  // Faithful reproduction of the real MailboxesTab flow with a SINGLE persistent
+  // EditMailboxModal instance (so the useForm() store survives across opens):
+  // open → change name → Save → close → reopen shows the updated value.
+  it("reflects the updated name on reopen after an in-place save", async () => {
+    const mocked = (await import("../../apiClient")).apiClient as unknown as {
+      patch: ReturnType<typeof vi.fn>;
+    };
+    mocked.patch.mockResolvedValue({ data: mailbox({ display_name: "New Name" }) });
+
+    function Harness() {
+      // Mirrors MailboxesTab: editTarget state, opened via a button, and the
+      // "row" reflects the latest saved value (as a list refetch would).
+      const [current, setCurrent] = useState(mailbox({ display_name: "Old Name" }));
+      const [target, setTarget] = useState<Mailbox | null>(null);
+      return (
+        <>
+          <button onClick={() => setTarget(current)}>open-edit</button>
+          <EditMailboxModal
+            open={target !== null}
+            mailbox={target}
+            onClose={() => {
+              // Simulate the list refetch surfacing the saved value.
+              setCurrent(mailbox({ display_name: "New Name" }));
+              setTarget(null);
+            }}
+          />
+        </>
+      );
+    }
+
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <App>
+          <Harness />
+        </App>
+      </QueryClientProvider>,
+    );
+
+    // Open, confirm the old value, change it, Save.
+    fireEvent.click(screen.getByText("open-edit"));
+    await waitFor(() => expect(displayNameInput().value).toBe("Old Name"));
+    fireEvent.change(displayNameInput(), { target: { value: "New Name" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(mocked.patch).toHaveBeenCalled());
+
+    // Reopen — the field must show the saved value, not blank or the old one.
+    await waitFor(() => expect(screen.queryByRole("textbox", { name: /display name/i })).toBeNull());
+    fireEvent.click(screen.getByText("open-edit"));
+    await waitFor(() => expect(displayNameInput().value).toBe("New Name"));
+  });
+});

--- a/panel-ui/src/components/mail/EditMailboxModal.tsx
+++ b/panel-ui/src/components/mail/EditMailboxModal.tsx
@@ -8,7 +8,6 @@
 // (Save applies to it); the other tabs are self-contained sections that
 // persist their own changes independently.
 import { App, Button, Drawer, Form, Grid, Input, InputNumber, Space, Switch, Tabs, Typography } from "antd";
-import { useEffect } from "react";
 
 import { useUpdateMailbox, type Mailbox } from "../../hooks/useMailboxes";
 import { MailboxForwardingSection } from "./MailboxForwardingSection";
@@ -38,16 +37,19 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
   const screens = Grid.useBreakpoint();
   const isDesktop = !!screens.md;
 
-  useEffect(() => {
-    if (open && mailbox) {
-      form.setFieldsValue({
-        display_name: mailbox.display_name ?? "",
-        quota_mib: Math.round(mailbox.quota_bytes / MIB),
-        enabled: !mailbox.is_disabled,
-        send_only: mailbox.send_only ?? false,
-      });
-    }
-  }, [open, mailbox, form]);
+  // GH #1615 (reported: reopening Edit showed a blank/stale form): prefill via
+  // the Form's own initialValues, NOT a useEffect(form.setFieldsValue). antd's
+  // FAQ warns against setFieldsValue for a Form in a lazily-rendered overlay
+  // (the Drawer mounts its children only when open). initialValues is re-read
+  // on every fresh mount, and with destroyOnHidden + clearOnDestroy the Form
+  // remounts clean each open, so it always reflects the current mailbox. This
+  // matches antd's form-in-modal demo and CreateMailboxWizardModal.
+  const initialValues: FormValues = {
+    display_name: mailbox?.display_name ?? "",
+    quota_mib: mailbox ? Math.round(mailbox.quota_bytes / MIB) : QUOTA_MIN_MIB,
+    enabled: mailbox ? !mailbox.is_disabled : true,
+    send_only: mailbox?.send_only ?? false,
+  };
 
   const submit = async () => {
     if (!mailbox) return;
@@ -97,7 +99,14 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
   };
 
   const accountTab = (
-    <Form form={form} layout="vertical" requiredMark={false}>
+    <Form
+      key={mailbox?.id ?? "closed"}
+      form={form}
+      layout="vertical"
+      requiredMark={false}
+      initialValues={initialValues}
+      clearOnDestroy
+    >
       <Form.Item
         label="Display name"
         name="display_name"
@@ -163,7 +172,7 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
       onClose={onClose}
       width={isDesktop ? 520 : undefined}
       placement="right"
-      destroyOnClose
+      destroyOnHidden
       extra={
         <Space>
           <Button onClick={onClose}>Cancel</Button>


### PR DESCRIPTION
## Problem (GH #1615, johnnyq)

Editing a mailbox (e.g. its display name) saved correctly, but **reopening Edit showed a blank/stale form** until a full page refresh.

The Account form prefilled itself with a `useEffect(() => form.setFieldsValue(...))` against a Form that lives inside a `destroyOnClose` Drawer. antd's own FAQ warns against exactly this — *"Instance created by `useForm` is not connect to any Form element … Before Modal opens, children elements do not exist in the view"* — a Form in a lazily-rendered overlay isn't mounted when the effect runs, so the write can land on nothing and the fields come up empty on a later open. The sibling `CreateMailboxWizardModal` and antd's [form-in-modal demo](https://ant.design/components/form#components-form-demo-form-in-modal) don't use that pattern.

This surfaced around the recent antd 5.22 → 6 trial upgrade (`cd5b2ba1a`), which did not touch this component; johnnyq's report is from that window.

## Fix

Drive the prefill through the Form's own `initialValues` (antd's documented approach), computed from the current `mailbox`:

- `destroyOnHidden` (the antd 6 name for `destroyOnClose`) + `clearOnDestroy` → the Form remounts clean on every open.
- `initialValues` is re-read on each fresh mount → the form always reflects the current mailbox.
- `key={mailbox?.id ?? "closed"}` guards switching the target mailbox without an intervening close (not possible today; cheap future-proofing).
- The `useEffect(setFieldsValue)` is removed.

## Verification — please read

I **could not reproduce the blank-on-reopen in the test harness**: jsdom mounts overlay children synchronously, so the `useEffect(setFieldsValue)` path works there and the original bug is browser-only (it depends on the overlay's lazy/animated mount). The two added tests therefore **pin the fixed behavior and guard against a regression** to the effect-based prefill — they are not a reproduction of the original bug:

- reopen with an updated mailbox shows the new value (not blank/stale);
- the full `open → edit → Save → close → reopen` flow with a single persistent modal instance shows the saved value.

`tsc`, `eslint`, and the full mail test suite (46 tests) are green.

@johnnyq — could you confirm on your side that reopening Edit now shows the current values? And if you still had the browser console open when it was broken, did you see a `[antd: Form] Instance created by useForm is not connect to any Form element` warning? That would confirm the mechanism above.

Known/unrelated: the `[antd: Drawer] width is deprecated, use size` warning is separate antd 6 migration debt across the codebase; left out of this PR.

GH #1615