### PR TITLE
feat(shared-resources): shared create lifecycle leaf so CLI and REST enforce one policy (JAB-339)

### DIFF
--- a/panel-api/cmd/server/shared_resource_cmd.go
+++ b/panel-api/cmd/server/shared_resource_cmd.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/mailaddr"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -33,7 +31,6 @@ func sharedResourceRepoFromDB() repository.SharedResourceRepository {
 	return repository.NewSharedResourceRepository(sharedDB)
 }
 
-var sharedResourceKindSet = map[string]bool{"mailbox": true, "calendar": true, "addressbook": true, "files": true}
 var sharedResourceRightSet = map[string]bool{"read": true, "readwrite": true, "admin": true}
 
 func newSharedResourceCmd() *cobra.Command {
@@ -89,13 +86,10 @@ func newSharedResourceCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a shared resource",
-		PreRunE: requireDB,
+		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if domainID == "" || name == "" || kind == "" {
 				return errors.New("--domain, --name, --kind required")
-			}
-			if !sharedResourceKindSet[kind] {
-				return fmt.Errorf("invalid --kind %q (mailbox|calendar|addressbook|files)", kind)
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 			defer cancel()
@@ -103,21 +97,20 @@ func newSharedResourceCreateCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("find domain %q: %w", domainID, err)
 			}
-			local, _, err := mailaddr.Canonicalise(name + "@" + dom.Name)
+			// The email-enabled gate, kind allowlist, canonicalisation,
+			// duplicate check, trimmed display name, persist, and best-effort
+			// apply are all in sharedresourceops — the same policy the REST
+			// handler runs, so the two adapters project identical state.
+			sr, err := createSharedResourceDirect(ctx, sharedResourceRepoFromDB(),
+				notifyAgentSharedResource, dom, kind, name, displayName)
 			if err != nil {
-				return fmt.Errorf("invalid name: %w", err)
-			}
-			email := local + "@" + dom.Name
-			now := time.Now().UTC()
-			sr := &models.SharedResource{
-				ID: ids.NewULID(), DomainID: dom.ID, Kind: kind,
-				LocalPart: &local, EmailCached: &email,
-				DisplayName: displayName, CreatedAt: now, UpdatedAt: now,
-			}
-			if err := sharedResourceRepoFromDB().Create(ctx, sr); err != nil {
-				return fmt.Errorf("create: %w", err)
+				return err
 			}
 			cliAuditOK(ctx, "shared_resource.create", "shared_resource", sr.ID, nil)
+			email := ""
+			if sr.EmailCached != nil {
+				email = *sr.EmailCached
+			}
 			fmt.Printf("created %s (%s) %s — converges on next reconcile pass\n", sr.ID, kind, email)
 			return nil
 		},

--- a/panel-api/cmd/server/shared_resource_ops.go
+++ b/panel-api/cmd/server/shared_resource_ops.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sharedresourceops"
+)
+
+const cliSharedResourceAgentTimeout = 15 * time.Second
+
+// createSharedResourceDirect mirrors POST /domains/:id/shared-resources: the
+// email-enabled gate, kind allowlist, canonicalisation, duplicate-address
+// check, trimmed display name, persist, and best-effort agent apply all live in
+// sharedresourceops, so the CLI enforces the exact same policy the REST handler
+// does and both project identical state.
+func createSharedResourceDirect(ctx context.Context, repo repository.SharedResourceRepository, notify agentNotifier, dom *models.Domain, kind, name, displayName string) (*models.SharedResource, error) {
+	return sharedresourceops.Create(ctx, sharedresourceops.Deps{Resources: repo}, sharedresourceops.CreateInput{
+		Domain:      dom,
+		Kind:        kind,
+		Name:        name,
+		DisplayName: displayName,
+	}, sharedresourceops.NotifyFunc(notify))
+}
+
+// notifyAgentSharedResource is the production agentNotifier wired off the global
+// sharedAgent. Swallows errors — ADR-0013 best-effort; the reconciler converges
+// from DB truth regardless.
+func notifyAgentSharedResource(ctx context.Context, cmd string, params any) {
+	if sharedAgent == nil {
+		return
+	}
+	agentCtx, cancel := context.WithTimeout(ctx, cliSharedResourceAgentTimeout)
+	defer cancel()
+	_, _ = sharedAgent.Call(agentCtx, cmd, params)
+}

