### PR TITLE
refactor(backups): route backup-schedule create through a shared lifecycle leaf (JAB-307)

### DIFF
--- a/panel-api/cmd/server/backup_schedule_cmd.go
+++ b/panel-api/cmd/server/backup_schedule_cmd.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupscheduleops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -168,10 +168,6 @@ func newBackupScheduleCreateCmd() *cobra.Command {
 			if cronExpr == "" {
 				return fmt.Errorf("either --cron or --preset is required")
 			}
-			next, err := internalbackup.NextFire(cronExpr, time.Now().UTC())
-			if err != nil {
-				return err
-			}
 			destIDs, err := resolveDestinationIDs(ctx, destinations)
 			if err != nil {
 				return err
@@ -180,43 +176,46 @@ func newBackupScheduleCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			s := &models.BackupSchedule{
-				ID:                  ids.NewULID(),
+			enabled := !disabled
+			in := backupscheduleops.CreateInput{
 				Kind:                kind,
-				CronExpr:            cronExpr,
-				Enabled:             !disabled,
+				UserIDs:             userIDs,
 				IncludeSystemBackup: includeSystem,
-				NextRunAt:           &next,
+				CronExpr:            cronExpr,
+				Enabled:             &enabled,
+				DestinationIDs:      destIDs,
 			}
 			if cmd.Flags().Changed("keep-daily") {
-				s.KeepDaily = &keepDaily
+				in.KeepDaily = &keepDaily
 			}
 			if cmd.Flags().Changed("keep-weekly") {
-				s.KeepWeekly = &keepWeekly
+				in.KeepWeekly = &keepWeekly
 			}
 			if cmd.Flags().Changed("keep-monthly") {
-				s.KeepMonthly = &keepMonthly
+				in.KeepMonthly = &keepMonthly
 			}
-			repo := backupScheduleRepoFromDB()
-			if err := repo.Create(ctx, s); err != nil {
-				return fmt.Errorf("create schedule: %w", err)
-			}
-			if len(destIDs) > 0 {
-				if err := repo.ReplaceDestinations(ctx, s.ID, destIDs); err != nil {
-					return fmt.Errorf("link destinations: %w", err)
-				}
-			}
-			if len(userIDs) > 0 {
-				if err := repo.ReplaceUsers(ctx, s.ID, userIDs); err != nil {
-					return fmt.Errorf("link users: %w", err)
-				}
+			// One shared lifecycle: admin-target rejection, system-kind
+			// normalization, cron validation, and the transactional
+			// row+memberships commit all live in the leaf now (JAB-307), so
+			// the CLI can no longer schedule an admin account or leave a
+			// half-written schedule when a join insert fails.
+			s, err := backupscheduleops.Create(ctx, backupscheduleops.Deps{
+				Schedules: backupScheduleRepoFromDB(),
+				Users:     repository.NewUserRepository(sharedDB),
+			}, in)
+			if err != nil {
+				return mapScheduleOpErr(err)
 			}
 			if jsonOutput {
 				return printJSON(s)
 			}
 			cliAuditOK(ctx, "backup_schedule.create", "backup_schedule", s.ID, nil)
+			next := ""
+			if s.NextRunAt != nil {
+				next = s.NextRunAt.Format(time.RFC3339)
+			}
 			fmt.Printf("Created schedule %s (%s, cron=%s, next=%s)\n",
-				s.ID, s.Kind, s.CronExpr, next.Format(time.RFC3339))
+				s.ID, s.Kind, s.CronExpr, next)
 			return nil
 		},
 	}
@@ -472,4 +471,18 @@ func resolveUserIDs(ctx context.Context, items []string) ([]string, error) {
 		out = append(out, u.ID)
 	}
 	return out, nil
+}
+
+// mapScheduleOpErr turns a backupscheduleops error into a caller-friendly CLI
+// error. Every path returns a non-nil error so the command exits non-zero
+// (a silently-accepted admin target would be feedback_silent_exit0_failures).
+func mapScheduleOpErr(err error) error {
+	var ure *backupscheduleops.UserRejectedError
+	if errors.As(err, &ure) {
+		if errors.Is(err, backupscheduleops.ErrAdminUser) {
+			return fmt.Errorf("user %s is an admin account and cannot be a backup-schedule target", ure.UserID)
+		}
+		return fmt.Errorf("user %s not found", ure.UserID)
+	}
+	return err
 }

