### PR TITLE
fix(backups): remove leaked credential file on any CLI destination create failure (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -146,24 +146,14 @@ func newBackupDestinationCreateCmd() *cobra.Command {
 				URL:     url,
 				Enabled: !disabled,
 			}
-			if len(env) > 0 {
-				if _, err := sharedAgent.Call(ctx, "backup.dest.creds_write", map[string]any{
-					"dest_id": d.ID,
-					"env":     env,
-				}); err != nil {
-					return fmt.Errorf("write credentials: %w", err)
-				}
-				ref := filepath.Join(credsDir, d.ID+".env")
-				d.CredentialsRef = &ref
-			}
-			if err := backupDestinationRepoFromDB().Create(ctx, d); err != nil {
+			// Credential-file write, persist, and compensate-on-any-failure all
+			// live in createBackupDestinationDirect so a failed create can never
+			// leak an orphaned secrets file (JAB-310 AC2).
+			if err := createBackupDestinationDirect(ctx, sharedAgent.Call, backupDestinationRepoFromDB(), d, env); err != nil {
 				if errors.Is(err, repository.ErrConflict) {
-					if d.CredentialsRef != nil {
-						_, _ = sharedAgent.Call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID})
-					}
 					return fmt.Errorf("destination name %q already exists", name)
 				}
-				return fmt.Errorf("create destination: %w", err)
+				return err
 			}
 			if jsonOutput {
 				return printJSON(d)

--- a/panel-api/cmd/server/backup_destination_ops.go
+++ b/panel-api/cmd/server/backup_destination_ops.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// createBackupDestinationDirect is the CLI testable core for `jabali destination
+// create`. It writes the destination's Agent credential file (when the caller
+// supplied env credentials), persists the row, and — on ANY persistence failure
+// — removes the just-written credential file so a transient DB error never
+// orphans a root:root 0600 secrets file (SSHPASS / cloud keys) on the box.
+//
+// This mirrors the REST handler's unconditional rollback
+// (internal/api/backup_destinations.go): the CLI previously deleted the file
+// only on a name-conflict, leaking it on every other create failure (JAB-310
+// AC2). The returned error preserves the wrapped cause, so the RunE can still
+// select the conflict-specific message via errors.Is(err, repository.ErrConflict).
+func createBackupDestinationDirect(ctx context.Context, call agentCaller, repo repository.BackupDestinationRepository, d *models.BackupDestination, env map[string]string) error {
+	if len(env) > 0 {
+		if _, err := call(ctx, "backup.dest.creds_write", map[string]any{
+			"dest_id": d.ID,
+			"env":     env,
+		}); err != nil {
+			return fmt.Errorf("write credentials: %w", err)
+		}
+		ref := filepath.Join(credsDir, d.ID+".env")
+		d.CredentialsRef = &ref
+	}
+	if err := repo.Create(ctx, d); err != nil {
+		// Compensate on EVERY failure, not just a name-conflict. Best-effort, but
+		// surface a failed cleanup so the operator isn't blind to a leaked secrets
+		// file (never silently swallowed).
+		if d.CredentialsRef != nil {
+			if _, derr := call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID}); derr != nil {
+				fmt.Fprintf(os.Stderr, "warning: credential file cleanup failed (%v); remove %s manually\n", derr, *d.CredentialsRef)
+			}
+		}
+		return fmt.Errorf("create destination: %w", err)
+	}
+	return nil
+}