--- a/panel-api/cmd/server/shared_resource_ops_test.go
+++ b/panel-api/cmd/server/shared_resource_ops_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeSRRepo implements repository.SharedResourceRepository for the CLI
+// testable-core. Only ExistsByEmail and Create carry behavior.
+type fakeSRRepo struct {
+	exists  bool
+	created []*models.SharedResource
+}
+
+func (f *fakeSRRepo) ExistsByEmail(context.Context, string) (bool, error) { return f.exists, nil }
+func (f *fakeSRRepo) Create(_ context.Context, r *models.SharedResource) error {
+	f.created = append(f.created, r)
+	return nil
+}
+func (f *fakeSRRepo) FindByID(context.Context, string) (*models.SharedResource, error) {
+	return nil, nil
+}
+func (f *fakeSRRepo) ListByDomainID(context.Context, string) ([]models.SharedResource, error) {
+	return nil, nil
+}
+func (f *fakeSRRepo) ListByDomainAndKind(context.Context, string, string) ([]models.SharedResource, error) {
+	return nil, nil
+}
+func (f *fakeSRRepo) ListAll(context.Context) ([]models.SharedResource, error) { return nil, nil }
+func (f *fakeSRRepo) UpdateMeta(context.Context, string, string) error         { return nil }
+func (f *fakeSRRepo) UpdateProjection(context.Context, string, string, string) error {
+	return nil
+}
+func (f *fakeSRRepo) Delete(context.Context, string) error { return nil }
+func (f *fakeSRRepo) ListGrants(context.Context, string) ([]models.SharedResourceGrant, error) {
+	return nil, nil
+}
+func (f *fakeSRRepo) ListAllGrants(context.Context) ([]models.SharedResourceGrant, error) {
+	return nil, nil
+}
+func (f *fakeSRRepo) ReplaceGrants(context.Context, string, []models.SharedResourceGrant) error {
+	return nil
+}
+func (f *fakeSRRepo) PruneGranteeGrants(context.Context, string, string) error { return nil }
+func (f *fakeSRRepo) AddTombstone(context.Context, string) error               { return nil }
+func (f *fakeSRRepo) ListTombstones(context.Context) ([]string, error)         { return nil, nil }
+func (f *fakeSRRepo) DeleteTombstone(context.Context, string) error            { return nil }
+
+// TestCreateSharedResourceDirect_RefusesOnDisabledEmail: the REST handler blocks
+// this with email_not_enabled; before this leaf the CLI silently created an
+// orphan on a mail-disabled domain. The CLI must now mirror the guard.
+func TestCreateSharedResourceDirect_RefusesOnDisabledEmail(t *testing.T) {
+	repo := &fakeSRRepo{}
+	dom := testDomain("dom1", "example.org", false) // email disabled
+	_, err := createSharedResourceDirect(context.Background(), repo, nil, dom, "calendar", "teamcal", "")
+	if err == nil {
+		t.Fatal("expected an error on a mail-disabled domain")
+	}
+	if len(repo.created) != 0 {
+		t.Fatalf("no row must be written on a disabled domain, got %d", len(repo.created))
+	}
+}
+
+// TestCreateSharedResourceDirect_RefusesDuplicate: the CLI gained the
+// pre-INSERT duplicate check the REST handler already had, so a taken address
+// yields a typed error instead of a raw UNIQUE-constraint driver failure.
+func TestCreateSharedResourceDirect_RefusesDuplicate(t *testing.T) {
+	repo := &fakeSRRepo{exists: true}
+	dom := testDomain("dom1", "example.org", true)
+	_, err := createSharedResourceDirect(context.Background(), repo, nil, dom, "calendar", "teamcal", "")
+	if err == nil {
+		t.Fatal("expected an error when the address is already taken")
+	}
+	if len(repo.created) != 0 {
+		t.Fatalf("no row must be written for a duplicate, got %d", len(repo.created))
+	}
+}
+
+// recordSR captures the best-effort apply so the test can assert the CLI fires
+// it — the AC3 parity guarantee (the CLI now projects the same state the REST
+// handler does, not just persists).
+type recordSR struct {
+	fired  bool
+	cmd    string
+	params map[string]any
+}
+
+func (r *recordSR) notify(_ context.Context, cmd string, params any) {
+	r.fired = true
+	r.cmd = cmd
+	if m, ok := params.(map[string]any); ok {
+		r.params = m
+	}
+}
+
+func TestCreateSharedResourceDirect_TrimsAndFiresApply(t *testing.T) {
+	repo := &fakeSRRepo{}
+	rec := &recordSR{}
+	dom := testDomain("dom1", "example.org", true)
+	sr, err := createSharedResourceDirect(context.Background(), repo, rec.notify, dom,
+		"calendar", "TeamCal", "  Team Calendar  ")
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("want 1 row persisted, got %d", len(repo.created))
+	}
+	if sr.DisplayName != "Team Calendar" {
+		t.Fatalf("DisplayName not trimmed: %q", sr.DisplayName)
+	}
+	if sr.EmailCached == nil || *sr.EmailCached != "teamcal@example.org" {
+		t.Fatalf("EmailCached = %v, want teamcal@example.org", sr.EmailCached)
+	}
+	// The load-bearing AC3 assertion: the CLI fires the same apply the REST
+	// handler does. Passing a nil notifier from the RunE reddens this.
+	if !rec.fired || rec.cmd != "sharedresource.apply" {
+		t.Fatalf("apply not fired: fired=%v cmd=%q", rec.fired, rec.cmd)
+	}
+	if rec.params["email"] != "teamcal@example.org" ||
+		rec.params["display_name"] != "Team Calendar" ||
+		rec.params["kind"] != "calendar" {
+		t.Fatalf("apply params wrong: %#v", rec.params)
+	}
+}
+
+// TestSharedResourceAdapters_RouteThroughLeaf source-pins that neither adapter's
+// create body hand-builds the row or fires the apply verb by string literal —
+// both must route through sharedresourceops so the policy has one owner.
+func TestSharedResourceAdapters_RouteThroughLeaf(t *testing.T) {
+	cli := mustRead(t, "shared_resource_cmd.go")
+	if !strings.Contains(cli, "createSharedResourceDirect(") {
+		t.Error("CLI create must call createSharedResourceDirect")
+	}
+	if strings.Contains(cli, "sharedResourceRepoFromDB().Create(ctx, sr)") {
+		t.Error("CLI must not hand-build + persist the row itself")
+	}
+	if strings.Contains(cli, `"sharedresource.apply"`) {
+		t.Error("CLI must not fire the apply verb by string literal")
+	}
+	// AC3: the create RunE must hand the production notifier to the leaf, or the
+	// apply silently no-ops and the CLI only persists. The behavioral tests pass
+	// a fake notifier, so this is the only thing pinning the real wiring.
+	if !strings.Contains(cli, "notifyAgentSharedResource, dom,") {
+		t.Error("CLI create must pass notifyAgentSharedResource so the apply fires (AC3)")
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/panel-api/internal/api/shared_resources.go
+++ b/panel-api/internal/api/shared_resources.go
@@ -8,26 +8,23 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/mailaddr"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sharedresourceops"
 )
 
 const sharedResourceAgentTimeout = 15 * time.Second
 
-var sharedResourceKinds = map[string]bool{
-	"mailbox": true, "calendar": true, "addressbook": true, "files": true,
-}
 var sharedResourceRights = map[string]bool{
 	"read": true, "readwrite": true, "admin": true,
 }
@@ -112,55 +109,38 @@ func (h *sharedResourceHandler) create(c *gin.Context) {
 	if !ok {
 		return
 	}
-	if !dom.EmailEnabled {
-		c.JSON(http.StatusConflict, gin.H{"error": "email_not_enabled",
-			"detail": "enable email on the domain before creating shared resources"})
-		return
-	}
 	var req createSharedResourceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
 		return
 	}
-	if !sharedResourceKinds[req.Kind] {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_kind"})
-		return
-	}
-	canonLocal, _, err := mailaddr.Canonicalise(req.Name + "@" + dom.Name)
+	// The email-enabled gate, kind allowlist, canonicalisation, duplicate-address
+	// check, trimmed display name, persist, and best-effort apply all live in
+	// sharedresourceops so the operator CLI enforces the identical policy.
+	sr, err := sharedresourceops.Create(c.Request.Context(),
+		sharedresourceops.Deps{Resources: h.cfg.Resources},
+		sharedresourceops.CreateInput{
+			Domain:      dom,
+			Kind:        req.Kind,
+			Name:        req.Name,
+			DisplayName: req.DisplayName,
+		}, h.notifyAgent)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_name", "detail": err.Error()})
+		switch {
+		case errors.Is(err, sharedresourceops.ErrEmailNotEnabled):
+			c.JSON(http.StatusConflict, gin.H{"error": "email_not_enabled",
+				"detail": "enable email on the domain before creating shared resources"})
+		case errors.Is(err, sharedresourceops.ErrInvalidKind):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_kind"})
+		case errors.Is(err, sharedresourceops.ErrInvalidName):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_name", "detail": err.Error()})
+		case errors.Is(err, sharedresourceops.ErrAddressTaken):
+			c.JSON(http.StatusConflict, gin.H{"error": "address_taken"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
 		return
 	}
-	ctx := c.Request.Context()
-	email := canonLocal + "@" + dom.Name
-	if exists, err := h.cfg.Resources.ExistsByEmail(ctx, email); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	} else if exists {
-		c.JSON(http.StatusConflict, gin.H{"error": "address_taken"})
-		return
-	}
-
-	now := time.Now().UTC()
-	local := canonLocal
-	sr := &models.SharedResource{
-		ID:          ids.NewULID(),
-		DomainID:    dom.ID,
-		Kind:        req.Kind,
-		LocalPart:   &local,
-		EmailCached: &email,
-		DisplayName: strings.TrimSpace(req.DisplayName),
-		CreatedAt:   now,
-		UpdatedAt:   now,
-	}
-	if err := h.cfg.Resources.Create(ctx, sr); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-	// Instant host provisioning (reconciler also converges).
-	h.notifyAgent(ctx, "sharedresource.apply", map[string]any{
-		"email": email, "display_name": sr.DisplayName, "kind": sr.Kind,
-	})
 	c.JSON(http.StatusCreated, sr)
 }
 

--- a/panel-api/internal/api/shared_resources_leaf_test.go
+++ b/panel-api/internal/api/shared_resources_leaf_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSharedResourceHTTP_RoutesThroughLeaf source-pins that the REST create
+// handler routes through sharedresourceops rather than hand-building + persisting
+// the row itself — so the create policy has one owner shared with the operator
+// CLI (JAB-339 AC3). (The separate rename handler still fires sharedresource.apply
+// directly; that is a different operation, out of this create-only slice.)
+func TestSharedResourceHTTP_RoutesThroughLeaf(t *testing.T) {
+	b, err := os.ReadFile("shared_resources.go")
+	if err != nil {
+		t.Fatalf("read shared_resources.go: %v", err)
+	}
+	src := string(b)
+	if !strings.Contains(src, "sharedresourceops.Create(") {
+		t.Error("create handler must call sharedresourceops.Create")
+	}
+	if strings.Contains(src, "h.cfg.Resources.Create(") {
+		t.Error("create handler must not persist the row itself")
+	}
+}

--- a/panel-api/internal/sharedresourceops/sharedresourceops.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops.go
@@ -1,0 +1,133 @@
+// Package sharedresourceops is the shared Shared-Resource Lifecycle (JAB-339,
+// ADR-0133): the create operation the REST handler and the operator CLI both
+// route through, so the email-enabled gate, the kind allowlist, address
+// canonicalization, the duplicate-address rule, the trimmed display name, and
+// the best-effort agent apply have one owner and cannot drift between the two.
+//
+// It follows the mailboxops sibling (JAB-291): authorization stays an adapter
+// concern — every entry point takes an already-loaded, already-authorized
+// domain (the REST handler checks the caller's claims; the operator CLI is
+// admin-by-construction). The DB rows are authoritative; the reconciler
+// projects each shared_resource into a Stalwart host principal + collection, so
+// the agent apply is best-effort and its failure never fails the create.
+package sharedresourceops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/mailaddr"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// kinds is the single source of truth for the shared-resource kind allowlist —
+// the REST handler and the CLI used to keep two separate copies. It matches the
+// migration's ENUM('mailbox','calendar','addressbook','files').
+var kinds = map[string]bool{
+	"mailbox": true, "calendar": true, "addressbook": true, "files": true,
+}
+
+// ValidKind reports whether kind is an allowed shared-resource kind.
+func ValidKind(kind string) bool { return kinds[kind] }
+
+// NotifyFunc is the best-effort agent notify (ADR-0013): its errors are
+// swallowed by the caller's implementation and never fail the create.
+type NotifyFunc func(ctx context.Context, cmd string, params any)
+
+// Deps carries the collaborators Create needs.
+type Deps struct {
+	Resources repository.SharedResourceRepository
+}
+
+// Sentinel errors. Adapters map these to their own transport (the HTTP handler
+// to specific status codes + body strings, the CLI to a returned error).
+var (
+	// ErrDeps means a required collaborator was not wired.
+	ErrDeps = errors.New("sharedresourceops: dependencies not wired")
+	// ErrEmailNotEnabled means the domain does not have email enabled, so a
+	// shared resource (an SMTP recipient / DAV principal) cannot be created.
+	ErrEmailNotEnabled = errors.New("sharedresourceops: email is not enabled on the domain")
+	// ErrInvalidKind means the kind is not in the allowlist.
+	ErrInvalidKind = errors.New("sharedresourceops: invalid kind")
+	// ErrInvalidName means the requested local part did not canonicalize.
+	ErrInvalidName = errors.New("sharedresourceops: invalid name")
+	// ErrAddressTaken means a resource already exists at the canonical address.
+	ErrAddressTaken = errors.New("sharedresourceops: address already in use")
+	// ErrInternal means an unexpected data-access failure.
+	ErrInternal = errors.New("sharedresourceops: internal error")
+)
+
+// CreateInput is one shared-resource creation. The domain is pre-loaded and
+// pre-authorized by the adapter (mirroring mailboxops.CreateInput).
+type CreateInput struct {
+	Domain      *models.Domain
+	Kind        string
+	Name        string // host address local part
+	DisplayName string
+}
+
+// Create enforces the EmailEnabled gate + the kind allowlist, canonicalizes the
+// address, rejects a duplicate before the insert, persists the row (with a
+// trimmed display name), and fires the best-effort agent apply. Returns the
+// persisted row.
+//
+// The order matches the REST handler it replaces: EmailEnabled → kind →
+// canonicalise → duplicate → persist. LocalPart / EmailCached are set for every
+// kind, exactly as both adapters did before this leaf (the migration reserves
+// them for kind='mailbox', but changing that is out of this slice's scope — the
+// leaf preserves today's behavior byte-for-byte).
+func Create(ctx context.Context, d Deps, in CreateInput, notify NotifyFunc) (*models.SharedResource, error) {
+	if d.Resources == nil || in.Domain == nil {
+		return nil, fmt.Errorf("%w: resources repo + domain required", ErrDeps)
+	}
+	if !in.Domain.EmailEnabled {
+		return nil, ErrEmailNotEnabled
+	}
+	if !ValidKind(in.Kind) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidKind, in.Kind)
+	}
+	canonLocal, _, err := mailaddr.Canonicalise(in.Name + "@" + in.Domain.Name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidName, err)
+	}
+	email := canonLocal + "@" + in.Domain.Name
+	// Pre-INSERT duplicate check: replaces the raw UNIQUE-constraint driver
+	// error with a typed one. The repository does NOT map the constraint to
+	// ErrConflict, so the narrow race between this check and the insert still
+	// surfaces as ErrInternal — the pre-check covers the common case, not the
+	// race.
+	if exists, err := d.Resources.ExistsByEmail(ctx, email); err != nil {
+		return nil, fmt.Errorf("%w: uniqueness check: %v", ErrInternal, err)
+	} else if exists {
+		return nil, ErrAddressTaken
+	}
+
+	now := time.Now().UTC()
+	local := canonLocal
+	sr := &models.SharedResource{
+		ID:          ids.NewULID(),
+		DomainID:    in.Domain.ID,
+		Kind:        in.Kind,
+		LocalPart:   &local,
+		EmailCached: &email,
+		DisplayName: strings.TrimSpace(in.DisplayName),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := d.Resources.Create(ctx, sr); err != nil {
+		return nil, fmt.Errorf("%w: insert: %v", ErrInternal, err)
+	}
+
+	// Instant host provisioning (reconciler also converges from DB truth).
+	if notify != nil {
+		notify(ctx, "sharedresource.apply", map[string]any{
+			"email": email, "display_name": sr.DisplayName, "kind": sr.Kind,
+		})
+	}
+	return sr, nil
+}

