### PR TITLE
feat(packages): CLI package edit fans out a php_exec change to existing pools (JAB-306)

### DIFF
--- a/panel-api/cmd/server/package_cmd.go
+++ b/panel-api/cmd/server/package_cmd.go
@@ -419,6 +419,12 @@ func newPackageEditCmd() *cobra.Command {
 				return err
 			}
 
+			// JAB-306 AC4: remember the pre-edit php_exec state so the pool
+			// re-render fans out only when the operator actually flips it (a
+			// value gate, not flag presence) — `--php-exec true` on an
+			// already-true package must not force a fleet-wide re-render.
+			prevPHPExec := p.PHPExecEnabled
+
 			didChange, err := applyPackageEditFlags(cmd.Flags().Changed, p, f)
 			if err != nil {
 				return err
@@ -437,6 +443,28 @@ func newPackageEditCmd() *cobra.Command {
 			}
 			if err := repo.Update(ctx, p); err != nil {
 				return fmt.Errorf("update package: %w", err)
+			}
+			// JAB-306 AC4/AC5: fan out a php_exec change to existing tenants
+			// AFTER the row persists. The reconciler sweep re-applies only
+			// pending/error pools, so without this a CLI php_exec flip would not
+			// reach a serving tenant until their next PHP-settings save. The CLI
+			// runs no reconciler, so the fan-out is DB-only: mark every serving
+			// pool on this package pending and let the ~60s sweep re-render it
+			// from the new package state (the same active->pending mechanism
+			// `jabali php pool reapply-all` uses). Strictly after Update — a
+			// persist failure returned above, so a failed edit fans out nothing
+			// (AC5: repository failure causes no fanout). SSH needs no
+			// equivalent: the SSH reconcile sweep re-reads the package and diffs
+			// group membership every tick (ssh_keys_reconcile.go), so a CLI
+			// ssh_enabled flip converges on its own.
+			if p.PHPExecEnabled != prevPHPExec {
+				fanCtx, fanCancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+				n, ferr := markPackagePHPPoolsPending(fanCtx, userRepo(), repository.NewPHPPoolRepository(sharedDB), p.ID)
+				fanCancel()
+				fmt.Fprintf(os.Stderr, "php_exec set to %v: marked %d serving PHP pool(s) pending; the reconciler re-renders them on its next sweep(s)\n", p.PHPExecEnabled, n)
+				if ferr != nil {
+					return fmt.Errorf("mark php pools pending after php_exec change: %w", ferr)
+				}
 			}
 			if jsonOutput {
 				return printJSON(p)
@@ -532,6 +560,68 @@ func newPackageDeleteCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "skip confirmation")
 	return cmd
+}
+
+// packageUserLister is the narrow user-repo behavior the php_exec fan-out
+// needs: enumerate users so it can find everyone on a package. Kept small so
+// markPackagePHPPoolsPending is unit-testable with a tiny fake.
+type packageUserLister interface {
+	List(ctx context.Context, opts repository.ListOptions) ([]models.User, int64, error)
+}
+
+// poolPendingMarker is the narrow pool-repo behavior the fan-out needs: read a
+// user's pools and flip a pool's status.
+type poolPendingMarker interface {
+	ListByUserID(ctx context.Context, userID string) ([]models.PHPPool, error)
+	SetStatus(ctx context.Context, id, status string, lastErr *string) error
+}
+
+// markPackagePHPPoolsPending flips every SERVING PHP pool (status active or
+// ready) of every user on packageID to "pending", so the reconciler re-renders
+// it from the current package state on its next sweep. This is the CLI
+// counterpart of the REST fanOutPHPPoolReapply (packages.go): the CLI runs no
+// reconciler, so it marks the rows DB-only and lets the ~60s sweep converge —
+// the same active->pending mechanism `jabali php pool reapply-all` uses
+// (markActivePoolsPending), extended to "ready" pools too. A settings-save
+// leaves a pool "ready" (phppoolops.ReconcileViaAgent); the sweep re-applies
+// only pending/error pools, so a serving pool in either active or ready state
+// is otherwise skipped. A php_exec tighten must reach both, so both serving
+// states are flipped. Pending/error pools are already in the sweep's work set
+// and are left as-is (re-marking an error pool would also hide its LastError).
+//
+// Users are enumerated the same bounded way as the REST fan-out (List up to
+// 10k, filter by package). Errors are collected per pool — a failed flip on one
+// tenant must not skip the others — and joined; the caller surfaces them and
+// exits non-zero so an operator sees a tighten that did not fully land.
+func markPackagePHPPoolsPending(ctx context.Context, users packageUserLister, pools poolPendingMarker, packageID string) (int, error) {
+	all, _, err := users.List(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		return 0, fmt.Errorf("list users: %w", err)
+	}
+	marked := 0
+	var errs []error
+	for i := range all {
+		u := &all[i]
+		if u.PackageID == nil || *u.PackageID != packageID {
+			continue
+		}
+		userPools, perr := pools.ListByUserID(ctx, u.ID)
+		if perr != nil {
+			errs = append(errs, fmt.Errorf("user %s: list pools: %w", u.ID, perr))
+			continue
+		}
+		for j := range userPools {
+			if userPools[j].Status != "active" && userPools[j].Status != "ready" {
+				continue
+			}
+			if serr := pools.SetStatus(ctx, userPools[j].ID, "pending", nil); serr != nil {
+				errs = append(errs, fmt.Errorf("pool %s: %w", userPools[j].ID, serr))
+				continue
+			}
+			marked++
+		}
+	}
+	return marked, errors.Join(errs...)
 }
 
 // resolvePackage accepts either a package ULID or its name (operators

