### PR TITLE
fix(appsec): split operator CRS exclusions into their own before-plugin file (GH #1655, GH #1653)

### DIFF
--- a/docs/adr/0124-crs-false-positive-exclusion-plugin.md
+++ b/docs/adr/0124-crs-false-positive-exclusion-plugin.md
@@ -77,3 +77,39 @@ First rule (9599100) excludes 933120 for `ARGS:_wp_http_referer` under
 - Couples to the CRS plugin glob path; a crowdsec packaging change could
   move it. Mitigated by the render-config rewrite + reload on every
   update surfacing a load error.
+
+## Amendment — operator exclusions split to a second file (GH #1655, 2026-09-11)
+
+JAB-227 added operator-managed exclusions (`jabali appsec exclusion add`,
+DB-backed) and originally appended them to the SAME `jabali-before.conf`
+this ADR describes. That combined file has two writers: `render-config`
+(built-ins **+** operator exclusions, from the DB) and the agent's
+boot-time `ApplyAppSecBeforePlugin` (built-ins **only** — the agent has no
+DB access). Once an operator added an exclusion the two writers diverged,
+and every agent restart (`jabali update`, crash, reboot, manual) rewrote
+the file to built-ins-only, **dropping every operator exclusion** until the
+next `render-config` — silently re-banning the operator's users. This was
+the likely root of "the exclusions I added keep coming back" on GH #1641.
+
+Fix: the operator section now renders to a **separate** file,
+`crs-plugins/jabali/jabali-operator-before.conf`
+(`CRSPluginOperatorBeforePath`), written only by `render-config` and never
+touched by the agent. Both files match the same
+`crs-plugins/*/*-before.conf` glob and load before the CRS detection
+rules; order between them is irrelevant (operator rules are self-contained
+`ctl:ruleRemoveById` in phase 1). `jabali-before.conf` is now written
+byte-identical by both writers, so they can no longer clobber each other.
+When the last exclusion is removed the operator file is deleted (a stale
+file would keep a since-removed exclusion live); a transient DB outage
+leaves it untouched rather than dropping live exclusions.
+
+Reload (GH #1653): `render-config` gained an opt-in `--reload` flag
+(best-effort `systemctl reload crowdsec` on a real diff). `exclusion
+add`/`rm` now print `render-config --reconcile --reload` so a manual
+change takes effect in one step. install.sh leaves the flag **off** and
+keeps its single deferred reload at the end of crowdsec setup, so an
+update never reloads crowdsec mid-run (the GH discussion #109 fresh-install
+ordering scar).
+
+The operator id range stays **9,597,000–9,597,999**, disjoint from the
+built-in 9,599,xxx range, so the two files never collide on SecRule ids.

--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -397,6 +397,7 @@ jabali appsec render-config [flags]
 **Flags:**
 
 - `--reconcile` — preserve operator jabali-mode/jabali-countries header from existing file (default true) (default `true`)
+- `--reload` — best-effort `systemctl reload crowdsec` after a real diff (default false; install.sh owns its own deferred reload, so leave off inside an update)
 
 ### `jabali audit`
 

--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -190,6 +190,19 @@ func sanitizeWebmailHosts(in []string) []string {
 // rewrites it on every install + `jabali update`.
 const CRSPluginBeforePath = "/var/lib/crowdsec/data/crs-plugins/jabali/jabali-before.conf"
 
+// CRSPluginOperatorBeforePath holds the operator-managed exclusions, split out
+// of CRSPluginBeforePath (GH #1655). The agent re-renders the built-in file
+// (CRSPluginBefore) at every boot from static content and has no database
+// access; when the operator section shared that file, each agent restart —
+// update, crash, reboot, manual — rewrote it to built-ins-only and dropped
+// every operator exclusion until the next `render-config`, silently re-banning
+// users. A separate file in the same hub-free jabali/ subdir — matched by the
+// same crs-plugins/*/*-before.conf glob — is written only by render-config and
+// never touched by the agent, so operator exclusions survive a restart. Order
+// relative to jabali-before.conf is irrelevant: operator rules are
+// self-contained ctl:ruleRemoveById in phase 1, with no cross-file dependency.
+const CRSPluginOperatorBeforePath = "/var/lib/crowdsec/data/crs-plugins/jabali/jabali-operator-before.conf"
+
 // CRSPluginBefore returns the body of the jabali CRS "before" plugin —
 // targeted CrowdSec AppSec / CRS false-positive exclusions that must run
 // before the detection + anomaly-scoring rules.

--- a/internal/appseccfg/exclusions.go
+++ b/internal/appseccfg/exclusions.go
@@ -100,6 +100,32 @@ func ValidateExclusion(e Exclusion) error {
 	return nil
 }
 
+// operatorBeforeFileHeader labels the standalone operator-managed before-plugin
+// file (CRSPluginOperatorBeforePath). Split out of jabali-before.conf (GH #1655)
+// so the agent's boot-time re-render of the built-in file — which has no
+// database access — can no longer overwrite operator exclusions.
+const operatorBeforeFileHeader = "# Managed by jabali — operator CRS \"before\" exclusions.\n" +
+	"# DO NOT hand-edit. Written by `jabali appsec render-config` from the panel\n" +
+	"# database (`jabali appsec exclusion add`/`rm`). Kept SEPARATE from\n" +
+	"# jabali-before.conf so the agent's boot re-render of the built-in file cannot\n" +
+	"# clobber these (GH #1655). Loaded before the CRS detection rules by the same\n" +
+	"# crs-plugins/*/*-before.conf glob; order relative to jabali-before.conf does\n" +
+	"# not matter (these are self-contained ctl:ruleRemoveById rules in phase 1).\n"
+
+// RenderOperatorBeforeFile returns the full body of the standalone
+// operator-managed before-plugin file, or "" when there are no operator
+// exclusions at all — the caller removes the file in that case so a
+// since-removed exclusion cannot linger live. A non-empty list always yields a
+// file, even if every entry fails validation: those render as SKIPPED comments
+// (see RenderExclusions), the breadcrumb an operator needs to see WHY a rule
+// vanished rather than debug the wrong thing.
+func RenderOperatorBeforeFile(list []Exclusion) string {
+	if len(list) == 0 {
+		return ""
+	}
+	return operatorBeforeFileHeader + RenderExclusions(list)
+}
+
 // RenderExclusions emits the operator-managed section of the before-plugin.
 //
 // Deterministic: sorted by (host, uri, rule) so an unchanged set renders

--- a/internal/appseccfg/exclusions_test.go
+++ b/internal/appseccfg/exclusions_test.go
@@ -188,6 +188,63 @@ func TestRenderExclusions_InvalidEntryIsReportedNotSwallowed(t *testing.T) {
 	}
 }
 
+// The standalone operator file (GH #1655) must be empty for an empty list — the
+// caller removes it in that case so a since-removed exclusion cannot linger live
+// — carry the SEPARATE-file header for a non-empty list, and still emit the
+// SKIPPED breadcrumb (never a bare empty file) when every entry is invalid.
+func TestRenderOperatorBeforeFile(t *testing.T) {
+	if got := RenderOperatorBeforeFile(nil); got != "" {
+		t.Errorf("empty list must render \"\" (signals file removal), got %q", got)
+	}
+
+	out := RenderOperatorBeforeFile([]Exclusion{validExclusion()})
+	if !strings.Contains(out, "Managed by jabali — operator CRS") {
+		t.Errorf("missing operator-file header:\n%s", out)
+	}
+	if !strings.Contains(out, "GH #1655") {
+		t.Errorf("header must explain the split (GH #1655):\n%s", out)
+	}
+	if !strings.Contains(out, "ctl:ruleRemoveById=931120") {
+		t.Errorf("valid exclusion not rendered into the file:\n%s", out)
+	}
+
+	// All-invalid list: still a file (header + SKIPPED breadcrumb), never "".
+	bad := validExclusion()
+	bad.RuleID = "949110" // anomaly blocker — rejected by ValidateExclusion
+	badOut := RenderOperatorBeforeFile([]Exclusion{bad})
+	if badOut == "" {
+		t.Fatal("all-invalid list rendered \"\" — would delete the file and hide the SKIPPED breadcrumb")
+	}
+	if !strings.Contains(badOut, "# SKIPPED") {
+		t.Errorf("invalid entry breadcrumb missing:\n%s", badOut)
+	}
+}
+
+// The two before-plugin files must stay disjoint: the built-in file the agent
+// re-renders at boot (CRSPluginBefore) must carry none of the operator content,
+// and the operator file none of the built-in content — otherwise the agent's
+// boot rewrite would again clobber operator rules (GH #1655), or their SecRule
+// ids would collide and CrowdSec would refuse to load.
+func TestBeforePluginFilesAreDisjoint(t *testing.T) {
+	if CRSPluginBeforePath == CRSPluginOperatorBeforePath {
+		t.Fatal("built-in and operator before-plugin files must be different paths")
+	}
+	builtin := CRSPluginBefore()
+	operator := RenderOperatorBeforeFile([]Exclusion{validExclusion()})
+
+	// Built-in file must not carry the operator id range (9,597,xxx) or header.
+	if strings.Contains(builtin, "id:"+itoa(OperatorExclusionIDBase)) {
+		t.Error("built-in file leaked an operator SecRule id — agent boot would clobber it")
+	}
+	if strings.Contains(builtin, "operator CRS \"before\" exclusions") {
+		t.Error("built-in file carries the operator section — the GH #1655 split is broken")
+	}
+	// Operator file must not carry the built-in wordpress-enable SecAction (9599000).
+	if strings.Contains(operator, "id:9599000") {
+		t.Error("operator file leaked the built-in wordpress-enable rule")
+	}
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/panel-agent/internal/commands/security_appsec_before.go
+++ b/panel-agent/internal/commands/security_appsec_before.go
@@ -1,12 +1,19 @@
 // Boot-time apply of the jabali CRS "before" exclusion plugin (GH #594).
 //
-// CRSPluginBefore() is static, single-sourced in internal/appseccfg — the SAME
-// content the panel-api `appsec render-config` CLI writes. Running it at agent
-// boot makes a shipped CRS-exclusion change (GH #404/#594) self-heal on the
-// `jabali update` restart, FLEET-WIDE, with no per-server operator step:
+// CRSPluginBefore() is static, single-sourced in internal/appseccfg. Running it
+// at agent boot makes a shipped CRS-exclusion change (GH #404/#594) self-heal on
+// the `jabali update` restart, FLEET-WIDE, with no per-server operator step:
 // update installs the new binaries + restarts jabali-agent → the NEW agent
-// boots → re-renders before.conf. Write-on-diff (no-op on a clean boot) and
-// byte-identical to the CLI writer, so the two never oscillate.
+// boots → re-renders CRSPluginBeforePath. Write-on-diff (no-op on a clean boot).
+//
+// This writes ONLY the built-in file (CRSPluginBeforePath). The panel-api
+// `appsec render-config` CLI writes the exact same built-in content to that same
+// path — so the two writers are byte-identical there and never oscillate — plus
+// the operator-managed exclusions to a SEPARATE file (CRSPluginOperatorBeforePath),
+// which this agent never touches. The split exists because the agent has no
+// database access: when the operator exclusions shared this file, every agent
+// restart rewrote it to built-ins-only and dropped them, re-banning users until
+// the next render-config (GH #1655). Keep this writer built-ins-only.
 package commands
 
 import (

--- a/panel-api/cmd/server/appsec_cmd.go
+++ b/panel-api/cmd/server/appsec_cmd.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -48,6 +52,7 @@ const (
 // (mode=off, no countries) — used only on a forced reset.
 func newAppSecRenderConfigCmd() *cobra.Command {
 	var reconcile bool
+	var reload bool
 	cmd := &cobra.Command{
 		Use:   "render-config",
 		Short: "Write /etc/crowdsec/appsec-configs/jabali-appsec.yaml from internal/appseccfg.Render",
@@ -71,8 +76,10 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Targeted CRS false-positive exclusions (jabali CRS "before"
 			// plugin). Independent of the geoblock config; loaded before
-			// REQUEST-933/949. Write-on-diff; the caller reloads crowdsec.
-			if err := writeCRSPluginBefore(cmd); err != nil {
+			// REQUEST-933/949. Write-on-diff; --reload (below) or the caller
+			// reloads crowdsec.
+			crsChanged, err := writeCRSPluginBefore(cmd)
+			if err != nil {
 				return err
 			}
 
@@ -126,21 +133,39 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 			// Write-on-diff: cheap before any nginx/crowdsec reload
 			// upstream that may key off mtime or content hash.
 			existing, _ := os.ReadFile(appsecConfigPath)
-			if string(existing) == body {
+			cfgChanged := string(existing) != body
+			if cfgChanged {
+				if err := atomicWriteAppSec(appsecConfigPath, body); err != nil {
+					return fmt.Errorf("write %s: %w", appsecConfigPath, err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(),
+					"written %s (mode=%s, countries=[%s], inband=%d rules)\n",
+					appsecConfigPath, mode, strings.Join(countries, ","), len(inband))
+			} else {
+				// "unchanged" on the last line is the install.sh reload gate: it
+				// reloads crowdsec whenever render-config prints anything else,
+				// and a before-plugin write above already made stdout non-empty.
 				fmt.Fprintln(cmd.OutOrStdout(), "unchanged")
-				return nil
 			}
-			if err := atomicWriteAppSec(appsecConfigPath, body); err != nil {
-				return fmt.Errorf("write %s: %w", appsecConfigPath, err)
+
+			// --reload applies the change on this box in one step, best-effort.
+			// Off by default: install.sh calls render-config early in an update
+			// and owns a single deferred reload at the end of its crowdsec setup,
+			// so an update never reloads crowdsec mid-run (the GH discussion #109
+			// fresh-install ordering scar). The operator/UI path passes --reload
+			// so `exclusion add` + render-config takes effect without a separate
+			// `systemctl reload crowdsec` (GH #1653).
+			if reload && (crsChanged || cfgChanged) {
+				reloadCrowdsec(cmd)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(),
-				"written %s (mode=%s, countries=[%s], inband=%d rules)\n",
-				appsecConfigPath, mode, strings.Join(countries, ","), len(inband))
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&reconcile, "reconcile", true,
 		"preserve operator jabali-mode/jabali-countries header from existing file (default true)")
+	cmd.Flags().BoolVar(&reload, "reload", false,
+		"best-effort `systemctl reload crowdsec` after a real diff (default false; "+
+			"install.sh owns its own deferred reload, so leave off inside an update)")
 	return cmd
 }
 
@@ -204,57 +229,174 @@ func detectInbandRules(dir string) []string {
 	return out
 }
 
-// writeCRSPluginBefore writes the jabali CRS "before" plugin
-// (appseccfg.CRSPluginBefore) to its CRS data path. Skips cleanly on a
-// host without crowdsec installed (CI, dev) so we never create a stray
-// /var/lib/crowdsec tree. Write-on-diff: returns without writing when
-// the content already matches.
-func writeCRSPluginBefore(cmd *cobra.Command) error {
-	if _, err := os.Stat("/var/lib/crowdsec/data"); err != nil {
-		return nil // crowdsec not installed here — nothing to manage
+// writeCRSPluginBefore reconciles the two jabali CRS "before" plugin files and
+// reports whether either changed (so --reload can gate a crowdsec reload).
+// Skips cleanly on a host without crowdsec (CI, dev) so we never create a stray
+// /var/lib/crowdsec tree.
+//
+// The two files, both matched by the crs-plugins/*/*-before.conf glob:
+//
+//   - CRSPluginBeforePath (jabali-before.conf): the built-in exclusions from
+//     appseccfg.CRSPluginBefore(). Written VERBATIM — byte-identical to what the
+//     agent's ApplyAppSecBeforePlugin writes at boot — so the two writers never
+//     diverge and never clobber each other (GH #1655).
+//   - CRSPluginOperatorBeforePath (jabali-operator-before.conf): the
+//     operator-managed exclusions from the DB. A SEPARATE file precisely because
+//     the agent — which has no DB access — re-renders the built-in file on every
+//     boot; before the split it wrote built-ins-only over the combined file and
+//     dropped every operator exclusion on each restart (GH #1655).
+//
+// render-config deliberately has no requireDB PreRunE: install.sh calls it
+// early, before the database necessarily exists, and it must still write the
+// built-in file on such a host. So the DB is opened best-effort here, and when
+// it is unreachable the operator file is left UNTOUCHED (never removed) — a
+// transient DB outage must not drop live exclusions and re-ban users, the exact
+// failure this split fixes.
+func writeCRSPluginBefore(cmd *cobra.Command) (changed bool, err error) {
+	if _, statErr := os.Stat("/var/lib/crowdsec/data"); statErr != nil {
+		return false, nil // crowdsec not installed here — nothing to manage
 	}
-	body := appseccfg.CRSPluginBefore()
 
-	// JAB-227: append operator-managed exclusions. They live in the DB rather
-	// than in this static template because only the operator can see the false
-	// positives specific to their tenants' apps. Best-effort: a DB that is not
-	// reachable must not stop the built-in exclusions being written, but the
-	// operator has to be told their entries are missing from this render rather
-	// than left assuming they applied.
-	// render-config deliberately has no requireDB PreRunE: install.sh calls it
-	// early, before the database necessarily exists, and it must still write the
-	// built-in exclusions on such a host. So open the DB best-effort here and
-	// carry on without the operator section if it is not reachable.
+	// Fetch operator exclusions best-effort. render-config has no requireDB
+	// PreRunE (install.sh calls it before the DB necessarily exists), so a
+	// missing or erroring DB must NOT block the built-in write below — and must
+	// leave the operator file UNTOUCHED (operatorKnown=false), never removed, so
+	// a transient outage cannot drop live exclusions and re-ban users.
+	var list []appseccfg.Exclusion
+	operatorKnown := false
 	if sharedDB == nil {
-		if err := initConfig(); err == nil {
+		if initErr := initConfig(); initErr == nil {
 			_ = initDB()
 		}
 	}
-	if sharedDB != nil {
-		excl, err := repository.NewCRSRuleExclusionRepository(sharedDB).List(cmd.Context())
-		if err != nil {
+	switch {
+	case sharedDB == nil:
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"! operator CRS exclusions NOT reconciled (database unavailable) — %s left as-is\n",
+			appseccfg.CRSPluginOperatorBeforePath)
+	default:
+		excl, listErr := repository.NewCRSRuleExclusionRepository(sharedDB).List(cmd.Context())
+		if listErr != nil {
 			fmt.Fprintf(cmd.OutOrStdout(),
-				"! operator CRS exclusions NOT rendered (%v) — built-in exclusions written without them\n", err)
-		} else if len(excl) > 0 {
-			list := make([]appseccfg.Exclusion, 0, len(excl))
+				"! operator CRS exclusions NOT reconciled (%v) — %s left as-is\n",
+				listErr, appseccfg.CRSPluginOperatorBeforePath)
+		} else {
+			list = make([]appseccfg.Exclusion, 0, len(excl))
 			for _, e := range excl {
 				list = append(list, appseccfg.Exclusion{
 					Host: e.Host, URIPrefix: e.URIPrefix, RuleID: e.RuleID, Note: e.Note,
 				})
 			}
-			body += appseccfg.RenderExclusions(list)
+			operatorKnown = true
 		}
 	}
 
-	existing, _ := os.ReadFile(appseccfg.CRSPluginBeforePath)
+	return reconcileCRSBeforeFiles(cmd.OutOrStdout(),
+		appseccfg.CRSPluginBeforePath, appseccfg.CRSPluginOperatorBeforePath, list, operatorKnown)
+}
+
+// reconcileCRSBeforeFiles writes the built-in before-plugin file verbatim and,
+// when the operator exclusions are known (DB reachable), the operator file —
+// removing it when the list is empty so a since-removed exclusion cannot linger
+// live. When operatorKnown is false the operator file is left exactly as-is.
+// Returns whether anything on disk changed (so --reload can gate a reload).
+//
+// Split from writeCRSPluginBefore so the invariant this fix (GH #1655) rests on
+// is unit-testable without a DB or the real /var/lib/crowdsec paths: the
+// built-in file is written byte-identical to what the agent boot writer emits
+// (appseccfg.CRSPluginBefore, no operator content appended), and operator
+// content only ever lands in operatorPath.
+func reconcileCRSBeforeFiles(out io.Writer, builtinPath, operatorPath string,
+	list []appseccfg.Exclusion, operatorKnown bool) (changed bool, err error) {
+
+	// 1. Built-in exclusions → builtinPath, VERBATIM.
+	wrote, err := writeOnDiff(builtinPath, appseccfg.CRSPluginBefore())
+	if err != nil {
+		return changed, err
+	}
+	if wrote {
+		changed = true
+		fmt.Fprintf(out, "written %s (CRS before-plugin, built-in)\n", builtinPath)
+	}
+
+	if !operatorKnown {
+		return changed, nil // DB unreachable — leave the operator file untouched
+	}
+
+	// 2. Operator-managed exclusions → operatorPath.
+	body := appseccfg.RenderOperatorBeforeFile(list)
+	if body == "" {
+		// No operator exclusions: remove the file so a since-removed exclusion
+		// cannot linger live. Absent already → no-op.
+		removed, rmErr := removeIfPresent(operatorPath)
+		if rmErr != nil {
+			return changed, fmt.Errorf("remove %s: %w", operatorPath, rmErr)
+		}
+		if removed {
+			changed = true
+			fmt.Fprintf(out, "removed %s (no operator exclusions)\n", operatorPath)
+		}
+		return changed, nil
+	}
+	wrote, err = writeOnDiff(operatorPath, body)
+	if err != nil {
+		return changed, err
+	}
+	if wrote {
+		changed = true
+		fmt.Fprintf(out, "written %s (CRS before-plugin, %d operator exclusion(s))\n", operatorPath, len(list))
+	}
+	return changed, nil
+}
+
+// writeOnDiff writes body to path via atomicWriteAppSec only when the current
+// content differs. Returns whether it wrote.
+func writeOnDiff(path, body string) (bool, error) {
+	existing, _ := os.ReadFile(path)
 	if string(existing) == body {
-		return nil
+		return false, nil
 	}
-	if err := atomicWriteAppSec(appseccfg.CRSPluginBeforePath, body); err != nil {
-		return fmt.Errorf("write %s: %w", appseccfg.CRSPluginBeforePath, err)
+	if err := atomicWriteAppSec(path, body); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "written %s (CRS before-plugin)\n", appseccfg.CRSPluginBeforePath)
-	return nil
+	return true, nil
+}
+
+// removeIfPresent removes path, treating an already-absent file as success.
+// Returns whether it actually removed anything.
+func removeIfPresent(path string) (bool, error) {
+	err := os.Remove(path)
+	switch {
+	case err == nil:
+		return true, nil
+	case os.IsNotExist(err):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// reloadCrowdsec applies a freshly-written appsec/before-plugin change on the
+// box. Best-effort, mirroring the agent boot path (panel-agent
+// security_appsec_before.go): reload, fall back to restart, never fail the
+// command. Gated on the CRS data tree so CI/dev never shells out. Invoked only
+// under --reload; install.sh leaves the flag off and owns its own deferred
+// reload (GH #1653 / the GH discussion #109 fresh-install ordering scar).
+func reloadCrowdsec(cmd *cobra.Command) {
+	if _, err := os.Stat("/var/lib/crowdsec/data"); err != nil {
+		return // crowdsec not installed — nothing to reload
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
+		if out2, err2 := exec.CommandContext(ctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"warn: crowdsec reload+restart failed: reload=%v (%s) restart=%v (%s)\n",
+				err, strings.TrimSpace(string(out)), err2, strings.TrimSpace(string(out2)))
+			return
+		}
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "reloaded crowdsec")
 }
 
 // atomicWriteAppSec writes via tmpfile + rename in the same dir so the

--- a/panel-api/cmd/server/appsec_cmd_test.go
+++ b/panel-api/cmd/server/appsec_cmd_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/appseccfg"
 )
 
 func TestReadOperatorHeader(t *testing.T) {
@@ -100,4 +104,129 @@ func TestDetectInbandRules(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("after touch got %v, want %v", got, want)
 	}
+}
+
+// reconcileCRSBeforeFiles is the core of the GH #1655 fix: operator exclusions
+// go to their OWN file so the agent's boot re-render of the built-in file (which
+// has no DB access) can no longer clobber them. These cases pin the invariants a
+// future edit could quietly break.
+func TestReconcileCRSBeforeFiles(t *testing.T) {
+	sample := []appseccfg.Exclusion{{
+		Host: "forum.example.com", URIPrefix: "/api/", RuleID: "931120", Note: "sample",
+	}}
+
+	// Case 1: rows present. Built-in file is byte-identical to what the agent
+	// boot writer emits (CRSPluginBefore verbatim, NO operator content), operator
+	// file carries exactly RenderOperatorBeforeFile.
+	t.Run("rows present — files disjoint and byte-exact", func(t *testing.T) {
+		dir := t.TempDir()
+		builtin := filepath.Join(dir, "jabali-before.conf")
+		operator := filepath.Join(dir, "jabali-operator-before.conf")
+
+		changed, err := reconcileCRSBeforeFiles(&bytes.Buffer{}, builtin, operator, sample, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Error("first write should report changed=true")
+		}
+		gotBuiltin, _ := os.ReadFile(builtin)
+		if string(gotBuiltin) != appseccfg.CRSPluginBefore() {
+			t.Error("built-in file is NOT byte-identical to CRSPluginBefore() — agent boot would clobber it (GH #1655)")
+		}
+		if strings.Contains(string(gotBuiltin), "ctl:ruleRemoveById=931120") {
+			t.Error("operator content leaked into the built-in file")
+		}
+		gotOperator, _ := os.ReadFile(operator)
+		if string(gotOperator) != appseccfg.RenderOperatorBeforeFile(sample) {
+			t.Error("operator file does not match RenderOperatorBeforeFile")
+		}
+
+		// Idempotent: a second pass writes nothing.
+		changed, err = reconcileCRSBeforeFiles(&bytes.Buffer{}, builtin, operator, sample, true)
+		if err != nil || changed {
+			t.Errorf("second pass should be a no-op, got changed=%v err=%v", changed, err)
+		}
+	})
+
+	// Case 2: last exclusion removed. A stale operator file must be deleted, not
+	// left with content that keeps a since-removed exclusion live.
+	t.Run("empty list removes a stale operator file", func(t *testing.T) {
+		dir := t.TempDir()
+		builtin := filepath.Join(dir, "jabali-before.conf")
+		operator := filepath.Join(dir, "jabali-operator-before.conf")
+		if err := os.WriteFile(builtin, []byte(appseccfg.CRSPluginBefore()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(operator, []byte(appseccfg.RenderOperatorBeforeFile(sample)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		changed, err := reconcileCRSBeforeFiles(&bytes.Buffer{}, builtin, operator, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Error("removing the operator file should report changed=true")
+		}
+		if _, err := os.Stat(operator); !os.IsNotExist(err) {
+			t.Errorf("operator file should be gone, stat err=%v", err)
+		}
+	})
+
+	// Case 3: DB unreachable (operatorKnown=false). The operator file must be
+	// left EXACTLY as-is — a transient outage cannot drop live exclusions.
+	t.Run("db down leaves the operator file untouched", func(t *testing.T) {
+		dir := t.TempDir()
+		builtin := filepath.Join(dir, "jabali-before.conf")
+		operator := filepath.Join(dir, "jabali-operator-before.conf")
+		if err := os.WriteFile(builtin, []byte(appseccfg.CRSPluginBefore()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		want := appseccfg.RenderOperatorBeforeFile(sample)
+		if err := os.WriteFile(operator, []byte(want), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		changed, err := reconcileCRSBeforeFiles(&bytes.Buffer{}, builtin, operator, nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Error("nothing changed (built-in already current, operator left as-is) — want changed=false")
+		}
+		got, _ := os.ReadFile(operator)
+		if string(got) != want {
+			t.Error("operator file was modified while the DB was unreachable — live exclusions at risk")
+		}
+	})
+
+	// Case 4: one-time migration off the old combined file. A box whose
+	// jabali-before.conf still holds built-ins + operator (the pre-#1655 format)
+	// must end with built-ins-only there and the operator file split out.
+	t.Run("migrates the combined pre-split file", func(t *testing.T) {
+		dir := t.TempDir()
+		builtin := filepath.Join(dir, "jabali-before.conf")
+		operator := filepath.Join(dir, "jabali-operator-before.conf")
+		combined := appseccfg.CRSPluginBefore() + appseccfg.RenderExclusions(sample)
+		if err := os.WriteFile(builtin, []byte(combined), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		changed, err := reconcileCRSBeforeFiles(&bytes.Buffer{}, builtin, operator, sample, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed {
+			t.Error("migration should report changed=true")
+		}
+		gotBuiltin, _ := os.ReadFile(builtin)
+		if string(gotBuiltin) != appseccfg.CRSPluginBefore() {
+			t.Error("combined file was not reduced to built-ins-only")
+		}
+		gotOperator, _ := os.ReadFile(operator)
+		if string(gotOperator) != appseccfg.RenderOperatorBeforeFile(sample) {
+			t.Error("operator exclusions were not split into their own file")
+		}
+	})
 }

--- a/panel-api/cmd/server/appsec_exclusion_cmd.go
+++ b/panel-api/cmd/server/appsec_exclusion_cmd.go
@@ -70,7 +70,7 @@ func newAppSecExclusionAddCmd() *cobra.Command {
 			}
 			fmt.Fprintf(cmd.OutOrStdout(),
 				"added %s — rule %s excluded for %s%s\n"+
-					"  apply with: jabali appsec render-config --reconcile\n",
+					"  apply with: jabali appsec render-config --reconcile --reload\n",
 				row.ID, ruleID, host, uriPrefix)
 			return nil
 		},
@@ -132,7 +132,7 @@ func newAppSecExclusionRmCmd() *cobra.Command {
 				return printJSON(map[string]any{"id": args[0], "deleted": true})
 			}
 			fmt.Fprintf(cmd.OutOrStdout(),
-				"removed %s\n  apply with: jabali appsec render-config --reconcile\n", args[0])
+				"removed %s\n  apply with: jabali appsec render-config --reconcile --reload\n", args[0])
 			return nil
 		},
 	}


### PR DESCRIPTION
## What

Operator-managed CRS exclusions (`jabali appsec exclusion add`) were appended to `jabali-before.conf` — the same file the agent re-renders from static built-in content at every boot. The agent has no database access, so it writes built-ins **only**. Once an operator added an exclusion, the two writers diverged and **every agent restart (update, crash, reboot, manual) clobbered the operator section** until the next `render-config`, silently re-banning the operator's users. This is the likely root of the recurring bans in GH #1641.

This PR splits the operator exclusions into their own before-plugin file so a restart can no longer drop them, and closes the related reload papercut (GH #1653).

## Changes

- **New file `jabali-operator-before.conf`** (`CRSPluginOperatorBeforePath`, same `crs-plugins/jabali/` dir, same `crs-plugins/*/*-before.conf` glob). `render-config` writes the operator exclusions there and the built-ins to `jabali-before.conf` **verbatim** — now byte-identical to what the agent's boot writer emits, so the two writers can never clobber each other. Order between the two files is irrelevant (operator rules are self-contained `ctl:ruleRemoveById` in phase 1).
- **Lifecycle:** removing the last exclusion **deletes** the operator file (a stale file would keep a since-removed exclusion live). A **transient DB outage leaves the operator file untouched** (never removed) — the built-ins still get written, and live exclusions are never dropped on a blip.
- **Reload (GH #1653):** `render-config` gains an opt-in `--reload` flag (best-effort `systemctl reload crowdsec` on a real diff). `exclusion add`/`rm` now print `render-config --reconcile --reload`, so a manual operator change takes effect in one step instead of appearing to do nothing.
- Agent comment corrected (the old "byte-identical to the CLI writer" claim was only true with zero operator exclusions); ADR-0124 amended.

## Scope / safety notes

- **Agent behavior is unchanged** — the panel-agent change is comment-only. The agent already wrote built-ins-only to `jabali-before.conf`; nothing about its runtime changes. So there is **no panel/agent version-skew concern**: an old agent against a new panel (or vice-versa) behaves exactly as before, minus the clobber.
- **install.sh needs no change.** The new file is auto-discovered by the existing CRS glob; the `render-config --reconcile` invocation is unchanged; and install.sh keeps owning its single **deferred** reload at the end of crowdsec setup (`_cs_dirty`, so an update never reloads crowdsec mid-run — the GH discussion #109 fresh-install ordering scar). `--reload` is deliberately left **off** there.
  - One small contract shift worth flagging: on a DB-down `render-config`, the command now prints a `! operator CRS exclusions NOT reconciled (database unavailable)` line. install.sh captures stdout and reloads when it's not `"unchanged"`, so a DB-down update now triggers the (deferred, end-of-function) reload even if nothing changed. Harmless — one reload, not mid-install — and the operator visibility is worth it.
- **GH #1653 is narrower than originally filed.** install.sh already reloads after `render-config` (via `_cs_dirty`, the deferred reload). The actual gap was only the **manual operator path** (`exclusion add` → operator runs `render-config` by hand → nothing reloaded). `--reload` closes exactly that gap.
- **One-time transition** on the update that ships this: if the new agent restarts *before* `render-config` runs, it rewrites `jabali-before.conf` to built-ins-only (stripping the old combined operator section) and the operator file doesn't exist yet — so operator exclusions are inactive for the few seconds until install.sh's deferred reload after `render-config` re-creates the operator file. Bounded, self-healing, and strictly better than today's **permanent** clobber on every restart. Covered by a migration test.
- **Uninstall/purge cleanup is unchanged.** install.sh never named `jabali-before.conf` either; both files live under `crs-plugins/jabali/`, removed with crowdsec's data tree.

## Tests

- `internal/appseccfg`: `RenderOperatorBeforeFile` (empty → removal signal, valid → header + rule, all-invalid → still a file with the SKIPPED breadcrumb); a disjointness guard between the two files.
- `panel-api/cmd/server`: `reconcileCRSBeforeFiles` pulled out as a pure, injectable-path core, with four cases — rows present (built-in file **byte-identical to `CRSPluginBefore()`**, operator file exact, idempotent second pass), empty list removes a stale operator file, **DB down leaves the operator file untouched**, and the one-time migration off the combined pre-split file.
- CLI-reference golden regenerated for the new `--reload` flag.

Relates to GH #1641. Follow-ups still open: GH #1650 (central Flarum 920450 handling — now has a clean landing spot: a row → the operator file), GH #1649 (admin UI for exclusions + explain).

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