--- a/panel-api/cmd/server/backup_schedule_cmd_source_test.go
+++ b/panel-api/cmd/server/backup_schedule_cmd_source_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The operator CLI backup-schedule create must delegate to the shared
+// backupscheduleops lifecycle (JAB-307) so it enforces the same admin-target
+// rejection and commits the row + memberships atomically. A regression back to
+// the raw repo.Create→ReplaceDestinations→ReplaceUsers sequence reddens this.
+func TestBackupScheduleCLICreate_RoutesThroughLifecycle(t *testing.T) {
+	src, err := os.ReadFile("backup_schedule_cmd.go")
+	require.NoError(t, err)
+	s := string(src)
+	start := strings.Index(s, "func newBackupScheduleCreateCmd(")
+	require.Greater(t, start, 0)
+	rest := s[start:]
+	end := strings.Index(rest, "\nfunc newBackupScheduleUpdateCmd(")
+	require.Greater(t, end, 0, "next command func not found")
+	body := rest[:end]
+
+	require.Contains(t, body, "backupscheduleops.Create(",
+		"CLI create must delegate to the shared lifecycle leaf")
+	require.NotContains(t, body, "repo.Create(",
+		"CLI create must not write the row directly (non-atomic)")
+	require.NotContains(t, body, "repo.ReplaceUsers(",
+		"CLI create must not link users directly (non-atomic)")
+	require.NotContains(t, body, "repo.ReplaceDestinations(",
+		"CLI create must not link destinations directly (non-atomic)")
+}

--- a/panel-api/internal/api/backup_schedule_lifecycle_source_test.go
+++ b/panel-api/internal/api/backup_schedule_lifecycle_source_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The admin backup-schedule create adapter must delegate to the shared
+// backupscheduleops lifecycle, not hand-roll the row + membership writes
+// (JAB-307). Reintroducing the non-atomic Create→ReplaceDestinations→
+// ReplaceUsers sequence in the create path reddens this.
+func TestBackupScheduleCreate_RoutesThroughLifecycle(t *testing.T) {
+	src, err := os.ReadFile("backup_schedules.go")
+	require.NoError(t, err)
+	body := scheduleFuncBody(t, string(src), "func (h *backupScheduleHandler) create(")
+
+	require.Contains(t, body, "backupscheduleops.Create(",
+		"create must delegate to the shared lifecycle leaf")
+	require.NotContains(t, body, "Schedules.Create(",
+		"create must not write the row directly (non-atomic)")
+	require.NotContains(t, body, "Schedules.ReplaceUsers(",
+		"create must not link users directly (non-atomic)")
+	require.NotContains(t, body, "Schedules.ReplaceDestinations(",
+		"create must not link destinations directly (non-atomic)")
+}
+
+// scheduleFuncBody returns the source of the function starting at sig, up to
+// the next top-level func declaration.
+func scheduleFuncBody(t *testing.T, src, sig string) string {
+	t.Helper()
+	i := strings.Index(src, sig)
+	require.Greater(t, i, 0, "signature not found: %s", sig)
+	rest := src[i+len(sig):]
+	if j := strings.Index(rest, "\nfunc "); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}

--- a/panel-api/internal/api/backup_schedules.go
+++ b/panel-api/internal/api/backup_schedules.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupscheduleops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -147,94 +147,50 @@ func (h *backupScheduleHandler) create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body", "detail": err.Error()})
 		return
 	}
-	// Kind defaults to account_backup so the UI doesn't have to send
-	// it explicitly. system_backup kind is still accepted for direct
-	// API callers (sysadmin tooling).
-	if req.Kind == "" {
-		req.Kind = models.BackupScheduleKindAccount
-	}
-	if req.Kind != models.BackupScheduleKindAccount && req.Kind != models.BackupScheduleKindSystem {
-		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_kind"})
-		return
-	}
-	// Normalise user_ids: drop empty strings, accept the legacy single
-	// user_id by promoting it into UserIDs.
+	// Adapter concern: promote the legacy single user_id into the
+	// multi-select UserIDs before handing resolved ids to the lifecycle.
 	if req.UserID != nil && *req.UserID != "" {
 		req.UserIDs = append(req.UserIDs, *req.UserID)
 	}
-	req.UserID = nil
-	cleanIDs := make([]string, 0, len(req.UserIDs))
-	for _, uid := range req.UserIDs {
-		if uid == "" {
-			continue
-		}
-		cleanIDs = append(cleanIDs, uid)
-	}
-	req.UserIDs = cleanIDs
-	if req.Kind == models.BackupScheduleKindAccount {
-		for _, uid := range req.UserIDs {
-			if h.cfg.Users == nil {
-				break
-			}
-			user, err := h.cfg.Users.FindByID(c.Request.Context(), uid)
-			if err != nil || user == nil {
-				c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "user_not_found", "detail": uid})
-				return
-			}
-			if user.IsAdmin {
-				c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "admin_user_not_allowed", "detail": uid})
-				return
-			}
-		}
-	} else {
-		req.UserIDs = nil
-	}
-	next, err := internalbackup.NextFire(req.CronExpr, time.Now().UTC())
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_cron", "detail": err.Error()})
-		return
-	}
 
