### PR TITLE
fix(files): fail closed on malformed agent replies in the HTTP raw-forward verbs (JAB-340)

### DIFF
--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -257,6 +256,14 @@ func (h *filesHandler) du(c *gin.Context) {
 	raw, err := h.cfg.Agent.Call(ctx, filesops.MethodDu, filesops.Du(h.scope(c, userID, username), p))
 	if err != nil {
 		respondAgentError(c, err)
+		return
+	}
+	// JAB-340 AC2: validate the reply before forwarding it. A malformed agent
+	// success body (an error blob, a JSON null) must not reach the browser as a
+	// 200 that only fails at response.json(); fail closed here. The raw bytes are
+	// forwarded unchanged on success so the wire stays byte-identical.
+	if _, err := filesops.DecodeDu(raw); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
 		return
 	}
 	c.Data(http.StatusOK, "application/json", raw)
@@ -933,6 +940,12 @@ func (h *filesHandler) extract(c *gin.Context) {
 			respondAgentError(c, err)
 			return
 		}
+		// JAB-340 AC2: a malformed start reply must not look like an accepted job
+		// the UI then polls with an empty id. Validate, then forward raw.
+		if _, err := filesops.DecodeJobStart(raw); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
+			return
+		}
 		c.Data(http.StatusAccepted, "application/json", raw)
 		return
 	}
@@ -942,8 +955,12 @@ func (h *filesHandler) extract(c *gin.Context) {
 		respondAgentError(c, err)
 		return
 	}
-	var res json.RawMessage = raw
-	c.Data(http.StatusOK, "application/json", res)
+	// JAB-340 AC2: fail closed on a malformed extract reply rather than forward it.
+	if _, err := filesops.DecodeExtract(raw); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", raw)
 }
 
 // jobStatus handles GET /files/jobs/:id — the progress of an async File Manager
@@ -955,12 +972,16 @@ func (h *filesHandler) jobStatus(c *gin.Context) {
 	if !ok {
 		return
 	}
-	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.job.status", map[string]string{
-		"job_id":   c.Param("id"),
-		"username": username,
-	})
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), filesops.MethodJobStatus,
+		filesops.JobStatus(username, c.Param("id")))
 	if err != nil {
 		respondAgentError(c, err)
+		return
+	}
+	// JAB-340 AC2: validate the snapshot before forwarding so a malformed reply
+	// can't reach the UI's progress poller as a 200 with no status.
+	if _, err := filesops.DecodeJobStatus(raw); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
 		return
 	}
 	c.Data(http.StatusOK, "application/json", raw)
@@ -1191,6 +1212,12 @@ func (h *filesHandler) copy(c *gin.Context) {
 			filesops.Copy(h.scope(c, userID, username), req.Path, dst))
 		if err != nil {
 			respondAgentError(c, err)
+			return
+		}
+		// JAB-340 AC2: validate the start reply before forwarding, so the UI never
+		// polls a job whose id came back empty from a malformed body.
+		if _, err := filesops.DecodeJobStart(raw); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
 			return
 		}
 		c.Data(http.StatusAccepted, "application/json", raw)