--- a/panel-api/internal/sharedresourceops/sharedresourceops_test.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops_test.go
@@ -1,0 +1,170 @@
+package sharedresourceops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeResRepo implements repository.SharedResourceRepository. Only ExistsByEmail
+// and Create carry behavior — the rest are unused by Create and return zero
+// values. created records every persisted row so a test can assert whether a
+// refusal wrote anything.
+type fakeResRepo struct {
+	exists   bool
+	existErr error
+	created  []*models.SharedResource
+}
+
+func (f *fakeResRepo) ExistsByEmail(_ context.Context, _ string) (bool, error) {
+	return f.exists, f.existErr
+}
+func (f *fakeResRepo) Create(_ context.Context, r *models.SharedResource) error {
+	f.created = append(f.created, r)
+	return nil
+}
+
+func (f *fakeResRepo) FindByID(context.Context, string) (*models.SharedResource, error) {
+	return nil, nil
+}
+func (f *fakeResRepo) ListByDomainID(context.Context, string) ([]models.SharedResource, error) {
+	return nil, nil
+}
+func (f *fakeResRepo) ListByDomainAndKind(context.Context, string, string) ([]models.SharedResource, error) {
+	return nil, nil
+}
+func (f *fakeResRepo) ListAll(context.Context) ([]models.SharedResource, error) { return nil, nil }
+func (f *fakeResRepo) UpdateMeta(context.Context, string, string) error         { return nil }
+func (f *fakeResRepo) UpdateProjection(context.Context, string, string, string) error {
+	return nil
+}
+func (f *fakeResRepo) Delete(context.Context, string) error { return nil }
+func (f *fakeResRepo) ListGrants(context.Context, string) ([]models.SharedResourceGrant, error) {
+	return nil, nil
+}
+func (f *fakeResRepo) ListAllGrants(context.Context) ([]models.SharedResourceGrant, error) {
+	return nil, nil
+}
+func (f *fakeResRepo) ReplaceGrants(context.Context, string, []models.SharedResourceGrant) error {
+	return nil
+}
+func (f *fakeResRepo) PruneGranteeGrants(context.Context, string, string) error { return nil }
+func (f *fakeResRepo) AddTombstone(context.Context, string) error               { return nil }
+func (f *fakeResRepo) ListTombstones(context.Context) ([]string, error)         { return nil, nil }
+func (f *fakeResRepo) DeleteTombstone(context.Context, string) error            { return nil }
+
+// recordingNotify captures the agent apply call so a test can assert the leaf
+// fires it with the right params.
+type recordingNotify struct {
+	fired  bool
+	cmd    string
+	params map[string]any
+}
+
+func (n *recordingNotify) fn(_ context.Context, cmd string, params any) {
+	n.fired = true
+	n.cmd = cmd
+	if m, ok := params.(map[string]any); ok {
+		n.params = m
+	}
+}
+
+func emailDomain() *models.Domain {
+	return &models.Domain{ID: "dom1", Name: "example.org", EmailEnabled: true}
+}
+
+func TestCreate_RefusesOnDisabledEmail(t *testing.T) {
+	repo := &fakeResRepo{}
+	dom := &models.Domain{ID: "dom1", Name: "example.org", EmailEnabled: false}
+	_, err := Create(context.Background(), Deps{Resources: repo}, CreateInput{
+		Domain: dom, Kind: "calendar", Name: "teamcal",
+	}, nil)
+	if !errors.Is(err, ErrEmailNotEnabled) {
+		t.Fatalf("want ErrEmailNotEnabled, got %v", err)
+	}
+	if len(repo.created) != 0 {
+		t.Fatalf("no row must be written on a disabled domain, got %d", len(repo.created))
+	}
+}
+
+func TestCreate_RefusesInvalidKind(t *testing.T) {
+	repo := &fakeResRepo{}
+	_, err := Create(context.Background(), Deps{Resources: repo}, CreateInput{
+		Domain: emailDomain(), Kind: "carrier-pigeon", Name: "teamcal",
+	}, nil)
+	if !errors.Is(err, ErrInvalidKind) {
+		t.Fatalf("want ErrInvalidKind, got %v", err)
+	}
+	if len(repo.created) != 0 {
+		t.Fatalf("no row must be written for an invalid kind, got %d", len(repo.created))
+	}
+}
+
+func TestCreate_RefusesInvalidName(t *testing.T) {
+	repo := &fakeResRepo{}
+	// A local part that cannot canonicalize (a space is not a valid address char).
+	_, err := Create(context.Background(), Deps{Resources: repo}, CreateInput{
+		Domain: emailDomain(), Kind: "calendar", Name: "bad name",
+	}, nil)
+	if !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("want ErrInvalidName, got %v", err)
+	}
+	if len(repo.created) != 0 {
+		t.Fatalf("no row must be written for an invalid name, got %d", len(repo.created))
+	}
+}
+
+func TestCreate_RefusesDuplicateAddress(t *testing.T) {
+	repo := &fakeResRepo{exists: true}
+	_, err := Create(context.Background(), Deps{Resources: repo}, CreateInput{
+		Domain: emailDomain(), Kind: "calendar", Name: "teamcal",
+	}, nil)
+	if !errors.Is(err, ErrAddressTaken) {
+		t.Fatalf("want ErrAddressTaken, got %v", err)
+	}
+	if len(repo.created) != 0 {
+		t.Fatalf("no row must be written when the address is taken, got %d", len(repo.created))
+	}
+}
+
+func TestCreate_HappyPathTrimsAndFiresApply(t *testing.T) {
+	repo := &fakeResRepo{}
+	notify := &recordingNotify{}
+	sr, err := Create(context.Background(), Deps{Resources: repo}, CreateInput{
+		Domain: emailDomain(), Kind: "calendar", Name: "TeamCal", DisplayName: "  Team Calendar  ",
+	}, notify.fn)
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("want 1 row written, got %d", len(repo.created))
+	}
+	if sr.DisplayName != "Team Calendar" {
+		t.Fatalf("DisplayName not trimmed: %q", sr.DisplayName)
+	}
+	if sr.EmailCached == nil || *sr.EmailCached != "teamcal@example.org" {
+		t.Fatalf("EmailCached = %v, want teamcal@example.org", sr.EmailCached)
+	}
+	if sr.LocalPart == nil || *sr.LocalPart != "teamcal" {
+		t.Fatalf("LocalPart = %v, want teamcal", sr.LocalPart)
+	}
+	if !notify.fired || notify.cmd != "sharedresource.apply" {
+		t.Fatalf("apply not fired: fired=%v cmd=%q", notify.fired, notify.cmd)
+	}
+	if notify.params["email"] != "teamcal@example.org" ||
+		notify.params["display_name"] != "Team Calendar" ||
+		notify.params["kind"] != "calendar" {
+		t.Fatalf("apply params wrong: %#v", notify.params)
+	}
+}
+
+func TestCreate_NilNotifyDoesNotPanic(t *testing.T) {
+	repo := &fakeResRepo{}
+	if _, err := Create(context.Background(), Deps{Resources: repo}, CreateInput{
+		Domain: emailDomain(), Kind: "files", Name: "teamfiles",
+	}, nil); err != nil {
+		t.Fatalf("nil notify happy path: %v", err)
+	}
+}