-	enabled := true
-	if req.Enabled != nil {
-		enabled = *req.Enabled
-	}
-	// include_system_backup is a no-op on kind=system_backup (those
-	// schedules already back up the system); silently normalise to
-	// false so the field isn't a confusing leftover after a kind flip.
-	includeSys := req.IncludeSystemBackup
-	if req.Kind == models.BackupScheduleKindSystem {
-		includeSys = false
-	}
-	s := &models.BackupSchedule{
-		ID:                  ids.NewULID(),
+	s, err := backupscheduleops.Create(c.Request.Context(), backupscheduleops.Deps{
+		Schedules: h.cfg.Schedules,
+		Users:     h.cfg.Users,
+	}, backupscheduleops.CreateInput{
 		Kind:                req.Kind,
-		UserID:              req.UserID,
-		IncludeSystemBackup: includeSys,
-		CronExpr:            strings.TrimSpace(req.CronExpr),
-		Enabled:             enabled,
+		UserIDs:             req.UserIDs,
+		IncludeSystemBackup: req.IncludeSystemBackup,
+		CronExpr:            req.CronExpr,
+		Enabled:             req.Enabled,
 		KeepDaily:           req.KeepDaily,
 		KeepWeekly:          req.KeepWeekly,
 		KeepMonthly:         req.KeepMonthly,
-		NextRunAt:           &next,
-	}
-	if err := h.cfg.Schedules.Create(c.Request.Context(), s); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
+		DestinationIDs:      req.DestinationIDs,
+	})
+	if err != nil {
+		writeScheduleOpError(c, err)
 		return
 	}
-	if len(req.DestinationIDs) > 0 {
-		if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), s.ID, req.DestinationIDs); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
-			return
-		}
-	}
-	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), s.ID, req.UserIDs); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
-		return
-	}
-	s.UserIDs = req.UserIDs
 	dests, _ := h.cfg.Schedules.GetDestinations(c.Request.Context(), s.ID)
 	c.JSON(http.StatusCreated, toScheduleDTO(s, dests))
