### PR TITLE
feat(domains): web domain aliases — Phase 1 backend spine (GH #1625)

### DIFF
--- a/panel-agent/internal/commands/domain_alias_sanitize_test.go
+++ b/panel-agent/internal/commands/domain_alias_sanitize_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import "testing"
+
+// GH #1625: server_name is raw nginx config, so sanitizeAliasServerNames is a
+// trust boundary — the panel already validated, but the agent RE-validates so a
+// value carrying a space, semicolon, brace, or newline can never break out of
+// the `server_name ...;` directive. Fail-closed: bad entries are DROPPED.
+func TestSanitizeAliasServerNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		domain  string
+		aliases []string
+		want    string
+	}{
+		{"none", "example.com", nil, ""},
+		{"single valid", "example.com", []string{"shop.example.net"}, " shop.example.net"},
+		{
+			"multiple valid, order preserved",
+			"example.com",
+			[]string{"shop.example.net", "www.brand.io"},
+			" shop.example.net www.brand.io",
+		},
+		{"lowercased", "example.com", []string{"Shop.Example.NET"}, " shop.example.net"},
+		{"trimmed", "example.com", []string{"  shop.example.net  "}, " shop.example.net"},
+		{"deduped", "example.com", []string{"a.example.net", "a.example.net"}, " a.example.net"},
+		{"skips primary", "example.com", []string{"example.com", "shop.example.net"}, " shop.example.net"},
+		{"skips www.primary", "example.com", []string{"www.example.com", "shop.example.net"}, " shop.example.net"},
+		// Injection / malformed inputs — every one dropped, nothing emitted raw.
+		{"drops semicolon injection", "example.com", []string{"evil.net; return 301 http://x"}, ""},
+		{"drops space", "example.com", []string{"a.net b.net"}, ""},
+		{"drops brace", "example.com", []string{"a.net}server{"}, ""},
+		{"drops newline", "example.com", []string{"a.net\nb.net"}, ""},
+		{"drops single label", "example.com", []string{"localhost"}, ""},
+		{"drops empty", "example.com", []string{""}, ""},
+		{"drops leading dot", "example.com", []string{".example.net"}, ""},
+		{
+			"keeps only the valid survivor",
+			"example.com",
+			[]string{"bad one", "good.example.net", "also;bad"},
+			" good.example.net",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeAliasServerNames(tc.domain, tc.aliases); got != tc.want {
+				t.Errorf("sanitizeAliasServerNames(%q, %v) = %q, want %q", tc.domain, tc.aliases, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -150,6 +150,14 @@ type domainCreateParams struct {
 	// inside the server block.
 	IPACLs []domainIPACLRule `json:"ip_acls,omitempty"`
 
+	// GH #1625 web domain aliases: additional hostnames added to the
+	// vhost's server_name so the domain's docroot answers on them too.
+	// The agent RE-SANITIZES every entry against domainRegex before
+	// rendering (config-injection trust boundary, like CacheBypassPaths)
+	// — a value that isn't a clean FQDN is DROPPED, never emitted raw
+	// into server_name. Empty ⇒ vhost byte-identical (feature off).
+	Aliases []string `json:"aliases,omitempty"`
+
 	// M50 per-directory password protection. Each rule produces one
 	// htpasswd file under /etc/jabali-panel/dir-privacy/<rule_id>.htpasswd
 	// and one `location ^~ <path>/ { auth_basic ...; }` block inside the
@@ -542,7 +550,7 @@ const vhostTemplate = `{{define "servebody"}}{{ if .IsEnabled }}
 {{ else }}    listen 80;
 {{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:80;
 {{ else }}    listen [::]:80;
-{{ end }}    server_name {{.Domain}} www.{{.Domain}};
+{{ end }}    server_name {{.Domain}} www.{{.Domain}}{{.ExtraServerNames}};
 {{ if .IsEnabled }}
     # ACME HTTP-01 webroot. Must be a location block — a server-level
     # redirect fires in nginx SERVER_REWRITE phase BEFORE FIND_CONFIG,
@@ -601,7 +609,7 @@ server {
     # parameter on nginx <1.25.1 (where the standalone directive is an
     # unknown-directive error), the http2 on directive on >=1.25.1
     # (where the listen parameter is deprecated and warns every reload).
-    server_name {{.Domain}} www.{{.Domain}};
+    server_name {{.Domain}} www.{{.Domain}}{{.ExtraServerNames}};
     ssl_certificate {{.SSLCertPath}};
     ssl_certificate_key {{.SSLKeyPath}};
     # JAB-69: modern TLS + Mozilla-intermediate ciphers (no 3DES/RC4/CBC-weak).
@@ -690,7 +698,12 @@ server {
 {{ end }}`
 
 type vhostData struct {
-	Domain             string
+	Domain string
+	// ExtraServerNames (GH #1625) is the sanitized web-domain-alias
+	// suffix appended after "{{.Domain}} www.{{.Domain}}" in server_name
+	// — a leading-space-joined list (" a.com b.com") or "" when none.
+	// Already re-validated against domainRegex by sanitizeAliasServerNames.
+	ExtraServerNames   string
 	PreviewHost        string
 	PreviewCertPath    string
 	PreviewKeyPath     string
@@ -980,6 +993,35 @@ func sanitizeBypassPaths(paths []string) string {
 	return "|" + strings.Join(parts, "|")
 }
 
+// sanitizeAliasServerNames re-validates the panel-supplied web domain
+// aliases (GH #1625) at the agent's config-generation trust boundary and
+// returns a server_name SUFFIX (" alias1 alias2", leading space) or ""
+// when none survive. Each entry is lower-cased, trimmed, and matched
+// against domainRegex — the SAME FQDN shape used for the primary domain
+// — so a value carrying a space, semicolon, brace, or newline (which
+// would break out of the `server_name ...;` directive) is DROPPED, never
+// emitted raw. Fail-closed, de-duplicated, and skips the primary domain
+// and www.<primary> (already in the hardcoded server_name) so no name is
+// listed twice.
+func sanitizeAliasServerNames(domain string, aliases []string) string {
+	primary := strings.ToLower(strings.TrimSpace(domain))
+	skip := map[string]bool{primary: true, "www." + primary: true}
+	seen := map[string]bool{}
+	names := make([]string, 0, len(aliases))
+	for _, a := range aliases {
+		a = strings.ToLower(strings.TrimSpace(a))
+		if a == "" || skip[a] || seen[a] || !domainRegex.MatchString(a) {
+			continue
+		}
+		seen[a] = true
+		names = append(names, a)
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return " " + strings.Join(names, " ")
+}
+
 // cacheQueryParamRE bounds an allowlist entry at the agent trust boundary:
 // lower-case alnum + underscore, 1-32 chars — the same guard the panel applies,
 // re-checked here so a name can never carry regex metacharacters into the
@@ -1063,7 +1105,10 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, phpDisplayErrors bool, phpErrorReporting *int, phpTimezone string, envVars []domainEnvVarParam, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, phpDisplayErrors bool, phpErrorReporting *int, phpTimezone string, envVars []domainEnvVarParam, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool, aliases []string) (string, error) {
+	// GH #1625: re-sanitize the panel-supplied aliases HERE (trust
+	// boundary) into the server_name suffix — never render them raw.
+	aliasServerNames := sanitizeAliasServerNames(domain, aliases)
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
 	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
@@ -1151,6 +1196,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	h2 := nginxHTTP2()
 	vhostData := vhostData{
 		Domain:                     domain,
+		ExtraServerNames:           aliasServerNames,
 		PreviewHost:                previewHost,
 		PreviewCertPath:            previewCertPath,
 		PreviewKeyPath:             previewKeyPath,
@@ -1445,7 +1491,7 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// panel always sends the field; writeVhost still forces it false if the
 	// cert file turns out to be missing on disk (#213).
 	redirectHTTPS, serveHTTPS := resolveHTTPSFlags(&p)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.PHPDisplayErrors, p.PHPErrorReporting, p.PHPTimezone, p.EnvVars, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.PHPDisplayErrors, p.PHPErrorReporting, p.PHPTimezone, p.EnvVars, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS, p.Aliases)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create_test.go
+++ b/panel-agent/internal/commands/domain_create_test.go
@@ -223,6 +223,59 @@ func TestDomainCreateHandler_IsEnabledTrue(t *testing.T) {
 	}
 }
 
+// GH #1625: the "aliases" wire field unmarshals into domainCreateParams and,
+// after re-sanitization, lands in server_name of BOTH the enabled and disabled
+// server blocks — so the docroot answers on the alias whether the site is live
+// or parked.
+func TestDomainCreateHandler_AliasesInServerName(t *testing.T) {
+	t.Parallel()
+
+	var params domainCreateParams
+	if err := json.Unmarshal([]byte(`{
+		"username": "testuser",
+		"domain": "example.com",
+		"doc_root": "/home/testuser/public_html/example.com",
+		"php_version": "8.3",
+		"aliases": ["shop.example.net", "www.brand.io", "bad name;"]
+	}`), &params); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(params.Aliases) != 3 {
+		t.Fatalf("Aliases = %v, want 3 entries off the wire", params.Aliases)
+	}
+
+	suffix := sanitizeAliasServerNames(params.Domain, params.Aliases)
+	// The malformed entry is dropped; the two clean ones survive, in order.
+	if suffix != " shop.example.net www.brand.io" {
+		t.Fatalf("sanitized suffix = %q", suffix)
+	}
+
+	for _, enabled := range []bool{true, false} {
+		tmpl, _ := template.New("vhost").Parse(vhostTemplate)
+		vd := vhostData{
+			Domain:           params.Domain,
+			ExtraServerNames: suffix,
+			DocRoot:          params.DocRoot,
+			HasPHP:           true,
+			PHPVersion:       params.PHPVersion,
+			Username:         params.Username,
+			IsEnabled:        enabled,
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, vd); err != nil {
+			t.Fatalf("template execute (enabled=%v): %v", enabled, err)
+		}
+		out := buf.String()
+		want := "server_name example.com www.example.com shop.example.net www.brand.io;"
+		if !strings.Contains(out, want) {
+			t.Errorf("enabled=%v: server_name missing aliases; want %q in:\n%s", enabled, want, out)
+		}
+		if strings.Contains(out, "bad name;") {
+			t.Errorf("enabled=%v: malformed alias leaked into config:\n%s", enabled, out)
+		}
+	}
+}
+
 func TestDomainCreateHandler_IsEnabledFalse(t *testing.T) {
 	t.Parallel()
 

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -425,6 +425,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 		deps.BWDaily = repository.NewBWDailyRepository(sharedDB)
 		deps.DomainIPACLs = repository.NewDomainIPACLRepository(sharedDB)
+		deps.WebDomainAliases = repository.NewWebDomainAliasRepository(sharedDB)
 		deps.DomainDirectoryPrivacy = repository.NewDomainDirectoryPrivacyRepository(sharedDB)
 		// M35: migration importers — Step 1 wires the repo only.
 		// Steps 3-7 land per-source importer code that calls these
@@ -545,6 +546,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// agent's domain.create payload; agent renders nginx directives
 		// inside the server block.
 		rec.WithDomainIPACLs(deps.DomainIPACLs)
+		// GH #1625: reconciler threads a domain's aliases into agent's
+		// domain.create server_name + the cert SAN set on every converge.
+		rec.WithWebDomainAliases(deps.WebDomainAliases)
 		rec.WithDomainDirectoryPrivacy(deps.DomainDirectoryPrivacy)
 		// M30 (ADR-0075): backup-restore workflow rows.
 		deps.BackupJobs = repository.NewBackupJobRepository(sharedDB)

--- a/panel-api/internal/api/docker_apps.go
+++ b/panel-api/internal/api/docker_apps.go
@@ -61,7 +61,13 @@ type DockerAppHandlerConfig struct {
 	// AND issues LE through the same path as tenant domains.
 	// ADR-0116 Decision 4.
 	Domains repository.DomainRepository
-	Agent   agent.AgentInterface
+	// WebDomainAliases (GH #1625) backs the cross-tenant hijack guard on the
+	// docker-app domain auto-create path: this path builds a `domains` row
+	// directly (not through createDomainOp), so it must run the same
+	// aliasCollision check or a docker app named after a victim's alias would
+	// hijack that server_name. Optional — nil skips (fail-open only when unwired).
+	WebDomainAliases repository.WebDomainAliasRepository
+	Agent            agent.AgentInterface
 	// Users resolves a tenant app's OS username for re-render hardening
 	// (Gitea #480). Optional; required only for tenant-owned app re-renders.
 	Users repository.UserRepository
@@ -543,6 +549,15 @@ func (h *dockerAppHandler) install(c *gin.Context) {
 					return
 				}
 			} else {
+				// GH #1625: same cross-tenant hijack guard createDomainOp runs —
+				// this direct-create path must not claim a server_name already
+				// held by another domain's alias.
+				if hit, clash := aliasCollision(ctx, h.cfg.WebDomainAliases, req.Domain); clash {
+					msg := "domain auto-create failed: name " + hit + " is used as an alias of another domain"
+					_ = h.cfg.Repo.UpdateStatus(ctx, app.ID, models.DockerAppStatusFailed, &msg)
+					c.JSON(http.StatusConflict, gin.H{"error": "domain_conflicts_alias", "detail": msg, "id": app.ID})
+					return
+				}
 				dom := &models.Domain{
 					ID:          ulid.Make().String(),
 					UserID:      claims.UserID,
@@ -1182,6 +1197,10 @@ func (h *dockerAppHandler) editDomainPorts(ctx context.Context, app *models.Dock
 							return &dockerEditError{http.StatusConflict, "domain_attach_failed", aerr.Error()}
 						}
 					} else {
+						// GH #1625: cross-tenant hijack guard (see the install path).
+						if hit, clash := aliasCollision(ctx, h.cfg.WebDomainAliases, newDomain); clash {
+							return &dockerEditError{http.StatusConflict, "domain_conflicts_alias", "the name " + hit + " is already used as an alias of another domain"}
+						}
 						dom := &models.Domain{
 							ID:          ulid.Make().String(),
 							UserID:      userID,

--- a/panel-api/internal/api/domain_aliases.go
+++ b/panel-api/internal/api/domain_aliases.go
@@ -1,0 +1,342 @@
+// Web domain aliases (GH #1625).
+//
+// Routes (mounted under /api/v1/domains/:id/aliases):
+//
+//	GET               list aliases for one domain
+//	POST              add an alias hostname
+//	DELETE /:alias_id remove one alias
+//
+// An alias is served from the SAME vhost + docroot as the owning web
+// domain: the reconciler adds every alias to the main server block's
+// server_name, and — only when the alias resolves DIRECTLY to this
+// server — to the domain's TLS cert as a SAN (a CDN-fronted alias is
+// left off the cert on purpose; see reconciler.sanHostnamesForDomain).
+//
+// Authorization mirrors the ACL routes: admins read+write any; users
+// only their own domains. Cross-tenant access returns 404 (not 403) to
+// avoid leaking domain existence.
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// DomainAliasHandlerConfig wires the routes. Domains + Aliases repos are
+// required; nil disables route registration. Certs + Settings are
+// optional enrichment (per-alias cert coverage and the panel-FQDN
+// denylist) — nil degrades safely.
+type DomainAliasHandlerConfig struct {
+	Domains  repository.DomainRepository
+	Aliases  repository.WebDomainAliasRepository
+	Certs    repository.SSLCertificateRepository
+	Settings repository.ServerSettingsRepository
+	// Reconciler hook so a CRUD mutation kicks an immediate domain
+	// converge (re-render server_name + reissue the cert) instead of
+	// waiting for the next tick.
+	Reconcile func(domainID string)
+}
+
+func RegisterDomainAliasRoutes(g *gin.RouterGroup, cfg DomainAliasHandlerConfig) {
+	if cfg.Domains == nil || cfg.Aliases == nil {
+		return
+	}
+	h := &domainAliasHandler{cfg: cfg}
+	rg := g.Group("/domains/:id/aliases")
+	rg.GET("", h.list)
+	rg.POST("", h.create)
+	rg.DELETE("/:alias_id", h.delete)
+}
+
+type domainAliasHandler struct{ cfg DomainAliasHandlerConfig }
+
+type createAliasRequest struct {
+	Hostname string `json:"hostname" binding:"required"`
+}
+
+// aliasRow is the wire shape: the stored alias plus its live certificate
+// coverage so the UI can show "cert pending — point DNS here" without a
+// second call. cert_status is "active" when the issued leaf cert already
+// names the alias, else "pending" (with pending_reason).
+type aliasRow struct {
+	models.WebDomainAlias
+	CertStatus    string `json:"cert_status"`
+	PendingReason string `json:"pending_reason,omitempty"`
+}
+
+const (
+	aliasCertActive  = "active"
+	aliasCertPending = "pending"
+)
+
+func (h *domainAliasHandler) list(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rows, err := h.cfg.Aliases.ListByDomain(c.Request.Context(), dom.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	out := make([]aliasRow, 0, len(rows))
+	covered := h.coveredSANs(c.Request.Context(), dom.ID)
+	reason := h.pendingReason(c.Request.Context())
+	for _, r := range rows {
+		row := aliasRow{WebDomainAlias: r, CertStatus: aliasCertPending, PendingReason: reason}
+		if _, ok := covered[strings.ToLower(r.Hostname)]; ok {
+			row.CertStatus = aliasCertActive
+			row.PendingReason = ""
+		}
+		out = append(out, row)
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
+}
+
+func (h *domainAliasHandler) create(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	var req createAliasRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	hostname, status, code, detail := h.validateAliasHostname(ctx, dom, req.Hostname)
+	if status != 0 {
+		c.JSON(status, gin.H{"error": code, "detail": detail})
+		return
+	}
+	row := &models.WebDomainAlias{
+		ID:       ids.NewULID(),
+		DomainID: dom.ID,
+		Hostname: hostname,
+	}
+	if err := h.cfg.Aliases.Create(ctx, row); err != nil {
+		// The UNIQUE index is the backstop for a race between the
+		// pre-check and the insert; surface it as the same 409.
+		if isDuplicateKeyErr(err) {
+			c.JSON(http.StatusConflict, gin.H{"error": "alias_exists", "detail": "that hostname is already an alias"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	c.JSON(http.StatusCreated, aliasRow{
+		WebDomainAlias: *row,
+		CertStatus:     aliasCertPending,
+		PendingReason:  h.pendingReason(ctx),
+	})
+}
+
+func (h *domainAliasHandler) delete(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	aliasID := c.Param("alias_id")
+	row, err := h.cfg.Aliases.FindByID(c.Request.Context(), aliasID)
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "alias_not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if row.DomainID != dom.ID {
+		// Cross-domain alias — same 404 as cross-tenant domain access.
+		c.JSON(http.StatusNotFound, gin.H{"error": "alias_not_found"})
+		return
+	}
+	if err := h.cfg.Aliases.Delete(c.Request.Context(), aliasID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	c.JSON(http.StatusOK, gin.H{"id": aliasID, "deleted": true})
+}
+
+// resolveDomain looks up the domain by URL :id, enforces ownership, and
+// writes the right HTTP error if it bails. Returns (nil, false) when the
+// caller should stop.
+func (h *domainAliasHandler) resolveDomain(c *gin.Context) (*models.Domain, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return nil, false
+	}
+	dom, err := h.cfg.Domains.FindByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return nil, false
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return nil, false
+	}
+	if !claims.IsAdmin && dom.UserID != claims.UserID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+		return nil, false
+	}
+	return dom, true
+}
+
+// aliasHelperPrefixes are the auto-derived helper subdomains the panel
+// serves for EVERY domain (its own vhost + mail/ACME server_name). An
+// alias equal to "<prefix><some other domain>" would add a second nginx
+// server block with the same server_name as that domain's helper vhost;
+// nginx keeps the first and silently drops the rest, so the alias could
+// shadow another tenant's mail or web vhost. Rejected at create. Kept in
+// lockstep with the agent's webmail_vhost server_name list and
+// reconciler.sanHostnamesForDomain (GH #1625).
+var aliasHelperPrefixes = []string{"www.", "mail.", "autoconfig.", "autodiscover.", "mta-sts."}
+
+// aliasCollision is the REVERSE of validateAliasHostname's helper check: it
+// reports whether creating (or renaming to) a domain named `name` would claim
+// an nginx server_name already held by another domain's web-domain alias.
+// validateAliasHostname stops an alias from colliding with an existing domain;
+// without this, a domain created AFTER an alias with the same name reopens the
+// exact cross-tenant vhost-hijack hole (a duplicate server_name across two
+// server blocks silently lets the first-loaded win — nginx -t only warns).
+// A domain named N claims N, www.N, and its four mail-helper server_names, so
+// all six are checked against the alias table regardless of the domain's
+// EmailEnabled: a domain can enable mail later and its helper vhost would then
+// collide. Returns the colliding hostname and true on a hit. A nil repo means
+// the feature is unwired → no collision (fail-open ONLY when unwired, never on
+// a live lookup error — FindByHostname's ErrNotFound is the only "no hit").
+func aliasCollision(ctx context.Context, aliases repository.WebDomainAliasRepository, name string) (string, bool) {
+	if aliases == nil {
+		return "", false
+	}
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return "", false
+	}
+	candidates := make([]string, 0, len(aliasHelperPrefixes)+1)
+	candidates = append(candidates, name)
+	for _, p := range aliasHelperPrefixes {
+		candidates = append(candidates, p+name)
+	}
+	for _, cand := range candidates {
+		if existing, err := aliases.FindByHostname(ctx, cand); err == nil && existing != nil {
+			return cand, true
+		}
+	}
+	return "", false
+}
+
+// validateAliasHostname normalizes + validates an alias hostname and
+// enforces the collision rules. Returns (normalized, 0, "", "") on
+// success, or (_, status, code, detail) to reject. Cheap syntactic
+// checks run before any DB lookup.
+func (h *domainAliasHandler) validateAliasHostname(ctx context.Context, dom *models.Domain, raw string) (string, int, string, string) {
+	host := normalizeDomainName(raw)
+	if err := validateDomainName(host); err != nil {
+		return "", http.StatusBadRequest, "invalid_hostname", err.Error()
+	}
+	if host == dom.Name {
+		return "", http.StatusBadRequest, "alias_is_primary", "that is already the domain's primary name"
+	}
+	if host == "www."+dom.Name {
+		return "", http.StatusBadRequest, "alias_is_www", "enable www via the domain's www option, not as an alias"
+	}
+	// A web-disabled domain (DNS-only zone / mail-only domain) has no vhost, so
+	// the reconciler never renders the alias into a server_name — the row would
+	// be inert yet still squat a globally-unique hostname (the cheapest domain
+	// type to create). Reject so an alias can only attach to a domain that
+	// actually serves it (GH #1625).
+	if dom.WebDisabled {
+		return "", http.StatusBadRequest, "domain_has_no_web", "aliases require a web-hosted domain; this domain has web hosting disabled"
+	}
+	// Panel FQDN — an alias here would shadow the panel's own vhost.
+	if h.cfg.Settings != nil {
+		if s, err := h.cfg.Settings.Get(ctx); err == nil && s != nil {
+			panelHost := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(s.Hostname), "."))
+			if panelHost != "" && host == panelHost {
+				return "", http.StatusConflict, "alias_reserved_panel", "that hostname is reserved by the panel"
+			}
+		}
+	}
+	// Bare apex of any domain on the server (own primary already caught).
+	if existing, err := h.cfg.Domains.FindByName(ctx, host); err == nil && existing != nil {
+		return "", http.StatusConflict, "alias_taken_by_domain", "that hostname is already a domain on this server"
+	}
+	// Helper server_name of any domain — the cross-tenant hijack vector.
+	for _, p := range aliasHelperPrefixes {
+		if !strings.HasPrefix(host, p) {
+			continue
+		}
+		base := strings.TrimPrefix(host, p)
+		if base == "" {
+			continue
+		}
+		if existing, err := h.cfg.Domains.FindByName(ctx, base); err == nil && existing != nil {
+			return "", http.StatusConflict, "alias_conflicts_helper", "that hostname is a reserved mail/web name for the domain " + base
+		}
+	}
+	// Global alias uniqueness (the DB UNIQUE index is the backstop).
+	if existing, err := h.cfg.Aliases.FindByHostname(ctx, host); err == nil && existing != nil {
+		return "", http.StatusConflict, "alias_exists", "that hostname is already an alias"
+	}
+	return host, 0, "", ""
+}
+
+// coveredSANs returns the lowercased SAN set the domain's ISSUED leaf
+// cert actually names, so the list handler can mark each alias
+// active/pending truthfully (no DNS lookup). Empty when there is no cert
+// repo, no cert row, or the leaf can't be read — every alias then reads
+// as pending, which is the safe under-report.
+func (h *domainAliasHandler) coveredSANs(ctx context.Context, domainID string) map[string]struct{} {
+	if h.cfg.Certs == nil {
+		return nil
+	}
+	cert, err := h.cfg.Certs.FindByDomainID(ctx, domainID)
+	if err != nil || cert == nil {
+		return nil
+	}
+	actual := actualWebCertSANs(cert.Status, cert.CertPath)
+	if len(actual) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(actual))
+	for _, s := range actual {
+		set[strings.ToLower(s)] = struct{}{}
+	}
+	return set
+}
+
+// pendingReason is the tenant-facing explanation of the deliberate
+// CDN-fronted-alias gap (GH #1625): only aliases that resolve directly
+// to this server are added to the cert.
+func (h *domainAliasHandler) pendingReason(ctx context.Context) string {
+	ip := ""
+	if h.cfg.Settings != nil {
+		if s, err := h.cfg.Settings.Get(ctx); err == nil && s != nil {
+			ip = strings.TrimSpace(s.PublicIPv4)
+		}
+	}
+	if ip != "" {
+		return "point an A/AAAA record for this hostname directly at " + ip +
+			" to include it on the certificate; CDN-fronted aliases are not added automatically"
+	}
+	return "point an A/AAAA record for this hostname directly at this server " +
+		"to include it on the certificate; CDN-fronted aliases are not added automatically"
+}

--- a/panel-api/internal/api/domain_aliases_test.go
+++ b/panel-api/internal/api/domain_aliases_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// The fakes embed the repository interfaces so only the methods
+// validateAliasHostname actually calls need bodies.
+
+type aliasTestDomains struct {
+	repository.DomainRepository
+	names map[string]*models.Domain
+}
+
+func (f aliasTestDomains) FindByName(_ context.Context, n string) (*models.Domain, error) {
+	if d, ok := f.names[strings.ToLower(n)]; ok {
+		return d, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type aliasTestAliases struct {
+	repository.WebDomainAliasRepository
+	taken map[string]bool
+}
+
+func (f aliasTestAliases) FindByHostname(_ context.Context, h string) (*models.WebDomainAlias, error) {
+	if f.taken[strings.ToLower(h)] {
+		return &models.WebDomainAlias{Hostname: strings.ToLower(h)}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type aliasTestSettings struct {
+	repository.ServerSettingsRepository
+	hostname string
+}
+
+func (f aliasTestSettings) Get(context.Context) (*models.ServerSettings, error) {
+	return &models.ServerSettings{Hostname: f.hostname, PublicIPv4: "203.0.113.9"}, nil
+}
+
+// GH #1625: validateAliasHostname is the security boundary — it must reject an
+// alias that would hijack another tenant's apex or helper vhost (a duplicate
+// nginx server_name silently lets the first server block win), the panel's own
+// FQDN, the domain's own primary/www, an already-claimed alias, and any value
+// that isn't a clean FQDN (config-injection). Everything else is accepted.
+func TestValidateAliasHostname(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "example.com", UserID: "u1"}
+	other := &models.Domain{ID: "d2", Name: "other.com", UserID: "u2"}
+	h := &domainAliasHandler{cfg: DomainAliasHandlerConfig{
+		Domains: aliasTestDomains{names: map[string]*models.Domain{
+			"example.com": dom,
+			"other.com":   other,
+		}},
+		Aliases:  aliasTestAliases{taken: map[string]bool{"taken.example.net": true}},
+		Settings: aliasTestSettings{hostname: "panel.host.com"},
+	}}
+
+	cases := []struct {
+		name string
+		in   string
+		code string // "" == accepted
+	}{
+		{"foreign subdomain accepted", "shop.brandy.io", ""},
+		{"own subdomain accepted", "blog.example.com", ""},
+		{"uppercase normalized + accepted", "Shop.Brandy.IO", ""},
+		{"own primary rejected", "example.com", "alias_is_primary"},
+		{"own www rejected", "www.example.com", "alias_is_www"},
+		{"another domain apex rejected", "other.com", "alias_taken_by_domain"},
+		{"another domain mail helper rejected", "mail.other.com", "alias_conflicts_helper"},
+		{"another domain www helper rejected", "www.other.com", "alias_conflicts_helper"},
+		{"another domain mta-sts helper rejected", "mta-sts.other.com", "alias_conflicts_helper"},
+		{"panel FQDN rejected", "panel.host.com", "alias_reserved_panel"},
+		{"already-claimed alias rejected", "taken.example.net", "alias_exists"},
+		{"semicolon injection rejected", "evil.net; return 301 http://x", "invalid_hostname"},
+		{"space rejected", "a b.net", "invalid_hostname"},
+		{"newline rejected", "a.net\nb.net", "invalid_hostname"},
+		{"single label rejected", "localhost", "invalid_hostname"},
+		{"empty rejected", "", "invalid_hostname"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, status, code, _ := h.validateAliasHostname(context.Background(), dom, tc.in)
+			if tc.code == "" {
+				if status != 0 {
+					t.Fatalf("expected accept, got status=%d code=%q", status, code)
+				}
+				if host != strings.ToLower(strings.TrimSpace(tc.in)) {
+					t.Errorf("normalized host = %q, want %q", host, strings.ToLower(strings.TrimSpace(tc.in)))
+				}
+				return
+			}
+			if code != tc.code {
+				t.Fatalf("code = %q (status %d), want %q", code, status, tc.code)
+			}
+			if status == 0 {
+				t.Errorf("rejection must carry a non-zero HTTP status")
+			}
+		})
+	}
+}
+
+// GH #1625: a web-disabled domain (DNS-only / mail-only) has no vhost, so an
+// alias would never render into a server_name — the row would be inert yet
+// squat a globally-unique hostname. validateAliasHostname must refuse it.
+func TestValidateAliasHostname_WebDisabled(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "example.com", UserID: "u1", WebDisabled: true}
+	h := &domainAliasHandler{cfg: DomainAliasHandlerConfig{
+		Domains: aliasTestDomains{names: map[string]*models.Domain{"example.com": dom}},
+		Aliases: aliasTestAliases{},
+	}}
+	_, status, code, _ := h.validateAliasHostname(context.Background(), dom, "shop.brandy.io")
+	if code != "domain_has_no_web" {
+		t.Fatalf("code = %q (status %d), want domain_has_no_web", code, status)
+	}
+	if status != 400 {
+		t.Errorf("status = %d, want 400", status)
+	}
+}
+
+// GH #1625: aliasCollision is the REVERSE guard — domain-create/rename must
+// reject a name whose apex OR any of its rendered server_names (www + the four
+// mail helpers) is already claimed by another domain's alias. Without it, a
+// domain created after a matching alias reopens the cross-tenant hijack hole
+// (duplicate nginx server_name → first-loaded wins).
+func TestAliasCollision(t *testing.T) {
+	aliases := aliasTestAliases{taken: map[string]bool{
+		"claimed.example.net":  true, // another domain's alias == this apex
+		"www.wwwclaimed.com":   true, // == this domain's www server_name
+		"mail.mailclaimed.com": true, // == this domain's mail helper server_name
+	}}
+	cases := []struct {
+		name    string
+		in      string
+		wantHit string
+		clash   bool
+	}{
+		{"apex collides", "claimed.example.net", "claimed.example.net", true},
+		{"www helper collides", "wwwclaimed.com", "www.wwwclaimed.com", true},
+		{"mail helper collides", "mailclaimed.com", "mail.mailclaimed.com", true},
+		{"uppercase normalized then collides", "Claimed.Example.NET", "claimed.example.net", true},
+		{"free name passes", "free.example.org", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hit, clash := aliasCollision(context.Background(), aliases, tc.in)
+			if clash != tc.clash {
+				t.Fatalf("clash = %v, want %v (hit %q)", clash, tc.clash, hit)
+			}
+			if clash && hit != tc.wantHit {
+				t.Errorf("hit = %q, want %q", hit, tc.wantHit)
+			}
+		})
+	}
+	// A nil repo means the feature is unwired — fail-open, never a collision.
+	if _, clash := aliasCollision(context.Background(), nil, "claimed.example.net"); clash {
+		t.Fatal("nil repo must not report a collision")
+	}
+	// An empty name is not a lookup.
+	if _, clash := aliasCollision(context.Background(), aliases, ""); clash {
+		t.Fatal("empty name must not report a collision")
+	}
+}

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -123,6 +123,15 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		return nil, &createDomainError{http.StatusBadRequest, "invalid_domain_name", err.Error()}
 	}
 
+	// GH #1625: reject a name whose apex/www/mail-helper server_name is already
+	// claimed by another domain's web-domain alias. ux_domains_name only guards
+	// domain-vs-domain; the alias table introduced the cross-table collision, so
+	// this closes the reverse of validateAliasHostname's own-side check. The name
+	// is already normalized by the caller (matches the alias table's lowercasing).
+	if hit, clash := aliasCollision(ctx, h.cfg.WebDomainAliases, in.Name); clash {
+		return nil, &createDomainError{http.StatusConflict, "domain_conflicts_alias", "the name " + hit + " is already used as an alias of another domain"}
+	}
+
 	if in.OwnerID == "" {
 		return nil, &createDomainError{http.StatusBadRequest, "user_id is required", ""}
 	}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -84,6 +84,11 @@ type DomainHandlerConfig struct {
 	ManagedIPs repository.ManagedIPRepository
 	// ServerSettings gates the tenant-safe nginx options opt-in (GH #307).
 	ServerSettings repository.ServerSettingsRepository
+	// WebDomainAliases (GH #1625) backs the reverse cross-tenant hijack guard:
+	// domain-create must reject a name whose apex/www/mail-helper server_name is
+	// already claimed by another domain's alias (aliasCollision). Optional — a
+	// nil repo skips the check (fail-open only when the alias feature is unwired).
+	WebDomainAliases repository.WebDomainAliasRepository
 	// AppInstalls (GH #1238 chown) backs the change-owner refusal: a domain
 	// with an app install carries the current owner's DB creds in its config,
 	// so re-owning it would leak a live cross-tenant credential. REQUIRED for

--- a/panel-api/internal/api/domains_rename.go
+++ b/panel-api/internal/api/domains_rename.go
@@ -59,6 +59,14 @@ func (h *domainHandler) rename(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_name", "message": verr.Error()})
 		return
 	}
+	// GH #1625: a rename assigns a new domains.name too, so it must run the same
+	// cross-tenant hijack guard create does — the new name must not claim a
+	// server_name already held by another domain's web-domain alias. (The
+	// domain's own aliases survive the rename; they are keyed by domain_id.)
+	if hit, clash := aliasCollision(ctx, h.cfg.WebDomainAliases, newName); clash {
+		c.JSON(http.StatusConflict, gin.H{"error": "domain_conflicts_alias", "message": "the name " + hit + " is already used as an alias of another domain"})
+		return
+	}
 
 	// *reconciler.Reconciler satisfies RenameReconciler, but pass it as a truly
 	// nil interface when unwired so RenameDomain's nil check holds (a typed-nil

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2122,6 +2122,28 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } }, { in: path, name: acl_id, required: true, schema: { type: string } } ]
       responses: { "204": { description: OK } }
 
+  /domains/{id}/aliases:
+    get:
+      tags: [Aliases]
+      summary: List web domain aliases
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+    post:
+      tags: [Aliases]
+      summary: Add a web domain alias
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "201": { description: Created } }
+
+  /domains/{id}/aliases/{alias_id}:
+    delete:
+      tags: [Aliases]
+      summary: Delete a web domain alias
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } }, { in: path, name: alias_id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
 
   # --- Active Tasks (auto) ---
 

--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -35,6 +35,10 @@ type SSLHandlerConfig struct {
 	PanelCerts     repository.PanelCertificateRepository
 	MailCerts      repository.MailCertificateRepository
 	ServerSettings repository.ServerSettingsRepository
+	// WebDomainAliases is optional (GH #1625): when set, the listed SAN
+	// policy includes a domain's aliases so the row's PendingSANs reflect
+	// them. nil → aliases omitted from the displayed SAN list only.
+	WebDomainAliases repository.WebDomainAliasRepository
 	// DNSZones is optional — required only for the ACME DNS-01 shared-cert
 	// flow; nil degrades that endpoint to 503.
 	DNSZones   repository.DNSZoneRepository
@@ -133,7 +137,7 @@ func (h *sslHandler) getSSL(c *gin.Context) {
 		Staging:       cert.Staging,
 		CertPath:      cert.CertPath,
 		KeyPath:       cert.KeyPath,
-		PendingSANs:   pendingWebSANs(cert.Status, cert.CertPath, domain.Name, webCertSANsForDomain(domain)),
+		PendingSANs:   pendingWebSANs(cert.Status, cert.CertPath, domain.Name, webCertSANsForDomain(domain, h.aliasHostnames(c.Request.Context(), domain.ID))),
 	}
 
 	c.JSON(http.StatusOK, gin.H{"ssl": resp})
@@ -597,7 +601,21 @@ func (h *sslHandler) webCertSANs(ctx context.Context, c repository.SSLCertificat
 	if err != nil || d == nil {
 		return base
 	}
-	return webCertSANsForDomain(d)
+	return webCertSANsForDomain(d, h.aliasHostnames(ctx, d.ID))
+}
+
+// aliasHostnames returns a domain's alias hostnames for the displayed
+// SAN policy, or nil when the repo is unwired or the read fails (GH
+// #1625). Best-effort: a miss only under-reports the SAN list.
+func (h *sslHandler) aliasHostnames(ctx context.Context, domainID string) []string {
+	if h.cfg.WebDomainAliases == nil {
+		return nil
+	}
+	names, err := h.cfg.WebDomainAliases.ListHostnamesByDomainID(ctx, domainID)
+	if err != nil {
+		return nil
+	}
+	return names
 }
 
 // webCertSANsForDomain is the pure policy (extracted for testing) — it
@@ -605,11 +623,16 @@ func (h *sslHandler) webCertSANs(ctx context.Context, c repository.SSLCertificat
 // www.<domain> is included ONLY when the domain opted into the www CNAME
 // (GH #895): otherwise there is no www DNS record, issuance omits it, and
 // listing it here over-reported coverage the cert never had.
-func webCertSANsForDomain(d *models.Domain) []string {
+func webCertSANsForDomain(d *models.Domain, aliases []string) []string {
 	sans := []string{d.Name}
 	if d.CreateWWW {
 		sans = append(sans, "www."+d.Name)
 	}
+	// GH #1625: explicit tenant aliases are SANs too. Appended before the
+	// SkipAutoSAN return (like opt-in www) — SkipAutoSAN opts out of the
+	// auto-derived mail helpers only, never explicit aliases. Kept in
+	// lockstep with reconciler.sanHostnamesForDomain (ADR-0070).
+	sans = append(sans, aliases...)
 	if d.SkipAutoSAN {
 		return sans
 	}

--- a/panel-api/internal/api/ssl_sans_test.go
+++ b/panel-api/internal/api/ssl_sans_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestWebCertSANsForDomain(t *testing.T) {
 	cases := []struct {
-		name string
-		dom  *models.Domain
-		want []string
+		name    string
+		dom     *models.Domain
+		aliases []string
+		want    []string
 	}{
 		{
 			name: "plain, www opted out (GH #895)",
@@ -48,10 +49,29 @@ func TestWebCertSANsForDomain(t *testing.T) {
 			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: true},
 			want: []string{"example.com", "www.example.com"},
 		},
+		{
+			// GH #1625: explicit aliases sit after www, before the auto helpers,
+			// mirroring reconciler.sanHostnamesForDomain's position (ADR-0070).
+			name:    "aliases, www in + email",
+			dom:     &models.Domain{Name: "example.com", EmailEnabled: true, CreateWWW: true},
+			aliases: []string{"shop.example.net", "www.brand.io"},
+			want: []string{
+				"example.com", "www.example.com",
+				"shop.example.net", "www.brand.io",
+				"mail.example.com", "autoconfig.example.com", "autodiscover.example.com",
+			},
+		},
+		{
+			// SkipAutoSAN drops the auto helpers but NOT explicit aliases.
+			name:    "SkipAutoSAN keeps aliases",
+			dom:     &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: false},
+			aliases: []string{"alias.example.net"},
+			want:    []string{"example.com", "alias.example.net"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := webCertSANsForDomain(tc.dom); !reflect.DeepEqual(got, tc.want) {
+			if got := webCertSANsForDomain(tc.dom, tc.aliases); !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("got %v want %v", got, tc.want)
 			}
 		})

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -82,6 +82,8 @@ type Deps struct {
 	StalwartAdminThrottle api.ThrottleDispatcher
 	BWDaily               repository.BWDailyRepository
 	DomainIPACLs          repository.DomainIPACLRepository
+	// GH #1625 — additional hostnames served from a web domain's vhost.
+	WebDomainAliases repository.WebDomainAliasRepository
 	// M6.6 — per-domain mail TLS rows.
 	MailCerts              repository.MailCertificateRepository
 	DomainDirectoryPrivacy repository.DomainDirectoryPrivacyRepository
@@ -481,6 +483,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 					ManagedIPs:      deps.ManagedIPs,
 					ServerSettings:  deps.ServerSettings,
 					BWDaily:         deps.BWDaily,
+					// GH #1625: arms the cross-tenant hijack guard on the
+					// JAB-233 automation create path (same as the GUI create).
+					WebDomainAliases: deps.WebDomainAliases,
 				},
 			})
 		}
@@ -732,6 +737,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// dropped from GET.
 				ManagedIPs:     deps.ManagedIPs,
 				ServerSettings: deps.ServerSettings,
+				// GH #1625: arms the reverse cross-tenant hijack guard so create
+				// AND rename reject a name already claimed by another domain's alias.
+				WebDomainAliases: deps.WebDomainAliases,
 				// GH #1238 change-owner (admin, JAB-380 step-up): AppInstalls
 				// arms the cross-tenant-credential refusal, AuditEvents records
 				// it, KratosClient gates the step-up.
@@ -750,6 +758,21 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			api.RegisterDomainIPACLRoutes(v1, api.DomainIPACLHandlerConfig{
 				Domains:   deps.Domains,
 				ACLs:      deps.DomainIPACLs,
+				Reconcile: schedule,
+			})
+		}
+		// GH #1625 — web domain aliases (extra server_name + cert SANs).
+		if deps.Domains != nil && deps.WebDomainAliases != nil {
+			var schedule func(string)
+			if deps.Reconciler != nil {
+				rec := deps.Reconciler
+				schedule = func(id string) { rec.Schedule(id) }
+			}
+			api.RegisterDomainAliasRoutes(v1, api.DomainAliasHandlerConfig{
+				Domains:   deps.Domains,
+				Aliases:   deps.WebDomainAliases,
+				Certs:     deps.SSLCerts,
+				Settings:  deps.ServerSettings,
 				Reconcile: schedule,
 			})
 		}
@@ -1002,9 +1025,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Agent:          deps.Agent,
 				PanelCerts:     deps.PanelCerts,
 				MailCerts:      deps.MailCerts,
-				ServerSettings: deps.ServerSettings,
-				Reconciler:     deps.Reconciler,
-				Config:         cfg,
+				ServerSettings:   deps.ServerSettings,
+				WebDomainAliases: deps.WebDomainAliases,
+				Reconciler:       deps.Reconciler,
+				Config:           cfg,
 			})
 		}
 		if deps.ServerSettings != nil {
@@ -1439,9 +1463,11 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Catalog:        deps.DockerCatalog,
 				ServerSettings: deps.ServerSettings,
 				Domains:        deps.Domains,
-				Agent:          deps.Agent,
-				Users:          deps.Users,
-				Log:            deps.Log,
+				// GH #1625: hijack guard on the docker-app domain auto-create path.
+				WebDomainAliases: deps.WebDomainAliases,
+				Agent:            deps.Agent,
+				Users:            deps.Users,
+				Log:              deps.Log,
 			})
 		}
 		// M49 (GH #170): tenant docker apps. Mounts /docker-apps on the