### PR DESCRIPTION
## What & why

The shared-resource **create** path was implemented twice — once in the REST handler (`internal/api/shared_resources.go`), once in the operator CLI (`cmd/server/shared_resource_cmd.go`) — and the two had drifted. The CLI create skipped three guards the REST handler enforced, and did not project the new resource to the host at all:

- **no email-enabled gate** — `jabali shared-resource create` on a mail-disabled domain silently wrote an orphan row the reconciler can never host;
- **no duplicate-address check** — a taken address surfaced as a raw `UNIQUE` constraint driver error instead of a clean pre-insert rejection;
- **no `TrimSpace` on the display name** — a CLI-created resource could carry leading/trailing whitespace the REST handler would have stripped;
- **no agent apply** — a CLI create waited for the next reconcile sweep, while a REST create provisioned the Stalwart host immediately.

This is the **create slice** of JAB-339 (Shared Resource Lifecycle, ADR-0133).

## Change

New `internal/sharedresourceops`, mirroring the `mailboxops` lifecycle leaf (JAB-291). A single `Create` takes an already-loaded, already-authorized domain and enforces, **in the REST handler's original order**, the email-enabled gate → kind allowlist → address canonicalisation → duplicate-address check → trimmed display name → persist → best-effort agent apply. Authorization stays adapter-side.