+}
+
+// writeScheduleOpError maps a backupscheduleops error to the wire codes the
+// admin REST surface has always emitted, so the contract is unchanged.
+func writeScheduleOpError(c *gin.Context, err error) {
+	var ure *backupscheduleops.UserRejectedError
+	switch {
+	case errors.Is(err, backupscheduleops.ErrInvalidKind):
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_kind"})
+	case errors.As(err, &ure) && errors.Is(err, backupscheduleops.ErrAdminUser):
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "admin_user_not_allowed", "detail": ure.UserID})
+	case errors.As(err, &ure):
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "user_not_found", "detail": ure.UserID})
+	case errors.Is(err, backupscheduleops.ErrInvalidCron):
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_cron", "detail": err.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
+	}
 }
 
 type updateScheduleRequest struct {

--- a/panel-api/internal/backupscheduleops/backupscheduleops.go
+++ b/panel-api/internal/backupscheduleops/backupscheduleops.go
@@ -1,0 +1,158 @@
+// Package backupscheduleops is the transport-neutral Backup Schedule Lifecycle
+// leaf (ADR-0083 <area>ops). It owns the create-side policy that the admin
+// REST handler, the operator CLI, and (future) the tenant path must all apply
+// identically: kind defaulting/validation, admin-user rejection, system-kind
+// normalization, cron validation before any write, and a single transactional
+// commit of the schedule row together with its destination and user links.
+//
+// Adapters keep what is genuinely theirs: id resolution (CLI resolves
+// --user email|username and --destination name into ids; the legacy REST
+// user_id single field is promoted into UserIDs), authorization, and output
+// shaping. The leaf receives already-resolved ids and returns the persisted
+// row or a typed error the adapter maps to its own status codes.
+//
+// Scope (JAB-307): create only. update / run-now / the tenant variant remain
+// adapter-local for follow-up slices; the parent stays open.
+package backupscheduleops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Sentinel errors. Adapters test with errors.Is and map to their own codes.
+var (
+	ErrInvalidKind  = errors.New("invalid backup schedule kind")
+	ErrInvalidCron  = errors.New("invalid cron expression")
+	ErrAdminUser    = errors.New("admin accounts cannot be backup-schedule targets")
+	ErrUserNotFound = errors.New("backup-schedule target user not found")
+)
+
+// UserRejectedError names the offending user id and wraps the reason
+// (ErrAdminUser or ErrUserNotFound) so an adapter can both branch on the
+// reason (errors.Is) and echo the id (the REST wire returns detail: <uid>).
+type UserRejectedError struct {
+	UserID string
+	Reason error
+}
+
+func (e *UserRejectedError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Reason.Error(), e.UserID)
+}
+
+func (e *UserRejectedError) Unwrap() error { return e.Reason }
+
+// UserFinder is the narrow slice of the user repository the leaf needs to
+// enforce the admin-target rule. A nil UserFinder skips the check (mirrors the
+// REST handler's Users == nil test seam).
+type UserFinder interface {
+	FindByID(ctx context.Context, id string) (*models.User, error)
+}
+
+// scheduleWriter is the one repository method the create path needs: the row
+// and both membership sets committed in a single transaction.
+type scheduleWriter interface {
+	CreateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs []string) error
+}
+
+// Deps are the leaf's collaborators, injected by the adapter.
+type Deps struct {
+	Schedules scheduleWriter
+	Users     UserFinder
+}
+
+// CreateInput is the resolved, transport-neutral create request. UserIDs and
+// DestinationIDs are already resolved to ids by the adapter.
+type CreateInput struct {
+	Kind                string
+	UserIDs             []string
+	IncludeSystemBackup bool
+	CronExpr            string
+	Enabled             *bool
+	KeepDaily           *int
+	KeepWeekly          *int
+	KeepMonthly         *int
+	DestinationIDs      []string
+}
+
+// Create validates and persists a backup schedule with its memberships. The
+// order of refusals is deliberate and shared: an invalid kind, an admin or
+// missing target user, and an invalid cron each abort with ZERO writes.
+func Create(ctx context.Context, d Deps, in CreateInput) (*models.BackupSchedule, error) {
+	kind := in.Kind
+	if kind == "" {
+		kind = models.BackupScheduleKindAccount
+	}
+	if kind != models.BackupScheduleKindAccount && kind != models.BackupScheduleKindSystem {
+		return nil, ErrInvalidKind
+	}
+
+	userIDs := cleanIDs(in.UserIDs)
+	includeSys := in.IncludeSystemBackup
+
+	if kind == models.BackupScheduleKindSystem {
+		// A system schedule has no per-user membership and the
+		// include-system flag is meaningless (it already is the system
+		// backup) — normalise both so a kind flip can't leave leftovers.
+		userIDs = nil
+		includeSys = false
+	} else if d.Users != nil {
+		// account_backup: every explicit target must exist and must not
+		// be an admin (an admin account is panel-only, nothing to back up).
+		for _, uid := range userIDs {
+			u, err := d.Users.FindByID(ctx, uid)
+			if err != nil || u == nil {
+				return nil, &UserRejectedError{UserID: uid, Reason: ErrUserNotFound}
+			}
+			if u.IsAdmin {
+				return nil, &UserRejectedError{UserID: uid, Reason: ErrAdminUser}
+			}
+		}
+	}
+
+	next, err := internalbackup.NextFire(in.CronExpr, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCron, err)
+	}
+
+	enabled := true
+	if in.Enabled != nil {
+		enabled = *in.Enabled
+	}
+
+	s := &models.BackupSchedule{
+		ID:                  ids.NewULID(),
+		Kind:                kind,
+		IncludeSystemBackup: includeSys,
+		CronExpr:            strings.TrimSpace(in.CronExpr),
+		Enabled:             enabled,
+		KeepDaily:           in.KeepDaily,
+		KeepWeekly:          in.KeepWeekly,
+		KeepMonthly:         in.KeepMonthly,
+		NextRunAt:           &next,
+	}
+	if err := d.Schedules.CreateWithMemberships(ctx, s, in.DestinationIDs, userIDs); err != nil {
+		return nil, err
+	}
+	s.UserIDs = userIDs
+	return s, nil
+}
+
+// cleanIDs drops empty ids, preserving order.
+func cleanIDs(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}