--- a/panel-api/internal/db/migrations/000293_web_domain_aliases.down.sql
+++ b/panel-api/internal/db/migrations/000293_web_domain_aliases.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS web_domain_aliases;

--- a/panel-api/internal/db/migrations/000293_web_domain_aliases.up.sql
+++ b/panel-api/internal/db/migrations/000293_web_domain_aliases.up.sql
@@ -1,0 +1,32 @@
+-- GH #1625: web domain aliases.
+--
+-- An alias is an additional hostname served from the SAME vhost and
+-- docroot as its owning web domain: the reconciler adds it to the main
+-- server block's server_name and — when it resolves DIRECTLY to this
+-- server — to the domain's TLS certificate as a SAN. Deleting the
+-- domain removes its aliases (ON DELETE CASCADE); the per-tick domain
+-- reconcile then re-renders the vhost without them.
+--
+-- hostname is globally UNIQUE (one alias name maps to exactly one
+-- domain), matching the ux_domains_name constraint on primary names.
+-- The create handler additionally rejects an alias that collides with
+-- any domains.name, the domain's own apex/www, or another tenant's
+-- mail/web helper server_name — a duplicate server_name across two
+-- nginx server blocks silently lets the first win (cross-tenant vhost
+-- hijack), which the UNIQUE index alone does not catch.
+--
+-- Same charset/collation as domains (utf8mb4_unicode_ci): a foreign key
+-- requires both columns to share a collation (MariaDB errno 150
+-- otherwise).
+CREATE TABLE web_domain_aliases (
+    id          CHAR(26)     NOT NULL PRIMARY KEY,
+    domain_id   CHAR(26)     NOT NULL,
+    hostname    VARCHAR(253) NOT NULL,
+    created_at  DATETIME(6)  NOT NULL,
+    updated_at  DATETIME(6)  NOT NULL,
+    UNIQUE INDEX ux_web_domain_aliases_hostname (hostname),
+    INDEX idx_web_domain_aliases_domain (domain_id),
+    CONSTRAINT fk_web_domain_aliases_domain
+        FOREIGN KEY (domain_id) REFERENCES domains (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/models/web_domain_alias.go
+++ b/panel-api/internal/models/web_domain_alias.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+// WebDomainAlias is an additional hostname served from the same vhost
+// and docroot as its owning web domain (GH #1625). The reconciler adds
+// every alias to the main server block's server_name; an alias that
+// resolves DIRECTLY to this server is also added to the domain's TLS
+// certificate as a SAN (reachableSANs gates that — a CDN-fronted alias
+// is intentionally left off the cert; see reconciler.sanHostnamesForDomain).
+//
+// Jabali is truth: the reconciler converges nginx + the cert to the set
+// of alias rows on every tick. hostname is globally unique across all
+// aliases (ux_web_domain_aliases_hostname); the create handler enforces
+// the wider "no collision with any domain name or helper server_name"
+// rule the DB index cannot express.
+type WebDomainAlias struct {
+	ID        string    `gorm:"type:char(26);primaryKey" json:"id"`
+	DomainID  string    `gorm:"type:char(26);not null;index:idx_web_domain_aliases_domain" json:"domain_id"`
+	Hostname  string    `gorm:"type:varchar(253);not null;uniqueIndex:ux_web_domain_aliases_hostname" json:"hostname"`
+	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+}
+
+func (WebDomainAlias) TableName() string { return "web_domain_aliases" }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -259,6 +259,10 @@ type Reconciler struct {
 	// agent dispatch omits the ip_acls field (no nginx directives
 	// rendered).
 	domainIPACLs repository.DomainIPACLRepository
+	// GH #1625 — additional hostnames served from a web domain's vhost.
+	// Optional; when nil the dispatch omits the aliases field and no
+	// alias SANs are added.
+	webDomainAliases repository.WebDomainAliasRepository
 	// M50 per-directory password protection repo. When nil, agent
 	// dispatch omits directory_privacy_rules → no htpasswd files
 	// written, no auth_basic location blocks rendered.
@@ -411,6 +415,34 @@ func (r *Reconciler) WithUserEgressDropSamples(repo repository.UserEgressDropSam
 func (r *Reconciler) WithDomainIPACLs(repo repository.DomainIPACLRepository) *Reconciler {
 	r.domainIPACLs = repo
 	return r
+}
+
+// WithWebDomainAliases injects the GH #1625 alias repo. When set, the
+// reconciler threads a domain's alias hostnames into the agent's
+// domain.create server_name and into the cert SAN set on every converge.
+func (r *Reconciler) WithWebDomainAliases(repo repository.WebDomainAliasRepository) *Reconciler {
+	r.webDomainAliases = repo
+	return r
+}
+
+// aliasHostnames returns a domain's alias hostnames for this converge
+// pass, or nil when the repo is unwired or the read fails. Fail-open on
+// purpose: a repo blip must not tank a domain converge or a cert renewal
+// — nil means "no aliases this pass", the vhost params stay unchanged,
+// and the next tick retries. GH #1625.
+func (r *Reconciler) aliasHostnames(ctx context.Context, domainID string) []string {
+	if r.webDomainAliases == nil {
+		return nil
+	}
+	aliasCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	names, err := r.webDomainAliases.ListHostnamesByDomainID(aliasCtx, domainID)
+	if err != nil {
+		r.log.Warn("ssl: failed to load web domain aliases; skipping them this pass",
+			"domain_id", domainID, "err", err)
+		return nil
+	}
+	return names
 }
 
 // WithDomainDirectoryPrivacy injects the M50 per-directory password
@@ -1959,6 +1991,16 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 		}
 	}
 
+	// GH #1625 web domain aliases. UNFILTERED on purpose: every alias
+	// goes into the vhost server_name regardless of DNS (no traffic → no
+	// harm; DNS flips → served immediately, the add-then-repoint flow).
+	// Only the CERT side (sanHostnamesForDomain → resolvableSANs →
+	// reachableSANs) gates on reachability, so a not-yet-pointed alias is
+	// served over HTTP but left off the cert until it resolves here.
+	if aliases := r.aliasHostnames(ctx, domain.ID); len(aliases) > 0 {
+		params["aliases"] = aliases
+	}
+
 	// M50 per-directory password protection. Fetch rules + their
 	// credentials so the agent can write the htpasswd file and emit
 	// one `location ^~ <path>/ { auth_basic ...; }` block per rule.
@@ -2659,7 +2701,7 @@ type sslSelfSignResult struct {
 // already covers it, so Outlook's direct
 // autodiscover.<domain>/autodiscover.xml probe lands on a cert that
 // names it instead of a TLS mismatch.
-func sanHostnamesForDomain(d *models.Domain) []string {
+func sanHostnamesForDomain(d *models.Domain, aliases []string) []string {
 	if d == nil {
 		return nil
 	}
@@ -2672,9 +2714,33 @@ func sanHostnamesForDomain(d *models.Domain) []string {
 	if d.CreateWWW {
 		out = append(out, "www."+d.Name)
 	}
+	// GH #1625 web domain aliases. An alias is served from the SAME
+	// docroot as the apex (the reconciler adds it to the main vhost's
+	// server_name), so unlike the mail helpers below a forwarded HTTP-01
+	// challenge for it COULD be answered from the token dir. Even so it
+	// is left on the DIRECT-ONLY footing (reachableSANs), NOT the fronted
+	// allowance the apex/www get, ON PURPOSE:
+	//
+	// An alias is usually a FOREIGN zone, so "resolves to the apex's CDN
+	// IPs" is a weak origin signal — a same-CDN alias may route to a
+	// different origin (the tenant's old box during a migration), the
+	// challenge 404s there, and that one failure tanks the WHOLE cert,
+	// apex included (arizot-e.com's shape). The apex's own fronted
+	// allowance can never do that: if the apex isn't reachable the cert
+	// was doomed regardless. A tenant-supplied alias must not widen the
+	// blast radius past its own coverage — so a CDN-fronted alias is
+	// simply left off the cert and reported "pending" (GH #1625), which
+	// resolvableSANs + reachableSANs already enforce for any non-apex/www
+	// name. Do not "fix" this by extending webNameKeepsFrontedAllowance
+	// to aliases.
+	//
+	// Appended before the SkipAutoSAN return (like opt-in www): aliases
+	// are EXPLICIT tenant SANs, not auto-derived helpers, so SkipAutoSAN
+	// (opt-out of mail/autoconfig/mta-sts) must not drop them.
+	out = append(out, aliases...)
 	// Tenant opt-out: when SkipAutoSAN is set, panel won't add the
 	// auto-derived helper SANs (mail/autoconfig/mta-sts) — only the base
-	// name (agent-side) and www.<domain> when opted in.
+	// name (agent-side), www.<domain> when opted in, and explicit aliases.
 	if d.SkipAutoSAN {
 		return out
 	}
@@ -2892,7 +2958,7 @@ func (r *Reconciler) sslEnsureSelfSigned(ctx context.Context, domain *models.Dom
 	}
 
 	ssParams := map[string]any{"domain": domain.Name, "days": 365}
-	if extras := sanHostnamesForDomain(domain); len(extras) > 0 {
+	if extras := sanHostnamesForDomain(domain, r.aliasHostnames(ctx, domain.ID)); len(extras) > 0 {
 		sanCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		if filtered := r.resolvableSANs(sanCtx, extras); len(filtered) > 0 {
 			ssParams["hostnames"] = filtered
@@ -3052,7 +3118,7 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 		"email":   srv.AdminEmail,
 		"staging": staging,
 	}
-	if extras := sanHostnamesForDomain(domain); len(extras) > 0 {
+	if extras := sanHostnamesForDomain(domain, r.aliasHostnames(issueCtx, domain.ID)); len(extras) > 0 {
 		// Drop unresolvable SAN names — they would otherwise fail
 		// HTTP-01 and tank the whole cert. The base name +
 		// www.<name> always remain (added agent-side).
@@ -3140,7 +3206,7 @@ func (r *Reconciler) ensureSelfSignFallback(ctx context.Context, domain *models.
 		"domain": domain.Name,
 		"days":   365,
 	}
-	if extras := sanHostnamesForDomain(domain); len(extras) > 0 {
+	if extras := sanHostnamesForDomain(domain, r.aliasHostnames(selfSignCtx, domain.ID)); len(extras) > 0 {
 		// Self-sign uses the SAME SAN filter so the fallback
 		// cert covers exactly what ACME will retry next tick.
 		if filtered := r.resolvableSANs(selfSignCtx, extras); len(filtered) > 0 {
@@ -3238,7 +3304,7 @@ func (r *Reconciler) sslRenewForDomain(ctx context.Context, domain *models.Domai
 	// round trip (two hook invocations + validation poll) against this
 	// call's default budget. tryACMEOrFallback re-detects fronting and
 	// gives the DNS-01 path its 4-minute budget.
-	if len(sanHostnamesForDomain(domain)) > 0 || cert.IssueMethod == issueMethodDNS01 {
+	if len(sanHostnamesForDomain(domain, r.aliasHostnames(ctx, domain.ID))) > 0 || cert.IssueMethod == issueMethodDNS01 {
 		r.tryACMEOrFallback(ctx, domain, cert)
 		return
 	}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2169,26 +2169,26 @@ func TestReconcileMysqlAdminShadow_BatchLimitOf50(t *testing.T) {
 // cert gen).
 func TestSANHostnamesForDomain(t *testing.T) {
 	t.Run("nil domain", func(t *testing.T) {
-		if got := sanHostnamesForDomain(nil); got != nil {
+		if got := sanHostnamesForDomain(nil, nil); got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
 	t.Run("email disabled, www out", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", EmailEnabled: false, CreateWWW: false}
-		if got := sanHostnamesForDomain(d); got != nil {
+		if got := sanHostnamesForDomain(d, nil); got != nil {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
 	t.Run("www opt-in adds www (GH #895)", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", EmailEnabled: false, CreateWWW: true}
-		got := sanHostnamesForDomain(d)
+		got := sanHostnamesForDomain(d, nil)
 		if len(got) != 1 || got[0] != "www.example.com" {
 			t.Errorf("got %v, want [www.example.com]", got)
 		}
 	})
 	t.Run("www opt-in + email keeps www first", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", EmailEnabled: true, CreateWWW: true}
-		got := sanHostnamesForDomain(d)
+		got := sanHostnamesForDomain(d, nil)
 		want := []string{"www.example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}
 		if len(got) != len(want) {
 			t.Fatalf("got %v, want %v", got, want)
@@ -2201,14 +2201,14 @@ func TestSANHostnamesForDomain(t *testing.T) {
 	})
 	t.Run("SkipAutoSAN + www opt-in keeps only www", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: true}
-		got := sanHostnamesForDomain(d)
+		got := sanHostnamesForDomain(d, nil)
 		if len(got) != 1 || got[0] != "www.example.com" {
 			t.Errorf("got %v, want [www.example.com]", got)
 		}
 	})
 	t.Run("email enabled", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", EmailEnabled: true}
-		got := sanHostnamesForDomain(d)
+		got := sanHostnamesForDomain(d, nil)
 		want := []string{"mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}
 		if len(got) != len(want) {
 			t.Fatalf("got %v, want %v", got, want)
@@ -2221,7 +2221,7 @@ func TestSANHostnamesForDomain(t *testing.T) {
 	})
 	t.Run("mta_sts only", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", MTASTSEnabled: true}
-		got := sanHostnamesForDomain(d)
+		got := sanHostnamesForDomain(d, nil)
 		want := []string{"mta-sts.example.com"}
 		if len(got) != 1 || got[0] != want[0] {
 			t.Errorf("got %v, want %v", got, want)
@@ -2229,7 +2229,7 @@ func TestSANHostnamesForDomain(t *testing.T) {
 	})
 	t.Run("email + mta_sts", func(t *testing.T) {
 		d := &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true}
-		got := sanHostnamesForDomain(d)
+		got := sanHostnamesForDomain(d, nil)
 		want := []string{"mail.example.com", "autoconfig.example.com", "autodiscover.example.com", "mta-sts.example.com"}
 		if len(got) != len(want) {
 			t.Fatalf("got %v, want %v", got, want)
@@ -2238,6 +2238,30 @@ func TestSANHostnamesForDomain(t *testing.T) {
 			if got[i] != w {
 				t.Errorf("[%d]: got %q, want %q", i, got[i], w)
 			}
+		}
+	})
+	t.Run("aliases append after helpers (GH #1625)", func(t *testing.T) {
+		d := &models.Domain{Name: "example.com", EmailEnabled: true, CreateWWW: true}
+		got := sanHostnamesForDomain(d, []string{"shop.example.net", "www.brand.io"})
+		want := []string{
+			"www.example.com",
+			"shop.example.net", "www.brand.io",
+			"mail.example.com", "autoconfig.example.com", "autodiscover.example.com",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i, w := range want {
+			if got[i] != w {
+				t.Errorf("[%d]: got %q, want %q", i, got[i], w)
+			}
+		}
+	})
+	t.Run("SkipAutoSAN keeps explicit aliases (GH #1625)", func(t *testing.T) {
+		d := &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: false}
+		got := sanHostnamesForDomain(d, []string{"alias.example.net"})
+		if len(got) != 1 || got[0] != "alias.example.net" {
+			t.Errorf("got %v, want [alias.example.net]", got)
 		}
 	})
 }

--- a/panel-api/internal/reconciler/san_reachable_test.go
+++ b/panel-api/internal/reconciler/san_reachable_test.go
@@ -131,6 +131,40 @@ func TestHelperVsWebSANDecision(t *testing.T) {
 	}
 }
 
+// GH #1625: a web domain alias is a non-apex/www name, so reachableSANs gives
+// it the DIRECT-ONLY test (apexForName == nil) — never the fronted allowance.
+// This is deliberate: an alias is usually a foreign zone, so a same-CDN match
+// with the apex is a weak origin signal, and a false positive would tank the
+// apex's own cert. See sanHostnamesForDomain's comment.
+func TestAliasSANIsDirectOnly(t *testing.T) {
+	const (
+		ourIP     = "203.0.113.10"
+		cf1       = "104.16.1.1"
+		otherHost = "198.51.100.7" // the tenant's old box, mid-migration
+		apex      = "example.com"
+	)
+	apexAddrs := []string{cf1}
+	ours := []string{ourIP}
+
+	// An alias never counts as a web name — so it does not get the apex-match.
+	if webNameKeepsFrontedAllowance("shop.example.net", apex) {
+		t.Error("an alias must NOT keep the fronted allowance")
+	}
+	// Alias pointing DIRECTLY at us: kept (this is the intended, working case).
+	if !sanReachability(ours, nil, ours) {
+		t.Error("alias resolving directly to us was dropped — it must be kept")
+	}
+	// Alias resolving to the APEX's CDN IPs: DROPPED. The decision case — a
+	// same-CDN alias may front a different origin, so it must not ride the cert.
+	if sanReachability(apexAddrs, nil, ours) {
+		t.Error("alias behind the apex CDN was kept — it must be dropped (direct-only)")
+	}
+	// Alias pointing at an unrelated host (old box during a repoint): DROPPED.
+	if sanReachability([]string{otherHost}, nil, ours) {
+		t.Error("alias resolving elsewhere was kept — it must be dropped")
+	}
+}
+
 func TestIntersects(t *testing.T) {
 	if intersects(nil, []string{"a"}) || intersects([]string{"a"}, nil) {
 		t.Error("empty input must not intersect")

--- a/panel-api/internal/reconciler/ssl_san_drift.go
+++ b/panel-api/internal/reconciler/ssl_san_drift.go
@@ -53,7 +53,7 @@ const (
 // the cert already covers everything, carries a wildcard (assumed to cover the
 // helpers — never churn it), or the domain wants no extra SANs. Uses the domain
 // flags carried on the ListAll row so no per-cert domain lookup is needed here.
-func sslSANDriftMissing(row repository.SSLCertificateWithDomain, certSANs []string) []string {
+func sslSANDriftMissing(row repository.SSLCertificateWithDomain, certSANs, aliases []string) []string {
 	dom := &models.Domain{
 		Name:          row.DomainName,
 		EmailEnabled:  row.EmailEnabled,
@@ -61,7 +61,7 @@ func sslSANDriftMissing(row repository.SSLCertificateWithDomain, certSANs []stri
 		CreateWWW:     row.CreateWWW,
 		MTASTSEnabled: row.MTASTSEnabled,
 	}
-	desired := sanHostnamesForDomain(dom)
+	desired := sanHostnamesForDomain(dom, aliases)
 	if len(desired) == 0 {
 		return nil
 	}
@@ -137,7 +137,10 @@ func (r *Reconciler) ReconcileSSLSANDrift(ctx context.Context) {
 		if err != nil {
 			continue // unreadable — ssl_observe already surfaces that separately
 		}
-		missing := sslSANDriftMissing(c, certSANs)
+		// GH #1625: aliases are desired SANs too, so a resolved alias
+		// added after issuance is drift the pass must notice. Fetched
+		// per eligible cert (hourly, fail-open nil).
+		missing := sslSANDriftMissing(c, certSANs, r.aliasHostnames(ctx, c.DomainID))
 		if len(missing) == 0 {
 			continue // cert already complete (or wildcard) — cheap skip, no IO/LE
 		}
@@ -172,7 +175,7 @@ func (r *Reconciler) expandCertSANsForDrift(ctx context.Context, cert repository
 		return
 	}
 
-	desired := sanHostnamesForDomain(dom)
+	desired := sanHostnamesForDomain(dom, r.aliasHostnames(ctx, dom.ID))
 	reachable := r.resolvableSANs(ctx, desired)
 	if len(reachable) > 0 {
 		reachable = r.reachableSANs(ctx, dom.Name, reachable)

--- a/panel-api/internal/reconciler/ssl_san_drift_test.go
+++ b/panel-api/internal/reconciler/ssl_san_drift_test.go
@@ -22,37 +22,37 @@ func TestSSLSANDriftMissing(t *testing.T) {
 	row := emailRow("example.com")
 
 	// Missing autodiscover — the motivating case.
-	miss := sslSANDriftMissing(row, []string{"example.com", "mail.example.com", "autoconfig.example.com"})
+	miss := sslSANDriftMissing(row, []string{"example.com", "mail.example.com", "autoconfig.example.com"}, nil)
 	if len(miss) != 1 || miss[0] != "autodiscover.example.com" {
 		t.Fatalf("missing = %v, want [autodiscover.example.com]", miss)
 	}
 
 	// Complete cert — no drift.
-	if m := sslSANDriftMissing(row, []string{"example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}); m != nil {
+	if m := sslSANDriftMissing(row, []string{"example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}, nil); m != nil {
 		t.Errorf("complete cert flagged drift: %v", m)
 	}
 
 	// Wildcard cert — assumed to cover the helpers, never churned.
-	if m := sslSANDriftMissing(row, []string{"example.com", "*.example.com"}); m != nil {
+	if m := sslSANDriftMissing(row, []string{"example.com", "*.example.com"}, nil); m != nil {
 		t.Errorf("wildcard cert flagged drift: %v", m)
 	}
 
 	// Case-insensitive match.
-	if m := sslSANDriftMissing(row, []string{"example.com", "Mail.Example.COM", "AUTOCONFIG.example.com", "autodiscover.example.com"}); m != nil {
+	if m := sslSANDriftMissing(row, []string{"example.com", "Mail.Example.COM", "AUTOCONFIG.example.com", "autodiscover.example.com"}, nil); m != nil {
 		t.Errorf("case difference flagged drift: %v", m)
 	}
 
 	// SkipAutoSAN → no helper SANs desired → no drift.
 	skip := row
 	skip.SkipAutoSAN = true
-	if m := sslSANDriftMissing(skip, []string{"example.com"}); m != nil {
+	if m := sslSANDriftMissing(skip, []string{"example.com"}, nil); m != nil {
 		t.Errorf("SkipAutoSAN flagged drift: %v", m)
 	}
 
 	// Email disabled → no mail helpers desired → no drift even with a bare cert.
 	nomail := row
 	nomail.EmailEnabled = false
-	if m := sslSANDriftMissing(nomail, []string{"example.com"}); m != nil {
+	if m := sslSANDriftMissing(nomail, []string{"example.com"}, nil); m != nil {
 		t.Errorf("email-disabled flagged drift: %v", m)
 	}
 }

--- a/panel-api/internal/reconciler/web_domain_alias_dispatch_test.go
+++ b/panel-api/internal/reconciler/web_domain_alias_dispatch_test.go
@@ -1,0 +1,60 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeAliasRepo is a minimal WebDomainAliasRepository for the reconciler
+// dispatch tests — only ListHostnamesByDomainID is exercised (GH #1625).
+type fakeAliasRepo struct{ byDomain map[string][]string }
+
+func (f *fakeAliasRepo) ListHostnamesByDomainID(_ context.Context, domainID string) ([]string, error) {
+	return f.byDomain[domainID], nil
+}
+func (f *fakeAliasRepo) Create(context.Context, *models.WebDomainAlias) error { return nil }
+func (f *fakeAliasRepo) FindByID(context.Context, string) (*models.WebDomainAlias, error) {
+	return nil, nil
+}
+func (f *fakeAliasRepo) ListByDomain(context.Context, string) ([]models.WebDomainAlias, error) {
+	return nil, nil
+}
+func (f *fakeAliasRepo) FindByHostname(context.Context, string) (*models.WebDomainAlias, error) {
+	return nil, nil
+}
+func (f *fakeAliasRepo) Delete(context.Context, string) error { return nil }
+
+// GH #1625: aliases must reach the agent's domain.create payload (so nginx
+// renders them into server_name) AND participate in the dispatch-change gate,
+// so adding/removing an alias re-dispatches while an unchanged set does not.
+func TestCreateDomainOnAgent_AliasesReachAgentAndTripGate(t *testing.T) {
+	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
+	ar := &fakeAliasRepo{byDomain: map[string][]string{dom.ID: {"shop.example.net"}}}
+	r.WithWebDomainAliases(ar)
+
+	r.createDomainOnAgent(context.Background(), dom, false)
+	call, ok := findAgentCall(ag, "domain.create")
+	if !ok {
+		t.Fatal("domain.create was not dispatched")
+	}
+	params := call.params.(map[string]any)
+	aliases, aOK := params["aliases"].([]string)
+	if !aOK || len(aliases) != 1 || aliases[0] != "shop.example.net" {
+		t.Fatalf("aliases param = %#v, want [shop.example.net]", params["aliases"])
+	}
+
+	// Unchanged alias set on the next periodic tick — no re-dispatch.
+	r.createDomainOnAgent(context.Background(), dom, false)
+	if got := countDomainCreate(ag); got != 1 {
+		t.Fatalf("unchanged alias set must not re-dispatch, got %d", got)
+	}
+
+	// Adding an alias changes the assembled params → the hash flips → re-dispatch.
+	ar.byDomain[dom.ID] = []string{"shop.example.net", "blog.example.net"}
+	r.createDomainOnAgent(context.Background(), dom, false)
+	if got := countDomainCreate(ag); got != 2 {
+		t.Fatalf("changed alias set must re-dispatch, got %d", got)
+	}
+}

--- a/panel-api/internal/repository/web_domain_alias_repository.go
+++ b/panel-api/internal/repository/web_domain_alias_repository.go
@@ -1,0 +1,105 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// WebDomainAliasRepository persists the additional hostnames served from
+// a web domain's vhost (GH #1625). The reconciler reads
+// ListHostnamesByDomainID every time it converges a domain to render the
+// server_name list and the cert SAN set.
+type WebDomainAliasRepository interface {
+	Create(ctx context.Context, row *models.WebDomainAlias) error
+	FindByID(ctx context.Context, id string) (*models.WebDomainAlias, error)
+	ListByDomain(ctx context.Context, domainID string) ([]models.WebDomainAlias, error)
+	// ListHostnamesByDomainID returns just the lowercased hostnames for
+	// one domain, ordered stably — the reconciler's single source of
+	// truth for a domain's aliases on a converge pass.
+	ListHostnamesByDomainID(ctx context.Context, domainID string) ([]string, error)
+	// FindByHostname resolves an alias by its (globally unique) hostname,
+	// or ErrNotFound when the name is free. The create handler uses it to
+	// enforce global uniqueness before insert (the DB index is the
+	// backstop, this is the friendly 409).
+	FindByHostname(ctx context.Context, hostname string) (*models.WebDomainAlias, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type webDomainAliasRepo struct{ db *gorm.DB }
+
+func NewWebDomainAliasRepository(db *gorm.DB) WebDomainAliasRepository {
+	return &webDomainAliasRepo{db: db}
+}
+
+func (r *webDomainAliasRepo) Create(ctx context.Context, row *models.WebDomainAlias) error {
+	now := time.Now().UTC()
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = now
+	}
+	if row.UpdatedAt.IsZero() {
+		row.UpdatedAt = now
+	}
+	return r.db.WithContext(ctx).Create(row).Error
+}
+
+func (r *webDomainAliasRepo) FindByID(ctx context.Context, id string) (*models.WebDomainAlias, error) {
+	var row models.WebDomainAlias
+	err := r.db.WithContext(ctx).First(&row, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *webDomainAliasRepo) ListByDomain(ctx context.Context, domainID string) ([]models.WebDomainAlias, error) {
+	var rows []models.WebDomainAlias
+	err := r.db.WithContext(ctx).
+		Where("domain_id = ?", domainID).
+		Order("hostname ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *webDomainAliasRepo) ListHostnamesByDomainID(ctx context.Context, domainID string) ([]string, error) {
+	var names []string
+	err := r.db.WithContext(ctx).
+		Model(&models.WebDomainAlias{}).
+		Where("domain_id = ?", domainID).
+		Order("hostname ASC").
+		Pluck("hostname", &names).Error
+	if err != nil {
+		return nil, err
+	}
+	for i, n := range names {
+		names[i] = strings.ToLower(strings.TrimSpace(n))
+	}
+	return names, nil
+}
+
+func (r *webDomainAliasRepo) FindByHostname(ctx context.Context, hostname string) (*models.WebDomainAlias, error) {
+	var row models.WebDomainAlias
+	err := r.db.WithContext(ctx).First(&row, "hostname = ?", strings.ToLower(strings.TrimSpace(hostname))).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *webDomainAliasRepo) Delete(ctx context.Context, id string) error {
+	return r.db.WithContext(ctx).Delete(&models.WebDomainAlias{}, "id = ?", id).Error
+}


### PR DESCRIPTION
## Web domain aliases — Phase 1 (backend spine)

An **alias** is an extra hostname served from a web domain's *existing* vhost +
docroot. Phase 1 lands the whole backend: table, model, repository, REST CRUD,
nginx `server_name` rendering, and resolve-gated TLS SANs. UI (a shared Aliases
tab, tenant + admin) is Phase 2.

### What ships

- **`web_domain_aliases`** table (migration `000293`, mirrors `000119_domain_ip_acls`:
  FK → `domains(id) ON DELETE CASCADE`, `utf8mb4_unicode_ci`, globally-unique
  `hostname`) + model + repository.
- **REST CRUD** `GET/POST/DELETE /domains/:id/aliases` — owner-scoped, admins any;
  cross-tenant access returns **404** (not 403) so domain existence never leaks.
- **`validateAliasHostname` denylist** — an alias is rejected when it equals:
  another domain's apex, any `{www,mail,autoconfig,autodiscover,mta-sts}.<domain>`
  helper `server_name`, the panel FQDN, the domain's own primary/www, an already-
  claimed alias, **a web-disabled domain** (DNS-only/mail-only → no vhost to serve
  it), or a config-injection payload (space/`;`/`{`/newline).
- **nginx `server_name`** — the reconciler renders every alias into the main
  server block (unfiltered — the add-then-repoint flow needs the name present
  before DNS moves); the **agent re-sanitizes** each alias against `domainRegex`
  (fail-closed) because `server_name` is raw config.
- **Resolve-gated cert SANs (DIRECT-ONLY)** — an alias reaches the domain's TLS
  cert **only when it resolves directly to this server**. A CDN-fronted alias is
  deliberately left *off* the cert and reported `pending`: a tenant-supplied
  alias that false-positived as "fronted by us" would poison the apex's own cert
  (526 under CF Full-strict — the arizot-e.com incident shape). The ADR-0070
  lockstep twin (`webCertSANsForDomain`) is kept in sync; the **SAN-drift** and
  **dispatch-change** gates both see aliases.
- **`aliasCollision` — the reverse guard.** `validateAliasHostname` stops an
  alias from colliding with an existing domain; the alias table then introduces
  the *opposite* hole — a domain created (or renamed to, or docker-app-auto-
  created as) a name matching an existing alias would emit a duplicate nginx
  `server_name`, and nginx silently keeps the first-loaded block (a cross-tenant
  vhost hijack; `nginx -t` only *warns*). `aliasCollision` checks a new domain's
  apex + `www` + the four mail helpers against the alias table and is wired into
  **`createDomainOp`** (GUI + JAB-233 automation), the **rename** handler, and
  **both docker-app domain auto-create** paths. `409 domain_conflicts_alias`.

### Tests

Unit tests encode the decisions: denylist (16 cases) + web-disabled + collision;
DIRECT-ONLY SAN gating (alias→us kept, alias→apex-CDN dropped, alias→unrelated
dropped); SAN append before `SkipAutoSAN` return in both lockstep copies; the
dispatch gate (alias reaches `params["aliases"]`, unchanged set skips, changed
set re-dispatches); agent `server_name` sanitize (injection dropped in both the
enabled and disabled vhost blocks); openapi coverage.

### Notes / follow-ups (not blockers)

- **`pending_reason` timing.** An already-*issued* cert picks up a newly-pointed
  alias only via the hourly SAN-drift pass (2/pass, 6h per-cert cooldown), so
  Phase 2 copy should say "added within ~1h once the record points here", not
  "instant".
- **Rename covered.** The `aliasCollision` guard runs in the rename handler
  (inline, `userops.RenameDomain` surface unchanged). A domain's *own* aliases
  survive a rename — they are keyed by `domain_id`.
- **Not enforced (by design):** an alias may be a subdomain of another user's
  domain (e.g. `shop.otheruser.com`) — that is *not* a `server_name` collision
  (it does not equal `otheruser.com` or its helpers), and domain-create itself
  does not reject foreign subdomains either, so aliases match that behaviour.
- **Out of scope for aliases:** reverse-proxy `sub_filter`/`proxy_redirect`
  rewrites still hardcode `www.<domain>` only — an alias on a proxied domain is
  reachable but not rewritten. Left for a later pass.
- **Phase 2/3:** shared Aliases tab UI (tenant `WebDomainPage` + admin
  `DomainEdit`) + the domains-list secondary text.

GH #1625
