### PR TITLE
fix(backups): route the operator-CLI schedule update through the lifecycle leaf (JAB-307)

### DIFF
--- a/panel-api/cmd/server/backup_schedule_cmd.go
+++ b/panel-api/cmd/server/backup_schedule_cmd.go
@@ -257,15 +257,7 @@ func newBackupScheduleUpdateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
-			repo := backupScheduleRepoFromDB()
-			s, err := repo.Get(ctx, args[0])
-			if err != nil {
-				if errors.Is(err, repository.ErrNotFound) {
-					return fmt.Errorf("schedule %q not found", args[0])
-				}
-				return fmt.Errorf("get: %w", err)
-			}
-			changed := false
+
 			if preset != "" {
 				p, ok := internalbackup.PresetCronExpr[preset]
 				if !ok {
@@ -273,75 +265,82 @@ func newBackupScheduleUpdateCmd() *cobra.Command {
 				}
 				cronExpr = p
 			}
+
+			in := backupscheduleops.UpdateInput{ID: args[0]}
 			if cronExpr != "" {
-				next, err := internalbackup.NextFire(cronExpr, time.Now().UTC())
-				if err != nil {
-					return err
-				}
-				s.CronExpr = cronExpr
-				s.NextRunAt = &next
-				changed = true
+				in.CronExpr = &cronExpr
 			}
 			if enable {
-				s.Enabled = true
-				changed = true
+				v := true
+				in.Enabled = &v
 			}
 			if disable {
-				s.Enabled = false
-				changed = true
+				v := false
+				in.Enabled = &v
 			}
-			if includeSystem == "true" {
-				s.IncludeSystemBackup = true
-				changed = true
-			} else if includeSystem == "false" {
-				s.IncludeSystemBackup = false
-				changed = true
+			switch includeSystem {
+			case "true":
+				v := true
+				in.IncludeSystemBackup = &v
+			case "false":
+				v := false
+				in.IncludeSystemBackup = &v
+			case "":
+			default:
+				return fmt.Errorf("invalid --include-system %q (want true or false)", includeSystem)
 			}
 			if cmd.Flags().Changed("keep-daily") {
-				s.KeepDaily = &keepDaily
-				changed = true
+				in.KeepDaily = &keepDaily
 			}
 			if cmd.Flags().Changed("keep-weekly") {
-				s.KeepWeekly = &keepWeekly
-				changed = true
+				in.KeepWeekly = &keepWeekly
 			}
 			if cmd.Flags().Changed("keep-monthly") {
-				s.KeepMonthly = &keepMonthly
-				changed = true
-			}
-			if changed {
-				if err := repo.Update(ctx, s); err != nil {
-					return fmt.Errorf("update schedule: %w", err)
-				}
+				in.KeepMonthly = &keepMonthly
 			}
 			if clearDests {
-				if err := repo.ReplaceDestinations(ctx, s.ID, nil); err != nil {
-					return fmt.Errorf("clear destinations: %w", err)
-				}
+				in.DestinationIDs = &[]string{}
 			} else if len(destinations) > 0 {
 				dstIDs, err := resolveDestinationIDs(ctx, destinations)
 				if err != nil {
 					return err
 				}
-				if err := repo.ReplaceDestinations(ctx, s.ID, dstIDs); err != nil {
-					return fmt.Errorf("link destinations: %w", err)
-				}
+				in.DestinationIDs = &dstIDs
 			}
 			if clearUsers {
-				if err := repo.ReplaceUsers(ctx, s.ID, nil); err != nil {
-					return fmt.Errorf("clear users: %w", err)
-				}
+				in.UserIDs = &[]string{}
 			} else if len(users) > 0 {
 				uIDs, err := resolveUserIDs(ctx, users)
 				if err != nil {
 					return err
 				}
-				if err := repo.ReplaceUsers(ctx, s.ID, uIDs); err != nil {
-					return fmt.Errorf("link users: %w", err)
-				}
+				in.UserIDs = &uIDs
 			}
-			if !changed && !clearDests && !clearUsers && len(destinations) == 0 && len(users) == 0 {
+
+			if in.CronExpr == nil && in.Enabled == nil && in.IncludeSystemBackup == nil &&
+				in.KeepDaily == nil && in.KeepWeekly == nil && in.KeepMonthly == nil &&
+				in.DestinationIDs == nil && in.UserIDs == nil {
 				return fmt.Errorf("no changes specified")
+			}
+
+			s, err := backupscheduleops.Update(ctx, backupscheduleops.Deps{
+				Schedules: backupScheduleRepoFromDB(),
+				Users:     repository.NewUserRepository(sharedDB),
+			}, in)
+			if err != nil {
+				var ure *backupscheduleops.UserRejectedError
+				switch {
+				case errors.Is(err, repository.ErrNotFound):
+					return fmt.Errorf("schedule %q not found", args[0])
+				case errors.As(err, &ure) && errors.Is(err, backupscheduleops.ErrAdminUser):
+					return fmt.Errorf("user %s is an admin account and cannot be a backup-schedule target", ure.UserID)
+				case errors.As(err, &ure):
+					return fmt.Errorf("user %s not found", ure.UserID)
+				case errors.Is(err, backupscheduleops.ErrInvalidCron):
+					return err
+				default:
+					return fmt.Errorf("update schedule: %w", err)
+				}
 			}
 			if jsonOutput {
 				return printJSON(s)

--- a/panel-api/cmd/server/backup_schedule_cmd_source_test.go
+++ b/panel-api/cmd/server/backup_schedule_cmd_source_test.go
@@ -32,3 +32,28 @@ func TestBackupScheduleCLICreate_RoutesThroughLifecycle(t *testing.T) {
 	require.NotContains(t, body, "repo.ReplaceDestinations(",
 		"CLI create must not link destinations directly (non-atomic)")
 }
+
+// The operator CLI backup-schedule update must likewise delegate to the shared
+// lifecycle leaf (JAB-307) — this is the path that previously skipped the
+// admin-target rejection entirely and wrote the row + memberships in three
+// separate statements. A regression back to that reddens this.
+func TestBackupScheduleCLIUpdate_RoutesThroughLifecycle(t *testing.T) {
+	src, err := os.ReadFile("backup_schedule_cmd.go")
+	require.NoError(t, err)
+	s := string(src)
+	start := strings.Index(s, "func newBackupScheduleUpdateCmd(")
+	require.Greater(t, start, 0)
+	rest := s[start:]
+	end := strings.Index(rest, "\nfunc newBackupScheduleDeleteCmd(")
+	require.Greater(t, end, 0, "next command func not found")
+	body := rest[:end]
+
+	require.Contains(t, body, "backupscheduleops.Update(",
+		"CLI update must delegate to the shared lifecycle leaf")
+	require.NotContains(t, body, "repo.Update(",
+		"CLI update must not write the row directly (skips admin-target rejection, non-atomic)")
+	require.NotContains(t, body, "repo.ReplaceUsers(",
+		"CLI update must not link users directly")
+	require.NotContains(t, body, "repo.ReplaceDestinations(",
+		"CLI update must not link destinations directly")
+}

--- a/panel-api/internal/backupscheduleops/backupscheduleops.go
+++ b/panel-api/internal/backupscheduleops/backupscheduleops.go
@@ -1,9 +1,10 @@
 // Package backupscheduleops is the transport-neutral Backup Schedule Lifecycle
-// leaf (ADR-0083 <area>ops). It owns the create-side policy that the admin
-// REST handler, the operator CLI, and (future) the tenant path must all apply
-// identically: kind defaulting/validation, admin-user rejection, system-kind
-// normalization, cron validation before any write, and a single transactional
-// commit of the schedule row together with its destination and user links.
+// leaf (ADR-0083 <area>ops). It owns the create- and update-side policy that
+// the admin REST handler, the operator CLI, and (future) the tenant path must
+// all apply identically: kind defaulting/validation, admin-user rejection,
+// system-kind normalization, cron validation before any write, and a single
+// transactional commit of the schedule row together with its destination and
+// user links.
 //
 // Adapters keep what is genuinely theirs: id resolution (CLI resolves
 // --user email|username and --destination name into ids; the legacy REST
@@ -11,8 +12,12 @@
 // shaping. The leaf receives already-resolved ids and returns the persisted
 // row or a typed error the adapter maps to its own status codes.
 //
-// Scope (JAB-307): create only. update / run-now / the tenant variant remain
-// adapter-local for follow-up slices; the parent stays open.
+// Scope (JAB-307): create, plus the operator-CLI update path (which previously
+// skipped the admin-target rejection entirely and wrote the row and its
+// memberships in three separate statements). The admin REST update still
+// applies this same policy inline; routing it onto Update to drop that
+// duplication is the next slice. run-now and the tenant variant remain
+// adapter-local. The parent stays open.
 package backupscheduleops
 
 import (
@@ -56,10 +61,16 @@ type UserFinder interface {
 	FindByID(ctx context.Context, id string) (*models.User, error)
 }
 
-// scheduleWriter is the one repository method the create path needs: the row
-// and both membership sets committed in a single transaction.
+// scheduleWriter is the repository surface the lifecycle needs. Create commits
+// the row and both membership sets in one transaction; Get loads the existing
+// row so Update can validate a patch against the stored (immutable) kind; and
+// UpdateWithMemberships commits the field changes together with any membership
+// replacement in one transaction, so a partial update can't leave the row's
+// membership silently diverged from what was asked.
 type scheduleWriter interface {
 	CreateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs []string) error
+	Get(ctx context.Context, id string) (*models.BackupSchedule, error)
+	UpdateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs *[]string) error
 }
 
 // Deps are the leaf's collaborators, injected by the adapter.
@@ -142,6 +153,94 @@ func Create(ctx context.Context, d Deps, in CreateInput) (*models.BackupSchedule
 		return nil, err
 	}
 	s.UserIDs = userIDs
+	return s, nil
+}
+
+// UpdateInput is a resolved, transport-neutral partial update. Every scalar is
+// a pointer: nil leaves that field unchanged, non-nil sets it. DestinationIDs
+// and UserIDs are likewise nil = leave the membership untouched, non-nil =
+// replace it (an empty account UserIDs fans out to every non-admin at tick
+// time, exactly as in Create). Ids are already resolved by the adapter. Kind is
+// deliberately absent: a schedule's kind is immutable, so the patch is always
+// validated against the stored kind.
+type UpdateInput struct {
+	ID                  string
+	CronExpr            *string
+	Enabled             *bool
+	IncludeSystemBackup *bool
+	KeepDaily           *int
+	KeepWeekly          *int
+	KeepMonthly         *int
+	DestinationIDs      *[]string
+	UserIDs             *[]string
+}
+
+// Update applies a partial change to an existing schedule and persists the row
+// and any membership replacement in one transaction. It enforces the SAME
+// policy as Create against the stored, immutable kind: on an account schedule
+// every explicit target user must exist and must not be an admin, and an
+// invalid cron aborts — each with ZERO writes; a system schedule keeps no
+// per-user membership and no include-system flag, so those patch fields are
+// ignored for it. This is the guard the operator CLI's hand-rolled update path
+// lacked: it wrote arbitrary --user ids straight through, so an admin account
+// could be attached to a schedule the create path would have refused.
+func Update(ctx context.Context, d Deps, in UpdateInput) (*models.BackupSchedule, error) {
+	s, err := d.Schedules.Get(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the user set to persist. Only account schedules carry per-user
+	// membership; for those, validate every target before any write. A system
+	// schedule ignores the patch (nil = leave untouched).
+	var userIDs *[]string
+	if in.UserIDs != nil && s.Kind == models.BackupScheduleKindAccount {
+		ids := cleanIDs(*in.UserIDs)
+		if d.Users != nil {
+			for _, uid := range ids {
+				u, err := d.Users.FindByID(ctx, uid)
+				if err != nil || u == nil {
+					return nil, &UserRejectedError{UserID: uid, Reason: ErrUserNotFound}
+				}
+				if u.IsAdmin {
+					return nil, &UserRejectedError{UserID: uid, Reason: ErrAdminUser}
+				}
+			}
+		}
+		userIDs = &ids
+	}
+
+	if in.CronExpr != nil {
+		next, err := internalbackup.NextFire(*in.CronExpr, time.Now().UTC())
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidCron, err)
+		}
+		s.CronExpr = strings.TrimSpace(*in.CronExpr)
+		s.NextRunAt = &next
+	}
+	if in.Enabled != nil {
+		s.Enabled = *in.Enabled
+	}
+	if in.IncludeSystemBackup != nil && s.Kind == models.BackupScheduleKindAccount {
+		// meaningless on a system schedule — it already is the system backup.
+		s.IncludeSystemBackup = *in.IncludeSystemBackup
+	}
+	if in.KeepDaily != nil {
+		s.KeepDaily = in.KeepDaily
+	}
+	if in.KeepWeekly != nil {
+		s.KeepWeekly = in.KeepWeekly
+	}
+	if in.KeepMonthly != nil {
+		s.KeepMonthly = in.KeepMonthly
+	}
+
+	if err := d.Schedules.UpdateWithMemberships(ctx, s, in.DestinationIDs, userIDs); err != nil {
+		return nil, err
+	}
+	if userIDs != nil {
+		s.UserIDs = *userIDs
+	}
 	return s, nil
 }
 

--- a/panel-api/internal/backupscheduleops/backupscheduleops_test.go
+++ b/panel-api/internal/backupscheduleops/backupscheduleops_test.go
@@ -32,14 +32,42 @@ type recordedCreate struct {
 	userIDs []string
 }
 
+type recordedUpdate struct {
+	s       *models.BackupSchedule
+	destIDs *[]string
+	userIDs *[]string
+}
+
 type fakeScheduleWriter struct {
-	calls []recordedCreate
-	err   error
+	calls   []recordedCreate
+	err     error
+	getRow  *models.BackupSchedule
+	getErr  error
+	updates []recordedUpdate
+	updErr  error
 }
 
 func (f *fakeScheduleWriter) CreateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs []string) error {
 	f.calls = append(f.calls, recordedCreate{s: s, destIDs: destIDs, userIDs: userIDs})
 	return f.err
+}
+
+func (f *fakeScheduleWriter) Get(ctx context.Context, id string) (*models.BackupSchedule, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.getRow, nil
+}
+
+func (f *fakeScheduleWriter) UpdateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs *[]string) error {
+	f.updates = append(f.updates, recordedUpdate{s: s, destIDs: destIDs, userIDs: userIDs})
+	return f.updErr
+}
+
+// updateDeps builds a leaf bound to a stored schedule of the given kind.
+func updateDeps(kind string, users map[string]*models.User) (Deps, *fakeScheduleWriter) {
+	w := &fakeScheduleWriter{getRow: &models.BackupSchedule{ID: "s1", Kind: kind, Enabled: true}}
+	return Deps{Schedules: w, Users: &fakeUserFinder{users: users}}, w
 }
 
 func accountDeps(users map[string]*models.User) (Deps, *fakeScheduleWriter) {
@@ -162,3 +190,109 @@ func TestCreate_WriterError_Propagates(t *testing.T) {
 	require.Nil(t, s)
 	require.ErrorIs(t, err, sentinel)
 }
+
+// --- Update ---
+
+// The load-bearing guard for this slice: the update path must refuse an admin
+// target with ZERO writes, exactly as Create does. This is what the operator
+// CLI's hand-rolled update lacked. Falsify: delete the u.IsAdmin branch in
+// Update → the writer records an update.
+func TestUpdate_AccountRejectsAdminUser_ZeroWrites(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindAccount, map[string]*models.User{"u1": {ID: "u1", IsAdmin: true}})
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", UserIDs: &[]string{"u1"}})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrAdminUser)
+	var ure *UserRejectedError
+	require.ErrorAs(t, err, &ure)
+	require.Equal(t, "u1", ure.UserID)
+	require.Empty(t, w.updates, "no write when a target is rejected")
+}
+
+func TestUpdate_AccountRejectsMissingUser_ZeroWrites(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindAccount, map[string]*models.User{})
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", UserIDs: &[]string{"ghost"}})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrUserNotFound)
+	require.Empty(t, w.updates)
+}
+
+// Invalid cron aborts before any write. Falsify: move NextFire below the
+// UpdateWithMemberships call → the writer records an update.
+func TestUpdate_InvalidCron_ZeroWrites(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindAccount, map[string]*models.User{})
+	bad := "not a cron"
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", CronExpr: &bad})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrInvalidCron)
+	require.Empty(t, w.updates)
+}
+
+// A system schedule keeps no per-user membership and no include-system flag, so
+// those patch fields are ignored — and because the membership isn't touched, an
+// admin id in the patch is neither validated nor attached (no error, no write of
+// users). Falsify: drop the `s.Kind == account` gate on the user branch → the
+// admin id is validated and the call errors.
+func TestUpdate_SystemKind_IgnoresUserAndIncludeFlag(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindSystem, map[string]*models.User{"u1": {ID: "u1", IsAdmin: true}})
+	inc := true
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", UserIDs: &[]string{"u1"}, IncludeSystemBackup: &inc})
+	require.NoError(t, err)
+	require.Len(t, w.updates, 1)
+	require.Nil(t, w.updates[0].userIDs, "system schedule membership left untouched")
+	require.False(t, s.IncludeSystemBackup, "include-system ignored on a system schedule")
+}
+
+// nil membership pointers leave both memberships untouched (only fields change).
+func TestUpdate_NilMembership_LeavesUntouched(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindAccount, nil)
+	on := true
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", Enabled: &on})
+	require.NoError(t, err)
+	require.Len(t, w.updates, 1)
+	require.Nil(t, w.updates[0].destIDs)
+	require.Nil(t, w.updates[0].userIDs)
+	require.True(t, s.Enabled)
+}
+
+// An empty (non-nil) account user patch clears the membership → fan-out to every
+// non-admin at tick time. The distinction from nil is load-bearing.
+func TestUpdate_EmptyUserPatch_ClearsMembership(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindAccount, map[string]*models.User{})
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", UserIDs: &[]string{}})
+	require.NoError(t, err)
+	require.Len(t, w.updates, 1)
+	require.NotNil(t, w.updates[0].userIDs, "empty patch still replaces (clears) the set")
+	require.Empty(t, *w.updates[0].userIDs)
+	require.Empty(t, s.UserIDs)
+}
+
+// A load error from Get propagates unchanged and nothing is written.
+func TestUpdate_GetError_Propagates(t *testing.T) {
+	sentinel := errors.New("row gone")
+	d, w := updateDeps(models.BackupScheduleKindAccount, nil)
+	w.getErr = sentinel
+	s, err := Update(context.Background(), d, UpdateInput{ID: "s1", Enabled: boolPtr(true)})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, sentinel)
+	require.Empty(t, w.updates)
+}
+
+func TestUpdate_HappyPath_AppliesPatch(t *testing.T) {
+	d, w := updateDeps(models.BackupScheduleKindAccount, map[string]*models.User{"u1": {ID: "u1"}})
+	cron := "0 5 * * *"
+	off := false
+	keep := 7
+	s, err := Update(context.Background(), d, UpdateInput{
+		ID: "s1", CronExpr: &cron, Enabled: &off, KeepDaily: &keep, UserIDs: &[]string{"u1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, w.updates, 1)
+	require.Equal(t, cron, s.CronExpr)
+	require.False(t, s.Enabled)
+	require.NotNil(t, s.KeepDaily)
+	require.Equal(t, 7, *s.KeepDaily)
+	require.NotNil(t, s.NextRunAt)
+	require.Equal(t, []string{"u1"}, s.UserIDs)
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/panel-api/internal/repository/backup_schedule_repository.go
+++ b/panel-api/internal/repository/backup_schedule_repository.go
@@ -31,6 +31,12 @@ type BackupScheduleRepository interface {
 	ListForUser(ctx context.Context, userID string) ([]models.BackupSchedule, error)
 	ListDue(ctx context.Context, now time.Time, limit int) ([]models.BackupSchedule, error)
 	Update(ctx context.Context, s *models.BackupSchedule) error
+	// UpdateWithMemberships commits the row's field changes together with any
+	// membership replacement in ONE transaction (nil destIDs/userIDs leaves
+	// that membership untouched). Same blast-radius reasoning as
+	// CreateWithMemberships: a partial update must never leave a runnable row
+	// whose membership silently differs from what was asked.
+	UpdateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs *[]string) error
 	UpdateNextRun(ctx context.Context, id string, nextRunAt time.Time) error
 	MarkRan(ctx context.Context, id string, ranAt, nextRunAt time.Time) error
 	Delete(ctx context.Context, id string) error
@@ -173,6 +179,45 @@ func (r *backupScheduleRepo) Update(ctx context.Context, s *models.BackupSchedul
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (r *backupScheduleRepo) UpdateWithMemberships(ctx context.Context, s *models.BackupSchedule, destIDs, userIDs *[]string) error {
+	s.UpdatedAt = time.Now().UTC()
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.BackupSchedule{}).
+			Where("id = ?", s.ID).
+			Updates(map[string]any{
+				"kind":                  s.Kind,
+				"user_id":               s.UserID,
+				"include_system_backup": s.IncludeSystemBackup,
+				"cron_expr":             s.CronExpr,
+				"content":               s.Content,
+				"cadence":               s.Cadence,
+				"enabled":               s.Enabled,
+				"keep_daily":            s.KeepDaily,
+				"keep_weekly":           s.KeepWeekly,
+				"keep_monthly":          s.KeepMonthly,
+				"next_run_at":           s.NextRunAt,
+				"updated_at":            s.UpdatedAt,
+			})
+		if res.Error != nil {
+			return translate(res.Error)
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		if destIDs != nil {
+			if err := replaceDestinationsTx(tx, s.ID, *destIDs); err != nil {
+				return err
+			}
+		}
+		if userIDs != nil {
+			if err := replaceUsersTx(tx, s.ID, *userIDs); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (r *backupScheduleRepo) UpdateNextRun(ctx context.Context, id string, nextRunAt time.Time) error {

--- a/panel-api/internal/repository/backup_schedule_repository_test.go
+++ b/panel-api/internal/repository/backup_schedule_repository_test.go
@@ -148,6 +148,68 @@ func TestBackupSchedule_CreateWithMemberships_UserLinkFails_RollsBack(t *testing
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// UpdateWithMemberships commits the field changes and a user-membership
+// replacement in one transaction. A nil destination pointer leaves that
+// membership untouched (no DELETE/INSERT). The UPDATE matcher requires `content`
+// in the SET clause — the same silent-drop allowlist guard as Update (GH #454).
+func TestBackupSchedule_UpdateWithMemberships_CommitsRowAndUsers(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupScheduleRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE .backup_schedules. SET .*.content.=").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `backup_schedule_users` WHERE schedule_id = \\?").
+		WithArgs("01J5SCHED0000000000000000A").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO `backup_schedule_users`").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	s := &models.BackupSchedule{
+		ID:       "01J5SCHED0000000000000000A",
+		Kind:     models.BackupScheduleKindAccount,
+		CronExpr: "0 3 * * *",
+		Enabled:  true,
+	}
+	users := []string{"01J5USER0000000000000000001"}
+	err := repo.UpdateWithMemberships(context.Background(), s, nil, &users)
+	require.NoError(t, err)
+	require.False(t, s.UpdatedAt.IsZero())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The atomicity guarantee for update: a failure replacing users rolls back the
+// field UPDATE too, so the row is never left committed with a membership that
+// silently differs from what was asked. Falsify: drop the tx wrapper → the
+// UPDATE commits and no Rollback is issued.
+func TestBackupSchedule_UpdateWithMemberships_UserLinkFails_RollsBack(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupScheduleRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE .backup_schedules. SET").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM `backup_schedule_users` WHERE schedule_id = \\?").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO `backup_schedule_users`").
+		WillReturnError(errFakeUserLink)
+	mock.ExpectRollback()
+
+	s := &models.BackupSchedule{
+		ID:       "01J5SCHED0000000000000000A",
+		Kind:     models.BackupScheduleKindAccount,
+		CronExpr: "0 3 * * *",
+		Enabled:  true,
+	}
+	users := []string{"01J5USER0000000000000000001"}
+	err := repo.UpdateWithMemberships(context.Background(), s, nil, &users)
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // GH #454: the Update column allowlist must include `content` — it was added to
 // the model (#570) after this method was written, and an omitted column is a
 // SILENT drop (the map-based Updates only writes listed columns). Regression


### PR DESCRIPTION
## What

The `jabali backup schedule update` command hand-rolled its change set — load the
row, mutate fields, then `repo.Update`, `ReplaceDestinations`, `ReplaceUsers` as
three separate statements. This routes it through the shared `backupscheduleops`
lifecycle by adding `backupscheduleops.Update`, closing two gaps.

## Security: admin-target rejection was skipped on update

`backupscheduleops.Create` refuses an admin account as a backup-schedule target
(an admin account is panel-only — nothing to back up), and the admin REST update
enforces the same rule inline. The **CLI** update did not: resolved `--user` ids
went straight into `ReplaceUsers`, so an admin account could be attached to a
schedule's membership through the update path that create would have refused. It
also applied `--include-system` regardless of kind, though the flag is
account-only.

## Atomicity

The three separate writes meant a failure after the row `UPDATE` (e.g. linking
users) left the schedule committed with a membership that silently differed from
what was asked — and for an account schedule an empty user set fans out to every
non-admin at tick time, so a partial write there *broadens* the blast radius.
`UpdateWithMemberships` commits the field changes and any membership replacement
in one transaction.

## The leaf operation

`backupscheduleops.Update` loads the row and validates the patch against the
stored, **immutable** kind: every account target must exist and must not be an
admin, and an invalid cron aborts — each with zero writes; a system schedule
keeps no per-user membership and no include-system flag. `UpdateInput` is a
pointer patch — a nil field is left unchanged; a non-nil `DestinationIDs`/`UserIDs`
replaces that membership (an empty account `UserIDs` clears it, i.e. fans out to
all non-admins, exactly as Create).

## Scope

CLI update only. The admin REST update already applies this policy inline;
routing it onto `Update` to drop that duplication is the next slice, and run-now
plus the tenant own-account path remain adapter-local. **JAB-307 stays a
module-parent.**

## Tests

Leaf matrix on `Update` (admin target refused with zero writes; missing target
refused; invalid cron aborts with zero writes; system schedule ignores the
user/include-system patch; nil membership pointers leave both untouched while a
non-nil empty account user set clears/fans out; Get error propagates; happy path
applies the patch). A repository sqlmock pair: `UpdateWithMemberships` commits
row + user-link in one transaction, and a failed user link rolls the whole thing
back. A CLI source-pin that the update command routes through
`backupscheduleops.Update` and no longer calls
`repo.Update`/`ReplaceUsers`/`ReplaceDestinations` directly.

The admin-rejection, invalid-cron, and rollback guards were each falsified by
neutralizing them in turn (dropping the `IsAdmin` branch, letting an invalid cron
proceed, swallowing the user-link error), confirming the matching test went red,
then reverted. The source-pin and remaining normalization tests are green pins.
`go build ./...` / `vet` / `gofmt` clean; `go test -race` green on
`internal/backupscheduleops`, `internal/repository`, and the `cmd/server` pin.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