--- a/panel-api/internal/backupscheduleops/backupscheduleops_test.go
+++ b/panel-api/internal/backupscheduleops/backupscheduleops_test.go
@@ -1,0 +1,164 @@
+package backupscheduleops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+const validCron = "0 3 * * *"
+
+// --- fakes ---
+
+type fakeUserFinder struct {
+	users map[string]*models.User
+}
+
+func (f *fakeUserFinder) FindByID(ctx context.Context, id string) (*models.User, error) {
+	u, ok := f.users[id]
+	if !ok {
+		return nil, nil // not found — the leaf treats a nil user as ErrUserNotFound
+	}
+	return u, nil
+}
+
+type recordedCreate struct {
+	s       *models.BackupSchedule
+	destIDs []string
+	userIDs []string
+}
+
+type fakeScheduleWriter struct {
+	calls []recordedCreate
+	err   error
+}
+
+func (f *fakeScheduleWriter) CreateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs []string) error {
+	f.calls = append(f.calls, recordedCreate{s: s, destIDs: destIDs, userIDs: userIDs})
+	return f.err
+}
+
+func accountDeps(users map[string]*models.User) (Deps, *fakeScheduleWriter) {
+	w := &fakeScheduleWriter{}
+	return Deps{Schedules: w, Users: &fakeUserFinder{users: users}}, w
+}
+
+// An admin account is panel-only — scheduling it as a backup target is refused
+// before any write. Falsify: delete the u.IsAdmin branch → the writer records a
+// create.
+func TestCreate_AccountRejectsAdminUser_ZeroWrites(t *testing.T) {
+	d, w := accountDeps(map[string]*models.User{"u1": {ID: "u1", IsAdmin: true}})
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind: models.BackupScheduleKindAccount, UserIDs: []string{"u1"}, CronExpr: validCron,
+	})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrAdminUser)
+	var ure *UserRejectedError
+	require.ErrorAs(t, err, &ure)
+	require.Equal(t, "u1", ure.UserID)
+	require.Empty(t, w.calls, "no write when a target is rejected")
+}
+
+// A target that does not resolve is refused with zero writes and names the id.
+func TestCreate_AccountRejectsMissingUser_ZeroWrites(t *testing.T) {
+	d, w := accountDeps(map[string]*models.User{})
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind: models.BackupScheduleKindAccount, UserIDs: []string{"ghost"}, CronExpr: validCron,
+	})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrUserNotFound)
+	var ure *UserRejectedError
+	require.ErrorAs(t, err, &ure)
+	require.Equal(t, "ghost", ure.UserID)
+	require.Empty(t, w.calls)
+}
+
+func TestCreate_InvalidKind_ZeroWrites(t *testing.T) {
+	d, w := accountDeps(nil)
+	s, err := Create(context.Background(), d, CreateInput{Kind: "bogus", CronExpr: validCron})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrInvalidKind)
+	require.Empty(t, w.calls)
+}
+
+// Invalid cron aborts before any write. Falsify: move NextFire below the
+// CreateWithMemberships call → the writer records a create.
+func TestCreate_InvalidCron_ZeroWrites(t *testing.T) {
+	d, w := accountDeps(map[string]*models.User{"u1": {ID: "u1"}})
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind: models.BackupScheduleKindAccount, UserIDs: []string{"u1"}, CronExpr: "not a cron",
+	})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrInvalidCron)
+	require.Empty(t, w.calls)
+}
+
+// A system schedule carries no users and no include-system flag — and the
+// admin-target check does NOT apply (so even an admin id in the input is simply
+// dropped, not an error). Guards the kind normalization.
+func TestCreate_SystemKind_DropsUsersAndIncludeFlag(t *testing.T) {
+	d, w := accountDeps(map[string]*models.User{"u1": {ID: "u1", IsAdmin: true}})
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind: models.BackupScheduleKindSystem, UserIDs: []string{"u1"}, IncludeSystemBackup: true, CronExpr: validCron,
+	})
+	require.NoError(t, err)
+	require.Len(t, w.calls, 1)
+	require.Nil(t, w.calls[0].userIDs, "system schedule has no user membership")
+	require.False(t, s.IncludeSystemBackup, "include-system normalised off for a system schedule")
+}
+
+func TestCreate_AccountHappyPath_PersistsWithMemberships(t *testing.T) {
+	d, w := accountDeps(map[string]*models.User{"u1": {ID: "u1"}})
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind:           models.BackupScheduleKindAccount,
+		UserIDs:        []string{"u1", ""}, // empty id is cleaned out
+		DestinationIDs: []string{"d1"},
+		CronExpr:       validCron,
+	})
+	require.NoError(t, err)
+	require.Len(t, w.calls, 1)
+	require.Equal(t, []string{"u1"}, w.calls[0].userIDs)
+	require.Equal(t, []string{"d1"}, w.calls[0].destIDs)
+	require.Equal(t, models.BackupScheduleKindAccount, s.Kind)
+	require.True(t, s.Enabled, "enabled defaults true when unset")
+	require.Equal(t, []string{"u1"}, s.UserIDs)
+	require.NotNil(t, s.NextRunAt)
+	require.NotEmpty(t, s.ID)
+}
+
+func TestCreate_EnabledFalseHonored(t *testing.T) {
+	d, _ := accountDeps(map[string]*models.User{"u1": {ID: "u1"}})
+	no := false
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind: models.BackupScheduleKindAccount, UserIDs: []string{"u1"}, CronExpr: validCron, Enabled: &no,
+	})
+	require.NoError(t, err)
+	require.False(t, s.Enabled)
+}
+
+// A nil Users finder skips the admin check (the REST test seam) — the create
+// still persists.
+func TestCreate_NilUserFinder_SkipsAdminCheck(t *testing.T) {
+	w := &fakeScheduleWriter{}
+	s, err := Create(context.Background(), Deps{Schedules: w, Users: nil}, CreateInput{
+		Kind: models.BackupScheduleKindAccount, UserIDs: []string{"u1"}, CronExpr: validCron,
+	})
+	require.NoError(t, err)
+	require.Len(t, w.calls, 1)
+	require.Equal(t, []string{"u1"}, s.UserIDs)
+}
+
+func TestCreate_WriterError_Propagates(t *testing.T) {
+	sentinel := errors.New("db down")
+	w := &fakeScheduleWriter{err: sentinel}
+	d := Deps{Schedules: w, Users: &fakeUserFinder{users: map[string]*models.User{"u1": {ID: "u1"}}}}
+	s, err := Create(context.Background(), d, CreateInput{
+		Kind: models.BackupScheduleKindAccount, UserIDs: []string{"u1"}, CronExpr: validCron,
+	})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, sentinel)
+}

