### PR TITLE
feat(cli): add `jabali db chown` to reassign a database owner (GH #1609)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1167,6 +1167,18 @@ Create a backup of a database (returns the dump path)
 jabali db backup <db-id|db-name>
 ```
 
+#### `jabali db chown`
+
+Reassign a database to a different owner (GH #1609)
+
+```
+jabali db chown <database> <new-owner> [flags]
+```
+
+**Flags:**
+
+- `--yes` — skip the confirmation prompt
+
 #### `jabali db config`
 
 View / set database tuning (mariadb/postgres)

--- a/panel-api/cmd/server/db_cmd.go
+++ b/panel-api/cmd/server/db_cmd.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -58,6 +59,7 @@ func newDBCmd() *cobra.Command {
 		newDBUserCmd(),
 		newDBPostgresCmd(),
 		newDBSSOCmd(),
+		newDBReassignCmd(),
 	)
 	registerDBOpsCmds(cmd)
 	return cmd
@@ -170,6 +172,86 @@ func newDBDeleteCmd() *cobra.Command {
 	return cmd
 }
 
+// newDBReassignCmd is the CLI parity for the REST admin change-of-owner
+// (POST /admin/databases/:id/chown, GH #1619). Both call the same
+// dbops.ReassignDatabaseOwner, so the refusal rules — shared DB user, prefix
+// mismatch, name collision, postgres-unsupported — are identical between CLI
+// and REST (GH #1609). Modelled on the sibling `domain chown` verb.
+func newDBReassignCmd() *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "chown <database> <new-owner>",
+		Short: "Reassign a database to a different owner (GH #1609)",
+		Long: `Reassign a database — and the DB users bound exclusively to it — to a
+different tenant, renaming them onto the new owner's prefix and re-granting
+access. Mirrors POST /admin/databases/:id/chown; both call the same
+dbops.ReassignDatabaseOwner.
+
+The move is refused when it would cross a hardening boundary: a DB user shared
+with another database or owner, a name not under the current owner's prefix, or a
+name collision under the new owner. Postgres databases are not supported yet.`,
+		Args:    cobra.ExactArgs(2),
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// The move fans out a rename of the database plus each exclusively
+			// bound DB user and its grants through the agent, so it uses the same
+			// 5-minute ceiling the REST handler and the domain chown CLI use — a
+			// 60s cancel mid-run can leave the box half-moved.
+			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+			defer cancel()
+
+			db, err := resolveDatabaseCLI(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			newOwner, err := resolveUser(ctx, args[1])
+			if err != nil {
+				return err
+			}
+			// Capture the current owner before the move, for the failure-audit
+			// subject (their resource was the target).
+			oldOwnerID := db.UserID
+
+			if !yes {
+				ok, cerr := confirm(fmt.Sprintf(
+					"Reassign database %q to %q? This renames the database and its dedicated users onto the new owner's prefix and re-grants access.",
+					db.Name, args[1]))
+				if cerr != nil {
+					return cerr
+				}
+				if !ok {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			res, err := dbops.ReassignDatabaseOwner(ctx, dbopsDeps(), dbops.ReassignInput{
+				DatabaseID: db.ID,
+				NewOwnerID: newOwner.ID,
+			})
+			if err != nil {
+				cliAuditErr(ctx, "database.chown", "database", db.ID, &oldOwnerID)
+				return mapDBopsErr(err)
+			}
+			// Success subject = NEW owner: the CLI audit row has no meta column for
+			// new_owner_id (unlike the REST auditDBChown), so the subject encodes
+			// who received the database.
+			cliAuditOK(ctx, "database.chown", "database", db.ID, &newOwner.ID)
+
+			if jsonOutput {
+				return json.NewEncoder(os.Stdout).Encode(res)
+			}
+			fmt.Fprintf(os.Stdout, "Reassigned database to %q (new name %s).\n", *newOwner.Username, res.NewName)
+			if len(res.RenamedUsers) > 0 {
+				fmt.Fprintf(os.Stdout, "Renamed DB users: %s\n", strings.Join(res.RenamedUsers, ", "))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
+	return cmd
+}
+
 // mapDBopsErr leaves the wrapped error in place but augments with
 // a user-readable suffix for the most common cases. Callers can
 // still errors.Is / errors.As against the dbops sentinels.
@@ -191,6 +273,18 @@ func mapDBopsErr(err error) error {
 			return fmt.Errorf("database is attached to application install %s — delete the app first", attached.InstallID)
 		}
 		return fmt.Errorf("database is attached to an application install — delete the app first")
+	case errors.Is(err, dbops.ErrReassignSameOwner):
+		return fmt.Errorf("database is already owned by that user")
+	case errors.Is(err, dbops.ErrReassignOwnerInvalid):
+		return fmt.Errorf("new owner must be a fully-provisioned tenant (needs a Linux username and an active package)")
+	case errors.Is(err, dbops.ErrReassignEngine):
+		return fmt.Errorf("reassigning a postgres database isn't supported yet")
+	case errors.Is(err, dbops.ErrReassignPrefix):
+		return fmt.Errorf("a name is not under the current owner's prefix — needs manual review")
+	case errors.Is(err, dbops.ErrReassignSharedUser):
+		return fmt.Errorf("a database user is shared with another database or owner — detach it first")
+	case errors.Is(err, dbops.ErrReassignCollision):
+		return fmt.Errorf("a name already exists under the new owner")
 	default:
 		return err
 	}

--- a/panel-api/cmd/server/db_cmd_chown_guard_test.go
+++ b/panel-api/cmd/server/db_cmd_chown_guard_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCLIDBChown_RoutesThroughDbops pins the GH #1609 CLI parity for the REST
+// admin change-of-owner (#1619). The operator CLI `jabali db chown` must route
+// the whole reassignment — the shared-user / prefix / collision refusals, the
+// engine guard, the rename + regrant fan-out — through the one canonical
+// dbops.ReassignDatabaseOwner the REST handler also uses, so CLI and REST refuse
+// and succeed identically. cmd/server has no DB/agent fixture, so this
+// source-pins the delegation; the reassignment behaviour itself is tested in
+// internal/dbops (dbops_chown_test.go).
+func TestCLIDBChown_RoutesThroughDbops(t *testing.T) {
+	src, err := os.ReadFile("db_cmd.go")
+	if err != nil {
+		t.Fatalf("read db_cmd.go: %v", err)
+	}
+	s := string(src)
+
+	// It must delegate to the shared function with the shared deps + input —
+	// not re-implement the rename/regrant transcript.
+	if !strings.Contains(s, "dbops.ReassignDatabaseOwner(ctx, dbopsDeps(), dbops.ReassignInput{") {
+		t.Fatal("CLI db chown must route through dbops.ReassignDatabaseOwner with dbopsDeps() (GH #1609)")
+	}
+
+	// The reassignment fans out multiple agent renames; a 60s cancel mid-run can
+	// leave the box half-moved. The verb must use the 5-minute ceiling the REST
+	// handler and the domain chown CLI use — NOT the 60s create/delete default.
+	if !strings.Contains(s, "context.WithTimeout(cmd.Context(), 5*time.Minute)") {
+		t.Fatal("db chown must use the 5-minute timeout (rename/regrant fan-out); a 60s cancel can half-move the box (GH #1609)")
+	}
+
+	// The audit subject on failure is the OLD owner, so the old owner id must be
+	// captured before the move (the shared fn mutates the row to the new owner).
+	if !strings.Contains(s, "oldOwnerID := db.UserID") {
+		t.Fatal("db chown must capture the old owner id before the move for the failure-audit subject (GH #1609)")
+	}
+
+	// Both outcomes are audited under a single action, mirroring the REST
+	// auditDBChown and the domain chown CLI sibling.
+	for _, want := range []string{
+		`cliAuditOK(ctx, "database.chown", "database", db.ID, &newOwner.ID)`,
+		`cliAuditErr(ctx, "database.chown", "database", db.ID, &oldOwnerID)`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("db chown must audit both outcomes: missing %q (GH #1609)", want)
+		}
+	}
+
+	// A refusal must surface a clean operator message, not a raw "dbops:" string,
+	// so every reassign sentinel is mapped in mapDBopsErr.
+	for _, sentinel := range []string{
+		"dbops.ErrReassignSameOwner",
+		"dbops.ErrReassignOwnerInvalid",
+		"dbops.ErrReassignEngine",
+		"dbops.ErrReassignPrefix",
+		"dbops.ErrReassignSharedUser",
+		"dbops.ErrReassignCollision",
+	} {
+		if !strings.Contains(s, sentinel) {
+			t.Fatalf("mapDBopsErr must map %s so a refusal reads cleanly on the CLI (GH #1609)", sentinel)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `jabali db chown <database> <new-owner>` — the operator-CLI parity for the REST admin change-of-owner (`POST /admin/databases/:id/chown`, GH #1619). Closes the "DB CLI parity" follow-up tracked on GH #1609.

Both callers now route through the same `dbops.ReassignDatabaseOwner`, so CLI and REST refuse and succeed identically: the shared-DB-user / prefix-mismatch / name-collision refusals, the engine guard (postgres unsupported), and the rename + regrant fan-out all live in the one shared function. The CLI is a thin flag-decode + output wrapper, matching the existing `db create` / `db delete` verbs.

## Shape (modelled on the sibling `domain chown`)

- Positional `<database> <new-owner>` args (`resolveDatabaseCLI` accepts id-or-name; `resolveUser` accepts email-or-username), matching `domain chown`.
- `--yes` flag over an interactive `confirm()` prompt.
- **5-minute timeout, not the 60s create/delete default.** The reassignment fans out a rename of the database plus each exclusively-bound DB user and its grants through the agent — the same ceiling the REST handler and `domain chown` use. A 60s cancel mid-run can leave the box half-moved.
- The six `ErrReassign*` sentinels are mapped in `mapDBopsErr`, so a refusal reads as a clean operator message instead of a raw `dbops:` string.

## Audit

Both outcomes are audited under action `database.chown`. On success the subject is the **new** owner; on failure the **old** owner (captured before the move). This is the same subject-swap the sibling `domain chown` CLI uses.

### Parity notes (intentional CLI/REST differences)

- **Audit metadata.** The REST `auditDBChown` records `new_owner_id` + `new_name` in the event meta with the subject fixed to the old owner. The CLI audit helper (`cliAudit`) has no meta column, so the CLI encodes "who received it" via the success subject instead. The audit trail therefore records the recipient in both paths, just in a different column on the CLI side. Widening `cliAudit` to carry meta is out of scope for this slice (it touches a shared helper used by every CLI verb).
- **Step-up auth.** The REST path requires JAB-380 recent-auth re-confirmation. The CLI has no session — the root shell is the authority, exactly as `db delete` / `domain chown` already are. The `--yes`-gated confirm is the CLI's guard.

## Tests

- New source-contract guard `TestCLIDBChown_RoutesThroughDbops` pins the thin-adapter invariants: routes through `dbops.ReassignDatabaseOwner` with `dbopsDeps()`, captures the old owner before the move, uses the 5-minute ceiling, audits both outcomes under `database.chown`, and maps every reassign sentinel. Verified with a falsify pass (flipping the timeout to 60s turns it red). The reassignment behaviour itself is already covered by `internal/dbops/dbops_chown_test.go`; this guard only pins the delegation, since `cmd/server` has no DB/agent fixture.
- `docs/site/platform/cli-reference.md` golden regenerated for the new subcommand.
- `go build`, `go vet`, and `go test -race ./cmd/server/` all green.

## Test plan

- [ ] `jabali db chown <db> <user>` moves a mariadb database + its dedicated users onto the new owner's prefix; `--yes` skips the prompt.
- [ ] Refusals surface clean messages: same owner, shared DB user, prefix mismatch, name collision, postgres engine.
- [ ] Audit rows appear under `database.chown` (success → new owner subject, failure → old owner subject).

GH #1609