--- a/panel-api/cmd/server/backup_destination_ops_test.go
+++ b/panel-api/cmd/server/backup_destination_ops_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeBackupDestRepo implements repository.BackupDestinationRepository for the
+// CLI testable core. Only Create carries behavior; the embedded interface makes
+// every other method a compile-time stub the core never calls.
+type fakeBackupDestRepo struct {
+	repository.BackupDestinationRepository
+	createErr    error
+	createCalled int
+}
+
+func (f *fakeBackupDestRepo) Create(_ context.Context, d *models.BackupDestination) error {
+	f.createCalled++
+	return f.createErr
+}
+
+// recordingAgent records each agent command (and its params), and can be told to
+// fail a specific command.
+type recordingAgent struct {
+	cmds    []string
+	params  map[string]map[string]any
+	failCmd string
+	failErr error
+}
+
+func (r *recordingAgent) call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	r.cmds = append(r.cmds, cmd)
+	if r.params == nil {
+		r.params = map[string]map[string]any{}
+	}
+	if m, ok := params.(map[string]any); ok {
+		r.params[cmd] = m
+	}
+	if cmd == r.failCmd {
+		return nil, r.failErr
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (r *recordingAgent) fired(cmd string) bool {
+	for _, c := range r.cmds {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+func newDest() *models.BackupDestination {
+	return &models.BackupDestination{ID: "dst-1", Name: "off-site", Kind: "sftp", URL: "sftp:u@h:/b"}
+}
+
+// TestCreateBackupDestinationDirect_CompensatesOnNonConflict is the load-bearing
+// guard for JAB-310 AC2: a transient (non-conflict) DB failure must remove the
+// just-written credential file. Before this slice the CLI compensated only on a
+// name-conflict, so this exact path leaked a root:root 0600 secrets file.
+func TestCreateBackupDestinationDirect_CompensatesOnNonConflict(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{createErr: errors.New("connection reset")}
+	d := newDest()
+
+	err := createBackupDestinationDirect(context.Background(), agent.call, repo, d, map[string]string{"SSHPASS": "s3cr3t"})
+	if err == nil {
+		t.Fatal("expected the create failure to propagate")
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("credential file was NOT cleaned up on a non-conflict failure (AC2 leak)")
+	}
+	if got := agent.params["backup.dest.creds_delete"]["dest_id"]; got != "dst-1" {
+		t.Fatalf("creds_delete dest_id = %v, want dst-1", got)
+	}
+}
+
+// TestCreateBackupDestinationDirect_CompensatesOnConflict pins that the fix keeps
+// the pre-existing conflict-branch cleanup — and that the wrapped error still
+// resolves to repository.ErrConflict so the RunE can pick its own message.
+func TestCreateBackupDestinationDirect_CompensatesOnConflict(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{createErr: repository.ErrConflict}
+	d := newDest()
+
+	err := createBackupDestinationDirect(context.Background(), agent.call, repo, d, map[string]string{"SSHPASS": "s3cr3t"})
+	if !errors.Is(err, repository.ErrConflict) {
+		t.Fatalf("want wrapped ErrConflict (so the RunE selects the name-in-use message), got %v", err)
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("conflict-branch cleanup was lost")
+	}
+}
+
+// TestCreateBackupDestinationDirect_NoEnvNoCredCalls: with no env credentials
+// there is no file to write or clean up, even when the persist fails. The
+// CredentialsRef gate must hold so we never delete what we never wrote.
+func TestCreateBackupDestinationDirect_NoEnvNoCredCalls(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{createErr: errors.New("boom")}
+	d := newDest()
+
+	if err := createBackupDestinationDirect(context.Background(), agent.call, repo, d, nil); err == nil {
+		t.Fatal("expected the create failure to propagate")
+	}
+	if agent.fired("backup.dest.creds_write") || agent.fired("backup.dest.creds_delete") {
+		t.Fatalf("no credential agent calls expected without env, got %v", agent.cmds)
+	}
+	if d.CredentialsRef != nil {
+		t.Fatalf("CredentialsRef must stay nil without env, got %q", *d.CredentialsRef)
+	}
+}
+
+// TestCreateBackupDestinationDirect_CredsWriteFailsBeforePersist: a failed
+// credential write returns before the row is persisted (nothing to roll back)
+// and never deletes.
+func TestCreateBackupDestinationDirect_CredsWriteFailsBeforePersist(t *testing.T) {
+	agent := &recordingAgent{failCmd: "backup.dest.creds_write", failErr: errors.New("agent down")}
+	repo := &fakeBackupDestRepo{}
+	d := newDest()
+
+	err := createBackupDestinationDirect(context.Background(), agent.call, repo, d, map[string]string{"SSHPASS": "s3cr3t"})
+	if err == nil || !strings.Contains(err.Error(), "write credentials") {
+		t.Fatalf("want a write-credentials error, got %v", err)
+	}
+	if repo.createCalled != 0 {
+		t.Fatalf("row must NOT be persisted after a creds_write failure, Create called %d", repo.createCalled)
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatal("nothing was written, so nothing must be deleted")
+	}
+}
+
+// TestBackupDestinationCreate_RoutesThroughCore source-pins that the RunE hands
+// the production agent caller to the core, rather than hand-rolling the
+// write/persist/compensate sequence inline again (the only thing guarding the
+// AC2 wiring, since the RunE itself is not unit-testable).
+func TestBackupDestinationCreate_RoutesThroughCore(t *testing.T) {
+	// The positive routing pin is the load-bearing one: it guarantees the create
+	// RunE hands the production agent caller to the core (where the AC2
+	// compensation lives). A whole-file negative on the creds_write/creds_delete
+	// literals would over-reach — the update and delete commands in the same file
+	// legitimately call those verbs inline (JAB-339 scar: don't pin a literal a
+	// sibling handler shares).
+	src := readOpsSource(t, "backup_destination_cmd.go")
+	if !strings.Contains(src, "createBackupDestinationDirect(ctx, sharedAgent.Call,") {
+		t.Error("create RunE must route through createBackupDestinationDirect with the production agent caller")
+	}
+}
+
+func readOpsSource(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## What

`jabali destination create` writes a backup destination's restic credential file (SSHPASS / cloud keys, `root:root` `0600`) through the agent before it persists the row. When the persist failed, it removed that file **only** on a name-conflict — every other failure (a transient DB error, a dropped connection) returned early and left the credential file orphaned on the box.

This routes the create command through a new testable core, `createBackupDestinationDirect`, which removes the credential file on **any** persist failure.

## Why

The REST handler already compensates on every create failure — `internal/api/backup_destinations.go` deletes the file before it branches on the error type. The CLI did not, so the two adapters had drifted: an operator hitting a transient failure from the CLI silently leaked a live secrets file.

The CLI core goes one step further than REST and **surfaces a failed cleanup on stderr**, where the REST path swallows that error (`deleteCreds` discards its result). Making the REST handler equally loud on a leaked-file cleanup is Module-level follow-up, not this slice.

## How

- Extract the credential-write / persist / compensate sequence into `createBackupDestinationDirect` (`cmd/server/backup_destination_ops.go`) with an injected `agentCaller` and repository, so it is unit-testable.
- Compensate on **every** persist failure via the existing `backup.dest.creds_delete` agent verb, gated on `CredentialsRef != nil` so we never delete what we never wrote.
- The returned error preserves the wrapped cause (`%w`), so the RunE still selects the existing `destination name %q already exists` message for a conflict. Both CLI error strings are unchanged byte-for-byte.

## Tests

A testable-core matrix in `backup_destination_ops_test.go`:
- a non-conflict persist failure removes the credential file (the leak this fixes);
- a conflict failure still cleans up and the wrapped error resolves to `ErrConflict`;
- no env means no credential agent calls at all, and `CredentialsRef` stays nil;
- a failed credential write returns before the row is persisted and deletes nothing;
- a source-pin that the create command routes through the core with the production agent caller.

The three behavioral guards were falsified by neutralizing each in turn (conflict-gating the cleanup, dropping the creds-write early return, and removing the env gate), confirming the matching test went red, and reverting. The conflict-regression and routing pins are green pins. `go build` / `vet` / `gofmt` clean; `go test -race` green on `cmd/server`.

## Scope

This is the create-compensation slice (**AC2**) of the Backup Destination Lifecycle module (JAB-310). AC1 (shared unsafe-SFTP-character validator) already shipped in PR #1303. The update path has the same write-then-persist shape but a different failure class (a stale file behind a live row, not an orphan), the local-vs-agent credential-path computation (AC5), and the swallowed REST-side cleanup all remain — so the **module parent stays Backlog**.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