--- a/panel-api/internal/api/files_async_test.go
+++ b/panel-api/internal/api/files_async_test.go
@@ -49,8 +49,10 @@ func TestExtractAsync_Returns202AndStartsJob(t *testing.T) {
 }
 
 func TestExtractSync_UsesBlockingVerb(t *testing.T) {
+	// The reply carries dest (the agent always sets it) so it passes the JAB-340
+	// fail-closed decode; this test only asserts the blocking verb is chosen.
 	agent := &mockAgent{callFn: func(_ context.Context, _ string, _ any) (json.RawMessage, error) {
-		return json.RawMessage(`{"extracted":3}`), nil
+		return json.RawMessage(`{"dest":"/home/alice","extracted":3}`), nil
 	}}
 	r := setupFilesRouter(t, "user1", agent)
 

--- a/panel-api/internal/api/files_failclosed_test.go
+++ b/panel-api/internal/api/files_failclosed_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// JAB-340 AC2: the HTTP file verbs that forward the agent's reply body verbatim
+// (du, extract, extract.start, copy.start, job.status) must validate it first —
+// a malformed agent *success* body must not reach the browser as a 200/202 that
+// only fails client-side at response.json(). These tests drive each handler with
+// a reply that decodes to a zero value (an error blob / JSON null) and assert the
+// handler fails closed; a valid reply is forwarded unchanged.
+//
+// Reverting any DecodeX guard in files.go turns the malformed case back into a
+// 200/202 and reddens the matching row here.
+
+func rawAgent(raw string) *mockAgent {
+	return &mockAgent{
+		callFn: func(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+			return json.RawMessage(raw), nil
+		},
+	}
+}
+
+func TestFilesDu_FailsClosedOnMalformedReply(t *testing.T) {
+	// du is the GH #1184 admin File Manager verb, so drive it through the admin
+	// router (adminGate passes, admin_root=true).
+	bad := setupAdminFilesRouter(t, rawAgent(`{"error":"boom"}`))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/files/du?path=/home/alice", nil)
+	w := httptest.NewRecorder()
+	bad.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatalf("du(error blob): got 200, want a fail-closed non-200; body=%s", w.Body.String())
+	}
+
+	// A du of an empty dir (total 0, no entries, but a real path) is a success.
+	ok := setupAdminFilesRouter(t, rawAgent(`{"path":"/home/alice","total":0,"entries":[]}`))
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/files/du?path=/home/alice", nil)
+	w = httptest.NewRecorder()
+	ok.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("du(valid empty dir): got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"path":"/home/alice"`) {
+		t.Fatalf("du(valid): reply not forwarded verbatim; body=%s", w.Body.String())
+	}
+}
+
+func TestFilesJobStatus_FailsClosedOnMalformedReply(t *testing.T) {
+	bad := setupFilesRouter(t, "user1", rawAgent(`null`))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/jobs/job-1", nil)
+	w := httptest.NewRecorder()
+	bad.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatalf("job.status(null): got 200, want a fail-closed non-200; body=%s", w.Body.String())
+	}
+
+	ok := setupFilesRouter(t, "user1", rawAgent(`{"job_id":"job-1","status":"running","done":0,"total":100,"started_at":"2026-01-02T03:04:05Z"}`))
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/files/jobs/job-1", nil)
+	w = httptest.NewRecorder()
+	ok.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("job.status(valid): got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"running"`) {
+		t.Fatalf("job.status(valid): reply not forwarded verbatim; body=%s", w.Body.String())
+	}
+}
+
+func TestFilesExtractSync_FailsClosedOnMalformedReply(t *testing.T) {
+	// Sync extract has no field-presence guard (a valid default-dest extract has
+	// an empty dest), so the fail-closed case is a malformed/truncated body.
+	bad := setupFilesRouter(t, "user1", rawAgent(`{"dest":`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/extract",
+		strings.NewReader(`{"path":"/home/alice/a.tar.gz"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	bad.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatalf("extract(error blob): got 200, want a fail-closed non-200; body=%s", w.Body.String())
+	}
+
+	ok := setupFilesRouter(t, "user1", rawAgent(`{"dest":"/home/alice","extracted":1,"skipped":0}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/files/extract",
+		strings.NewReader(`{"path":"/home/alice/a.tar.gz"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	ok.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("extract(valid): got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFilesExtractStart_FailsClosedOnMalformedReply(t *testing.T) {
+	bad := setupFilesRouter(t, "user1", rawAgent(`{"error":"boom"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/extract?async=1",
+		strings.NewReader(`{"path":"/home/alice/a.tar.gz"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	bad.ServeHTTP(w, req)
+	if w.Code == http.StatusAccepted {
+		t.Fatalf("extract.start(error blob): got 202, want a fail-closed non-202; body=%s", w.Body.String())
+	}
+
+	ok := setupFilesRouter(t, "user1", rawAgent(`{"job_id":"job-9"}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/files/extract?async=1",
+		strings.NewReader(`{"path":"/home/alice/a.tar.gz"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	ok.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("extract.start(valid): got %d want 202; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFilesCopyStart_FailsClosedOnMalformedReply(t *testing.T) {
+	bad := setupFilesRouter(t, "user1", rawAgent(`{"error":"boom"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/copy?async=1",
+		strings.NewReader(`{"path":"/home/alice/a.txt","dest_dir":"/home/alice/b"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	bad.ServeHTTP(w, req)
+	if w.Code == http.StatusAccepted {
+		t.Fatalf("copy.start(error blob): got 202, want a fail-closed non-202; body=%s", w.Body.String())
+	}
+
+	ok := setupFilesRouter(t, "user1", rawAgent(`{"job_id":"job-9"}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/files/copy?async=1",
+		strings.NewReader(`{"path":"/home/alice/a.txt","dest_dir":"/home/alice/b"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	ok.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("copy.start(valid): got %d want 202; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/panel-api/internal/filesops/decode.go
+++ b/panel-api/internal/filesops/decode.go
@@ -57,6 +57,54 @@ type StatResult struct {
 	IsSymlink bool   `json:"is_symlink"`
 }
 
+// DuEntry is one child of a files.du reply (a per-entry byte total).
+type DuEntry struct {
+	Name       string `json:"name"`
+	IsDir      bool   `json:"is_dir"`
+	Size       int64  `json:"size"`
+	HasSubdirs bool   `json:"has_subdirs"`
+}
+
+// DuResult is a decoded files.du reply. Mirrors the agent's filesDuResponse.
+type DuResult struct {
+	Path    string    `json:"path"`
+	Total   int64     `json:"total"`
+	Entries []DuEntry `json:"entries"`
+}
+
+// ExtractResult is a decoded synchronous files.extract reply. It has no
+// non-omittable identity field to guard on: the agent returns dest as the
+// caller's raw dest param (files_extract.go), which is empty for the common
+// "extract into the archive's parent" action, and extracted/skipped are
+// legitimately 0 for an empty archive. So DecodeExtract fails closed on a
+// malformed body only (like DecodeList), never on a field-presence check that
+// would false-fail a real default-dest extract.
+type ExtractResult struct {
+	Dest      string `json:"dest"`
+	Extracted int    `json:"extracted"`
+	Skipped   int    `json:"skipped"`
+}
+
+// JobStartResult is a decoded files.extract.start / files.copy.start reply: the
+// id of the background job the agent kicked off. Both start verbs return the
+// same {job_id} shape.
+type JobStartResult struct {
+	JobID string `json:"job_id"`
+}
+
+// JobStatusResult is a decoded files.job.status reply. Mirrors the agent's
+// fileJobSnapshot. Result carries the finished job's verb-specific payload
+// (e.g. an ExtractResult) and is left as raw JSON here.
+type JobStatusResult struct {
+	JobID     string          `json:"job_id"`
+	Status    string          `json:"status"`
+	Done      int64           `json:"done"`
+	Total     int64           `json:"total"`
+	Result    json.RawMessage `json:"result,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	StartedAt string          `json:"started_at"`
+}
+
 // ErrTruncated reports that a full-content read came back truncated because the
 // file exceeds the agent's read cap. Callers that need the whole file (download,
 // CLI read/download) turn this into a failure so a partial file is never written
@@ -76,6 +124,24 @@ var ErrNoArchivePath = errors.New("agent did not return an archive path")
 // only a normalized echo of the caller's input, so it is the weaker identity
 // field to hang this check on.)
 var ErrNoStatMode = errors.New("agent did not return a file mode for the stat")
+
+// ErrNoDuPath reports that a files.du reply decoded cleanly but carried no path.
+// Path is the field a successful du can never omit: the agent sets it to the
+// resolved canonical directory it measured. Total and Entries are NOT usable as
+// the identity field — a du of an empty directory legitimately returns total 0
+// and no entries, so guarding on either would false-fail a real empty dir. An
+// empty path therefore means the body was not a du result at all (an agent error
+// blob, or a JSON null decoding into a zero-valued struct).
+var ErrNoDuPath = errors.New("agent did not return a path for the disk-usage reply")
+
+// ErrNoJobID reports that a files.extract.start / files.copy.start reply decoded
+// cleanly but carried no job id — an id the caller must have to poll the job.
+var ErrNoJobID = errors.New("agent did not return a job id")
+
+// ErrNoJobStatus reports that a files.job.status reply decoded cleanly but
+// carried no status. Every real job snapshot has a non-empty status
+// (queued/running/done/failed); an empty one means the body was not a snapshot.
+var ErrNoJobStatus = errors.New("agent did not return a status for the job")
 
 // DecodeList decodes a files.list reply, failing closed on a malformed body.
 func DecodeList(raw []byte) (ListResult, error) {
@@ -119,6 +185,56 @@ func DecodeStat(raw []byte) (StatResult, error) {
 	}
 	if r.Mode == "" {
 		return StatResult{}, ErrNoStatMode
+	}
+	return r, nil
+}
+
+// DecodeDu decodes a files.du reply, failing closed on a malformed body or a
+// reply that carries no path (see ErrNoDuPath).
+func DecodeDu(raw []byte) (DuResult, error) {
+	var r DuResult
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return DuResult{}, fmt.Errorf("decode files.du reply: %w", err)
+	}
+	if r.Path == "" {
+		return DuResult{}, ErrNoDuPath
+	}
+	return r, nil
+}
+
+// DecodeExtract decodes a synchronous files.extract reply, failing closed on a
+// malformed body. See ExtractResult for why there is no field-presence guard
+// here (a valid default-dest extract carries an empty dest).
+func DecodeExtract(raw []byte) (ExtractResult, error) {
+	var r ExtractResult
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return ExtractResult{}, fmt.Errorf("decode files.extract reply: %w", err)
+	}
+	return r, nil
+}
+
+// DecodeJobStart decodes a files.extract.start / files.copy.start reply, failing
+// closed on a malformed body or a missing job id (see ErrNoJobID).
+func DecodeJobStart(raw []byte) (JobStartResult, error) {
+	var r JobStartResult
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return JobStartResult{}, fmt.Errorf("decode files job-start reply: %w", err)
+	}
+	if r.JobID == "" {
+		return JobStartResult{}, ErrNoJobID
+	}
+	return r, nil
+}
+
+// DecodeJobStatus decodes a files.job.status reply, failing closed on a
+// malformed body or a reply that carries no status (see ErrNoJobStatus).
+func DecodeJobStatus(raw []byte) (JobStatusResult, error) {
+	var r JobStatusResult
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return JobStatusResult{}, fmt.Errorf("decode files.job.status reply: %w", err)
+	}
+	if r.Status == "" {
+		return JobStatusResult{}, ErrNoJobStatus
 	}
 	return r, nil
 }

--- a/panel-api/internal/filesops/decode_test.go
+++ b/panel-api/internal/filesops/decode_test.go
@@ -106,3 +106,105 @@ func TestDecodeStat(t *testing.T) {
 		t.Fatalf("DecodeStat decoded wrong: %+v", got)
 	}
 }
+
+func TestDecodeDu(t *testing.T) {
+	// Malformed body fails closed with a decode error.
+	if _, err := DecodeDu([]byte(`{`)); err == nil {
+		t.Fatal("DecodeDu(malformed) = nil error, want a decode error")
+	}
+	// AC2, load-bearing: an agent error blob decodes into a zero struct with an
+	// empty path and must fail closed.
+	if _, err := DecodeDu([]byte(`{"error":"boom"}`)); !errors.Is(err, ErrNoDuPath) {
+		t.Fatalf("DecodeDu(error blob) = %v, want ErrNoDuPath", err)
+	}
+	// JSON null decodes without error into a zero value; the path guard rejects it.
+	if _, err := DecodeDu([]byte(`null`)); !errors.Is(err, ErrNoDuPath) {
+		t.Fatalf("DecodeDu(null) = %v, want ErrNoDuPath", err)
+	}
+	// Regression against a zero-value guard: a du of an EMPTY directory is a real
+	// success — total 0, no entries — and must decode cleanly. Guarding on total
+	// or entries instead of path would false-fail this.
+	empty, err := DecodeDu([]byte(`{"path":"/home/shuki/empty","total":0,"entries":[]}`))
+	if err != nil {
+		t.Fatalf("DecodeDu(empty dir) = %v, want nil (0 bytes is a valid du)", err)
+	}
+	if empty.Path != "/home/shuki/empty" || empty.Total != 0 || len(empty.Entries) != 0 {
+		t.Fatalf("DecodeDu(empty dir) decoded wrong: %+v", empty)
+	}
+	got, err := DecodeDu([]byte(`{"path":"/home/shuki","total":4096,"entries":[{"name":"a","is_dir":true,"size":4096,"has_subdirs":true}]}`))
+	if err != nil {
+		t.Fatalf("DecodeDu(valid): %v", err)
+	}
+	if got.Path != "/home/shuki" || got.Total != 4096 || len(got.Entries) != 1 ||
+		got.Entries[0].Name != "a" || !got.Entries[0].IsDir || got.Entries[0].Size != 4096 || !got.Entries[0].HasSubdirs {
+		t.Fatalf("DecodeDu decoded wrong: %+v", got)
+	}
+}
+
+func TestDecodeExtract(t *testing.T) {
+	// A malformed (truncated) body fails closed — the AC2 guarantee for extract.
+	if _, err := DecodeExtract([]byte(`{`)); err == nil {
+		t.Fatal("DecodeExtract(malformed) = nil error, want a decode error")
+	}
+	// Regression: a valid extract into the archive's parent carries an EMPTY dest
+	// (the agent echoes the raw, omitted dest param) and 0/0 counts for an empty
+	// archive. This must decode cleanly — a dest-presence guard would 500 the
+	// common "extract here" action in production.
+	def, err := DecodeExtract([]byte(`{"dest":"","extracted":0,"skipped":0}`))
+	if err != nil {
+		t.Fatalf("DecodeExtract(default-dest) = %v, want nil (empty dest is valid)", err)
+	}
+	if def.Dest != "" || def.Extracted != 0 || def.Skipped != 0 {
+		t.Fatalf("DecodeExtract(default-dest) decoded wrong: %+v", def)
+	}
+	got, err := DecodeExtract([]byte(`{"dest":"/home/shuki/out","extracted":3,"skipped":1}`))
+	if err != nil {
+		t.Fatalf("DecodeExtract(valid): %v", err)
+	}
+	if got.Dest != "/home/shuki/out" || got.Extracted != 3 || got.Skipped != 1 {
+		t.Fatalf("DecodeExtract decoded wrong: %+v", got)
+	}
+}
+
+func TestDecodeJobStart(t *testing.T) {
+	if _, err := DecodeJobStart([]byte(`{`)); err == nil {
+		t.Fatal("DecodeJobStart(malformed) = nil error, want a decode error")
+	}
+	// An error blob has no job_id and must fail closed, so the UI never polls an
+	// empty id as if a job had started.
+	if _, err := DecodeJobStart([]byte(`{"error":"boom"}`)); !errors.Is(err, ErrNoJobID) {
+		t.Fatalf("DecodeJobStart(error blob) = %v, want ErrNoJobID", err)
+	}
+	if _, err := DecodeJobStart([]byte(`null`)); !errors.Is(err, ErrNoJobID) {
+		t.Fatalf("DecodeJobStart(null) = %v, want ErrNoJobID", err)
+	}
+	got, err := DecodeJobStart([]byte(`{"job_id":"job-abc123"}`))
+	if err != nil {
+		t.Fatalf("DecodeJobStart(valid): %v", err)
+	}
+	if got.JobID != "job-abc123" {
+		t.Fatalf("DecodeJobStart decoded wrong: %+v", got)
+	}
+}
+
+func TestDecodeJobStatus(t *testing.T) {
+	if _, err := DecodeJobStatus([]byte(`{`)); err == nil {
+		t.Fatal("DecodeJobStatus(malformed) = nil error, want a decode error")
+	}
+	// An error blob has no status and must fail closed.
+	if _, err := DecodeJobStatus([]byte(`{"error":"boom"}`)); !errors.Is(err, ErrNoJobStatus) {
+		t.Fatalf("DecodeJobStatus(error blob) = %v, want ErrNoJobStatus", err)
+	}
+	if _, err := DecodeJobStatus([]byte(`null`)); !errors.Is(err, ErrNoJobStatus) {
+		t.Fatalf("DecodeJobStatus(null) = %v, want ErrNoJobStatus", err)
+	}
+	// A running job with 0 bytes done so far is a real success (done 0 is not the
+	// identity field — status is).
+	got, err := DecodeJobStatus([]byte(`{"job_id":"job-1","status":"running","done":0,"total":100,"started_at":"2026-01-02T03:04:05Z"}`))
+	if err != nil {
+		t.Fatalf("DecodeJobStatus(running) = %v, want nil", err)
+	}
+	if got.JobID != "job-1" || got.Status != "running" || got.Done != 0 || got.Total != 100 {
+		t.Fatalf("DecodeJobStatus decoded wrong: %+v", got)
+	}
+}

--- a/panel-api/internal/filesops/filesops.go
+++ b/panel-api/internal/filesops/filesops.go
@@ -49,6 +49,7 @@ const (
 	MethodArchive      = "files.archive"
 	MethodExtract      = "files.extract"
 	MethodExtractStart = "files.extract.start"
+	MethodJobStatus    = "files.job.status"
 )
 
 // Scope is the resolved target-user identity every files.* verb carries.

--- a/panel-api/internal/filesops/params.go
+++ b/panel-api/internal/filesops/params.go
@@ -117,6 +117,16 @@ type ExtractParams struct {
 	Dest      string `json:"dest,omitempty"`
 }
 
+// JobStatusParams is the files.job.status request. Unlike every other verb it
+// carries no Scope: a background job (GH #1392) is looked up by its id plus the
+// caller's verified username — the agent returns a job ONLY to the username it
+// was started for, so one tenant can never poll another's job. There is no path
+// and no admin_root.
+type JobStatusParams struct {
+	JobID    string `json:"job_id"`
+	Username string `json:"username"`
+}
+
 // ---- builders: stamp a Scope onto the verb-specific fields ----
 //
 // Each returns the concrete params struct for its verb; the adapter passes it to
@@ -174,4 +184,10 @@ func Archive(s Scope, paths []string) ArchiveParams {
 
 func Extract(s Scope, path, dest string) ExtractParams {
 	return ExtractParams{UserID: s.UserID, Username: s.Username, AdminRoot: s.AdminRoot, Path: path, Dest: dest}
+}
+
+// JobStatus builds a files.job.status request from the caller's verified
+// username and the job id being polled.
+func JobStatus(username, jobID string) JobStatusParams {
+	return JobStatusParams{JobID: jobID, Username: username}
 }

--- a/panel-api/internal/filesops/params_test.go
+++ b/panel-api/internal/filesops/params_test.go
@@ -39,6 +39,7 @@ func TestWireShape(t *testing.T) {
 		{"files.archive", Archive(s, []string{"/home/shuki/a.txt", "/home/shuki/b"}), []string{"paths", "user_id", "username"}},
 		{"files.extract", Extract(s, "/home/shuki/a.tar.gz", ""), []string{"path", "user_id", "username"}},
 		{"files.extract_with_dest", Extract(s, "/home/shuki/a.tar.gz", "/home/shuki/out"), []string{"dest", "path", "user_id", "username"}},
+		{"files.job.status", JobStatus("shuki", "job-123"), []string{"job_id", "username"}},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## What & why

Five HTTP File Manager verbs forwarded the agent's reply body to the browser **verbatim**, with no fail-closed decode: `du`, the synchronous `extract`, the async `extract.start` and `copy.start`, and `job.status` each ended in `c.Data(..., raw)`. An agent RPC *error* was still caught (the `Agent.Call` error path → `respondAgentError`), but a malformed agent **success** body — an error blob, a JSON null, a truncated payload — was forwarded as a 200/202 that only failed client-side at `response.json()`.

JAB-340 AC2 is adapter-agnostic: *"Malformed Agent replies never become success."* The CLI side of that was closed with the list/stat fail-closed decoders (#1519, #1562); this closes the **HTTP** side, which was the remaining AC2 residual.

## Change

Four new reply decoders in `internal/filesops`, each failing closed the way the existing `DecodeList`/`DecodeStat` do:

- **`DecodeDu`** — guards on `path`. A du of an empty directory legitimately returns `total 0` and no entries, so total/entries cannot be the identity field (guarding on either would false-fail a real empty dir). The agent always sets `path` to the resolved canonical directory (`files_du.go`).
- **`DecodeExtract`** — **malformed-body only**, like `DecodeList`. The sync extract reply has no non-omittable identity field: the agent echoes `dest` as the caller's *raw* dest param (`files_extract.go:174` → `Dest: destRel`, and `destRel := p.Dest`), which is **empty** for the common "extract into the archive's parent" action; `extracted`/`skipped` are 0 for an empty archive. A dest-presence guard would 500 a valid default-dest extract in production, so there is deliberately no field guard here.
- **`DecodeJobStart`** — guards on `job_id`; shared by `extract.start` and `copy.start` (both return the same `{job_id}` shape).
- **`DecodeJobStatus`** — guards on `status` (a job is `"running"` from construction, `file_jobs.go`).

At each of the five `c.Data` sites the handler now decode-validates then forwards the **raw bytes unchanged** on success.

### Wire notes (for review)

1. **Success is byte-identical at all five sites**; only a malformed body changes: `200/202 → 500`. (Sync extract previously wrapped `raw` in a `json.RawMessage` before `c.Data` — same `[]byte`, zero delta.)
2. **500 `internal_error` "bad agent response"**, matching the in-file `list`/`tree`/`download` precedent for a malformed reply — not `me_disk_usage`'s 502. Chosen for consistency within `files.go`.
3. **`job.status` is now typed.** It was the last untyped HTTP file verb (a string-literal method + inline `map[string]string`); folded into filesops as `MethodJobStatus` + a `JobStatus(username, jobID)` builder, closing an AC1 parity-table hole. The map→struct marshals the same keys (`job_id`, `username`); `TestJobStatus_ForwardsClaimsUsername` stays green.
4. **One test-stub change:** `TestExtractSync_UsesBlockingVerb` returned `{"extracted":3}` (no dest) — realistic for the verb-selection assertion, but the real agent always includes `dest`, so its reply now includes `dest`. Behavior asserted (blocking verb chosen) is unchanged.
5. **`me_disk_usage` left untouched** — it is a separate `files.du` consumer that already fails closed (`files_du_decode`), and its test stub feeds a *path-less* du reply, so sharing the path-guarded `DecodeDu` would false-fail it. It is not part of the raw-forward gap.

## Tests

- `filesops` decode tests for each new decoder (valid / malformed / error-blob / null), including a **du-of-empty-dir** case and a **default-dest / empty-archive extract** case that would red-fail a naive zero-value guard.
- A params wire-shape row for `files.job.status`.
- End-to-end handler tests (`files_failclosed_test.go`): a malformed reply on each of the five routes fails closed; a valid one is forwarded (`du` via the admin router, the rest via the tenant router).
- Every guard falsified by neutralizing it and confirming RED across both the decoder unit tests and the handler tests, then reverted.
- `go build ./...`, `go vet`, `gofmt` clean; `go test -race` green on `internal/filesops`, `internal/api`, `cmd/server`. No CLI change (the CLI has no du / extract.start / copy.start / job.status raw-forward — those are HTTP-only).

## Acceptance criteria

This closes AC2's HTTP residual; folding `job.status` into the parity table closes the AC1 hole. With AC1 (parity), AC3 (shared rename/move/copy/archive validation), AC4 (`RequireComplete`), and AC5 (adapter-only audit/output) already met on `main`, **all five ACs are now met — proposing JAB-340 Done on merge** (awaiting confirmation; not closing here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
