### PR TITLE
fix(backups): compensate an orphaned credential file when a CLI destination update fails to persist (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -214,6 +214,12 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Capture whether the DB row already had a credential file BEFORE any
+			// mutation. It gates the compensating cleanup at persist time: only a
+			// file this update newly wrote (row had none) may be removed on
+			// failure — a pre-existing file is still referenced by the surviving
+			// row (JAB-310).
+			origHadCredsFile := d.CredentialsRef != nil
 			changed := false
 			if cmd.Flags().Changed("name") {
 				d.Name = name
@@ -331,8 +337,11 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 			if !changed {
 				return fmt.Errorf("no changes specified")
 			}
-			if err := backupDestinationRepoFromDB().Update(ctx, d); err != nil {
-				return fmt.Errorf("update destination: %w", err)
+			// Persist and, on failure, compensate a credential file this update
+			// newly wrote so a transient DB error can't orphan a secrets file
+			// behind a NULL row (JAB-310).
+			if err := updateBackupDestinationDirect(ctx, sharedAgent.Call, backupDestinationRepoFromDB(), d, origHadCredsFile); err != nil {
+				return err
 			}
 			if jsonOutput {
 				return printJSON(d)

--- a/panel-api/cmd/server/backup_destination_ops.go
+++ b/panel-api/cmd/server/backup_destination_ops.go
@@ -45,3 +45,41 @@ func createBackupDestinationDirect(ctx context.Context, call agentCaller, repo r
 	}
 	return nil
 }
+
+// updateBackupDestinationDirect is the CLI testable core for the persist step of
+// `jabali destination update`. It persists the mutated row and — when this update
+// wrote a BRAND-NEW credential file — removes that just-written file on ANY
+// persistence failure, so a transient DB error can't leave an orphaned root:root
+// 0600 secrets file (SSHPASS / cloud keys) behind a row that never got the
+// reference (JAB-310).
+//
+// The gate rests on an invariant of the update RunE: d.CredentialsRef only goes
+// nil -> non-nil inside a creds_write branch. So origHadCredsFile == false (the
+// DB row had no credential file before this call) together with
+// d.CredentialsRef != nil means exactly "we wrote a new file this call, and the
+// row that survives the failed persist references none" — a true orphan.
+//
+// A PRE-EXISTING credential file (origHadCredsFile true) is deliberately LEFT in
+// place on failure: the surviving row still references it (the path is
+// deterministic per dest_id), so deleting it would break the destination that
+// remains in the DB. That reverse case — a --clear-creds followed by a failed
+// persist, leaving the row pointing at a now-missing file — is a separate class
+// (not a leak) and out of scope here.
+//
+// sharedAgent is *agent.Client (a pointer), so the call value is safe to build
+// even on the DB-only update paths where the agent was never initialised: the
+// compensation branch is the only caller and it is reached only after a
+// creds_write this call, which required the credential agent. Cleanup is
+// best-effort but a failed cleanup is surfaced, never silently swallowed
+// (JAB-275).
+func updateBackupDestinationDirect(ctx context.Context, call agentCaller, repo repository.BackupDestinationRepository, d *models.BackupDestination, origHadCredsFile bool) error {
+	if err := repo.Update(ctx, d); err != nil {
+		if !origHadCredsFile && d.CredentialsRef != nil {
+			if _, derr := call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID}); derr != nil {
+				fmt.Fprintf(os.Stderr, "warning: credential file cleanup failed (%v); remove %s manually\n", derr, *d.CredentialsRef)
+			}
+		}
+		return fmt.Errorf("update destination: %w", err)
+	}
+	return nil
+}

--- a/panel-api/cmd/server/backup_destination_ops_test.go
+++ b/panel-api/cmd/server/backup_destination_ops_test.go
@@ -19,11 +19,18 @@ type fakeBackupDestRepo struct {
 	repository.BackupDestinationRepository
 	createErr    error
 	createCalled int
+	updateErr    error
+	updateCalled int
 }
 
 func (f *fakeBackupDestRepo) Create(_ context.Context, d *models.BackupDestination) error {
 	f.createCalled++
 	return f.createErr
+}
+
+func (f *fakeBackupDestRepo) Update(_ context.Context, d *models.BackupDestination) error {
+	f.updateCalled++
+	return f.updateErr
 }
 
 // recordingAgent records each agent command (and its params), and can be told to
@@ -153,6 +160,111 @@ func TestBackupDestinationCreate_RoutesThroughCore(t *testing.T) {
 	src := readOpsSource(t, "backup_destination_cmd.go")
 	if !strings.Contains(src, "createBackupDestinationDirect(ctx, sharedAgent.Call,") {
 		t.Error("create RunE must route through createBackupDestinationDirect with the production agent caller")
+	}
+}
+
+// TestUpdateBackupDestinationDirect_CompensatesOrphanOnPersistFail is the
+// load-bearing guard: this update wrote a brand-new credential file (the row had
+// none before), and the persist failed — the orphaned secrets file must be
+// removed so it isn't left behind a NULL row.
+func TestUpdateBackupDestinationDirect_CompensatesOrphanOnPersistFail(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{updateErr: errors.New("connection reset")}
+	d := newDest()
+	ref := "/var/lib/jabali/creds/dst-1.env"
+	d.CredentialsRef = &ref // a creds_write earlier in this update set it
+
+	err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false)
+	if err == nil {
+		t.Fatal("expected the update failure to propagate")
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("newly-written credential file was NOT cleaned up on persist failure (orphan leak)")
+	}
+	if got := agent.params["backup.dest.creds_delete"]["dest_id"]; got != "dst-1" {
+		t.Fatalf("creds_delete dest_id = %v, want dst-1", got)
+	}
+}
+
+// TestUpdateBackupDestinationDirect_PreExistingRefNotDeletedOnFail is the other
+// load-bearing guard: a credential file the DB row ALREADY referenced must NOT be
+// removed on a persist failure — the surviving row still points at it, so
+// deleting it would break the live destination.
+func TestUpdateBackupDestinationDirect_PreExistingRefNotDeletedOnFail(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{updateErr: errors.New("connection reset")}
+	d := newDest()
+	ref := "/var/lib/jabali/creds/dst-1.env"
+	d.CredentialsRef = &ref
+
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, true); err == nil {
+		t.Fatal("expected the update failure to propagate")
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatal("a pre-existing credential file (still referenced by the surviving row) must NOT be deleted")
+	}
+}
+
+// TestUpdateBackupDestinationDirect_NoRefNoDelete: nothing to clean up when the
+// update wrote no credential file, even on a persist failure.
+func TestUpdateBackupDestinationDirect_NoRefNoDelete(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{updateErr: errors.New("boom")}
+	d := newDest() // CredentialsRef nil
+
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false); err == nil {
+		t.Fatal("expected the update failure to propagate")
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatalf("no credential file was written, so nothing must be deleted, got %v", agent.cmds)
+	}
+}
+
+// TestUpdateBackupDestinationDirect_SuccessNoCompensation: a successful persist
+// touches no agent cleanup.
+func TestUpdateBackupDestinationDirect_SuccessNoCompensation(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{}
+	d := newDest()
+	ref := "/var/lib/jabali/creds/dst-1.env"
+	d.CredentialsRef = &ref
+
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.updateCalled != 1 {
+		t.Fatalf("Update called %d times, want 1", repo.updateCalled)
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatal("no cleanup expected on success")
+	}
+}
+
+// TestBackupDestinationUpdate_RoutesThroughCore source-pins that the update RunE
+// hands the production agent caller to the compensating core, and that it
+// captures origHadCredsFile BEFORE the --clear-creds branch — capturing it later
+// would misread a cleared ref as "no pre-existing file" and wrongly compensate a
+// file the surviving row still references.
+func TestBackupDestinationUpdate_RoutesThroughCore(t *testing.T) {
+	src := readOpsSource(t, "backup_destination_cmd.go")
+	start := strings.Index(src, "func newBackupDestinationUpdateCmd(")
+	if start < 0 {
+		t.Fatal("update command not found")
+	}
+	body := src[start:]
+	if end := strings.Index(body, "\nfunc newBackupDestinationRotatePasswordCmd("); end > 0 {
+		body = body[:end]
+	}
+	if !strings.Contains(body, "updateBackupDestinationDirect(ctx, sharedAgent.Call,") {
+		t.Error("update RunE must route the persist through updateBackupDestinationDirect with the production agent caller")
+	}
+	capIdx := strings.Index(body, "origHadCredsFile := d.CredentialsRef != nil")
+	clearIdx := strings.Index(body, "if clearCreds {")
+	if capIdx < 0 {
+		t.Fatal("origHadCredsFile capture not found")
+	}
+	if clearIdx < 0 || capIdx > clearIdx {
+		t.Error("origHadCredsFile must be captured BEFORE the --clear-creds branch mutates CredentialsRef")
 	}
 }
 