--- a/panel-api/cmd/server/package_cmd_fanout_test.go
+++ b/panel-api/cmd/server/package_cmd_fanout_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes: the two narrow interfaces markPackagePHPPoolsPending accepts ---
+
+type fakePkgUserLister struct {
+	users   []models.User
+	listErr error
+}
+
+func (f *fakePkgUserLister) List(ctx context.Context, opts repository.ListOptions) ([]models.User, int64, error) {
+	if f.listErr != nil {
+		return nil, 0, f.listErr
+	}
+	return f.users, int64(len(f.users)), nil
+}
+
+type setStatusCall struct {
+	poolID string
+	status string
+}
+
+type fakePoolMarker struct {
+	poolsByUser map[string][]models.PHPPool
+	listErrUser string // ListByUserID returns an error for this user id
+	setErrPool  string // SetStatus returns an error for this pool id
+	calls       []setStatusCall
+}
+
+func (f *fakePoolMarker) ListByUserID(ctx context.Context, userID string) ([]models.PHPPool, error) {
+	if f.listErrUser != "" && userID == f.listErrUser {
+		return nil, errors.New("boom list pools")
+	}
+	return f.poolsByUser[userID], nil
+}
+
+func (f *fakePoolMarker) SetStatus(ctx context.Context, id, status string, lastErr *string) error {
+	if f.setErrPool != "" && id == f.setErrPool {
+		return errors.New("boom set status")
+	}
+	f.calls = append(f.calls, setStatusCall{poolID: id, status: status})
+	return nil
+}
+
+// Only serving pools (active or ready) of users ON the package are flipped;
+// pending/error pools and users on other packages (or no package) are left
+// alone.
+func TestMarkPackagePHPPoolsPending_OnlyPackageUsersServingPools(t *testing.T) {
+	pkgA := "pkgAAAAAAAAAAAAAAAAAAAAAAAA"
+	pkgB := "pkgBBBBBBBBBBBBBBBBBBBBBBBB"
+	users := &fakePkgUserLister{users: []models.User{
+		{ID: "u1", PackageID: &pkgA},
+		{ID: "u2", PackageID: &pkgA},
+		{ID: "u3", PackageID: &pkgB}, // different package — untouched
+		{ID: "u4", PackageID: nil},   // no package — untouched
+	}}
+	pools := &fakePoolMarker{poolsByUser: map[string][]models.PHPPool{
+		"u1": {
+			{ID: "p1a", UserID: "u1", Status: "active"},
+			{ID: "p1b", UserID: "u1", Status: "ready"},
+			{ID: "p1c", UserID: "u1", Status: "pending"}, // already in sweep set
+			{ID: "p1d", UserID: "u1", Status: "error"},   // preserve LastError
+		},
+		"u2": {
+			{ID: "p2a", UserID: "u2", Status: "ready"},
+		},
+		"u3": {
+			{ID: "p3a", UserID: "u3", Status: "active"}, // other package
+		},
+	}}
+
+	n, err := markPackagePHPPoolsPending(context.Background(), users, pools, pkgA)
+	require.NoError(t, err)
+	require.Equal(t, 3, n) // p1a, p1b, p2a
+
+	got := map[string]bool{}
+	for _, c := range pools.calls {
+		require.Equal(t, "pending", c.status)
+		got[c.poolID] = true
+	}
+	require.Equal(t, map[string]bool{"p1a": true, "p1b": true, "p2a": true}, got)
+	require.NotContains(t, got, "p1c") // pending untouched
+	require.NotContains(t, got, "p1d") // error untouched
+	require.NotContains(t, got, "p3a") // other package untouched
+}
+
+// A pool a tenant left "ready" via a settings-save is still flipped — the sweep
+// re-applies only pending/error, so without this a php_exec tighten never
+// reaches it. Guards the active-OR-ready filter (falsify: drop "ready").
+func TestMarkPackagePHPPoolsPending_ReadyPoolFlipped(t *testing.T) {
+	pkg := "pkg00000000000000000000000000"
+	users := &fakePkgUserLister{users: []models.User{{ID: "u1", PackageID: &pkg}}}
+	pools := &fakePoolMarker{poolsByUser: map[string][]models.PHPPool{
+		"u1": {{ID: "ponly", UserID: "u1", Status: "ready"}},
+	}}
+
+	n, err := markPackagePHPPoolsPending(context.Background(), users, pools, pkg)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Len(t, pools.calls, 1)
+	require.Equal(t, "ponly", pools.calls[0].poolID)
+}
+
+// A failed flip on one pool surfaces as an error but must not skip the others,
+// and the count reflects the flips that landed.
+func TestMarkPackagePHPPoolsPending_PartialFailureJoinsErrors(t *testing.T) {
+	pkg := "pkg11111111111111111111111111"
+	users := &fakePkgUserLister{users: []models.User{
+		{ID: "u1", PackageID: &pkg},
+		{ID: "u2", PackageID: &pkg},
+	}}
+	pools := &fakePoolMarker{
+		poolsByUser: map[string][]models.PHPPool{
+			"u1": {{ID: "bad", UserID: "u1", Status: "active"}},
+			"u2": {{ID: "good", UserID: "u2", Status: "active"}},
+		},
+		setErrPool: "bad",
+	}
+
+	n, err := markPackagePHPPoolsPending(context.Background(), users, pools, pkg)
+	require.Error(t, err)
+	require.Equal(t, 1, n)
+	require.Len(t, pools.calls, 1)
+	require.Equal(t, "good", pools.calls[0].poolID)
+}
+
+// A list-pools failure for one user is collected but the others still process.
+func TestMarkPackagePHPPoolsPending_ListPoolsErrorForOneUserContinues(t *testing.T) {
+	pkg := "pkg22222222222222222222222222"
+	users := &fakePkgUserLister{users: []models.User{
+		{ID: "u1", PackageID: &pkg},
+		{ID: "u2", PackageID: &pkg},
+	}}
+	pools := &fakePoolMarker{
+		poolsByUser: map[string][]models.PHPPool{
+			"u2": {{ID: "p2", UserID: "u2", Status: "active"}},
+		},
+		listErrUser: "u1",
+	}
+
+	n, err := markPackagePHPPoolsPending(context.Background(), users, pools, pkg)
+	require.Error(t, err)
+	require.Equal(t, 1, n)
+	require.Len(t, pools.calls, 1)
+	require.Equal(t, "p2", pools.calls[0].poolID)
+}
+
+// A user-list failure fans out nothing.
+func TestMarkPackagePHPPoolsPending_ListUsersErrorNoWrites(t *testing.T) {
+	users := &fakePkgUserLister{listErr: errors.New("db down")}
+	pools := &fakePoolMarker{poolsByUser: map[string][]models.PHPPool{}}
+
+	n, err := markPackagePHPPoolsPending(context.Background(), users, pools, "pkg")
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, pools.calls)
+}
+
+// Source contract for the edit-command fan-out: the php_exec change is captured
+// before the flags mutate the row (value gate), and the fan-out runs strictly
+// after persistence (AC5: a failed Update fans out nothing). These orderings are
+// load-bearing and easy to break in a refactor, so pin them in source.
+func TestPackageEdit_PHPExecFanoutSourceContract(t *testing.T) {
+	src, err := os.ReadFile("package_cmd.go")
+	require.NoError(t, err)
+	s := string(src)
+
+	iPrev := strings.Index(s, "prevPHPExec := p.PHPExecEnabled")
+	iApply := strings.Index(s, "applyPackageEditFlags(cmd.Flags().Changed")
+	iUpdate := strings.Index(s, "repo.Update(ctx, p)")
+	iGate := strings.Index(s, "if p.PHPExecEnabled != prevPHPExec {")
+	iFanout := strings.Index(s, "markPackagePHPPoolsPending(fanCtx")
+
+	require.Greater(t, iPrev, 0, "edit must capture the pre-edit php_exec state")
+	require.Greater(t, iApply, 0)
+	require.Greater(t, iUpdate, 0)
+	require.Greater(t, iGate, 0, "fan-out must be value-gated on a php_exec change")
+	require.Greater(t, iFanout, 0, "edit must fan out a php_exec change")
+
+	require.Less(t, iPrev, iApply, "prevPHPExec must be read before applyPackageEditFlags mutates the row")
+	require.Less(t, iUpdate, iFanout, "fan-out must run strictly after repo.Update (AC5)")
+	require.Less(t, iGate, iFanout, "the value gate must guard the fan-out")
+}


