### PR TITLE
fix(ui): keep the panel hostname in the tab title under branding (GH #1604)

### DIFF
--- a/panel-ui/src/hooks/useBranding.title.test.tsx
+++ b/panel-ui/src/hooks/useBranding.title.test.tsx
@@ -1,0 +1,60 @@
+// GH #1604: useApplyBrandingToTitle used to overwrite document.title with a
+// host-less string on mount (brandText === "" while the branding query is
+// pending, and again when an unbranded panel resolves to ""), which silently
+// defeated #1618's "<host> | Jabali Panel" tab title on every panel. These
+// tests pin that the branding hook now composes through buildPageTitle so the
+// address-bar host always survives. The first case is RED against the old
+// inline `brandText ? \`${brandText} — Panel\` : "Jabali Panel"` write.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+vi.mock("../apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from "../apiClient";
+import { useApplyBrandingToTitle } from "./useBranding";
+import { buildPageTitle } from "../lib/pageTitle";
+
+const mockGet = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+const brandingResponse = (brandText: string) => ({
+  data: { panel_brand_text: brandText },
+});
+
+describe("useApplyBrandingToTitle (GH #1604 — keep the host)", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    document.title = "boot";
+  });
+
+  it("keeps the hostname when no custom brand is set", async () => {
+    mockGet.mockResolvedValue(brandingResponse(""));
+    renderHook(() => useApplyBrandingToTitle(), { wrapper: makeWrapper() });
+    const host = window.location.hostname; // jsdom default: "localhost"
+    await waitFor(() => {
+      expect(document.title).toBe(buildPageTitle(host, ""));
+    });
+    // Explicit: the host is preserved, not overwritten to the bare product
+    // name (the pre-fix behavior this guards against).
+    expect(document.title).toBe(`${host} | Jabali Panel`);
+  });
+
+  it("composes a custom brand after the host once branding loads", async () => {
+    mockGet.mockResolvedValue(brandingResponse("Acme"));
+    renderHook(() => useApplyBrandingToTitle(), { wrapper: makeWrapper() });
+    const host = window.location.hostname;
+    await waitFor(() => {
+      expect(document.title).toBe(`${host} | Acme — Panel`);
+    });
+  });
+});

--- a/panel-ui/src/hooks/useBranding.ts
+++ b/panel-ui/src/hooks/useBranding.ts
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 import { apiClient } from "../apiClient";
+import { buildPageTitle } from "../lib/pageTitle";
 
 type BrandingInfo = {
   panel_brand_text: string;
@@ -105,10 +106,13 @@ export function logoURL(variant: "light" | "dark", hasCustom: boolean): string {
 }
 
 // useApplyBrandingToTitle keeps document.title in sync with brandText.
-// Empty value falls back to "Jabali Panel".
+// It composes through buildPageTitle so the address-bar host (GH #1604)
+// stays in the tab title — this hook used to overwrite document.title with a
+// host-less string on mount, which silently defeated #1604 on every panel.
+// Empty brand falls back to the default product name.
 export function useApplyBrandingToTitle() {
   const { brandText } = useBranding();
   useEffect(() => {
-    document.title = brandText ? `${brandText} — Panel` : "Jabali Panel";
+    document.title = buildPageTitle(window.location.hostname, brandText);
   }, [brandText]);
 }

--- a/panel-ui/src/lib/pageTitle.test.ts
+++ b/panel-ui/src/lib/pageTitle.test.ts
@@ -24,4 +24,24 @@ describe("buildPageTitle (GH #1604)", () => {
     expect(buildPageTitle(null)).toBe("Jabali Panel");
     expect(buildPageTitle(undefined)).toBe("Jabali Panel");
   });
+
+  it("composes a custom brand as the suffix, keeping the host", () => {
+    expect(buildPageTitle("panel.example.com", "Acme")).toBe(
+      "panel.example.com | Acme — Panel",
+    );
+  });
+
+  it("uses the default product name when the brand is empty/whitespace", () => {
+    expect(buildPageTitle("host.local", "")).toBe("host.local | Jabali Panel");
+    expect(buildPageTitle("host.local", "   ")).toBe("host.local | Jabali Panel");
+    expect(buildPageTitle("host.local", null)).toBe("host.local | Jabali Panel");
+  });
+
+  it("drops the host prefix but keeps the brand when host is empty", () => {
+    expect(buildPageTitle("", "Acme")).toBe("Acme — Panel");
+  });
+
+  it("trims a custom brand", () => {
+    expect(buildPageTitle("host.local", "  Acme  ")).toBe("host.local | Acme — Panel");
+  });
 });

