### PR TITLE
refactor(sshkeys): route account-restore SSH keys through an explicit restore operation (JAB-292)

### DIFF
--- a/panel-api/internal/backupmetadata/apply.go
+++ b/panel-api/internal/backupmetadata/apply.go
@@ -26,6 +26,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeyops"
 )
 
 // ApplyResult counts what landed during a single Apply call.
@@ -446,8 +447,14 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 		}
 	}
 
-	// 6) SSH keys.
+	// 6) SSH keys. Persist through the shared restore operation (JAB-292 AC4) so
+	// this is no longer a direct ssh_keys writer and per-owner authorized_keys
+	// convergence has one coalescing point. Backup restore follows the
+	// reconciler-tick convergence model the rest of restored state uses (see
+	// applyRestoreMetadata), so the batch carries no Scheduler — restored keys
+	// re-converge on the next tick, not immediately.
 	if d.SSHKeys != nil {
+		batch := sshkeyops.NewRestoreBatch(sshkeyops.Deps{Keys: d.SSHKeys})
 		for _, k := range m.SSHKeys {
 			row := &models.SSHKey{
 				ID:          k.ID,
@@ -457,8 +464,8 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 				Fingerprint: k.Fingerprint,
 				CreatedAt:   now,
 			}
-			if err := d.SSHKeys.Create(ctx, row); err != nil {
-				if errors.Is(err, repository.ErrConflict) {
+			if err := batch.Restore(ctx, row); err != nil {
+				if errors.Is(err, sshkeyops.ErrDuplicate) {
 					r.Skipped++
 					continue
 				}
@@ -467,6 +474,7 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 			}
 			r.SSHKeys++
 		}
+		batch.Flush()
 	}
 
 	// 7) Cron jobs.

--- a/panel-api/internal/backupmetadata/apply_sshkeys_test.go
+++ b/panel-api/internal/backupmetadata/apply_sshkeys_test.go
@@ -1,0 +1,72 @@
+package backupmetadata
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// restoreSSHRepo fails a chosen key ID with a repository conflict (the shape a
+// duplicate key restore hits) and counts the rest as persisted.
+type restoreSSHRepo struct {
+	repository.SSHKeyRepository
+	conflictIDs map[string]bool
+	created     int
+}
+
+func (r *restoreSSHRepo) Create(_ context.Context, k *models.SSHKey) error {
+	if r.conflictIDs[k.ID] {
+		return repository.ErrConflict
+	}
+	r.created++
+	return nil
+}
+
+// The load-bearing behavioral guard for JAB-292 AC4 routing: a duplicate SSH key
+// during restore is a SKIP (already present), not a hard error, and it must not
+// stop the surrounding restore. A source-pin can't see this — it depends on the
+// conflict being recognized as sshkeyops.ErrDuplicate after the row is routed
+// through the shared RestoreBatch. Falsify by reverting apply.go's conflict test
+// to errors.Is(err, repository.ErrConflict): RestoreBatch returns ErrDuplicate
+// (not ErrConflict), so the duplicate lands in r.Errors and r.Skipped stays 0.
+func TestApply_SSHKeys_DuplicateSkipsAndContinues(t *testing.T) {
+	users := &createGuardUsersRepo{}
+	keys := &restoreSSHRepo{conflictIDs: map[string]bool{"k1": true}}
+	meta := &internalbackup.AccountMetadata{
+		User: internalbackup.MetadataUser{ID: "u1", Email: "u@example.com"},
+		SSHKeys: []internalbackup.MetadataSSHKey{
+			{ID: "k1", Name: "dup", PublicKey: "ssh-ed25519 AAAA1 dup", Fingerprint: "SHA256:aaa"},
+			{ID: "k2", Name: "ok", PublicKey: "ssh-ed25519 AAAA2 ok", Fingerprint: "SHA256:bbb"},
+		},
+	}
+
+	r := Apply(context.Background(), meta, Deps{Users: users, SSHKeys: keys})
+
+	require.Equal(t, 1, r.SSHKeys, "the non-duplicate key is persisted")
+	require.Equal(t, 1, r.Skipped, "the duplicate key is skipped, not counted as created")
+	require.Empty(t, r.Errors, "a duplicate SSH key during restore is not a hard error")
+	require.Equal(t, 1, keys.created, "exactly the non-duplicate row reached the repo")
+}
+
+// Source-pin: apply.go persists SSH keys through the shared restore operation and
+// no longer writes ssh_keys rows directly. The negative on d.SSHKeys.Create is
+// safe here — §6 was its only call site in apply.go (no sibling shares it), so it
+// catches a regression back to direct-write, the exact AC4 point.
+func TestApply_SSHKeys_RoutesThroughRestoreBatch(t *testing.T) {
+	src, err := os.ReadFile("apply.go")
+	require.NoError(t, err)
+	s := string(src)
+
+	require.Contains(t, s, "sshkeyops.NewRestoreBatch(",
+		"restore must route SSH keys through the shared RestoreBatch (JAB-292 AC4)")
+	require.Contains(t, s, "sshkeyops.ErrDuplicate",
+		"the duplicate branch must match the module's ErrDuplicate, not repository.ErrConflict")
+	require.NotContains(t, s, "d.SSHKeys.Create(",
+		"apply.go must not write ssh_keys rows directly any more")
+}

--- a/panel-api/internal/sshkeyops/sshkeyops.go
+++ b/panel-api/internal/sshkeyops/sshkeyops.go
@@ -15,10 +15,14 @@
 // reconciler's next ≤60s tick). Keeping scheduling behind the interface makes
 // it the single coalescing point a future restore-batch slice can reuse.
 //
-// Not yet routed through here: the restore paths that still write ssh_keys rows
-// directly (internal/backupmetadata/apply.go, internal/migrate/cpanel/
-// restore_sshkeys.go). JAB-292 stays a module-parent until those use an explicit
-// restore operation that batches scheduling per owner (AC4).
+// Restore paths use the explicit RestoreBatch operation (below): the HTTP/CLI
+// account restore (internal/backupmetadata/apply.go) is routed through it, so it
+// no longer writes ssh_keys rows directly. Still direct: the cPanel migration
+// importer (internal/migrate/cpanel/restore_sshkeys.go) — its duplicate
+// detection string-matches the raw driver error ("Duplicate entry"/"1062")
+// rather than repository.ErrConflict, so routing it through RestoreBatch (which
+// maps only ErrConflict) changes its cross-job conflict behavior and needs its
+// own pass. JAB-292 stays a module-parent until it too uses RestoreBatch (AC4).
 package sshkeyops
 
 import (
@@ -139,4 +143,57 @@ func (d Deps) schedule(userID string) {
 	if d.Scheduler != nil {
 		d.Scheduler.ScheduleUser(userID)
 	}
+}
+
+// RestoreBatch is the explicit restore operation (JAB-292 AC4): the single seam
+// a restore path uses to re-insert many SSH keys and then converge each affected
+// owner's authorized_keys exactly once.
+//
+// Unlike Add, Restore does NOT parse or re-fingerprint — it persists the row as
+// given, because a restore trusts its source (a backup manifest carries the
+// original ID + fingerprint; a migration importer has already parsed and
+// fingerprinted). Scheduling is coalesced: however many keys a single owner
+// gains, Flush schedules that owner once, and only if at least one of their rows
+// actually persisted (a batch of nothing-but-conflicts schedules nothing).
+//
+// A caller restoring under a live reconciler passes a real Scheduler for
+// immediate, batched convergence; a caller whose convergence is tick-based (the
+// backup account restore, which re-converges all restored state on the
+// reconciler's next tick) or which runs without a reconciler passes a nil
+// Scheduler and Flush is a no-op.
+type RestoreBatch struct {
+	d      Deps
+	owners map[string]struct{}
+}
+
+// NewRestoreBatch starts an empty batch bound to d. Deps.Scheduler may be nil
+// (tick-based / no reconciler), in which case Flush schedules nothing.
+func NewRestoreBatch(d Deps) *RestoreBatch {
+	return &RestoreBatch{d: d, owners: map[string]struct{}{}}
+}
+
+// Restore persists one already-built row. A repository conflict (the key already
+// exists for the owner) becomes ErrDuplicate so the caller records it as
+// already-present and keeps going; any other persistence error is returned
+// unwrapped. Only a successful persist marks the owner for convergence, so a
+// failed or duplicate row never schedules anything.
+func (b *RestoreBatch) Restore(ctx context.Context, row *models.SSHKey) error {
+	if err := b.d.Keys.Create(ctx, row); err != nil {
+		if errors.Is(err, repository.ErrConflict) {
+			return ErrDuplicate
+		}
+		return err
+	}
+	b.owners[row.UserID] = struct{}{}
+	return nil
+}
+
+// Flush schedules convergence exactly once for every owner that had at least one
+// row persisted since the last Flush, then clears the set. Idempotent: a second
+// Flush with no new successful Restore schedules nothing.
+func (b *RestoreBatch) Flush() {
+	for userID := range b.owners {
+		b.d.schedule(userID)
+	}
+	b.owners = map[string]struct{}{}
 }

--- a/panel-api/internal/sshkeyops/sshkeyops_test.go
+++ b/panel-api/internal/sshkeyops/sshkeyops_test.go
@@ -171,3 +171,122 @@ func TestRemoveKey_DeleteError_NoSchedule(t *testing.T) {
 	require.Error(t, err)
 	require.Empty(t, sched.users, "a failed delete schedules nothing")
 }
+
+// restoreFakeRepo records every persisted row and can fail a specific row ID
+// (with a conflict or an arbitrary error) — the batch tests need per-row
+// outcomes, which the single-error fakeKeyRepo above can't express.
+type restoreFakeRepo struct {
+	repository.SSHKeyRepository
+	conflict map[string]bool
+	fail     map[string]error
+	created  []*models.SSHKey
+}
+
+func (r *restoreFakeRepo) Create(_ context.Context, k *models.SSHKey) error {
+	if e := r.fail[k.ID]; e != nil {
+		return e
+	}
+	if r.conflict[k.ID] {
+		return repository.ErrConflict
+	}
+	r.created = append(r.created, k)
+	return nil
+}
+
+func row(id, owner string) *models.SSHKey { return &models.SSHKey{ID: id, UserID: owner} }
+
+// The load-bearing batch guard: many keys across owners converge each owner
+// exactly once, regardless of how many keys that owner gained.
+func TestRestoreBatch_SchedulesEachOwnerOnce(t *testing.T) {
+	repo := &restoreFakeRepo{}
+	sched := &fakeSched{}
+	b := NewRestoreBatch(Deps{Keys: repo, Scheduler: sched})
+
+	for _, r := range []*models.SSHKey{row("k1", "alice"), row("k2", "alice"), row("k3", "bob")} {
+		require.NoError(t, b.Restore(context.Background(), r))
+	}
+	b.Flush()
+
+	require.Len(t, repo.created, 3, "every row persisted")
+	require.ElementsMatch(t, []string{"alice", "bob"}, sched.users,
+		"each affected owner scheduled exactly once, never per-key")
+}
+
+// A batch that only ever hits conflicts for an owner schedules nothing for that
+// owner (AC2: no successful mutation → no convergence).
+func TestRestoreBatch_AllConflictsForOwner_NotScheduled(t *testing.T) {
+	repo := &restoreFakeRepo{conflict: map[string]bool{"k1": true}}
+	sched := &fakeSched{}
+	b := NewRestoreBatch(Deps{Keys: repo, Scheduler: sched})
+
+	err := b.Restore(context.Background(), row("k1", "alice"))
+	require.ErrorIs(t, err, ErrDuplicate, "a repository conflict maps to ErrDuplicate for the caller")
+	b.Flush()
+
+	require.Empty(t, sched.users, "an owner with only conflicts is never scheduled")
+}
+
+// One success alongside a conflict for the same owner still schedules once.
+func TestRestoreBatch_MixedSuccessAndConflict_SchedulesOnce(t *testing.T) {
+	repo := &restoreFakeRepo{conflict: map[string]bool{"k2": true}}
+	sched := &fakeSched{}
+	b := NewRestoreBatch(Deps{Keys: repo, Scheduler: sched})
+
+	require.NoError(t, b.Restore(context.Background(), row("k1", "alice")))
+	require.ErrorIs(t, b.Restore(context.Background(), row("k2", "alice")), ErrDuplicate)
+	b.Flush()
+
+	require.Equal(t, []string{"alice"}, sched.users, "one persisted row is enough, and only once")
+}
+
+// A non-conflict persistence error is returned unwrapped (not ErrDuplicate) and
+// the owner is not scheduled.
+func TestRestoreBatch_NonConflictError_Unwrapped_NotScheduled(t *testing.T) {
+	repo := &restoreFakeRepo{fail: map[string]error{"k1": errors.New("db down")}}
+	sched := &fakeSched{}
+	b := NewRestoreBatch(Deps{Keys: repo, Scheduler: sched})
+
+	err := b.Restore(context.Background(), row("k1", "alice"))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrDuplicate, "a non-conflict store error is not a duplicate")
+	require.Contains(t, err.Error(), "db down")
+	b.Flush()
+	require.Empty(t, sched.users, "a failed persist schedules nothing")
+}
+
+// Restore persists the row as given — it does NOT re-parse or re-fingerprint
+// (the "restore != Add" distinction): a restore trusts the manifest/importer's
+// fingerprint, even one Add's parser would never produce.
+func TestRestoreBatch_PersistsRowAsGiven_NoRefingerprint(t *testing.T) {
+	repo := &restoreFakeRepo{}
+	b := NewRestoreBatch(Deps{Keys: repo})
+
+	in := &models.SSHKey{ID: "k1", UserID: "alice", PublicKey: "ssh-ed25519 AAAAopaque", Fingerprint: "SHA256:from-manifest"}
+	require.NoError(t, b.Restore(context.Background(), in))
+
+	require.Len(t, repo.created, 1)
+	require.Equal(t, "SHA256:from-manifest", repo.created[0].Fingerprint, "fingerprint stored verbatim, not recomputed")
+	require.Equal(t, "ssh-ed25519 AAAAopaque", repo.created[0].PublicKey, "public key stored verbatim")
+}
+
+// Flush is idempotent: a second Flush with no new successful Restore schedules
+// nothing more (the owner set resets after the first drain).
+func TestRestoreBatch_Flush_Idempotent(t *testing.T) {
+	repo := &restoreFakeRepo{}
+	sched := &fakeSched{}
+	b := NewRestoreBatch(Deps{Keys: repo, Scheduler: sched})
+
+	require.NoError(t, b.Restore(context.Background(), row("k1", "alice")))
+	b.Flush()
+	b.Flush()
+
+	require.Equal(t, []string{"alice"}, sched.users, "the second Flush drains an empty set")
+}
+
+// A nil Scheduler (tick-based restore / no reconciler) must not panic.
+func TestRestoreBatch_NilScheduler_NoPanic(t *testing.T) {
+	repo := &restoreFakeRepo{}
+	b := NewRestoreBatch(Deps{Keys: repo})
+	require.NoError(t, b.Restore(context.Background(), row("k1", "alice")))
+	require.NotPanics(t, b.Flush)
+}


### PR DESCRIPTION
## What

Account restore (`internal/backupmetadata/apply.go`) wrote `ssh_keys` rows directly, bypassing the `sshkeyops` lifecycle that REST and the operator CLI already share. That left the restore path as the last place SSH-key persistence and per-owner `authorized_keys` convergence weren't expressed in one implementation (JAB-292 AC4).

This adds `sshkeyops.RestoreBatch` — an explicit restore operation — and routes `apply.go`'s SSH-key section through it.

## Why

`RestoreBatch` persists a batch of already-built rows and **coalesces convergence**: however many keys a single owner gains, its `authorized_keys` is scheduled at most once, and only if at least one of its rows actually persisted. Unlike `sshkeyops.Add`, `Restore` does **not** parse or re-fingerprint — a restore trusts its source (a backup manifest carries the original id + fingerprint), so the row is stored as given.

## Not a convergence change — structural only

Backup account restore deliberately re-converges all restored state on the reconciler's next tick (see `applyRestoreMetadata`: *"the same convergence model the rest of restored state follows"*), and the restore handler holds no reconciler. So the batch here carries a **nil `Scheduler`** and `Flush` is a no-op — restored SSH keys re-converge on the next tick exactly as before. What changes is that persistence now flows through the module, and the batching seam exists for any future caller that runs under a live reconciler. Nothing here claims "converges immediately."

## Scope

Closes AC4 for the **account-restore path only**. The cPanel migration importer (`internal/migrate/cpanel/restore_sshkeys.go`) still writes rows directly: its duplicate detection string-matches the **raw driver error** (`"Duplicate entry"` / `"1062"`) rather than `repository.ErrConflict`, so routing it through `RestoreBatch` (which maps only `ErrConflict` → `ErrDuplicate`) changes its cross-job conflict behavior and deserves its own behavioral pass. **JAB-292 stays a module-parent** until that importer is routed too.

## Tests

Leaf matrix on `RestoreBatch`: each owner scheduled exactly once across many keys; an owner with only conflicts (or a failed persist) is scheduled nothing; a repository conflict surfaces as `ErrDuplicate` while any other error is returned unwrapped; the row is stored with its given fingerprint (no re-parse); `Flush` is idempotent; a nil `Scheduler` does not panic. Plus a behavioral guard at the apply level — a duplicate SSH key during restore is **skipped and the restore continues**, not a hard error — and a source-pin that `apply.go` routes through `RestoreBatch` and no longer calls `SSHKeys.Create` directly.

The three behavioral guards were falsified by neutralizing each in turn (dropping the per-owner coalescing, marking an owner on a conflict, and reverting `apply.go`'s duplicate check to `repository.ErrConflict`), confirming the matching test went red, and reverting. The source-pin is a green pin. `go build ./...` / `vet` / `gofmt` clean; `go test -race` green on `internal/sshkeyops` and `internal/backupmetadata`.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
