### PR TITLE
feat(dns): custom DNS templates — admin-managed presets seeded at create (GH #1627)

### DIFF
--- a/panel-api/cmd/server/cli_create.go
+++ b/panel-api/cmd/server/cli_create.go
@@ -296,6 +296,14 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 	if !models.ValidMailProvider(mailProvider) {
 		return nil, nil, fmt.Errorf("invalid --mail %q (want jabali|none|m365|google)", mailProvider)
 	}
+	// GH #1627: 'custom' is the posture of a domain created from a DNS template,
+	// not a directly-selectable provider — ValidMailProvider recognises it (so a
+	// persisted row validates) but the CLI must not create a bare 'custom' domain
+	// with no template (an inert external domain with no mail records). DNS
+	// templates are not a CLI feature in this phase; reject the value at input.
+	if mailProvider == models.MailProviderCustom {
+		return nil, nil, fmt.Errorf("invalid --mail %q (custom is the posture of a domain created from a DNS template; not selectable on the CLI)", mailProvider)
+	}
 	mailEnabled, mailSkipSAN := models.DeriveMailFlags(mailProvider)
 	if !webEnabled && !dnsEnabled && !mailEnabled {
 		return nil, nil, fmt.Errorf("select at least one service: web hosting (--web-enabled), DNS (--manage-dns), or mail (--mail)")

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -204,6 +204,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		domainRepo := repository.NewDomainRepository(sharedDB)
 		dnsZoneRepo := repository.NewDNSZoneRepository(sharedDB)
 		dnsRecordRepo := repository.NewDNSRecordRepository(sharedDB)
+		dnsTemplateRepo := repository.NewDNSTemplateRepository(sharedDB)
 		sslCertRepo := repository.NewSSLCertificateRepository(sharedDB)
 		sharedCertRepo := repository.NewSharedCertificateRepository(sharedDB)
 		mailRBLStateRepo := repository.NewMailRBLStateRepository(sharedDB)
@@ -278,6 +279,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		deps.Users = userRepo
 		deps.Packages = packageRepo
 		deps.Domains = domainRepo
+		deps.DNSTemplates = dnsTemplateRepo // GH #1627
 		deps.DomainTeardowns = repository.NewDomainTeardownRepository(sharedDB)
 		deps.SSO = ssoService
 		// M37 Phase 4: Adminer SSO bridge — engine-aware mint + PG shadow.
@@ -347,6 +349,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// until the operator re-saved the disclaimer.
 		phases.RegisterPhase(phases.NewDisclaimerPhase(sharedAgent))
 		rec.WithDNSRepos(dnsZoneRepo, dnsRecordRepo, serverSettingsRepo)
+		rec.WithDNSTemplates(dnsTemplateRepo) // GH #1627: seed template records at zone bootstrap
 		rec.WithSSLCerts(sslCertRepo)
 		rec.WithPHPPools(phpPoolRepo)
 		// GH #601/#616: the reconciler needs the installs repo to gather a

--- a/panel-api/internal/api/dns_templates.go
+++ b/panel-api/internal/api/dns_templates.go
@@ -1,0 +1,243 @@
+// Custom DNS templates (GH #1627).
+//
+// Admin routes (mounted under /api/v1/admin, RequireAdmin):
+//
+//	GET    /dns-templates          list templates (with records)
+//	POST   /dns-templates          create a template
+//	GET    /dns-templates/:id      one template (with records)
+//	PUT    /dns-templates/:id      replace a template's fields + records
+//	DELETE /dns-templates/:id      delete a template
+//
+// Tenant route (mounted on the authed base group):
+//
+//	GET    /dns-templates          list templates (id/name/description only)
+//
+// A template is a named preset of DNS records an admin defines once; a tenant
+// selects one at Web Domain / DNS Zone create (dns_template_id) and the
+// reconciler seeds its records into the fresh zone. Templates are GLOBAL in
+// this phase — every tenant sees every template — which is why the tenant list
+// carries no ownership scope: a tenant can already type any record into their
+// own zone, so a template is convenience, not an entitlement (GH #282 does not
+// apply). Each record is validated at admin-create with the SAME
+// ValidateDNSRecord the tenant DNS record API uses, so a template can never
+// carry a record the record API would reject.
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// DNSTemplateHandlerConfig wires the routes. A nil Templates repo disables
+// registration (the feature is unwired).
+type DNSTemplateHandlerConfig struct {
+	Templates repository.DNSTemplateRepository
+}
+
+type dnsTemplateHandler struct{ cfg DNSTemplateHandlerConfig }
+
+// RegisterAdminDNSTemplateRoutes mounts the admin CRUD under an already
+// RequireAdmin-gated group.
+func RegisterAdminDNSTemplateRoutes(admin *gin.RouterGroup, cfg DNSTemplateHandlerConfig) {
+	if cfg.Templates == nil {
+		return
+	}
+	h := &dnsTemplateHandler{cfg: cfg}
+	g := admin.Group("/dns-templates")
+	g.GET("", h.adminList)
+	g.POST("", h.create)
+	g.GET("/:id", h.get)
+	g.PUT("/:id", h.update)
+	g.DELETE("/:id", h.delete)
+}
+
+// RegisterDNSTemplateRoutes mounts the tenant-visible read-only list on the
+// authed base group.
+func RegisterDNSTemplateRoutes(v1 *gin.RouterGroup, cfg DNSTemplateHandlerConfig) {
+	if cfg.Templates == nil {
+		return
+	}
+	h := &dnsTemplateHandler{cfg: cfg}
+	v1.GET("/dns-templates", h.tenantList)
+}
+
+type dnsTemplateRecordInput struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Content  string `json:"content"`
+	TTL      int    `json:"ttl"`
+	Priority int    `json:"priority"`
+}
+
+type dnsTemplateInput struct {
+	Name        string                   `json:"name"`
+	Description string                   `json:"description"`
+	Records     []dnsTemplateRecordInput `json:"records"`
+}
+
+// dnsTemplateSummary is the tenant-facing shape: no record bodies.
+type dnsTemplateSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+const dnsTemplateMaxRecords = 100
+
+// buildTemplate validates the input and returns a populated (unsaved) template
+// with fresh record IDs, or an (http status, code, detail) rejection.
+func buildTemplate(in dnsTemplateInput) (*models.DNSTemplate, int, string, string) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return nil, http.StatusBadRequest, "name_required", "a template name is required"
+	}
+	if len(name) > 120 {
+		return nil, http.StatusBadRequest, "name_too_long", "template name exceeds 120 characters"
+	}
+	if len(in.Description) > 500 {
+		return nil, http.StatusBadRequest, "description_too_long", "template description exceeds 500 characters"
+	}
+	if len(in.Records) > dnsTemplateMaxRecords {
+		return nil, http.StatusBadRequest, "too_many_records", "a template may hold at most 100 records"
+	}
+	tmpl := &models.DNSTemplate{
+		ID:          ids.NewULID(),
+		Name:        name,
+		Description: strings.TrimSpace(in.Description),
+		// Non-nil so a zero-record template serialises as "records": [] rather
+		// than null (a null slice renders blank in the SPA table).
+		Records: make([]models.DNSTemplateRecord, 0, len(in.Records)),
+	}
+	for i, rin := range in.Records {
+		// Validate each record with the SAME validator the tenant record API
+		// runs. ValidateDNSRecord normalises Type/Name/Content in place, so the
+		// stored blueprint is already canonical. The {domain} token is a literal
+		// here (no whitespace), so it passes for MX/CNAME/TXT and is only
+		// rejected where it makes no sense (e.g. an A record needs a real IP).
+		probe := &models.DNSRecord{
+			Name:     rin.Name,
+			Type:     rin.Type,
+			Content:  rin.Content,
+			TTL:      rin.TTL,
+			Priority: rin.Priority,
+		}
+		if err := ValidateDNSRecord(probe); err != nil {
+			return nil, http.StatusBadRequest, "invalid_record", "record " + strconv.Itoa(i+1) + ": " + err.Error()
+		}
+		tmpl.Records = append(tmpl.Records, models.DNSTemplateRecord{
+			ID:       ids.NewULID(),
+			Name:     probe.Name,
+			Type:     probe.Type,
+			Content:  probe.Content,
+			TTL:      probe.TTL,
+			Priority: probe.Priority,
+		})
+	}
+	return tmpl, 0, "", ""
+}
+
+func (h *dnsTemplateHandler) create(c *gin.Context) {
+	var in dnsTemplateInput
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	tmpl, status, code, detail := buildTemplate(in)
+	if status != 0 {
+		c.JSON(status, gin.H{"error": code, "detail": detail})
+		return
+	}
+	if err := h.cfg.Templates.Create(c.Request.Context(), tmpl); err != nil {
+		if isDuplicateKeyErr(err) {
+			c.JSON(http.StatusConflict, gin.H{"error": "name_taken", "detail": "a template with that name already exists"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusCreated, tmpl)
+}
+
+func (h *dnsTemplateHandler) update(c *gin.Context) {
+	var in dnsTemplateInput
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	tmpl, status, code, detail := buildTemplate(in)
+	if status != 0 {
+		c.JSON(status, gin.H{"error": code, "detail": detail})
+		return
+	}
+	tmpl.ID = c.Param("id")
+	if err := h.cfg.Templates.Update(c.Request.Context(), tmpl); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		case isDuplicateKeyErr(err):
+			c.JSON(http.StatusConflict, gin.H{"error": "name_taken", "detail": "a template with that name already exists"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, tmpl)
+}
+
+func (h *dnsTemplateHandler) get(c *gin.Context) {
+	tmpl, err := h.cfg.Templates.FindByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, tmpl)
+}
+
+func (h *dnsTemplateHandler) adminList(c *gin.Context) {
+	tmpls, err := h.cfg.Templates.List(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if tmpls == nil {
+		tmpls = []models.DNSTemplate{}
+	}
+	c.JSON(http.StatusOK, gin.H{"templates": tmpls})
+}
+
+func (h *dnsTemplateHandler) delete(c *gin.Context) {
+	if err := h.cfg.Templates.Delete(c.Request.Context(), c.Param("id")); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"deleted": true})
+}
+
+func (h *dnsTemplateHandler) tenantList(c *gin.Context) {
+	tmpls, err := h.cfg.Templates.ListSummaries(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	out := make([]dnsTemplateSummary, 0, len(tmpls))
+	for _, t := range tmpls {
+		out = append(out, dnsTemplateSummary{ID: t.ID, Name: t.Name, Description: t.Description})
+	}
+	c.JSON(http.StatusOK, gin.H{"templates": out})
+}

--- a/panel-api/internal/api/dns_templates_test.go
+++ b/panel-api/internal/api/dns_templates_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #1627: buildTemplate is the admin-create validation boundary. Each record
+// runs through the SAME ValidateDNSRecord the tenant DNS API uses, so a
+// template can never carry a record the record API would reject. The {domain}
+// token is a literal at this stage (no whitespace) and passes for MX/CNAME/TXT.
+func TestBuildTemplate(t *testing.T) {
+	t.Run("valid template normalises records", func(t *testing.T) {
+		tmpl, status, code, _ := buildTemplate(dnsTemplateInput{
+			Name:        "  Acme SaaS  ",
+			Description: "external mail + verification",
+			Records: []dnsTemplateRecordInput{
+				{Name: "@", Type: "mx", Content: "mail.{domain}", Priority: 10},
+				{Name: "@", Type: "TXT", Content: `"v=spf1 include:acme.example -all"`},
+				{Name: "autoconfig", Type: "cname", Content: "config.acme.example"},
+			},
+		})
+		if status != 0 {
+			t.Fatalf("expected accept, got status=%d code=%q", status, code)
+		}
+		if tmpl.Name != "Acme SaaS" {
+			t.Errorf("name not trimmed: %q", tmpl.Name)
+		}
+		if len(tmpl.Records) != 3 {
+			t.Fatalf("records = %d, want 3", len(tmpl.Records))
+		}
+		if tmpl.Records[0].Type != "MX" {
+			t.Errorf("type not upper-normalised: %q", tmpl.Records[0].Type)
+		}
+		if tmpl.Records[0].Content != "mail.{domain}" {
+			t.Errorf("{domain} token must survive validation literally, got %q", tmpl.Records[0].Content)
+		}
+		for i := range tmpl.Records {
+			if tmpl.Records[i].ID == "" {
+				t.Errorf("record %d got no id", i)
+			}
+		}
+	})
+
+	cases := []struct {
+		name string
+		in   dnsTemplateInput
+		code string
+	}{
+		{"empty name", dnsTemplateInput{Name: "  "}, "name_required"},
+		{
+			"bad record: A with non-IP",
+			dnsTemplateInput{Name: "t", Records: []dnsTemplateRecordInput{{Name: "@", Type: "A", Content: "not-an-ip"}}},
+			"invalid_record",
+		},
+		{
+			"bad record: unknown type",
+			dnsTemplateInput{Name: "t", Records: []dnsTemplateRecordInput{{Name: "@", Type: "ZZZ", Content: "x"}}},
+			"invalid_record",
+		},
+		{
+			"bad record: empty name",
+			dnsTemplateInput{Name: "t", Records: []dnsTemplateRecordInput{{Name: "", Type: "TXT", Content: "x"}}},
+			"invalid_record",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, status, code, _ := buildTemplate(tc.in)
+			if code != tc.code {
+				t.Fatalf("code = %q (status %d), want %q", code, status, tc.code)
+			}
+			if status == 0 {
+				t.Error("rejection must carry a non-zero status")
+			}
+		})
+	}
+
+	t.Run("too many records", func(t *testing.T) {
+		recs := make([]dnsTemplateRecordInput, dnsTemplateMaxRecords+1)
+		for i := range recs {
+			recs[i] = dnsTemplateRecordInput{Name: "@", Type: "TXT", Content: "x"}
+		}
+		_, _, code, _ := buildTemplate(dnsTemplateInput{Name: "t", Records: recs})
+		if code != "too_many_records" {
+			t.Fatalf("code = %q, want too_many_records", code)
+		}
+	})
+}
+
+// fakeDNSTemplates is a minimal DNSTemplateRepository for the createDomainOp
+// gating tests — only FindByID is exercised.
+type fakeDNSTemplates struct {
+	repository.DNSTemplateRepository
+	byID map[string]*models.DNSTemplate
+}
+
+func (f fakeDNSTemplates) FindByID(_ context.Context, id string) (*models.DNSTemplate, error) {
+	if t, ok := f.byID[id]; ok {
+		return t, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// GH #1627: selecting a custom DNS template at create flips the domain to the
+// external 'custom' mail posture, records mail_template_id (read once by the
+// reconciler to seed the template), and is fail-closed on every misuse.
+func TestCreateDomainOp_DNSTemplate(t *testing.T) {
+	uname := "alice"
+	owner := &models.User{ID: "u-alice", Email: "alice@example.com", Username: &uname}
+	const tmplID = "tmpl-01"
+
+	newH := func(withTemplates bool) *domainHandler {
+		cfg := DomainHandlerConfig{Users: newAbUsers(owner), Domains: newDCDomains()}
+		if withTemplates {
+			cfg.DNSTemplates = fakeDNSTemplates{byID: map[string]*models.DNSTemplate{
+				tmplID: {ID: tmplID, Name: "Acme SaaS"},
+			}}
+		}
+		return &domainHandler{cfg: cfg}
+	}
+
+	t.Run("template selected → custom posture + template id + external mail", func(t *testing.T) {
+		d, oerr := createDomainOp(context.Background(), newH(true), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "shop.example.com",
+			DNSTemplateID: tmplID,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v (%s)", oerr.Code, oerr.Detail)
+		}
+		if d.MailProvider != models.MailProviderCustom {
+			t.Errorf("MailProvider = %q, want custom", d.MailProvider)
+		}
+		if d.MailTemplateID == nil || *d.MailTemplateID != tmplID {
+			t.Errorf("MailTemplateID = %v, want %q", d.MailTemplateID, tmplID)
+		}
+		if d.EmailEnabled {
+			t.Error("a custom-template domain is external — EmailEnabled must be false")
+		}
+		if !d.SkipAutoSAN {
+			t.Error("a custom-template domain must skip Jabali auto-SANs")
+		}
+	})
+
+	rejections := []struct {
+		name string
+		in   createDomainInput
+		code string
+	}{
+		{
+			"caller-supplied custom provider is reserved",
+			createDomainInput{OwnerID: owner.ID, Name: "a.example.com", MailProvider: models.MailProviderCustom},
+			"mail_provider_custom_reserved",
+		},
+		{
+			"template + explicit provider is exclusive",
+			createDomainInput{OwnerID: owner.ID, Name: "b.example.com", DNSTemplateID: tmplID, MailProvider: models.MailProviderM365},
+			"template_and_provider_exclusive",
+		},
+		{
+			"template requires panel-hosted DNS",
+			createDomainInput{OwnerID: owner.ID, Name: "c.example.com", DNSTemplateID: tmplID, DNSDisabled: true},
+			"template_requires_dns",
+		},
+		{
+			"unknown template id",
+			createDomainInput{OwnerID: owner.ID, Name: "d.example.com", DNSTemplateID: "does-not-exist"},
+			"unknown_dns_template",
+		},
+	}
+	for _, tc := range rejections {
+		t.Run(tc.name, func(t *testing.T) {
+			_, oerr := createDomainOp(context.Background(), newH(true), tc.in)
+			if oerr == nil {
+				t.Fatalf("expected rejection %q, got success", tc.code)
+			}
+			if oerr.Code != tc.code {
+				t.Fatalf("code = %q, want %q", oerr.Code, tc.code)
+			}
+		})
+	}
+
+	t.Run("template selected but feature unwired → 503 fail-closed", func(t *testing.T) {
+		_, oerr := createDomainOp(context.Background(), newH(false), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "e.example.com",
+			DNSTemplateID: tmplID,
+		})
+		if oerr == nil || oerr.Code != "dns_templates_unavailable" {
+			t.Fatalf("want dns_templates_unavailable, got %v", oerr)
+		}
+	})
+}

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -57,9 +57,15 @@ type createDomainInput struct {
 	MailProvider    string // "" → jabali
 	M365Onmicrosoft string
 	GoogleDKIM      string
-	SSLMode         string // "" → le
-	CreateWWW       bool
-	TempURLEnabled  bool
+	// DNSTemplateID (GH #1627) is a custom DNS template the tenant selected at
+	// create. When set it OVERRIDES the mail posture to external ('custom') and
+	// the reconciler seeds the template's records into the fresh zone. Empty for
+	// every non-template create. Mutually exclusive with an explicit mail
+	// provider, and requires the panel to host DNS (DNSDisabled=false).
+	DNSTemplateID  string
+	SSLMode        string // "" → le
+	CreateWWW      bool
+	TempURLEnabled bool
 	// ReverseProxy (GH #1175): make this a reverse-proxy domain — the panel
 	// allocates a loopback port and the vhost proxies `/` to it. No DocRoot/PHP.
 	ReverseProxy bool
@@ -257,6 +263,36 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 	if !models.ValidMailProvider(mailProvider) {
 		return nil, &createDomainError{http.StatusBadRequest, "invalid_mail_provider", ""}
 	}
+	// GH #1627: 'custom' is the posture of a template-created domain; it is set
+	// ONLY by the dns_template_id path below, never accepted as caller input
+	// (a bare 'custom' with no template would be an inert external domain).
+	if mailProvider == models.MailProviderCustom {
+		return nil, &createDomainError{http.StatusBadRequest, "mail_provider_custom_reserved", "select a DNS template via dns_template_id rather than setting mail_provider=custom directly"}
+	}
+	// GH #1627: a chosen custom DNS template overrides the mail posture to
+	// external ('custom'); its records are seeded into the zone by the reconciler
+	// at bootstrap. It is mutually exclusive with an explicit external provider,
+	// and requires the panel to host DNS (nothing to seed into otherwise).
+	var mailTemplateID *string
+	if tmplID := strings.TrimSpace(in.DNSTemplateID); tmplID != "" {
+		if h.cfg.DNSTemplates == nil {
+			return nil, &createDomainError{http.StatusServiceUnavailable, "dns_templates_unavailable", "DNS templates are not enabled on this server"}
+		}
+		if mailProvider != models.MailProviderJabali {
+			return nil, &createDomainError{http.StatusBadRequest, "template_and_provider_exclusive", "a DNS template sets the mail posture; do not also select a mail provider"}
+		}
+		if !dnsEnabled {
+			return nil, &createDomainError{http.StatusBadRequest, "template_requires_dns", "a DNS template seeds records into the panel-hosted zone; this domain has DNS hosted externally"}
+		}
+		if _, terr := h.cfg.DNSTemplates.FindByID(ctx, tmplID); terr != nil {
+			if errors.Is(terr, repository.ErrNotFound) {
+				return nil, &createDomainError{http.StatusBadRequest, "unknown_dns_template", "the selected DNS template does not exist"}
+			}
+			return nil, &createDomainError{http.StatusInternalServerError, "dns_template_lookup_failed", ""}
+		}
+		mailProvider = models.MailProviderCustom
+		mailTemplateID = &tmplID
+	}
 	// GH #1409: never enable Jabali mail on a domain when the mail module isn't
 	// installed — coerce to "none" so we don't provision mail that can't run.
 	// The GUI already defaults to None; this guards API / automation callers
@@ -324,6 +360,7 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		MailProvider:    mailProvider,
 		M365Onmicrosoft: strPtrOrNil(m365Tenant),
 		GoogleDKIM:      strPtrOrNil(googleDKIM),
+		MailTemplateID:  mailTemplateID, // GH #1627: nil unless a template was chosen
 		EmailEnabled:    mailEnabled,
 		SkipAutoSAN:     mailSkipSAN,
 		CreateWWW:       in.CreateWWW,

--- a/panel-api/internal/api/domain_email.go
+++ b/panel-api/internal/api/domain_email.go
@@ -237,6 +237,16 @@ func (h *domainEmailHandler) enable(c *gin.Context) {
 		return
 	}
 
+	// GH #1627: a domain created from a custom DNS template carries the external
+	// 'custom' mail posture. Enabling Jabali mail on it would provision a
+	// Stalwart mailbox + DKIM records beside the template's own external MX/SPF
+	// (a split, conflicting posture). Blocked in this phase — delete + recreate
+	// the domain without a template to host mail on Jabali.
+	if dom.MailProvider == models.MailProviderCustom {
+		c.JSON(http.StatusConflict, gin.H{"error": "template_posture_locked", "detail": "this domain was created from a DNS template and uses external mail; enabling Jabali mail is not supported for it"})
+		return
+	}
+
 	selector, pubKey, warnings, err := domainmailops.Enable(ctx, h.deps(), dom)
 	if err != nil {
 		// Translate the module's sentinel errors back to HTTP responses.

--- a/panel-api/internal/api/domain_email_test.go
+++ b/panel-api/internal/api/domain_email_test.go
@@ -166,6 +166,26 @@ func TestDomainEmail_Enable_ForbiddenOtherOwner(t *testing.T) {
 	require.False(t, domains.domains["dom1"].EmailEnabled)
 }
 
+// TestDomainEmail_Enable_CustomTemplatePostureLocked — GH #1627: a domain
+// created from a custom DNS template carries the external 'custom' mail
+// posture. Enabling Jabali mail on it must be refused (409) and must never
+// reach the agent, so the template's external MX/SPF is not shadowed by a
+// Jabali mailbox + DKIM.
+func TestDomainEmail_Enable_CustomTemplatePostureLocked(t *testing.T) {
+	ma := &mockAgent{}
+	r, domains := domainEmailTestRouter(t, ma, false, "user1")
+	domains.domains["dom1"].MailProvider = models.MailProviderCustom
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/domains/dom1/email", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusConflict, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "template_posture_locked")
+	require.Equal(t, 0, ma.callCount, "agent must not be contacted for a custom-posture domain")
+	require.False(t, domains.domains["dom1"].EmailEnabled)
+}
+
 // TestDomainEmail_Disable_KeepsDKIM — disable clears email_enabled and
 // email_enabled_at but MUST preserve dkim_selector + dkim_public_key
 // so a later re-enable doesn't roll the key (ADR-0043).

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -89,6 +89,13 @@ type DomainHandlerConfig struct {
 	// already claimed by another domain's alias (aliasCollision). Optional — a
 	// nil repo skips the check (fail-open only when the alias feature is unwired).
 	WebDomainAliases repository.WebDomainAliasRepository
+	// DNSTemplates (GH #1627) resolves a tenant-selected custom DNS template at
+	// create: it validates the template exists and flips the domain to the
+	// external 'custom' mail posture + records mail_template_id, which the
+	// reconciler reads once to seed the template's records. Optional — nil makes
+	// a create that names a dns_template_id return 503 (fail-closed), never a
+	// silent skip.
+	DNSTemplates repository.DNSTemplateRepository
 	// AppInstalls (GH #1238 chown) backs the change-owner refusal: a domain
 	// with an app install carries the current owner's DB creds in its config,
 	// so re-owning it would leak a live cross-tenant credential. REQUIRED for
@@ -1197,6 +1204,21 @@ func (h *domainHandler) update(c *gin.Context) {
 		mp := *req.MailProvider
 		if !models.ValidMailProvider(mp) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_mail_provider"})
+			return
+		}
+		// GH #1627: 'custom' is the internal posture for a domain created from a
+		// DNS template — it is never a directly-selectable provider on a live
+		// switch (ValidMailProvider recognises it only so persisted rows pass),
+		// and a template domain's mail posture can't yet be switched away in
+		// this phase: doing so would strand the template's own external apex
+		// MX/SPF (unmarked, Managed=false) beside a re-asserted Jabali apex →
+		// two apex SPF = RFC 7208 permerror. Delete + recreate to change it.
+		if mp == models.MailProviderCustom {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "mail_provider_custom_reserved", "detail": "the 'custom' posture is selected by choosing a DNS template at domain creation, not via a provider switch"})
+			return
+		}
+		if domain.MailProvider == models.MailProviderCustom {
+			c.JSON(http.StatusConflict, gin.H{"error": "template_posture_locked", "detail": "this domain was created from a DNS template; switching its mail posture is not yet supported — delete and recreate the domain to change it"})
 			return
 		}
 		var m365In, gdkimIn string

--- a/panel-api/internal/api/domains_mail_template_lock_test.go
+++ b/panel-api/internal/api/domains_mail_template_lock_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"github.com/gin-gonic/gin"
+)
+
+// GH #1627: 'custom' is the internal mail posture for a domain created from a
+// custom DNS template. The live PATCH /domains/:id mail-provider switch must
+// neither accept 'custom' as a target (it is only reachable by picking a
+// template at create) nor let a template domain switch its posture away
+// (that would strand the template's external apex MX/SPF beside a re-asserted
+// Jabali apex → double SPF).
+func mailProviderPatchRouter(dom *models.Domain) (*gin.Engine, *mockDomainRepo) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: dom.UserID})
+		c.Next()
+	})
+	repo := newMockDomainRepo()
+	repo.domains[dom.ID] = dom
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{}}
+	RegisterDomainRoutes(v1, DomainHandlerConfig{Domains: repo, ServerSettings: settings})
+	return r, repo
+}
+
+func patchMailProvider(r *gin.Engine, id, provider string) *httptest.ResponseRecorder {
+	body := bytes.NewBufferString(`{"mail_provider":"` + provider + `"}`)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/domains/"+id, body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestDomainPatch_MailProvider_CustomReserved(t *testing.T) {
+	dom := &models.Domain{ID: "d1", UserID: "u1", Name: "example.com", MailProvider: models.MailProviderJabali}
+	r, repo := mailProviderPatchRouter(dom)
+
+	w := patchMailProvider(r, "d1", models.MailProviderCustom)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "mail_provider_custom_reserved") {
+		t.Errorf("body = %q, want mail_provider_custom_reserved", w.Body.String())
+	}
+	if repo.domains["d1"].MailProvider != models.MailProviderJabali {
+		t.Errorf("provider mutated to %q, must stay jabali", repo.domains["d1"].MailProvider)
+	}
+}
+
+func TestDomainPatch_MailProvider_TemplatePostureLocked(t *testing.T) {
+	for _, target := range []string{models.MailProviderJabali, models.MailProviderM365, models.MailProviderNone} {
+		t.Run(target, func(t *testing.T) {
+			dom := &models.Domain{ID: "d1", UserID: "u1", Name: "example.com", MailProvider: models.MailProviderCustom}
+			r, repo := mailProviderPatchRouter(dom)
+
+			w := patchMailProvider(r, "d1", target)
+			if w.Code != http.StatusConflict {
+				t.Fatalf("code = %d, want 409: %s", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "template_posture_locked") {
+				t.Errorf("body = %q, want template_posture_locked", w.Body.String())
+			}
+			if repo.domains["d1"].MailProvider != models.MailProviderCustom {
+				t.Errorf("provider switched to %q, must stay custom", repo.domains["d1"].MailProvider)
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -983,6 +983,105 @@ paths:
                 is_admin: { type: boolean, default: false }
       responses: { "201": { description: Created } }
 
+  # ----------------------------------------------------- DNS Templates ---
+
+  /dns-templates:
+    get:
+      tags: [DNS Templates]
+      summary: List custom DNS templates (tenant-visible summaries) (GH #1627)
+      description: |
+        Returns id/name/description for every custom DNS template, so the Web
+        Domain / DNS Zone create form can offer them. Templates are global —
+        every tenant sees every template.
+      responses: { "200": { description: OK } }
+
+  /admin/dns-templates:
+    get:
+      tags: [DNS Templates]
+      summary: List custom DNS templates with their records (admin) (GH #1627)
+      responses: { "200": { description: OK } }
+    post:
+      tags: [DNS Templates]
+      summary: Create a custom DNS template (admin)
+      description: |
+        Each record is validated with the same DNS record validator the tenant
+        record API uses. The single supported substitution token is {domain},
+        replaced with the zone name when the reconciler seeds the records.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:        { type: string, maxLength: 120 }
+                description: { type: string, maxLength: 500 }
+                records:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, type]
+                    properties:
+                      name:     { type: string }
+                      type:     { type: string, enum: [A, AAAA, CNAME, MX, TXT, NS, SRV, CAA] }
+                      content:  { type: string }
+                      ttl:      { type: integer }
+                      priority: { type: integer }
+      responses:
+        "201": { description: Created }
+        "400": { description: Invalid template or record }
+        "409": { description: A template with that name already exists }
+
+  /admin/dns-templates/{id}:
+    get:
+      tags: [DNS Templates]
+      summary: Get one custom DNS template with its records (admin)
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200": { description: OK }
+        "404": { description: Not found }
+    put:
+      tags: [DNS Templates]
+      summary: Replace a custom DNS template's fields and records (admin)
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:        { type: string, maxLength: 120 }
+                description: { type: string, maxLength: 500 }
+                records:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, type]
+                    properties:
+                      name:     { type: string }
+                      type:     { type: string, enum: [A, AAAA, CNAME, MX, TXT, NS, SRV, CAA] }
+                      content:  { type: string }
+                      ttl:      { type: integer }
+                      priority: { type: integer }
+      responses:
+        "200": { description: Updated }
+        "400": { description: Invalid template or record }
+        "404": { description: Not found }
+        "409": { description: A template with that name already exists }
+    delete:
+      tags: [DNS Templates]
+      summary: Delete a custom DNS template (admin)
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200": { description: Deleted }
+        "404": { description: Not found }
+
   # ----------------------------------------------- Admin: Server Settings ---
 
   /admin/settings/free-hostname/register:

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -66,6 +66,7 @@ type Deps struct {
 	NotificationEventSettings repository.NotificationEventSettingRepository
 	DNSZones                  repository.DNSZoneRepository
 	DNSRecords                repository.DNSRecordRepository
+	DNSTemplates              repository.DNSTemplateRepository
 	SSLCerts                  repository.SSLCertificateRepository
 	SharedCerts               repository.SharedCertificateRepository
 	// MailRBLStates (M47 Wave 5) backs the curated-RBL eventsource
@@ -480,6 +481,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 					SharedCerts:     deps.SharedCerts,
 					DNSZones:        deps.DNSZones,
 					DNSRecords:      deps.DNSRecords,
+					// GH #1627: resolve a tenant-selected custom DNS template on
+					// the JAB-233 automation create path (same as GUI create).
+					DNSTemplates:    deps.DNSTemplates,
 					ManagedIPs:      deps.ManagedIPs,
 					ServerSettings:  deps.ServerSettings,
 					BWDaily:         deps.BWDaily,
@@ -729,7 +733,9 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// create still works — auto-enable is skipped cleanly.
 				DNSZones:   deps.DNSZones,
 				DNSRecords: deps.DNSRecords,
-				BWDaily:    deps.BWDaily,
+				// GH #1627: resolves a tenant-selected custom DNS template at create.
+				DNSTemplates: deps.DNSTemplates,
+				BWDaily:      deps.BWDaily,
 				// M24: lets PATCH listen_ipv*_id resolve FK + family + the
 				// is_user_selectable check, and lets GET denormalize
 				// listen_ipv4 / listen_ipv6 onto each row. Optional —
@@ -1548,6 +1554,14 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Settings:     deps.ServerSettings,
 				Destinations: deps.BackupDestinations,
 			})
+		}
+		// GH #1627: custom DNS templates. Admin CRUD under the RequireAdmin
+		// group; a read-only list on the authed base group so a tenant's create
+		// form can offer the available templates (global — every tenant sees all).
+		if deps.DNSTemplates != nil {
+			adminTmpl := v1.Group("/admin", middleware.RequireAdmin())
+			api.RegisterAdminDNSTemplateRoutes(adminTmpl, api.DNSTemplateHandlerConfig{Templates: deps.DNSTemplates})
+			api.RegisterDNSTemplateRoutes(v1, api.DNSTemplateHandlerConfig{Templates: deps.DNSTemplates})
 		}
 		// M44: Automation API token management. Admin mints + revokes
 		// HMAC-signed tokens; the matching public read-only routes

--- a/panel-api/internal/app/openapi_coverage_test.go
+++ b/panel-api/internal/app/openapi_coverage_test.go
@@ -53,6 +53,7 @@ func fullDeps() Deps {
 		NotificationEventSettings: repository.NewNotificationEventSettingRepository(db),
 		DNSZones: repository.NewDNSZoneRepository(db),
 		DNSRecords: repository.NewDNSRecordRepository(db),
+		DNSTemplates: repository.NewDNSTemplateRepository(db),
 		SSLCerts: repository.NewSSLCertificateRepository(db),
 		MailRBLStates: repository.NewMailRBLStateRepository(db),
 		DMARCAggregate: repository.NewDMARCAggregateRepository(db),

--- a/panel-api/internal/db/migrations/000294_dns_templates.down.sql
+++ b/panel-api/internal/db/migrations/000294_dns_templates.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domains DROP COLUMN mail_template_id;
+DROP TABLE IF EXISTS dns_template_records;
+DROP TABLE IF EXISTS dns_templates;

--- a/panel-api/internal/db/migrations/000294_dns_templates.up.sql
+++ b/panel-api/internal/db/migrations/000294_dns_templates.up.sql
@@ -1,0 +1,55 @@
+-- GH #1627: admin-managed custom DNS templates.
+--
+-- A DNS template is a named, admin-defined preset of DNS records — the stored
+-- equivalent of the built-in Jabali / Microsoft 365 / Google Workspace mail
+-- presets that live in code (dnscompile). A tenant may select a template when
+-- creating a Web Domain or DNS Zone; the reconciler seeds the template's
+-- records ONCE into the fresh zone (managed=0, tenant-editable — never
+-- re-asserted), and the domain is created with the external-mail posture
+-- (mail_provider='custom'), so the mail-provider reconciler hands the zone off
+-- entirely rather than pruning the template's own apex MX/SPF.
+--
+-- Templates are GLOBAL in this phase (visible to every tenant); per-package
+-- assignment is a later phase. Record content is validated at admin-create
+-- with the same DNS record validator the tenant record API uses.
+--
+-- Migration-number note (GH #1627): 000293 also numbers the unmerged web-domain
+-- aliases migration (#1634). Whichever of the two merges SECOND renumbers to the
+-- next free version at rebase — the embedded-migrations completeness test
+-- (contiguous, no duplicate version) catches the collision.
+
+CREATE TABLE dns_templates (
+    id          CHAR(26)        NOT NULL PRIMARY KEY,
+    name        VARCHAR(120)    NOT NULL,
+    description VARCHAR(500)    NOT NULL DEFAULT '',
+    created_at  DATETIME(6)     NOT NULL,
+    updated_at  DATETIME(6)     NOT NULL,
+    UNIQUE INDEX ux_dns_templates_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE dns_template_records (
+    id          CHAR(26)        NOT NULL PRIMARY KEY,
+    template_id CHAR(26)        NOT NULL,
+    name        VARCHAR(255)    NOT NULL,
+    type        VARCHAR(16)     NOT NULL,
+    content     VARCHAR(4096)   NOT NULL,
+    ttl         INT             NOT NULL DEFAULT 3600,
+    priority    INT             NOT NULL DEFAULT 0,
+    sort_order  INT             NOT NULL DEFAULT 0,
+    created_at  DATETIME(6)     NOT NULL,
+    updated_at  DATETIME(6)     NOT NULL,
+    INDEX idx_dns_template_records_template (template_id, sort_order),
+    CONSTRAINT fk_dns_template_records_template
+        FOREIGN KEY (template_id) REFERENCES dns_templates (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- The domain records WHICH template it was created from (nullable), so the
+-- reconciler can seed that template's records the first time it bootstraps the
+-- zone. Deliberately NOT a foreign key: it is an informational "created-from"
+-- reference read exactly once at zone bootstrap; a later template delete leaves
+-- a harmless dangling id (the reconciler's FindByID returns not-found → seeds
+-- nothing), so no ON DELETE behaviour is needed and the big domains table
+-- gains no cross-table constraint.
+ALTER TABLE domains
+    ADD COLUMN mail_template_id CHAR(26) NULL;

--- a/panel-api/internal/models/dns_template.go
+++ b/panel-api/internal/models/dns_template.go
@@ -1,0 +1,46 @@
+package models
+
+import "time"
+
+// DNSTemplate (GH #1627) is an admin-defined, named preset of DNS records a
+// tenant may select when creating a Web Domain or DNS Zone. It is the stored
+// equivalent of the built-in Jabali / Microsoft 365 / Google Workspace mail
+// presets that live in code (dnscompile). Global in this phase — every tenant
+// sees every template; per-package assignment is a later phase.
+type DNSTemplate struct {
+	ID          string    `gorm:"type:char(26);primaryKey" json:"id"`
+	Name        string    `gorm:"type:varchar(120);not null;uniqueIndex:ux_dns_templates_name" json:"name"`
+	Description string    `gorm:"type:varchar(500);not null;default:''" json:"description"`
+	CreatedAt   time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+
+	// Records is the ordered record set. It is loaded EXPLICITLY by the
+	// repository (gorm:"-", not an association) so the API and the reconciler
+	// control the query and its ordering — mirrors how DNSTemplate's records
+	// are seeded and read, never lazy-loaded mid-request.
+	Records []DNSTemplateRecord `gorm:"-" json:"records"`
+}
+
+// TableName pins the table (GORM would otherwise pluralise to "dns_templates",
+// which happens to match — pinned explicitly for clarity + rename safety).
+func (DNSTemplate) TableName() string { return "dns_templates" }
+
+// DNSTemplateRecord is one record blueprint inside a DNSTemplate. Its shape
+// mirrors models.DNSRecord (and is validated by the same api.ValidateDNSRecord)
+// minus the zone/managed columns — a template record is a blueprint, not a live
+// row. The single supported substitution token is {domain}: it is replaced with
+// the zone name in Name and Content when the reconciler seeds the record.
+type DNSTemplateRecord struct {
+	ID         string    `gorm:"type:char(26);primaryKey" json:"id"`
+	TemplateID string    `gorm:"type:char(26);not null;index:idx_dns_template_records_template" json:"template_id"`
+	Name       string    `gorm:"type:varchar(255);not null" json:"name"`
+	Type       string    `gorm:"type:varchar(16);not null" json:"type"`
+	Content    string    `gorm:"type:varchar(4096);not null" json:"content"`
+	TTL        int       `gorm:"type:int;not null;default:3600" json:"ttl"`
+	Priority   int       `gorm:"type:int;not null;default:0" json:"priority"`
+	SortOrder  int       `gorm:"type:int;not null;default:0" json:"sort_order"`
+	CreatedAt  time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt  time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+}
+
+func (DNSTemplateRecord) TableName() string { return "dns_template_records" }

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -405,6 +405,12 @@ type Domain struct {
 	// the provider's DKIM records are simply not published.
 	M365Onmicrosoft *string    `gorm:"column:m365_onmicrosoft;type:varchar(255)" json:"m365_onmicrosoft,omitempty"`
 	GoogleDKIM      *string    `gorm:"column:google_dkim;type:text" json:"google_dkim,omitempty"`
+	// MailTemplateID (GH #1627) records which custom DNS template this domain
+	// was created from, when MailProvider=="custom". The reconciler reads it
+	// ONCE at fresh-zone bootstrap to seed the template's records (tenant-owned,
+	// never re-asserted). Nil for every non-template domain. Not a foreign key:
+	// a later template delete leaves a harmless dangling id (seeds nothing).
+	MailTemplateID *string    `gorm:"column:mail_template_id;type:char(26)" json:"mail_template_id,omitempty"`
 	DkimSelector    *string    `gorm:"type:varchar(64)" json:"dkim_selector,omitempty"`
 	DkimPublicKey   *string    `gorm:"type:text" json:"dkim_public_key,omitempty"`
 	EmailEnabledAt  *time.Time `gorm:"type:datetime(6)" json:"email_enabled_at,omitempty"`

--- a/panel-api/internal/models/mail_provider.go
+++ b/panel-api/internal/models/mail_provider.go
@@ -9,12 +9,24 @@ const (
 	MailProviderNone   = "none"   // no mail anywhere — no mail records, no mail SANs
 	MailProviderM365   = "m365"   // Microsoft 365
 	MailProviderGoogle = "google" // Google Workspace
+	// MailProviderCustom (GH #1627) is the posture of a domain created from a
+	// custom DNS template: mail (and other services) live wherever the template's
+	// records point. Like m365/google it is external — Jabali is not the MTA and
+	// no Jabali mail SANs go on the cert. Unlike them the reconciler asserts
+	// NOTHING for it: reconcileMailProviderRecords hands the zone off entirely so
+	// the template's own apex MX/SPF/DKIM survive as tenant-owned records. It is
+	// NEVER caller-supplied — createDomainOp sets it only when a dns_template_id
+	// is chosen, and rejects a request that names it directly.
+	MailProviderCustom = "custom"
 )
 
 // ValidMailProvider reports whether p is a recognised provider value.
+// MailProviderCustom is recognised (so a persisted 'custom' row validates
+// everywhere), but createDomainOp rejects it as CALLER input — 'custom' is only
+// reachable by selecting a dns_template_id (GH #1627).
 func ValidMailProvider(p string) bool {
 	switch p {
-	case MailProviderJabali, MailProviderNone, MailProviderM365, MailProviderGoogle:
+	case MailProviderJabali, MailProviderNone, MailProviderM365, MailProviderGoogle, MailProviderCustom:
 		return true
 	default:
 		return false
@@ -25,7 +37,7 @@ func ValidMailProvider(p string) bool {
 // other than Jabali (M365 / Google) — i.e. Jabali is not the MTA but the
 // domain still has mail (so provider DNS records are published).
 func MailProviderIsExternal(p string) bool {
-	return p == MailProviderM365 || p == MailProviderGoogle
+	return p == MailProviderM365 || p == MailProviderGoogle || p == MailProviderCustom
 }
 
 // DeriveMailFlags returns the (EmailEnabled, SkipAutoSAN) pair implied by a
@@ -33,8 +45,8 @@ func MailProviderIsExternal(p string) bool {
 // provider intent — callers must use it on create/edit so the columns the
 // reconciler + cert paths read stay consistent with the enum.
 //
-//	jabali          -> (true,  false)  Jabali MTA + jabali mail SANs on cert
-//	none/m365/google-> (false, true)   not the Jabali MTA; no jabali mail SANs
+//	jabali                 -> (true,  false)  Jabali MTA + jabali mail SANs on cert
+//	none/m365/google/custom-> (false, true)   not the Jabali MTA; no jabali mail SANs
 func DeriveMailFlags(provider string) (emailEnabled, skipAutoSAN bool) {
 	if provider == MailProviderJabali {
 		return true, false

--- a/panel-api/internal/reconciler/dns_template_seed.go
+++ b/panel-api/internal/reconciler/dns_template_seed.go
@@ -1,0 +1,71 @@
+package reconciler
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// WithDNSTemplates wires the custom-DNS-template repo so the fresh-zone
+// bootstrap can seed a template's records (GH #1627). Optional — without it,
+// a domain created from a template simply gets no seeded records.
+func (r *Reconciler) WithDNSTemplates(repo repository.DNSTemplateRepository) *Reconciler {
+	r.dnsTemplates = repo
+	return r
+}
+
+// dnsTemplateSeeds returns the DNS records to seed into a freshly-bootstrapped
+// zone for a domain created from a custom DNS template (GH #1627). It reads the
+// domain's mail_template_id ONCE here — the records are tenant-owned
+// (Managed=false) and never re-asserted, mirroring the #1540 dns-only apex
+// seeds. The single supported substitution token, {domain}, is replaced with
+// the zone name in each record's Content only. Names stay verbatim: DNS record
+// names are RELATIVE to the zone (@, mail, autoconfig...) and the zone writer
+// re-qualifies them, so a {domain} token in a Name would double-qualify
+// (shop.example.com.shop.example.com).
+//
+// Returns nil (seed nothing) when: the repo is unwired, the domain carries no
+// template id, or the template can't be loaded (e.g. it was deleted after the
+// domain was created — the id is not a foreign key, so a stale reference simply
+// yields no records rather than an error).
+func (r *Reconciler) dnsTemplateSeeds(ctx context.Context, domain *models.Domain, zoneID, zoneName string) []models.DNSRecord {
+	if r.dnsTemplates == nil || domain == nil || domain.MailTemplateID == nil || *domain.MailTemplateID == "" {
+		return nil
+	}
+	tmpl, err := r.dnsTemplates.FindByID(ctx, *domain.MailTemplateID)
+	if err != nil || tmpl == nil {
+		// Not-found is expected if the template was deleted post-create; any
+		// other error is transient — either way, seed nothing this tick.
+		r.log.Warn("dns template seed: template not loaded", "domain", domain.Name, "template_id", *domain.MailTemplateID, "err", err)
+		return nil
+	}
+	now := time.Now().UTC()
+	out := make([]models.DNSRecord, 0, len(tmpl.Records))
+	for _, tr := range tmpl.Records {
+		out = append(out, models.DNSRecord{
+			ID:        ids.NewULID(),
+			ZoneID:    zoneID,
+			Name:      tr.Name,
+			Type:      tr.Type,
+			Content:   substituteDomainToken(tr.Content, zoneName),
+			TTL:       tr.TTL,
+			Priority:  tr.Priority,
+			Managed:   false, // tenant-owned: seeded once, never re-asserted
+			IsEnabled: true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+	}
+	return out
+}
+
+// substituteDomainToken replaces the {domain} token with the zone name. It is
+// the only template token in this phase; richer tokens (server IP, mail host)
+// are a later phase.
+func substituteDomainToken(s, zoneName string) string {
+	return strings.ReplaceAll(s, "{domain}", zoneName)
+}

--- a/panel-api/internal/reconciler/dns_template_seed_test.go
+++ b/panel-api/internal/reconciler/dns_template_seed_test.go
@@ -1,0 +1,113 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeTemplateRepo is a minimal DNSTemplateRepository for the seed tests.
+type fakeTemplateRepo struct {
+	repository.DNSTemplateRepository
+	byID map[string]*models.DNSTemplate
+}
+
+func (f *fakeTemplateRepo) FindByID(_ context.Context, id string) (*models.DNSTemplate, error) {
+	if t, ok := f.byID[id]; ok {
+		return t, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// GH #1627: dnsTemplateSeeds turns a template's blueprints into tenant-owned
+// zone records — {domain} substituted, Managed=false (never re-asserted), and
+// fail-safe to nil when the repo/template is missing.
+func TestDNSTemplateSeeds(t *testing.T) {
+	tmplID := "tmpl-01"
+	repo := &fakeTemplateRepo{byID: map[string]*models.DNSTemplate{
+		tmplID: {
+			ID: tmplID, Name: "Acme",
+			Records: []models.DNSTemplateRecord{
+				{Name: "@", Type: "MX", Content: "mail.{domain}", Priority: 10, TTL: 3600},
+				{Name: "_dmarc", Type: "TXT", Content: `"v=DMARC1; p=none; rua=mailto:postmaster@{domain}"`, TTL: 3600},
+			},
+		},
+	}}
+	r := &Reconciler{dnsTemplates: repo, log: slog.New(slog.DiscardHandler)}
+
+	dom := &models.Domain{ID: "d1", Name: "shop.example.com", MailProvider: models.MailProviderCustom, MailTemplateID: strptr(tmplID)}
+	seeds := r.dnsTemplateSeeds(context.Background(), dom, "zone-1", "shop.example.com")
+	if len(seeds) != 2 {
+		t.Fatalf("seeds = %d, want 2", len(seeds))
+	}
+	if seeds[0].Content != "mail.shop.example.com" {
+		t.Errorf("{domain} not substituted in content: %q", seeds[0].Content)
+	}
+	if seeds[1].Content != `"v=DMARC1; p=none; rua=mailto:postmaster@shop.example.com"` {
+		t.Errorf("{domain} not substituted in TXT: %q", seeds[1].Content)
+	}
+	for i, s := range seeds {
+		if s.Managed {
+			t.Errorf("seed %d must be tenant-owned (Managed=false)", i)
+		}
+		if !s.IsEnabled {
+			t.Errorf("seed %d must be enabled", i)
+		}
+		if s.ZoneID != "zone-1" {
+			t.Errorf("seed %d wrong zone: %q", i, s.ZoneID)
+		}
+		if s.ID == "" {
+			t.Errorf("seed %d got no id", i)
+		}
+	}
+
+	// Fail-safe nil paths.
+	if got := r.dnsTemplateSeeds(context.Background(), &models.Domain{ID: "d2"}, "z", "d2.example"); got != nil {
+		t.Error("no template id → nil seeds")
+	}
+	missing := &models.Domain{ID: "d3", MailTemplateID: strptr("gone")}
+	if got := r.dnsTemplateSeeds(context.Background(), missing, "z", "d3.example"); got != nil {
+		t.Error("deleted template → nil seeds (no panic)")
+	}
+	rNil := &Reconciler{log: slog.New(slog.DiscardHandler)}
+	if got := rNil.dnsTemplateSeeds(context.Background(), dom, "z", "shop.example.com"); got != nil {
+		t.Error("unwired repo → nil seeds")
+	}
+}
+
+// fakeCountDNSRecords counts mutations so the custom hand-off can be asserted
+// as "never touches the zone".
+type fakeCountDNSRecords struct {
+	repository.DNSRecordRepository
+	listCalls, deleteCalls, createCalls int
+}
+
+func (f *fakeCountDNSRecords) ListByZoneID(context.Context, string) ([]models.DNSRecord, error) {
+	f.listCalls++
+	return nil, nil
+}
+func (f *fakeCountDNSRecords) Delete(context.Context, string) error { f.deleteCalls++; return nil }
+func (f *fakeCountDNSRecords) Create(context.Context, *models.DNSRecord) error {
+	f.createCalls++
+	return nil
+}
+
+// GH #1627: reconcileMailProviderRecords must hand off entirely for a custom
+// domain — no list, no prune, no assert — so the template's own apex MX/SPF
+// survive. (Contrast 'none', which prunes any non-mail-apex apex SPF.)
+func TestReconcileMailProviderRecords_CustomHandsOff(t *testing.T) {
+	recs := &fakeCountDNSRecords{}
+	r := &Reconciler{dnsRecords: recs, log: slog.New(slog.DiscardHandler)}
+	zone := &models.DNSZone{ID: "z1", Name: "shop.example.com"}
+	dom := &models.Domain{ID: "d1", Name: "shop.example.com", MailProvider: models.MailProviderCustom}
+
+	r.reconcileMailProviderRecords(context.Background(), zone, dom, &models.ServerSettings{})
+
+	if recs.listCalls != 0 || recs.deleteCalls != 0 || recs.createCalls != 0 {
+		t.Fatalf("custom domain must not touch the zone: list=%d delete=%d create=%d",
+			recs.listCalls, recs.deleteCalls, recs.createCalls)
+	}
+}

--- a/panel-api/internal/reconciler/mail_provider_reconcile.go
+++ b/panel-api/internal/reconciler/mail_provider_reconcile.go
@@ -35,6 +35,14 @@ func (r *Reconciler) reconcileMailProviderRecords(ctx context.Context, zone *mod
 	if provider == "" {
 		provider = models.MailProviderJabali
 	}
+	// GH #1627: a custom-template domain owns its own mail records (seeded once
+	// at zone bootstrap, tenant-editable). The reconciler asserts NOTHING for it
+	// — no build, no prune — so the template's apex MX/SPF/DKIM are never
+	// clobbered. This hand-off is the whole reason 'custom' is a distinct
+	// provider value rather than reusing 'none' (which prunes apex SPF/MX).
+	if provider == models.MailProviderCustom {
+		return
+	}
 
 	existing, err := r.dnsRecords.ListByZoneID(ctx, zone.ID)
 	if err != nil {

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -42,6 +42,9 @@ type Reconciler struct {
 	users          repository.UserRepository
 	dnsZones       repository.DNSZoneRepository
 	dnsRecords     repository.DNSRecordRepository
+	// dnsTemplates (GH #1627) seeds a custom template's records into a fresh
+	// zone at bootstrap. nil-safe — an unwired panel just skips the seed.
+	dnsTemplates repository.DNSTemplateRepository
 	sslCerts       repository.SSLCertificateRepository
 	serverSettings repository.ServerSettingsRepository
 	// dnsPreflight resolves a hostname against EXTERNAL resolvers before an
@@ -2552,7 +2555,18 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 					return
 				}
 			}
-			r.log.Info("bootstrapped DNS zone", "zone", zone.Name, "records", len(boots))
+			// GH #1627: a domain created from a custom DNS template seeds the
+			// template's records here — tenant-owned (Managed=false), one-shot,
+			// never re-asserted. mail_provider='custom' makes
+			// reconcileMailProviderRecords hand the zone off, so these survive.
+			tmplSeeds := r.dnsTemplateSeeds(ctx, domain, zone.ID, zone.Name)
+			for i := range tmplSeeds {
+				if err := r.dnsRecords.Create(ctx, &tmplSeeds[i]); err != nil {
+					r.log.Error("dns template seed failed", "zone", zone.Name, "err", err)
+					return
+				}
+			}
+			r.log.Info("bootstrapped DNS zone", "zone", zone.Name, "records", len(boots)+len(tmplSeeds))
 		} else {
 			r.log.Error("find zone failed", "domain", domain.Name, "err", err)
 			return

--- a/panel-api/internal/repository/dns_template_repository.go
+++ b/panel-api/internal/repository/dns_template_repository.go
@@ -1,0 +1,165 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// DNSTemplateRepository persists admin-managed custom DNS templates (GH #1627).
+// A template owns an ordered set of record blueprints in a child table; the
+// repository loads them explicitly (never a lazy association) so the API and
+// the reconciler control the query. Create/Update write the template and its
+// records atomically so a half-written template can never be seeded.
+type DNSTemplateRepository interface {
+	// Create inserts the template and its Records in one transaction. The
+	// caller sets IDs + timestamps on the template; the repo stamps each
+	// record's ID/TemplateID/SortOrder/timestamps.
+	Create(ctx context.Context, tmpl *models.DNSTemplate) error
+	// FindByID returns the template WITH its records ordered by sort_order.
+	FindByID(ctx context.Context, id string) (*models.DNSTemplate, error)
+	// List returns every template WITH its records (admin management view).
+	List(ctx context.Context) ([]models.DNSTemplate, error)
+	// ListSummaries returns every template WITHOUT records (the tenant picker
+	// only needs id/name/description).
+	ListSummaries(ctx context.Context) ([]models.DNSTemplate, error)
+	// Update replaces the template's name/description AND its full record set
+	// (delete-all + re-insert) in one transaction.
+	Update(ctx context.Context, tmpl *models.DNSTemplate) error
+	// Delete removes the template; its records go via ON DELETE CASCADE.
+	Delete(ctx context.Context, id string) error
+}
+
+type dnsTemplateRepo struct{ db *gorm.DB }
+
+func NewDNSTemplateRepository(db *gorm.DB) DNSTemplateRepository {
+	return &dnsTemplateRepo{db: db}
+}
+
+func (r *dnsTemplateRepo) Create(ctx context.Context, tmpl *models.DNSTemplate) error {
+	now := time.Now().UTC()
+	if tmpl.CreatedAt.IsZero() {
+		tmpl.CreatedAt = now
+	}
+	tmpl.UpdatedAt = now
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Omit("Records").Create(tmpl).Error; err != nil {
+			return err
+		}
+		return insertTemplateRecords(tx, tmpl.ID, tmpl.Records, now)
+	})
+}
+
+func (r *dnsTemplateRepo) FindByID(ctx context.Context, id string) (*models.DNSTemplate, error) {
+	var tmpl models.DNSTemplate
+	err := r.db.WithContext(ctx).First(&tmpl, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	recs, err := r.recordsFor(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	tmpl.Records = recs
+	return &tmpl, nil
+}
+
+func (r *dnsTemplateRepo) List(ctx context.Context) ([]models.DNSTemplate, error) {
+	tmpls, err := r.ListSummaries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range tmpls {
+		recs, err := r.recordsFor(ctx, tmpls[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		tmpls[i].Records = recs
+	}
+	return tmpls, nil
+}
+
+func (r *dnsTemplateRepo) ListSummaries(ctx context.Context) ([]models.DNSTemplate, error) {
+	var tmpls []models.DNSTemplate
+	err := r.db.WithContext(ctx).Order("name ASC").Find(&tmpls).Error
+	if err != nil {
+		return nil, err
+	}
+	return tmpls, nil
+}
+
+func (r *dnsTemplateRepo) Update(ctx context.Context, tmpl *models.DNSTemplate) error {
+	now := time.Now().UTC()
+	tmpl.UpdatedAt = now
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.DNSTemplate{}).
+			Where("id = ?", tmpl.ID).
+			Updates(map[string]any{
+				"name":        tmpl.Name,
+				"description": tmpl.Description,
+				"updated_at":  now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		// Replace the record set wholesale — delete-all then re-insert. Editing
+		// a template does NOT rewrite any zone that was already seeded from it
+		// (records are one-shot); it only changes what a FUTURE create seeds.
+		if err := tx.Where("template_id = ?", tmpl.ID).Delete(&models.DNSTemplateRecord{}).Error; err != nil {
+			return err
+		}
+		return insertTemplateRecords(tx, tmpl.ID, tmpl.Records, now)
+	})
+}
+
+func (r *dnsTemplateRepo) Delete(ctx context.Context, id string) error {
+	res := r.db.WithContext(ctx).Delete(&models.DNSTemplate{}, "id = ?", id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *dnsTemplateRepo) recordsFor(ctx context.Context, templateID string) ([]models.DNSTemplateRecord, error) {
+	var recs []models.DNSTemplateRecord
+	err := r.db.WithContext(ctx).
+		Where("template_id = ?", templateID).
+		Order("sort_order ASC, created_at ASC").
+		Find(&recs).Error
+	if err != nil {
+		return nil, err
+	}
+	return recs, nil
+}
+
+// insertTemplateRecords stamps and inserts the record set inside the caller's
+// transaction. The caller is responsible for having assigned each record's ID
+// (the API stamps a ULID per record); SortOrder is (re)assigned by slice index
+// so the stored order is the order the admin submitted.
+func insertTemplateRecords(tx *gorm.DB, templateID string, recs []models.DNSTemplateRecord, now time.Time) error {
+	for i := range recs {
+		recs[i].TemplateID = templateID
+		recs[i].SortOrder = i
+		if recs[i].CreatedAt.IsZero() {
+			recs[i].CreatedAt = now
+		}
+		recs[i].UpdatedAt = now
+		if err := tx.Create(&recs[i]).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Admin-managed **DNS templates** a tenant can select when creating a web domain. Picking a template seeds its records into the fresh zone **once** (tenant-owned, never re-asserted) and puts the domain into a new external **`custom`** mail posture — Jabali does not host mail for it, the template's own MX/SPF/verification records do.

Decisions that shaped this (from the issue thread):
- **Template model = peer of M365/Google (replace).** A custom template appears in the same selector as Jabali/M365/Google; selecting one seeds its records at create and carries external-mail posture. No Jabali MTA, no collision rules.
- **Visibility = global (all tenants).** Admin templates are visible to every tenant. Per-package gating is a later phase.

## How

**Model & storage**
- `dns_templates` + `dns_template_records` (migration `000293`).
- `domains.mail_template_id` — informational, read **once** at bootstrap (deliberately not an FK; a deleted template just yields no seeds).
- `MailProviderCustom = "custom"`: `reconcileMailProviderRecords` hands the zone off entirely (no build, **no prune**) so the template's apex MX/SPF survive. Contrast `none`, which prunes any non-mail-apex apex SPF. External posture via `DeriveMailFlags` (EmailEnabled=false, SkipAutoSAN=true); `BootstrapRecords` gates apex MX/SPF/_dmarc on `includeMail` (false for custom) → zero Jabali apex rows → no double-SPF.

**Seeding** happens in the reconciler fresh-zone block (mirrors the #1540 `dnsOnlyApexSeeds` Managed=false precedent), not in createDomainOp — so the template id must persist on the domain. `{domain}` is substituted into record **Content only**; Names stay relative (the zone writer re-qualifies, so a token in a Name would double-qualify).

**API**
- Admin CRUD: `GET/POST /admin/dns-templates`, `GET/PUT/DELETE /admin/dns-templates/{id}`.
- Tenant summary: `GET /dns-templates` (names only, under `combinedAuth`).
- `buildTemplate` validates every record through the **same** `ValidateDNSRecord` the tenant DNS record API uses, so a template can never carry a record the record API would reject.

**Fail-closed input boundaries** — `custom` is recognised by `ValidMailProvider` only so persisted rows validate; it is never caller-selectable:
- `createDomainOp` + CLI reject caller-supplied `custom`.
- `PATCH /domains/:id` rejects `custom` as a target **and** refuses to switch a template domain's posture away (`409 template_posture_locked`) — switching to jabali would re-assert a Jabali apex beside the template's unmarked external apex (double SPF = RFC 7208 permerror).
- `POST /domains/:id/email` refuses to enable Jabali mail on a custom domain (would provision a Stalwart mailbox + DKIM beside the template's external MX).

## Scope

**Phase 1 = backend spine.** Deferred: UI provider-selector option + admin template manager, per-package assignment, richer substitution tokens (server IP, mail host), CLI template support. The existing mail-provider `<Select>` has no `custom` option yet, so a template domain shows a blank provider until the UI phase.

## Migration note

`000293` is also used by the unmerged **#1625 (PR #1634)** on a sibling branch off the same `origin/main`. Whichever merges second renumbers to `000294` at rebase; `TestEmbeddedMigrationsComplete` enforces contiguity and catches the collision. The migration is **not** executed live in CI (mirrors 000119); `type`/`content`/`priority` are already columns on `dns_records`, not reserved words.

## Test plan

- [x] `go build ./...` (both modules), `go vet`
- [x] `-race` on internal/api, reconciler, repository, app, db, models + cmd/server
- [x] New: `TestBuildTemplate`, `TestCreateDomainOp_DNSTemplate`, `TestDNSTemplateSeeds`, `TestReconcileMailProviderRecords_CustomHandsOff`, `TestDomainPatch_MailProvider_CustomReserved`, `TestDomainPatch_MailProvider_TemplatePostureLocked`, `TestDomainEmail_Enable_CustomTemplatePostureLocked`
- [x] openapi coverage + strict-parse; gofmt clean
- [ ] Live migration apply on a test box (defer to deploy)

GH #1627