### PR TITLE
feat(domains): shared owner-eligibility gate for domain create (JAB-279)

### DIFF
--- a/panel-api/cmd/server/cli_create.go
+++ b/panel-api/cmd/server/cli_create.go
@@ -14,6 +14,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -261,11 +262,20 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 	if err != nil {
 		return nil, nil, err
 	}
-	if owner.IsAdmin {
+	// Owner-eligibility gate (JAB-279) — the same domainops policy the REST
+	// handler runs. Routing through the leaf closes a CLI gap: the CLI never
+	// checked owner.Suspended, so a suspended owner could get a live vhost from
+	// the command line while the account stayed locked. The messages stay the
+	// CLI's own (the leaf owns the policy, each adapter owns its transport).
+	switch err := domainops.CheckOwnerEligible(owner); {
+	case errors.Is(err, domainops.ErrAdminCannotHost):
 		return nil, nil, fmt.Errorf("admin users cannot host domains — create a regular user")
-	}
-	if owner.Username == nil || *owner.Username == "" {
+	case errors.Is(err, domainops.ErrOwnerSuspended):
+		return nil, nil, fmt.Errorf("user %q is suspended — unsuspend before adding domains", owner.ID)
+	case errors.Is(err, domainops.ErrOwnerNoUsername):
 		return nil, nil, fmt.Errorf("user %q has no username — inconsistent state", owner.ID)
+	case err != nil:
+		return nil, nil, err
 	}
 
 	// All subsequent DB ops use the resolved ULID, not the free-form

--- a/panel-api/cmd/server/domain_create_owner_gate_test.go
+++ b/panel-api/cmd/server/domain_create_owner_gate_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCLICreateDomain_RoutesOwnerGateThroughLeaf source-pins that the CLI create
+// runs the shared domainops eligibility gate rather than its own inline checks.
+// createDomainDirect calls initConfig / initDB and is not behaviorally testable
+// in a unit test, so this source-pin is the load-bearing guard: it is the only
+// thing that catches the CLI reverting to its old, drifted gate — which never
+// checked owner.Suspended, so a suspended owner could get a live vhost from the
+// command line (JAB-279 AC3).
+func TestCLICreateDomain_RoutesOwnerGateThroughLeaf(t *testing.T) {
+	src := readGoSource(t, "cli_create.go")
+
+	if !strings.Contains(src, "domainops.CheckOwnerEligible(owner)") {
+		t.Error("CLI create must run the shared domainops.CheckOwnerEligible gate")
+	}
+	// The suspended branch is the gap this slice closes; pin that the CLI now
+	// maps it, so a future edit that drops it reddens here.
+	if !strings.Contains(src, "domainops.ErrOwnerSuspended") {
+		t.Error("CLI create must refuse a suspended owner (domainops.ErrOwnerSuspended)")
+	}
+	// The old inline admin check must be gone — its presence means the CLI is
+	// gating itself again instead of routing through the leaf.
+	if strings.Contains(src, "if owner.IsAdmin {") {
+		t.Error("CLI create must not keep its own inline owner.IsAdmin check")
+	}
+}
+
+func readGoSource(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -12,6 +12,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -205,18 +206,19 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		return nil, &createDomainError{http.StatusInternalServerError, "internal", ""}
 	}
 
-	// Admins are panel-only — no /home/<name>, so domains can't host under them.
-	if user.IsAdmin {
+	// Owner-eligibility gate (JAB-279): admins are panel-only (no /home/<name>);
+	// suspended owners must not get a live vhost while the account stays locked;
+	// a hosting user always has a username. The policy lives in domainops so the
+	// CLI runs the identical gate; the adapter maps each sentinel to the status
+	// code and body it returned before the leaf existed.
+	switch err := domainops.CheckOwnerEligible(user); {
+	case errors.Is(err, domainops.ErrAdminCannotHost):
 		return nil, &createDomainError{http.StatusBadRequest, "admin_cannot_host", "admin users are panel-only — create a regular user to host domains"}
-	}
-
-	// Suspended users can't acquire new domains — a fresh vhost would be live
-	// while the account stays locked, defeating the suspend cascade.
-	if user.Suspended {
+	case errors.Is(err, domainops.ErrOwnerSuspended):
 		return nil, &createDomainError{http.StatusConflict, "user_suspended", "user is suspended — unsuspend before adding domains"}
-	}
-
-	if user.Username == nil || *user.Username == "" {
+	case err != nil:
+		// ErrOwnerNoUsername (and ErrOwnerNil) — an inconsistent state, surfaced
+		// as the same opaque internal error the handler returned before.
 		return nil, &createDomainError{http.StatusInternalServerError, "internal", ""}
 	}
 

--- a/panel-api/internal/api/domain_create_owner_eligibility_test.go
+++ b/panel-api/internal/api/domain_create_owner_eligibility_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestCreateDomainOp_OwnerEligibility characterizes the owner-eligibility gate
+// the REST handler now runs through domainops (JAB-279). It pins the two
+// caller-visible refusals — an admin owner and a suspended owner — to the exact
+// status codes and error codes the handler returned before the leaf existed, and
+// asserts no domain row is persisted on either. The suspended case is also the
+// falsify vehicle for the CLI parity fix: before this slice the CLI skipped it.
+func TestCreateDomainOp_OwnerEligibility(t *testing.T) {
+	uname := "alice"
+
+	run := func(owner *models.User) (*createDomainError, *dcDomains) {
+		users := newAbUsers(owner)
+		dom := newDCDomains()
+		h := &domainHandler{cfg: DomainHandlerConfig{Users: users, Domains: dom}}
+		_, oerr := createDomainOp(context.Background(), h, createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "shop.example.com",
+			MailProvider:  models.MailProviderNone,
+			SSLMode:       models.SSLModeNone,
+			SkipInlineSSL: true,
+		})
+		return oerr, dom
+	}
+
+	t.Run("admin owner cannot host", func(t *testing.T) {
+		oerr, dom := run(&models.User{ID: "u-admin", Username: &uname, IsAdmin: true})
+		if oerr == nil || oerr.Status != 400 || oerr.Code != "admin_cannot_host" {
+			t.Fatalf("want 400 admin_cannot_host, got %+v", oerr)
+		}
+		if len(dom.created) != 0 {
+			t.Fatalf("no domain must be persisted on refusal, got %d", len(dom.created))
+		}
+	})
+
+	t.Run("suspended owner is refused", func(t *testing.T) {
+		oerr, dom := run(&models.User{ID: "u-susp", Username: &uname, Suspended: true})
+		if oerr == nil || oerr.Status != 409 || oerr.Code != "user_suspended" {
+			t.Fatalf("want 409 user_suspended, got %+v", oerr)
+		}
+		if len(dom.created) != 0 {
+			t.Fatalf("no domain must be persisted on refusal, got %d", len(dom.created))
+		}
+	})
+}

--- a/panel-api/internal/domainops/domainops.go
+++ b/panel-api/internal/domainops/domainops.go
@@ -1,0 +1,60 @@
+// Package domainops is the shared Domain Lifecycle Module (JAB-279): the
+// transport-neutral policy the REST handler and the operator CLI both route
+// through, so the eligibility gate that decides whether an owner may acquire a
+// new domain has one owner and cannot drift between the two adapters.
+//
+// Authorization and identity resolution stay adapter concerns (ADR-0083): every
+// entry point takes an already-loaded owner. The REST handler resolves it from
+// the request's OwnerID and maps a missing owner to its own 404; the CLI
+// resolves it via resolveUser (email / username / ULID). This leaf only decides
+// whether that owner is eligible to host a domain, and returns typed sentinels
+// each adapter maps to its own transport, with no HTTP knowledge here.
+package domainops
+
+import (
+	"errors"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Sentinel errors. Adapters map these to their own transport — the REST handler
+// to the status codes and body strings it returned before this leaf, the CLI to
+// a returned error.
+var (
+	// ErrOwnerNil means no owner was supplied — a wiring bug, not a policy result.
+	ErrOwnerNil = errors.New("domainops: owner is nil")
+	// ErrAdminCannotHost means the owner is a panel-only admin. Admins have no
+	// /home/<name>, so a domain cannot host under them.
+	ErrAdminCannotHost = errors.New("domainops: admin users cannot host domains")
+	// ErrOwnerSuspended means the owner is administratively suspended. A fresh
+	// vhost would be live while the account stays locked, defeating the suspend
+	// cascade, so the create must fail before allocation or persistence.
+	ErrOwnerSuspended = errors.New("domainops: owner is suspended")
+	// ErrOwnerNoUsername means the owner has no username — an inconsistent state
+	// (a hosting user always has one). The adapter surfaces it as an internal error.
+	ErrOwnerNoUsername = errors.New("domainops: owner has no username")
+)
+
+// CheckOwnerEligible reports whether owner may acquire a new domain, in the REST
+// handler's original order: admin first, then suspended, then username. It
+// returns nil when the owner is eligible, or one of the sentinels above.
+//
+// AC3 of JAB-279: suspended, admin, and missing owners must fail before any port
+// allocation or persistence. This predicate is the single gate both adapters
+// call before they build or persist the row, so the CLI can no longer create a
+// live vhost for a suspended owner (a gap the REST handler never had).
+func CheckOwnerEligible(owner *models.User) error {
+	if owner == nil {
+		return ErrOwnerNil
+	}
+	if owner.IsAdmin {
+		return ErrAdminCannotHost
+	}
+	if owner.Suspended {
+		return ErrOwnerSuspended
+	}
+	if owner.Username == nil || *owner.Username == "" {
+		return ErrOwnerNoUsername
+	}
+	return nil
+}

--- a/panel-api/internal/domainops/domainops_test.go
+++ b/panel-api/internal/domainops/domainops_test.go
@@ -1,0 +1,65 @@
+package domainops
+
+import (
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func strptr(s string) *string { return &s }
+
+// TestCheckOwnerEligible_Admin: a panel-only admin has no /home/<name>, so a
+// domain cannot host under them — both adapters must refuse before persistence.
+func TestCheckOwnerEligible_Admin(t *testing.T) {
+	err := CheckOwnerEligible(&models.User{IsAdmin: true, Username: strptr("root")})
+	if !errors.Is(err, ErrAdminCannotHost) {
+		t.Fatalf("admin owner: want ErrAdminCannotHost, got %v", err)
+	}
+}
+
+// TestCheckOwnerEligible_Suspended is the load-bearing gap this slice closes:
+// the CLI never ran this check, so a suspended owner could get a live vhost from
+// the command line. The gate must refuse a suspended owner on both adapters.
+func TestCheckOwnerEligible_Suspended(t *testing.T) {
+	err := CheckOwnerEligible(&models.User{Suspended: true, Username: strptr("alice")})
+	if !errors.Is(err, ErrOwnerSuspended) {
+		t.Fatalf("suspended owner: want ErrOwnerSuspended, got %v", err)
+	}
+}
+
+// TestCheckOwnerEligible_NoUsername: a hosting user always has a username; its
+// absence is an inconsistent state the adapter surfaces as an internal error.
+func TestCheckOwnerEligible_NoUsername(t *testing.T) {
+	if err := CheckOwnerEligible(&models.User{}); !errors.Is(err, ErrOwnerNoUsername) {
+		t.Fatalf("nil username: want ErrOwnerNoUsername, got %v", err)
+	}
+	if err := CheckOwnerEligible(&models.User{Username: strptr("")}); !errors.Is(err, ErrOwnerNoUsername) {
+		t.Fatalf("empty username: want ErrOwnerNoUsername, got %v", err)
+	}
+}
+
+// TestCheckOwnerEligible_Nil guards the wiring bug — a missing owner is not a
+// policy result, but it must never read as eligible.
+func TestCheckOwnerEligible_Nil(t *testing.T) {
+	if err := CheckOwnerEligible(nil); !errors.Is(err, ErrOwnerNil) {
+		t.Fatalf("nil owner: want ErrOwnerNil, got %v", err)
+	}
+}
+
+// TestCheckOwnerEligible_Eligible: a regular, unsuspended, named owner passes.
+func TestCheckOwnerEligible_Eligible(t *testing.T) {
+	if err := CheckOwnerEligible(&models.User{Username: strptr("alice")}); err != nil {
+		t.Fatalf("eligible owner: want nil, got %v", err)
+	}
+}
+
+// TestCheckOwnerEligible_Order pins the REST handler's original precedence:
+// admin is reported before suspended when an owner is both. Reordering the gate
+// would change which sentinel (and which adapter status code) a caller sees.
+func TestCheckOwnerEligible_Order(t *testing.T) {
+	err := CheckOwnerEligible(&models.User{IsAdmin: true, Suspended: true, Username: strptr("root")})
+	if !errors.Is(err, ErrAdminCannotHost) {
+		t.Fatalf("admin+suspended: want ErrAdminCannotHost first, got %v", err)
+	}
+}


### PR DESCRIPTION
## What & why

The gate that decides whether a user may acquire a new domain was implemented twice — once in the REST orchestration (`internal/api/domain_create_op.go` `createDomainOp`) and once in the operator CLI (`cmd/server/cli_create.go` `createDomainDirect`) — and the two had drifted. The CLI copy was missing a check the REST handler enforced:

- **no suspended-owner check** — `jabali domain create --user <suspended>` stood up a **live vhost for a suspended owner** from the command line, while the account stayed administratively locked. That defeats the suspend cascade every other path relies on (a suspended user's sites are meant to go offline, not gain new ones).

This is the **owner-eligibility slice** of JAB-279 (Domain Lifecycle Module).

## Change

New `internal/domainops`, a transport-neutral leaf with one predicate:

```go
func CheckOwnerEligible(owner *models.User) error
```

It refuses, in the REST handler's original order, a panel-only **admin** (no `/home/<name>` to host under), a **suspended** owner, and an owner with **no username** (an inconsistent state), returning typed sentinels (`ErrAdminCannotHost`, `ErrOwnerSuspended`, `ErrOwnerNoUsername`, plus `ErrOwnerNil` for the wiring bug). The leaf has **no HTTP knowledge** — each adapter maps the sentinels to its own transport.

Both adapters now route through it:

- the **REST handler** (`createDomainOp`) maps the sentinels to the exact status codes and body strings it returned before (`admin_cannot_host` 400, `user_suspended` 409, and the opaque `internal` 500 for a missing username);
- the **CLI** (`createDomainDirect`) gains the previously-missing suspended refusal and routes its admin/username checks through the leaf, keeping its own operator-facing messages.

**Automation rides the REST op for free** — `automation_billing.go` calls the same `createDomainOp`, so it inherits the gate with no change.

Identity resolution stays adapter-side (ADR-0083): the REST handler resolves the owner from the request's `OwnerID` (and maps a missing owner to its own 404), the CLI resolves it via `resolveUser` (email / username / ULID). The leaf only decides eligibility for an already-loaded owner, and the gate runs **before** the quota / document-root / persistence steps in both adapters, so a refusal never allocates or writes.

### Notes for review

1. **REST behavior byte-identical** — same status codes, same body strings; the `domainops:` sentinel prefix never reaches the wire (the adapter supplies its own detail literals). `ErrOwnerNoUsername` and `ErrOwnerNil` both map to the same opaque `internal` 500 the handler returned before.
2. **CLI behavior change is the fix** — a suspended owner is now refused (`user %q is suspended — unsuspend before adding domains`) instead of silently getting a live vhost. Admin and missing-username refusals are unchanged.
3. **No new subcommand or route** — cli-reference golden and openapi untouched.

## Tests

- `domainops` unit tests: each refusal (admin, suspended, no-username), the eligible path, the nil-owner guard, and the **admin-before-suspended order** pin.
- An HTTP characterization test (`TestCreateDomainOp_OwnerEligibility`) pinning the admin (400 `admin_cannot_host`) and suspended (409 `user_suspended`) refusals with **no domain row persisted** on either.
- A CLI source-pin (`createDomainDirect` calls `initConfig`/`initDB` and is not unit-testable): asserts the create routes through `domainops.CheckOwnerEligible`, maps `ErrOwnerSuspended`, and no longer keeps its own inline `owner.IsAdmin` check.
- Every guard falsified by neutralizing it (a compiling neutralization), confirming the matching test(s) went **red**, and reverting.
- `go build ./...`, `go vet`, `gofmt` clean; `go test -race` green on `internal/domainops`, `internal/api`, `cmd/server`.

## Acceptance criteria

- **AC3** (suspended / admin / missing owners fail before allocation or persistence) — **met on both adapters** (the CLI suspended gap is closed); automation inherits it.
- **AC6** (typed domain errors mapped by each adapter, no HTTP knowledge in the module) — **pattern established** for the eligibility errors.

Remaining JAB-279 work is deferred to later slices, so **the module parent stays Backlog**:

- **AC2 name pipeline** — the CLI still does not normalize `--name`, and `validateDomainName` is duplicated (`internal/api/domains.go:206` vs `cmd/server/cli_create.go:459`);
- **document-root confinement** — the CLI takes `in.DocRoot` unvalidated (`cli_create.go:321`); the REST handler runs `validateDocumentRoot` / `validateTenantDocumentRoot`;
- **alias-collision**, **mail-module coercion / m365 / DNS-template**, and the **live back-half** (reverse-proxy port allocation + compensation, persistence, shared-cert attach, inline SSL, reconciliation scheduling — AC1/AC4/AC5).

Two other domain creators are **outside the ticket's three named adapters** (REST / automation / CLI) and are intentionally not touched here: the backup-restore replay (`internal/backupmetadata/apply.go`) and the docker-app auto-provision (`internal/api/docker_apps*.go`), both of which call `Domains.Create` directly.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