--- a/panel-api/internal/repository/backup_schedule_repository.go
+++ b/panel-api/internal/repository/backup_schedule_repository.go
@@ -18,6 +18,13 @@ import (
 
 type BackupScheduleRepository interface {
 	Create(ctx context.Context, s *models.BackupSchedule) error
+	// CreateWithMemberships commits the schedule row together with its
+	// destination and user links in ONE transaction. A join-write failure
+	// rolls the whole thing back, so a create never leaves a runnable row
+	// whose membership silently differs from what was asked (an
+	// account schedule with no users fans out to every non-admin at tick
+	// time — a partial write there broadens, not narrows, the blast radius).
+	CreateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs []string) error
 	Get(ctx context.Context, id string) (*models.BackupSchedule, error)
 	GetWithDestinations(ctx context.Context, id string) (*models.BackupSchedule, error)
 	List(ctx context.Context) ([]models.BackupSchedule, error)
@@ -59,6 +66,28 @@ func (r *backupScheduleRepo) Create(ctx context.Context, s *models.BackupSchedul
 		return translate(err)
 	}
 	return nil
+}
+
+func (r *backupScheduleRepo) CreateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs []string) error {
+	now := time.Now().UTC()
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = now
+	}
+	if s.UpdatedAt.IsZero() {
+		s.UpdatedAt = now
+	}
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(s).Error; err != nil {
+			return translate(err)
+		}
+		if err := replaceDestinationsTx(tx, s.ID, destIDs); err != nil {
+			return err
+		}
+		if err := replaceUsersTx(tx, s.ID, userIDs); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (r *backupScheduleRepo) Get(ctx context.Context, id string) (*models.BackupSchedule, error) {
@@ -208,27 +237,34 @@ func (r *backupScheduleRepo) GetDestinations(ctx context.Context, scheduleID str
 
 func (r *backupScheduleRepo) ReplaceDestinations(ctx context.Context, scheduleID string, destIDs []string) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("schedule_id = ?", scheduleID).
-			Delete(&models.BackupScheduleDestination{}).Error; err != nil {
-			return translate(err)
-		}
-		if len(destIDs) == 0 {
-			return nil
-		}
-		now := time.Now().UTC()
-		rows := make([]models.BackupScheduleDestination, 0, len(destIDs))
-		for _, id := range destIDs {
-			rows = append(rows, models.BackupScheduleDestination{
-				ScheduleID:    scheduleID,
-				DestinationID: id,
-				CreatedAt:     now,
-			})
-		}
-		if err := tx.Create(&rows).Error; err != nil {
-			return translate(err)
-		}
-		return nil
+		return replaceDestinationsTx(tx, scheduleID, destIDs)
 	})