--- a/panel-ui/src/lib/pageTitle.ts
+++ b/panel-ui/src/lib/pageTitle.ts
@@ -4,19 +4,37 @@
 // instance's tab is identifiable at a glance. The host comes from
 // window.location, not server settings, so it is correct before login and
 // reflects exactly the address the tab was opened on (an IP shows as the IP).
+//
+// The suffix is branding-aware: when the operator has set a custom panel
+// brand text (Look and feel), it reads "<host> | <brand> — Panel"; otherwise
+// the default product name. This is the single builder both title writers go
+// through — boot (setPageTitle in main.tsx) and the branding effect
+// (useApplyBrandingToTitle) — so the branding hook can no longer overwrite the
+// host away, which is what silently defeated #1604 before this.
 
-const SUFFIX = "Jabali Panel";
+const DEFAULT_SUFFIX = "Jabali Panel";
 
 /**
- * buildPageTitle returns the document title for a given address-bar host.
- * An empty or whitespace-only host falls back to the bare product name.
+ * buildPageTitle returns the document title for a given address-bar host and
+ * optional custom brand text. An empty/whitespace host drops the prefix and
+ * falls back to the suffix alone; an empty/whitespace brand uses the default
+ * product name.
  */
-export function buildPageTitle(hostname: string | null | undefined): string {
+export function buildPageTitle(
+  hostname: string | null | undefined,
+  brandText?: string | null,
+): string {
   const host = (hostname ?? "").trim();
-  return host ? `${host} | ${SUFFIX}` : SUFFIX;
+  const brand = (brandText ?? "").trim();
+  const suffix = brand ? `${brand} — Panel` : DEFAULT_SUFFIX;
+  return host ? `${host} | ${suffix}` : suffix;
 }
 
-/** setPageTitle applies buildPageTitle(window.location.hostname) to the tab. */
+/**
+ * setPageTitle applies the host-only title at boot, before branding loads.
+ * The branding effect later re-applies through buildPageTitle with the brand
+ * text; both writes agree on the host, so there is no flash.
+ */
 export function setPageTitle(): void {
   document.title = buildPageTitle(window.location.hostname);
 }


### PR DESCRIPTION
## Problem

#1618 (merged, `d84130236`) added the `<host> | Jabali Panel` tab title johnnyq asked for in #1604 — `setPageTitle()` at `main.tsx` boot. But it **never actually took effect on `main`**: the branding hook `useApplyBrandingToTitle` (from the earlier M28 branding work, `77f4533ba`) is mounted app-wide at `App.tsx:141`, and on mount its effect overwrote `document.title` with a host-less string:

```ts
document.title = brandText ? `${brandText} — Panel` : "Jabali Panel";
```

On an unbranded panel `brandText` stays `""`, so after the branding query resolves the effect's deps never change and the host is dropped **permanently**, a moment after boot. So every panel showed the static `Jabali Panel` again — exactly the complaint #1604 was meant to fix. Not a regression from #1618; #1618's write was simply overwritten by the pre-existing hook.

## Fix

One branding-aware builder that both title writers go through:

```ts
buildPageTitle(host)         // boot           -> "<host> | Jabali Panel"
buildPageTitle(host, brand)  // branding effect -> "<host> | <brand> — Panel"
```

- The **host is always the prefix**; a custom brand only replaces the product-name **suffix**, so branded installs keep their `<brand> — Panel` form while the host stays visible.
- `useApplyBrandingToTitle` now calls `buildPageTitle(window.location.hostname, brandText)` — the inline format string is deleted (dedup).
- Boot and the branding effect agree on the host, so there is no title flash.

Minimal by design: this does **not** change the branded title scheme (still `<brand> — Panel`); it only prepends the host that #1604 asked for.

## Test plan

- [x] `tsc`, `eslint`, `npm run build` — clean
- [x] `buildPageTitle` unit: host/brand/whitespace/empty permutations (9 pass)
- [x] `useApplyBrandingToTitle` renderHook test (QueryClientProvider + mocked `/branding`): asserts the host survives both an **unbranded** (`localhost | Jabali Panel`) and a **branded** (`localhost | Acme — Panel`) response. **Verified RED** against the old inline write (`'Jabali Panel'` / `'Acme — Panel'`, host-less), GREEN with the fix.
- [x] `vitest run src/hooks` — 41 pass, no regressions
- Note: verified via the jsdom `document.title` assertions above rather than a live browser; the value written is `window.location.hostname` in production.

GH #1604