### PR TITLE
fix(migrate): route cPanel SSH-key import through the shared lifecycle leaf (JAB-292)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_sshkeys.go
+++ b/panel-api/internal/migrate/cpanel/restore_sshkeys.go
@@ -3,6 +3,7 @@ package cpanel
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeyops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sshkeys"
 )
 
@@ -32,10 +34,15 @@ type SSHKeyImportResult struct {
 // keep the first occurrence per fingerprint and record the rest
 // as 'duplicate' in Skipped.
 //
-// Cross-job dedup (same key already in jabali ssh_keys table)
-// is the SSHKeyRepository's existing UNIQUE-by-fingerprint
-// guarantee — Create returns ErrConflict and we record it as
-// 'already_present'.
+// Cross-job dedup (same key already in jabali ssh_keys table) is
+// the SSHKeyRepository's existing UNIQUE-by-fingerprint guarantee.
+// Persistence runs through the shared sshkeyops.RestoreBatch (the
+// same lifecycle leaf REST and account restore use), so a conflict
+// surfaces as sshkeyops.ErrDuplicate and we record it as
+// 'already_present'. The batch carries a nil Scheduler because a
+// migration runs without a reconciler; per-owner authorized_keys
+// converge on the reconciler's next tick, as the rest of restored
+// state does.
 //
 // targetUserID must be the destination jabali user the restore
 // stage created moments earlier. ID is the FK target.
@@ -52,6 +59,13 @@ func ImportSSHKeys(ctx context.Context, repo repository.SSHKeyRepository, parsed
 
 	res := &SSHKeyImportResult{}
 	seen := map[string]struct{}{}
+
+	// Route persistence through the shared lifecycle leaf. A migration has no
+	// running reconciler, so the batch takes a nil Scheduler and Flush is a
+	// no-op; restored keys converge on the next reconciler tick. Deferred so an
+	// owner whose rows already persisted is still flushed if a later row aborts.
+	batch := sshkeyops.NewRestoreBatch(sshkeyops.Deps{Keys: repo})
+	defer batch.Flush()
 
 	for _, akPath := range parsed.SSHAuthorized {
 		f, err := os.Open(akPath)
@@ -101,8 +115,8 @@ func ImportSSHKeys(ctx context.Context, repo repository.SSHKeyRepository, parsed
 				Fingerprint: fp,
 				CreatedAt:   time.Now().UTC(),
 			}
-			if err := repo.Create(ctx, row); err != nil {
-				if isConflict(err) {
+			if err := batch.Restore(ctx, row); err != nil {
+				if errors.Is(err, sshkeyops.ErrDuplicate) {
 					res.Skipped = append(res.Skipped, fmt.Sprintf("%s:%d already_present (fp=%s)", akPath, lineNum, fp))
 					continue
 				}
@@ -132,17 +146,6 @@ func keyNameFromComment(normalized string) string {
 		return strings.TrimSpace(parts[2])
 	}
 	return "imported-key"
-}
-
-// isConflict matches MariaDB duplicate-key errors. Repos return
-// raw GORM errors; the wrapped UNIQUE-violation message contains
-// the "Duplicate entry" / "1062" tokens.
-func isConflict(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "Duplicate entry") || strings.Contains(s, "1062")
 }
 
 // ctxIsLive returns false when the caller's context is cancelled.

--- a/panel-api/internal/migrate/cpanel/restore_sshkeys_batch_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_sshkeys_batch_test.go
@@ -1,0 +1,135 @@
+package cpanel
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Three real, distinct ed25519 keys so ParseAndFingerprint succeeds and the
+// within-file fingerprint dedup keeps all three (distinct fp -> distinct rows,
+// each reaching the repository).
+const (
+	batchKey1 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP3RoqVsYV0MGQ0fy/pveTZyDL/MQbeicZUoHVwe8iO4 k1@test"
+	batchKey2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE6F4ploenKuyOSGo+yh/b0i+2Y/ZPx+tf1xerS0Hu7X k2@test"
+	batchKey3 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDP0pPcj4UCNFN1VkK4vFGNiisMmabnfoknVwPNhNswR k3@test"
+)
+
+// injectSSHRepo is a SSHKeyRepository that fails a chosen Create call. errOn maps
+// a 1-based Create call index to the error that call returns; a call not in the
+// map succeeds and its row is recorded. It embeds the interface so only Create
+// needs an implementation.
+type injectSSHRepo struct {
+	repository.SSHKeyRepository
+	errOn   map[int]error
+	created []*models.SSHKey
+	n       int
+}
+
+func (f *injectSSHRepo) Create(_ context.Context, k *models.SSHKey) error {
+	f.n++
+	if err := f.errOn[f.n]; err != nil {
+		return err
+	}
+	f.created = append(f.created, k)
+	return nil
+}
+
+func writeAuthKeys(t *testing.T, lines ...string) *ParsedTarball {
+	t.Helper()
+	dir := t.TempDir()
+	ak := filepath.Join(dir, "authorized_keys")
+	if err := os.WriteFile(ak, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &ParsedTarball{SSHAuthorized: []string{ak}}
+}
+
+// The load-bearing guard for this slice. A key already present in the ssh_keys
+// table (repository.ErrConflict) must be recorded as already_present and the
+// import must KEEP GOING — it is not a hard error. This is the pre-existing bug
+// the old isConflict() carried: it string-matched the raw driver message, but
+// the repository already translates 1062 to the bare repository.ErrConflict
+// sentinel, so the conflict went unrecognized and aborted the whole import.
+//
+// Falsify: replace the errors.Is(err, sshkeyops.ErrDuplicate) check in
+// ImportSSHKeys with the old inline string match
+// (strings.Contains(err.Error(),"Duplicate entry")||strings.Contains(err.Error(),"1062")).
+// ErrDuplicate's message matches neither, so the conflict aborts and this test
+// goes red (err != nil, Created == 1).
+func TestImportSSHKeys_ConflictSkipsAndContinues(t *testing.T) {
+	repo := &injectSSHRepo{errOn: map[int]error{2: repository.ErrConflict}}
+	parsed := writeAuthKeys(t, batchKey1, batchKey2, batchKey3)
+
+	res, err := ImportSSHKeys(context.Background(), repo, parsed, "01USERULID0000000000000000", true)
+	if err != nil {
+		t.Fatalf("ImportSSHKeys returned error, want nil: %v", err)
+	}
+	if res.Created != 2 {
+		t.Fatalf("Created = %d, want 2 (conflict skipped, others imported)", res.Created)
+	}
+	if len(repo.created) != 2 {
+		t.Fatalf("persisted rows = %d, want 2", len(repo.created))
+	}
+	var present int
+	for _, s := range res.Skipped {
+		if strings.Contains(s, "already_present") {
+			present++
+		}
+	}
+	if present != 1 {
+		t.Fatalf("already_present skips = %d, want 1 (skipped=%v)", present, res.Skipped)
+	}
+}
+
+// A non-conflict persistence error still aborts the import mid-run and returns a
+// wrapped error with the partial result — cPanel's chosen semantic, distinct
+// from account restore's continue-on-error. Pin it so routing through the batch
+// did not silently soften it.
+//
+// Falsify: change the abort `return res, fmt.Errorf(...)` in ImportSSHKeys to
+// `continue` and this goes red (err == nil, Created == 2).
+func TestImportSSHKeys_NonConflictErrorAborts(t *testing.T) {
+	boom := errors.New("db exploded")
+	repo := &injectSSHRepo{errOn: map[int]error{2: boom}}
+	parsed := writeAuthKeys(t, batchKey1, batchKey2, batchKey3)
+
+	res, err := ImportSSHKeys(context.Background(), repo, parsed, "01USERULID0000000000000000", true)
+	if err == nil {
+		t.Fatal("ImportSSHKeys returned nil error, want abort")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("error does not wrap the underlying failure: %v", err)
+	}
+	if res.Created != 1 {
+		t.Fatalf("Created = %d, want 1 (aborted after first row)", res.Created)
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("persisted rows = %d, want 1", len(repo.created))
+	}
+}
+
+// Source-pin: ImportSSHKeys persists through the shared lifecycle leaf and no
+// longer carries its own duplicate-detection helper. Green pin. The negative
+// assertion is file-scoped (isConflict was unexported with a single call site).
+func TestImportSSHKeys_RoutesThroughRestoreBatch(t *testing.T) {
+	src, err := os.ReadFile("restore_sshkeys.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(src)
+	for _, want := range []string{"sshkeyops.NewRestoreBatch(", "sshkeyops.ErrDuplicate"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("restore_sshkeys.go no longer contains %q — routing regressed", want)
+		}
+	}
+	if strings.Contains(s, "func isConflict") {
+		t.Error("restore_sshkeys.go still defines isConflict — the raw-driver string match should be gone")
+	}
+}

--- a/panel-api/internal/sshkeyops/sshkeyops.go
+++ b/panel-api/internal/sshkeyops/sshkeyops.go
@@ -15,14 +15,11 @@
 // reconciler's next ≤60s tick). Keeping scheduling behind the interface makes
 // it the single coalescing point a future restore-batch slice can reuse.
 //
-// Restore paths use the explicit RestoreBatch operation (below): the HTTP/CLI
-// account restore (internal/backupmetadata/apply.go) is routed through it, so it
-// no longer writes ssh_keys rows directly. Still direct: the cPanel migration
-// importer (internal/migrate/cpanel/restore_sshkeys.go) — its duplicate
-// detection string-matches the raw driver error ("Duplicate entry"/"1062")
-// rather than repository.ErrConflict, so routing it through RestoreBatch (which
-// maps only ErrConflict) changes its cross-job conflict behavior and needs its
-// own pass. JAB-292 stays a module-parent until it too uses RestoreBatch (AC4).
+// Restore paths use the explicit RestoreBatch operation (below): both the
+// HTTP/CLI account restore (internal/backupmetadata/apply.go) and the cPanel
+// migration importer (internal/migrate/cpanel/restore_sshkeys.go) route through
+// it, so no path writes ssh_keys rows directly anymore. That closes the last
+// bypass of the lifecycle for JAB-292 AC4.
 package sshkeyops
 
 import (


### PR DESCRIPTION
## What

The cPanel migration importer (`internal/migrate/cpanel/restore_sshkeys.go`) was
the last path that wrote `ssh_keys` rows directly, bypassing the `sshkeyops`
lifecycle that REST, the operator CLI, and account restore already share. This
routes it through `sshkeyops.RestoreBatch`, closing JAB-292 AC4.

## Also fixes a latent bug

The importer carried its own `isConflict` helper whose comment assumed *"Repos
return raw GORM errors"* and string-matched the driver's `"Duplicate entry"` /
`"1062"` tokens. But `SSHKeyRepository.Create` runs `translateSSHKey`, which maps
a 1062 duplicate to the **bare** `repository.ErrConflict` sentinel — `.Error()`
is `"repository: conflict"`, which contains neither token. So `isConflict` never
recognized a cross-job duplicate: under `--preserve-source-state`, a single key
already present in the `ssh_keys` table returned an unrecognized error and
**aborted the entire SSH import** for that user.

Routing through `RestoreBatch` surfaces the conflict as `sshkeyops.ErrDuplicate`,
which the importer records as `already_present` and then keeps going.

## Structural, not a convergence change

A migration runs without a reconciler, so the batch takes a **nil `Scheduler`**
and `Flush` is a no-op; restored keys converge on the reconciler's next tick, the
same model the rest of restored state follows. Nothing converges immediately. The
mid-run hard-error abort for any non-conflict failure is preserved — that is
cPanel's chosen semantic, distinct from account restore's continue-on-error.
`isConflict` is deleted (its sole caller is gone).

## Tests

Package `cpanel`: a duplicate key mid-import is skipped as `already_present` and
the import continues (`Created` counts the rest); a non-conflict persistence error
still aborts mid-run with a wrapped error and the partial result. Both behavioral
guards were falsified by neutralizing each in turn — breaking the `ErrDuplicate`
recognition made the duplicate abort the import (reproducing the pre-existing
bug), and turning the abort into a `continue` let the hard error pass — each went
red, then reverted. A source-pin that the importer routes through
`NewRestoreBatch` and no longer defines `isConflict` is a green pin. The existing
JAB-53 quarantine guard (source keys inert without opt-in) runs unchanged.

`go build ./...` / `vet` / `gofmt` clean; `go test -race` green on
`internal/migrate/cpanel` and `internal/sshkeyops`.

## Scope

This is the last direct `ssh_keys` writer, so JAB-292 AC4 is now fully met and all
five ACs are covered — the parent becomes a Done-candidate once this merges. The
cloudpanel and directadmin migration adapters reuse `cpanel.ImportSSHKeys`
unchanged, so they pick up the fix for free.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