+}
+
+// replaceDestinationsTx runs the delete+insert against a caller-supplied tx so
+// it can compose into a larger transaction (CreateWithMemberships) without
+// opening a nested transaction on a different handle.
+func replaceDestinationsTx(tx *gorm.DB, scheduleID string, destIDs []string) error {
+	if err := tx.Where("schedule_id = ?", scheduleID).
+		Delete(&models.BackupScheduleDestination{}).Error; err != nil {
+		return translate(err)
+	}
+	if len(destIDs) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	rows := make([]models.BackupScheduleDestination, 0, len(destIDs))
+	for _, id := range destIDs {
+		rows = append(rows, models.BackupScheduleDestination{
+			ScheduleID:    scheduleID,
+			DestinationID: id,
+			CreatedAt:     now,
+		})
+	}
+	if err := tx.Create(&rows).Error; err != nil {
+		return translate(err)
+	}
+	return nil
 }
 
 func (r *backupScheduleRepo) GetUserIDs(ctx context.Context, scheduleID string) ([]string, error) {
@@ -246,25 +282,31 @@ func (r *backupScheduleRepo) GetUserIDs(ctx context.Context, scheduleID string) 
 
 func (r *backupScheduleRepo) ReplaceUsers(ctx context.Context, scheduleID string, userIDs []string) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("schedule_id = ?", scheduleID).
-			Delete(&models.BackupScheduleUser{}).Error; err != nil {
-			return translate(err)
-		}
-		if len(userIDs) == 0 {
-			return nil
-		}
-		now := time.Now().UTC()
-		rows := make([]models.BackupScheduleUser, 0, len(userIDs))
-		for _, id := range userIDs {
-			rows = append(rows, models.BackupScheduleUser{
-				ScheduleID: scheduleID,
-				UserID:     id,
-				CreatedAt:  now,
-			})
-		}
-		if err := tx.Create(&rows).Error; err != nil {
-			return translate(err)
-		}
-		return nil
+		return replaceUsersTx(tx, scheduleID, userIDs)
 	})
+}
+
+// replaceUsersTx runs the delete+insert against a caller-supplied tx so it can
+// compose into CreateWithMemberships without a nested transaction.
+func replaceUsersTx(tx *gorm.DB, scheduleID string, userIDs []string) error {
+	if err := tx.Where("schedule_id = ?", scheduleID).
+		Delete(&models.BackupScheduleUser{}).Error; err != nil {
+		return translate(err)
+	}
+	if len(userIDs) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	rows := make([]models.BackupScheduleUser, 0, len(userIDs))
+	for _, id := range userIDs {
+		rows = append(rows, models.BackupScheduleUser{
+			ScheduleID: scheduleID,
+			UserID:     id,
+			CreatedAt:  now,
+		})
+	}
+	if err := tx.Create(&rows).Error; err != nil {
+		return translate(err)
+	}
+	return nil
 }