### PR DESCRIPTION
## JAB-306 AC4/AC5 — CLI package edit fans out a `php_exec` change

`jabali package edit --php-exec <bool>` persisted the package row but never re-rendered the PHP pools of the tenants on that package. The reconciler sweep re-applies only `pending`/`error` pools, so a serving pool (`active` or `ready`) kept its old `disable_functions` until the tenant's next PHP-settings save. Turning `php_exec` **off** via the CLI was therefore a silent fail-to-tighten — the exec lockdown did not reach existing tenants — which the REST update path avoids via its `ReapplyPHPPoolForUser` fan-out.

### What this does

The CLI process runs no reconciler, so the fan-out is DB-only, mirroring the REST gate: after the row persists, mark every **serving** pool on the package `pending` and let the reconciler re-render it from the new package state on its next sweep. This is the same `active -> pending` mechanism `jabali php pool reapply-all` already uses (`markActivePoolsPending`), extended to `ready` pools (left by a settings-save) that the sweep would otherwise skip.

- **Value-gated**, not flag-presence-gated: the pre-edit `php_exec` is captured before the flags mutate the row, and the fan-out runs only when the value actually changes — `--php-exec true` on an already-true package does not force a fleet-wide re-render.
- **AC5 by construction**: the fan-out runs strictly *after* a successful `repo.Update`, so a failed persist fans out nothing. Pinned by `TestPackageEdit_PHPExecFanoutSourceContract`.
- **Partial-failure loud**: a failed flip on one tenant does not skip the others; the errors are joined and the command exits non-zero so an operator sees a tighten that did not fully land.

