### PR TITLE
fix(backups): route the admin REST schedule update through the lifecycle leaf (JAB-307)

### DIFF
--- a/panel-api/internal/api/backup_schedule_lifecycle_source_test.go
+++ b/panel-api/internal/api/backup_schedule_lifecycle_source_test.go
@@ -27,6 +27,40 @@ func TestBackupScheduleCreate_RoutesThroughLifecycle(t *testing.T) {
 		"create must not link destinations directly (non-atomic)")
 }
 
+// The admin backup-schedule update adapter must likewise delegate to the
+// shared lifecycle leaf (JAB-307). This is the path that wrote the row,
+// destinations, and users as three separate statements; routing it through the
+// leaf commits them in one transaction and drops the inline copy of the
+// admin-target rejection / kind-gate the leaf already owns. Reintroducing the
+// non-atomic Update→ReplaceDestinations→ReplaceUsers sequence reddens this.
+func TestBackupScheduleUpdate_RoutesThroughLifecycle(t *testing.T) {
+	src, err := os.ReadFile("backup_schedules.go")
+	require.NoError(t, err)
+	body := scheduleFuncBody(t, string(src), "func (h *backupScheduleHandler) update(")
+
+	require.Contains(t, body, "backupscheduleops.Update(",
+		"update must delegate to the shared lifecycle leaf")
+	require.Contains(t, body, `writeScheduleOpError(c, err, "db_update")`,
+		"update must keep emitting db_update as its generic 500 code")
+	require.NotContains(t, body, "Schedules.Update(",
+		"update must not write the row directly (non-atomic)")
+	require.NotContains(t, body, "Schedules.ReplaceUsers(",
+		"update must not link users directly (non-atomic)")
+	require.NotContains(t, body, "Schedules.ReplaceDestinations(",
+		"update must not link destinations directly (non-atomic)")
+}
+
+// Parameterising writeScheduleOpError with a per-operation dbErrCode must not
+// silently flip the create path's generic 500 string; create keeps db_create.
+func TestBackupScheduleCreate_KeepsDbCreateCode(t *testing.T) {
+	src, err := os.ReadFile("backup_schedules.go")
+	require.NoError(t, err)
+	body := scheduleFuncBody(t, string(src), "func (h *backupScheduleHandler) create(")
+
+	require.Contains(t, body, `writeScheduleOpError(c, err, "db_create")`,
+		"create must keep emitting db_create as its generic 500 code")
+}
+
 // scheduleFuncBody returns the source of the function starting at sig, up to
 // the next top-level func declaration.
 func scheduleFuncBody(t *testing.T, src, sig string) string {

--- a/panel-api/internal/api/backup_schedules.go
+++ b/panel-api/internal/api/backup_schedules.go
@@ -9,7 +9,6 @@ package api
 import (
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -168,7 +167,7 @@ func (h *backupScheduleHandler) create(c *gin.Context) {
 		DestinationIDs:      req.DestinationIDs,
 	})
 	if err != nil {
-		writeScheduleOpError(c, err)
+		writeScheduleOpError(c, err, "db_create")
 		return
 	}
 	dests, _ := h.cfg.Schedules.GetDestinations(c.Request.Context(), s.ID)
@@ -176,8 +175,12 @@ func (h *backupScheduleHandler) create(c *gin.Context) {
 }
 
 // writeScheduleOpError maps a backupscheduleops error to the wire codes the
-// admin REST surface has always emitted, so the contract is unchanged.
-func writeScheduleOpError(c *gin.Context, err error) {
+// admin REST surface has always emitted, so the contract is unchanged. The
+// policy codes are shared by every lifecycle call; dbErrCode is the generic
+// 500 string for the caller's operation ("db_create" for create, "db_update"
+// for update), since the leaf's single transactional write can't tell the row
+// change apart from the membership replacement.
+func writeScheduleOpError(c *gin.Context, err error, dbErrCode string) {
 	var ure *backupscheduleops.UserRejectedError
 	switch {
 	case errors.Is(err, backupscheduleops.ErrInvalidKind):
@@ -189,7 +192,7 @@ func writeScheduleOpError(c *gin.Context, err error) {
 	case errors.Is(err, backupscheduleops.ErrInvalidCron):
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_cron", "detail": err.Error()})
 	default:
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": dbErrCode})
 	}
 }
 
@@ -206,79 +209,50 @@ type updateScheduleRequest struct {
 
 func (h *backupScheduleHandler) update(c *gin.Context) {
 	id := c.Param("id")
-	s, err := h.cfg.Schedules.Get(c.Request.Context(), id)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_get"})
-		return
-	}
 	var req updateScheduleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body", "detail": err.Error()})
 		return
 	}
-	if req.CronExpr != nil {
-		next, err := internalbackup.NextFire(*req.CronExpr, time.Now().UTC())
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_cron", "detail": err.Error()})
+	// Route the whole patch through the lifecycle leaf. It validates the
+	// change against the stored, immutable kind (on an account schedule every
+	// explicit target user must exist and must not be an admin; an invalid
+	// cron aborts) and persists the field changes plus any membership
+	// replacement in ONE transaction. The previous inline path wrote the row,
+	// destinations, and users as three separate statements, so a failure after
+	// the row committed left the schedule with a membership that silently
+	// differed from the request — and for an account schedule an empty user
+	// set fans out to every non-admin at tick time, so a partial write there
+	// broadens the blast radius. (Admin-target rejection was already enforced
+	// on this surface inline; this change is atomicity plus de-duplication of
+	// the policy the leaf already owns.)
+	s, err := backupscheduleops.Update(c.Request.Context(), backupscheduleops.Deps{
+		Schedules: h.cfg.Schedules,
+		Users:     h.cfg.Users,
+	}, backupscheduleops.UpdateInput{
+		ID:                  id,
+		CronExpr:            req.CronExpr,
+		Enabled:             req.Enabled,
+		IncludeSystemBackup: req.IncludeSystemBackup,
+		KeepDaily:           req.KeepDaily,
+		KeepWeekly:          req.KeepWeekly,
+		KeepMonthly:         req.KeepMonthly,
+		DestinationIDs:      req.DestinationIDs,
+		UserIDs:             req.UserIDs,
+	})
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
 			return
 		}
-		s.CronExpr = strings.TrimSpace(*req.CronExpr)
-		s.NextRunAt = &next
-	}
-	if req.Enabled != nil {
-		s.Enabled = *req.Enabled
-	}
-	if req.IncludeSystemBackup != nil && s.Kind == models.BackupScheduleKindAccount {
-		s.IncludeSystemBackup = *req.IncludeSystemBackup
-	}
-	if req.KeepDaily != nil {
-		s.KeepDaily = req.KeepDaily
-	}
-	if req.KeepWeekly != nil {
-		s.KeepWeekly = req.KeepWeekly
-	}
-	if req.KeepMonthly != nil {
-		s.KeepMonthly = req.KeepMonthly
-	}
-	if err := h.cfg.Schedules.Update(c.Request.Context(), s); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
+		writeScheduleOpError(c, err, "db_update")
 		return
 	}
-	if req.DestinationIDs != nil {
-		if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), s.ID, *req.DestinationIDs); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
-			return
-		}
-	}
-	if req.UserIDs != nil && s.Kind == models.BackupScheduleKindAccount {
-		clean := make([]string, 0, len(*req.UserIDs))
-		for _, uid := range *req.UserIDs {
-			if uid == "" {
-				continue
-			}
-			if h.cfg.Users != nil {
-				user, err := h.cfg.Users.FindByID(c.Request.Context(), uid)
-				if err != nil || user == nil {
-					c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "user_not_found", "detail": uid})
-					return
-				}
-				if user.IsAdmin {
-					c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "admin_user_not_allowed", "detail": uid})
-					return
-				}
-			}
-			clean = append(clean, uid)
-		}
-		if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), s.ID, clean); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
-			return
-		}
-		s.UserIDs = clean
-	} else {
+	// Output shaping: the leaf sets s.UserIDs only when it replaced the account
+	// membership (a non-nil, possibly-empty slice — never null). For every
+	// other case re-read the current membership so the DTO reflects what's
+	// stored, matching the shape this surface has always returned.
+	if req.UserIDs == nil || s.Kind != models.BackupScheduleKindAccount {
 		ids, _ := h.cfg.Schedules.GetUserIDs(c.Request.Context(), s.ID)
 		s.UserIDs = ids
 	}


### PR DESCRIPTION
## What

The admin REST `PUT /admin/backup-schedules/:id` handler hand-rolled its change
set — it loaded the row, mutated fields, then issued `Update`,
`ReplaceDestinations`, and `ReplaceUsers` as three separate statements, and kept
its own inline copy of the admin-target rejection and system-kind gate. This
routes it through the shared `backupscheduleops` lifecycle via
`backupscheduleops.Update`, the same leaf the create path and the operator CLI
already use.

## Atomicity (why this is a fix, not just a refactor)

The three separate writes meant a failure after the row `UPDATE` — for example
while linking users — left the schedule committed with a membership that
silently differed from the request. For an account schedule an empty user set
fans out to every non-admin at tick time, so a partial write there *broadens*
the blast radius rather than narrowing it. `backupscheduleops.Update` persists
the field changes and any membership replacement in one transaction
(`UpdateWithMemberships`), exactly the fix #1654 applied to the operator CLI
update path.

## Not a security fix on this surface

Unlike the CLI slice (#1654), admin-target rejection was already enforced here
inline — `h.cfg.Users` is wired at `app.go`, so the `IsAdmin` check ran. This
change is atomicity plus de-duplication of the policy the leaf already owns; it
does not close a missing guard.

## Wire contract

Surface-visible codes are unchanged on the happy path and for every policy
rejection (`invalid_kind`, `admin_user_not_allowed`, `user_not_found`,
`invalid_cron`, `not_found`). `writeScheduleOpError` gained a per-operation
`dbErrCode` argument so create keeps `db_create` and update keeps `db_update`.

Deliberate, low-risk deltas (no `panel-ui` consumer branches on any of these —
verified by grep):
- The three 500 sub-codes the inline path emitted — `db_get`,
  `db_link_destinations`, `db_link_users` — collapse into `db_update`, because
  the single transaction can't tell a row-write failure apart from a
  membership-link failure.
- Two precedence shifts inherited from the leaf's order (already the CLI slice's
  behaviour): a malformed body is reported before a missing id, and when both
  the cron and a target user are invalid the user rejection is reported first.
- `invalid_cron` keeps its code; its `detail` now carries the leaf's
  `"invalid cron expression: "` prefix.

The response DTO shape is unchanged: `toScheduleDTO` already renders `user_ids`
as `[]` never `null`, and the adapter re-reads the current membership for the
DTO on every path the leaf doesn't set it.

## Scope

Admin REST update only. Run-now and the tenant own-account path
(`/me/backup-schedules/:id` — a separate surface that denies admins and never
takes arbitrary memberships) remain adapter-local. **JAB-307 stays a
module-parent.**

## Tests

Extends the REST lifecycle source-pin: the update handler must route through
`backupscheduleops.Update` and no longer call `Schedules.Update` /
`ReplaceUsers` / `ReplaceDestinations` directly, and both create and update must
keep their own generic 500 code after the helper was parameterised. The
update-routing and `db_update` pins were each falsified — flipping the update's
code to `db_create`, and reintroducing a direct `Schedules.Update` call —
confirming the matching assertion went red, then reverted.

The admin-target rejection, atomicity, and cron behaviour themselves are already
covered by the `backupscheduleops.Update` matrix and the repository
`UpdateWithMemberships` transaction tests shipped in #1654. `go build ./...` /
`vet` / `gofmt` clean; `go test` green on `internal/api`.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