Both adapters now route through it:

- the **REST handler** passes its notifier and maps the leaf's sentinels to the exact status codes and bodies it returned before (`email_not_enabled` 409, `invalid_kind` 400, `invalid_name` 400, `address_taken` 409, else 500);
- the **CLI** create gains a `createSharedResourceDirect` testable core and a `notifyAgentSharedResource` notifier — the same `notifyAgentMailbox` / `notifyAgentMailGroup` pattern the sibling CLIs already use, **not a new surface** — and switches its `PreRunE` to `requireDBAndAgent` so the apply actually fires (`initAgent` only constructs the client; the `.Call` inside the notifier is best-effort and swallows errors, so a down socket does not fail the create).

The kind allowlist, previously duplicated in both adapters (`sharedResourceKinds` in the API, `sharedResourceKindSet` in the CLI — identical sets), now has one owner: `sharedresourceops.ValidKind`. Both copies are deleted.

### Wire notes (for review)

1. **REST success body unchanged** — 201 with the persisted row; `LocalPart` / `EmailCached` are still set for every kind, exactly as both adapters did before. The leaf preserves today's behavior byte-for-byte (the migration reserves those for `kind='mailbox'`, but changing that is out of this slice).
2. **Three error-ordering shifts, none test-pinned:**
   - the REST handler now binds the body **before** the email-enabled gate (a malformed body to a mail-disabled domain is a 400 rather than a 409);
   - the CLI now resolves the domain **before** checking the kind (a bad `--kind` on a missing domain surfaces the domain error first);
   - the `invalid_name` detail string gains a `sharedresourceops: invalid name:` prefix — the error **code** is unchanged.