### SSH needs no CLI change (AC4, SSH half)

The SSH reconcile sweep re-reads `pkg.SSHEnabled` on every call (`ssh_keys_reconcile.go:98-101`) and diffs sftp-group membership for all users every tick (`:303-317`), so a CLI `ssh_enabled` flip converges on its own with no marker. This matches REST's own framing — its comment at `packages.go:435-440` calls the 60s sweep "the safety net" and the fan-out just "makes the change feel immediate." Under that reading (sweep = correctness, fan-out = immediacy) AC4 is met on both adapters.

### Deferred vs immediate — a parity difference to be aware of

REST fans out **immediately** (detached goroutine calling the reconciler); the CLI defers to the **next sweep**. This is convention-fitting for the CLI (`mailbox_shares_cmd.go` prints the same "converges on next sweep" contract) and correct, but it is a UX parity *difference*. If byte-for-byte UX parity is wanted, the follow-up (option a) is to wire a Reconciler + agent client into the CLI process and call `ReapplyPHPPoolForUser` synchronously — deliberately not done here to keep the CLI a direct-DB process with no agent-socket dependency.

### Known edge (documented, not fixed)

A partial fan-out failure has no idempotent re-trigger via `edit`: the row is persisted and the value gate now sees no change, so re-running `--php-exec false` is a no-op. Recovery is `jabali php pool reapply-all` or toggling the value twice. The realistic trigger is a DB failure in the milliseconds between the two writes (in which case `Update` itself would usually have failed first). Not worth a new flag.

### Two observations (pre-existing, not addressed here)

- `markActivePoolsPending` (used by `reapply-all` and `dr promote`) filters `Status=="active"` only, so a template change misses `ready` pools too — same class as the gap this PR closes for the package path.
- `fanOutPHPPoolReapply` logs and swallows a `users.List` error with no durable marker (fail-silent), unlike the per-pool path which leaves an `error` status the sweep retries.

### Tests

- `markPackagePHPPoolsPending` unit tests: package filter, serving-state filter (`active`/`ready` flipped; `pending`/`error` and other-package pools untouched), `ready`-pool inclusion, partial-failure error-join, list-users / list-pools error handling.
- `TestPackageEdit_PHPExecFanoutSourceContract`: source-pins the value gate (captured before the flags mutate the row) and the after-persist ordering (AC5).
- Four falsifies run RED then reverted (serving filter, package filter, ordering pin, value-gate pin).
- `gofmt` clean, `go vet` clean, full `go test -race ./cmd/server/` green, CLI-reference golden passes without `-update` (no new flags — behaviour only).

### JAB-306 closeout

With this slice, all five acceptance criteria read as met:

- **AC1** identical rows — `#1568` (shared `packageops.Validate`) + `#1578` (full entitlement flags, explicit create-defaulting).
- **AC2** invalid never persists — `#1568`.
- **AC3** no adapter can omit an entitlement — `#1578`.
- **AC4** SSH/PHP change fans out after persistence — this PR (PHP via pending-mark + sweep; SSH met by sweep).
- **AC5** repository failure causes no fan-out — this PR (after-persist ordering) + REST by construction.

Proposing JAB-306 → Done on merge, same as the JAB-308 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