--- a/panel-api/internal/repository/backup_schedule_repository_test.go
+++ b/panel-api/internal/repository/backup_schedule_repository_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
+
+var errFakeUserLink = errors.New("boom user link")
 
 func TestBackupSchedule_Create_StampsTimestamps(t *testing.T) {
 	db, mock, raw := newMockBackupDB(t)
@@ -72,6 +75,76 @@ func TestBackupSchedule_ReplaceDestinations_AtomicReplace(t *testing.T) {
 		"01J5SCHED0000000000000000A",
 		[]string{"01J5DEST00000000000000000A", "01J5DEST00000000000000000B"})
 	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// JAB-307: CreateWithMemberships commits the row and both membership sets in
+// ONE transaction — a single Begin, the INSERT + the delete/insert pairs, then
+// Commit.
+func TestBackupSchedule_CreateWithMemberships_CommitsRowAndLinks(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupScheduleRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO `backup_schedules`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("DELETE FROM `backup_schedule_destinations` WHERE schedule_id = \\?").
+		WithArgs("01J5SCHED0000000000000000A").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO `backup_schedule_destinations`").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `backup_schedule_users` WHERE schedule_id = \\?").
+		WithArgs("01J5SCHED0000000000000000A").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO `backup_schedule_users`").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	s := &models.BackupSchedule{
+		ID:       "01J5SCHED0000000000000000A",
+		Kind:     models.BackupScheduleKindAccount,
+		CronExpr: "0 3 * * *",
+		Enabled:  true,
+	}
+	err := repo.CreateWithMemberships(context.Background(), s,
+		[]string{"01J5DEST00000000000000000A"},
+		[]string{"01J5USER0000000000000000001"})
+	require.NoError(t, err)
+	require.False(t, s.CreatedAt.IsZero())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The atomicity guarantee: a failure linking users rolls back the whole
+// transaction, so the schedule row is NOT left committed with the wrong (here,
+// empty → "all non-admins") membership. Falsify: drop the tx wrapper / commit
+// the row before the links → this expects a Rollback that never happens.
+func TestBackupSchedule_CreateWithMemberships_UserLinkFails_RollsBack(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupScheduleRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO `backup_schedules`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("DELETE FROM `backup_schedule_destinations` WHERE schedule_id = \\?").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM `backup_schedule_users` WHERE schedule_id = \\?").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO `backup_schedule_users`").
+		WillReturnError(errFakeUserLink)
+	mock.ExpectRollback()
+
+	s := &models.BackupSchedule{
+		ID:       "01J5SCHED0000000000000000A",
+		Kind:     models.BackupScheduleKindAccount,
+		CronExpr: "0 3 * * *",
+		Enabled:  true,
+	}
+	err := repo.CreateWithMemberships(context.Background(), s,
+		nil, // no destinations → no dest INSERT
+		[]string{"01J5USER0000000000000000001"})
+	require.Error(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
## What & why

Creating a backup schedule assembled the row and its two membership sets with **three separate, non-transactional** repository calls — `Create`, then `ReplaceDestinations`, then `ReplaceUsers` — in both the admin REST handler and the operator CLI. A join-write failure after the row was inserted left a runnable schedule whose membership silently differed from what was asked.

That silent difference is a security concern, not a cosmetic one: an **account schedule with an empty user set fans out to every non-admin user at tick time** (scheduler resolves the empty set to all non-admins). So a dropped `ReplaceUsers` broadens the backup's blast radius rather than narrowing it.

The CLI also never rejected an admin account as a schedule target, a rule the REST handler has always enforced.

## Change

Introduce `internal/backupscheduleops` — the transport-neutral Backup Schedule Lifecycle leaf (ADR-0083 `<area>ops` family, alongside `packageops`/`dbops`/`settingsops`/`sshkeyops`). It owns the create-side policy both adapters must apply identically:

- kind defaulting (`""` → account) and validation,
- admin-target rejection and missing-user rejection,
- system-kind normalization (no users, include-system flag forced off),
- cron validation **before any write**,
- a single transactional commit of the row together with its destination and user links.

Adapters keep what is genuinely theirs: id resolution (CLI resolves `--user` email/username and `--destination` name into ids; REST promotes the legacy `user_id` single field into `UserIDs`), authorization, and output shaping.

The transactional commit is a new repository method `CreateWithMemberships`, wrapping the row insert plus both membership replacements in one gorm transaction. The existing `ReplaceDestinations` / `ReplaceUsers` now delegate to shared per-tx helpers (`replaceDestinationsTx` / `replaceUsersTx`) so the composed transaction never nests on a second `r.db` handle.

**Scope is the create path only.** JAB-307 is a multi-AC parent; the update path, run-now, and the tenant schedule variant remain adapter-local for follow-up slices, so the parent stays open.

## Behavior changes worth a reviewer's eye

- **CLI now refuses an admin account as a target** (was silently accepted). This is the headline — brings the CLI to parity with REST.
- **CLI error ordering**: a create with both a bad `--user` and a bad `--cron` now reports the user error first (leaf validates users before cron, matching REST). Previously the CLI reported cron first. Cosmetic.
- **REST `invalid_cron` detail string** gained an `"invalid cron expression: "` prefix (the wrapped-error `%w: %v` form). The wire **code** is unchanged (`invalid_cron`); only the human `detail` text changed. No test asserts the detail body (the one `invalid_cron` test asserts the code).
- REST create response is otherwise byte-identical: the DTO reads `s.UserIDs` (leaf populates) and `s.UserID` (nil on create in both old and new paths); `content`/`cadence` were DB-defaulted before and still are.

## Tests

- Leaf unit tests: each refusal (admin user, missing user, invalid kind, invalid cron) asserts **zero writes**; plus system-kind normalization, happy-path persistence with memberships, `Enabled=false` honored, nil `UserFinder` skips the admin check, writer-error propagation.
- Repository sqlmock tests: the row + both link sets commit together in one transaction, and roll back as one when a link insert fails.
- Source pins on both adapters: the create path delegates to `backupscheduleops.Create(` and no longer issues the raw `Create → ReplaceDestinations → ReplaceUsers` sequence.
- All three new guards were falsified (RED confirmed by running, then reverted). Full `go test -race` green on `backupscheduleops`, `repository`, `api`, `cmd/server`; `gofmt` + `go vet` clean. CLI-reference golden unaffected (no flag/subcommand change) and green in the `cmd/server` suite.

Closes AC1 (admin-reject, both adapters), AC2 (create-path defaulting), AC3 (invalid-cron no-write — CLI already did, now shared), and AC4 (atomic row+links) **for the create path**. AC5 (run-now) and the update path remain follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