3. **Duplicate check is pre-insert.** The repository does not map the `UNIQUE` violation to `ErrConflict`, so the narrow race between the check and the insert still surfaces as an internal error — the pre-check covers the common case, not the race.
4. **`invalid_kind` kept detail-less** (matching the old body); no new subcommand (cli-reference golden untouched) and no new route (openapi untouched).

## Tests

- `sharedresourceops` unit tests for each refusal (disabled email, invalid kind, invalid name, duplicate address — each asserts **zero rows written**) and the happy path (trimmed display name, cached email, apply fired with the right params + a nil-notifier no-panic case).
- A CLI testable-core test that the CLI now mirrors the disabled-email and duplicate guards and fires the same apply.
- Source-pin tests that **both** adapters route through the leaf rather than hand-building and persisting the row, and that the CLI RunE passes the production notifier (the only thing pinning the AC3 apply wiring).
- Every guard falsified by neutralizing it, confirming the matching test went **red**, and reverting — including the RunE-notifier wiring (arg → `nil` → red).
- `go build ./...`, `go vet`, `gofmt` clean; `go test -race` green on `internal/sharedresourceops`, `internal/api`, `cmd/server`.

## Acceptance criteria

- **AC1** (CLI/HTTP parity for the operation) — met for **create**: both adapters share one create policy leaf.
- **AC2** (resources require an email-enabled domain) — met on both adapters (the CLI gap is closed).
- **AC3** (equivalent CLI/HTTP inputs persist **and** project identical state) — met for **create**: identical persisted row + the same best-effort `sharedresource.apply`.
- **AC4** (grantee existence / domain policy) and **AC5** (delete tombstone before best-effort destroy) — **not this slice**.

The grant projection, the delete tombstone, and the grantee-existence policy remain, so **the module parent stays Backlog**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