### PR DESCRIPTION
## What

`jabali destination update` writes the destination's Agent credential file
(SSHPASS / cloud secrets, root:root 0600) via `backup.dest.creds_write` when a
`--env` / `--env-stdin` / `--sftp-password` flag is set, then persists the row.
If the row `UPDATE` failed **after a first-time credential write** — the
destination had no credential file before this call — the function returned the
error and left the just-written secrets file on disk behind a row whose
`CredentialsRef` stayed NULL: an **orphaned secrets file**, the same leak class
the create path fixed in #1647.

## Fix

Route the persist step through a new testable core `updateBackupDestinationDirect`,
which removes the just-written file on ANY persistence failure — but **only when
the row that survives the failed persist references no credential file**. A
pre-existing file is deliberately left in place: the surviving row still
references it (the path is deterministic per `dest_id`), so deleting it would
break the live destination. The RunE captures `origHadCredsFile` before any
mutation and passes it to the core; the gate rests on the RunE invariant that
`CredentialsRef` only goes nil → non-nil inside a `creds_write` branch. Cleanup
is best-effort, but a failed cleanup is surfaced on stderr, never silently
swallowed (JAB-275). The CLI error string is unchanged (`update destination: %w`).

## Scope

Closes the leak on the CLI update path. Named, out of scope:
- **Admin REST update** (`internal/api/backup_destinations.go`) has the SAME
  leak — it writes creds then returns `db_update` on a failed `repo.Update` with
  no compensation. Bringing it to compensate is a module follow-up.
- **`--clear-creds` then a failed persist** — the row then references a
  now-missing file: a different, non-leak class.
- The **delete command's swallowed `creds_delete`**.

**JAB-310 stays a module-parent.**

## Tests

A matrix on `updateBackupDestinationDirect` — an orphan (row had no file, this
call wrote one, persist fails) is cleaned up; a pre-existing file (row already
referenced it) is NOT deleted on failure; no file written means no cleanup; a
successful persist touches no agent cleanup. Plus a source-pin that the update
RunE routes the persist through the core with the production agent caller AND
captures `origHadCredsFile` before the `--clear-creds` branch (capturing it later
would misread a cleared ref as "no pre-existing file" and wrongly compensate a
file the surviving row still references).

The orphan-compensation and pre-existing-preservation guards, and the
capture-ordering pin, were each falsified — disabling the compensation, dropping
the `origHadCredsFile` gate, and moving the capture after `--clear-creds` —
confirming the matching test went red, then reverted. `go build ./...` / `vet` /
`gofmt` clean; `go test -race` green on `cmd/server`.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
