### PR TITLE
fix(backups): compensate an orphaned credential file when the admin REST destination update fails to persist (JAB-310)

### DIFF
--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -335,6 +335,11 @@ func (h *backupDestinationHandler) update(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_get"})
 		return
 	}
+	// origHadCredsFile records whether the DB row already had a credential file
+	// BEFORE this call. It gates the persist-failure compensation below and MUST
+	// be captured here, before the --clear-creds and creds-write blocks mutate
+	// d.CredentialsRef.
+	origHadCredsFile := d.CredentialsRef != nil
 	var req updateDestinationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body", "detail": err.Error()})
@@ -403,6 +408,18 @@ func (h *backupDestinationHandler) update(c *gin.Context) {
 		d.CredentialsRef = &path
 	}
 	if err := h.repo.Update(c.Request.Context(), d); err != nil {
+		// Compensate a just-written credential file. If this update wrote a
+		// brand-new file (the row had none before) and the persist then failed,
+		// the file would otherwise be orphaned behind a row whose credentials_ref
+		// stayed NULL — the same root:root 0600 secrets leak the create handler
+		// compensates above and the CLI update path fixed under JAB-310. A PRE-EXISTING
+		// file is deliberately left in place: the surviving row still references
+		// it (the path is deterministic per id), so deleting it would break the
+		// live destination. deleteCreds is best-effort and, unlike the CLI, stays
+		// silent on a cleanup failure by existing design (a separate follow-up).
+		if !origHadCredsFile && d.CredentialsRef != nil {
+			h.deleteCreds(c.Request.Context(), d.ID)
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
 		return
 	}

--- a/panel-api/internal/api/backup_destinations_update_compensation_test.go
+++ b/panel-api/internal/api/backup_destinations_update_compensation_test.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// credsRecordingAgent records every agent command in order and returns a canned
+// creds_write reply so writeCreds succeeds. It lets a test assert whether the
+// destination's credential file was removed (backup.dest.creds_delete).
+type credsRecordingAgent struct {
+	commands []string
+}
+
+func (a *credsRecordingAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	a.commands = append(a.commands, cmd)
+	if cmd == "backup.dest.creds_write" {
+		return json.RawMessage(`{"path":"/etc/jabali-panel/restic-remotes/dst-1.env"}`), nil
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (a *credsRecordingAgent) count(cmd string) int {
+	n := 0
+	for _, c := range a.commands {
+		if c == cmd {
+			n++
+		}
+	}
+	return n
+}
+
+// updFakeDestRepo returns a preset destination from Get and a preset error from
+// Update. Every other repository method is promoted from the embedded nil
+// interface and panics if called — the update handler calls only Get and Update.
+type updFakeDestRepo struct {
+	repository.BackupDestinationRepository
+	getDest   *models.BackupDestination
+	updateErr error
+}
+
+func (r *updFakeDestRepo) Get(_ context.Context, _ string) (*models.BackupDestination, error) {
+	return r.getDest, nil
+}
+
+func (r *updFakeDestRepo) Update(_ context.Context, _ *models.BackupDestination) error {
+	return r.updateErr
+}
+
+// updDo drives backupDestinationHandler.update directly (skipping the admin
+// middleware) with a PATCH body and an :id param.
+func updDo(h *backupDestinationHandler, id string, body map[string]any) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	raw, _ := json.Marshal(body)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/admin/backup-destinations/"+id, bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	h.update(c)
+	return w
+}
+
+// A first-time credential write (row had no file) followed by a failed persist
+// must remove the just-written file, or it orphans a root:root 0600 secrets file
+// behind a row whose credentials_ref stayed NULL. Load-bearing.
+func TestBackupDestinationUpdate_CompensatesOrphanOnPersistFail(t *testing.T) {
+	ag := &credsRecordingAgent{}
+	repo := &updFakeDestRepo{
+		getDest:   &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3},
+		updateErr: errors.New("db down"),
+	}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"credentials_env": map[string]string{"AWS_SECRET_ACCESS_KEY": "x"}})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", w.Code)
+	}
+	if got := ag.count("backup.dest.creds_write"); got != 1 {
+		t.Fatalf("creds_write fired %d times, want 1", got)
+	}
+	if got := ag.count("backup.dest.creds_delete"); got != 1 {
+		t.Fatalf("orphaned credential file not compensated: creds_delete fired %d times, want 1", got)
+	}
+}
+
+// A PRE-EXISTING credential file (the row already referenced one) must NOT be
+// deleted on a failed persist: the surviving row still points at it (the path is
+// deterministic per id), so deleting it would break the live destination.
+// Load-bearing.
+func TestBackupDestinationUpdate_PreExistingRefNotDeletedOnFail(t *testing.T) {
+	ref := "/etc/jabali-panel/restic-remotes/dst-1.env"
+	ag := &credsRecordingAgent{}
+	repo := &updFakeDestRepo{
+		getDest:   &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3, CredentialsRef: &ref},
+		updateErr: errors.New("db down"),
+	}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"credentials_env": map[string]string{"AWS_SECRET_ACCESS_KEY": "x"}})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", w.Code)
+	}
+	if got := ag.count("backup.dest.creds_delete"); got != 0 {
+		t.Fatalf("pre-existing credential file wrongly deleted on failure: creds_delete fired %d times, want 0", got)
+	}
+}
+
+// A metadata-only update (no credentials_env) writes no file, so a failed
+// persist must touch neither creds verb.
+func TestBackupDestinationUpdate_NoCredsNoDelete(t *testing.T) {
+	ag := &credsRecordingAgent{}
+	repo := &updFakeDestRepo{
+		getDest:   &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3},
+		updateErr: errors.New("db down"),
+	}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"enabled": false})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", w.Code)
+	}
+	if wr, del := ag.count("backup.dest.creds_write"), ag.count("backup.dest.creds_delete"); wr != 0 || del != 0 {
+		t.Fatalf("no credential file written this call, but agent creds verbs fired: write=%d delete=%d", wr, del)
+	}
+}
+
+// A successful update must not remove the credential file it just wrote.
+func TestBackupDestinationUpdate_SuccessNoCompensation(t *testing.T) {
+	ag := &credsRecordingAgent{}
+	repo := &updFakeDestRepo{
+		getDest: &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3},
+		// updateErr nil => persist succeeds
+	}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"credentials_env": map[string]string{"AWS_SECRET_ACCESS_KEY": "x"}})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", w.Code)
+	}
+	if got := ag.count("backup.dest.creds_delete"); got != 0 {
+		t.Fatalf("successful update must not remove the credential file: creds_delete fired %d times", got)
+	}
+}
+
+// Source-pin: origHadCredsFile must be captured BEFORE the --clear-creds block.
+// The behavioral matrix above cannot exercise a clear-then-rewrite in the same
+// call cleanly (two creds_delete sources), so pin the ordering directly. If the
+// capture moved after --clear-creds, a clear-then-rewrite would read
+// origHadCredsFile as false and wrongly delete a file the surviving row still
+// references.
+func TestBackupDestinationUpdate_CapturesOrigRefBeforeClearCreds(t *testing.T) {
+	src, err := os.ReadFile("backup_destinations.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	body := string(src)
+	capIdx := strings.Index(body, "origHadCredsFile := d.CredentialsRef != nil")
+	if capIdx < 0 {
+		t.Fatal("origHadCredsFile capture not found in the update handler")
+	}
+	clearIdx := strings.Index(body, "if req.ClearCreds {")
+	if clearIdx < 0 {
+		t.Fatal("--clear-creds block not found")
+	}
+	if capIdx > clearIdx {
+		t.Fatal("origHadCredsFile must be captured BEFORE the --clear-creds block")
+	}
+}


### PR DESCRIPTION
## What

The admin REST endpoint `PATCH /api/v1/admin/backup-destinations/:id` writes the
destination's Agent credential file (SSHPASS / cloud secrets, root:root 0600) via
`backup.dest.creds_write` when the request carries `credentials_env`, then
persists the row. If the row `Update` failed **after a first-time credential
write** — the destination had no credential file before this call — the handler
returned `db_update` and left the just-written secrets file on disk behind a row
whose `credentials_ref` stayed NULL: an **orphaned secrets file**. This is the
same leak class the create handler in this same file already compensates and the
CLI update path fixed under JAB-310 in #1658 — which named this REST path as its
follow-up. This is that follow-up.

## Fix

On any `Update` failure the handler now removes the just-written file — but
**only when the row that survives the failed persist references no credential
file** (`origHadCredsFile == false && d.CredentialsRef != nil`). A pre-existing
file is deliberately left in place: the surviving row still references it (the
path is deterministic per id), so deleting it would break the live destination.

The handler captures `origHadCredsFile` right after the row is loaded, **before**
the `--clear-creds` and creds-write blocks mutate `CredentialsRef`; the gate
rests on the handler invariant that `CredentialsRef` only goes nil → non-nil
inside a creds-write branch.

## Scope — not parity

`deleteCreds` still **swallows** its cleanup error: the CLI surfaces a failed
cleanup on stderr, REST stays silent by existing design. That is unchanged here —
one class per slice — and remains a named follow-up. Also named, out of scope:

- **`--clear-creds` then a failed persist** — the row then references a
  now-missing file: a different, non-leak class.
- The **delete command's swallowed `creds_delete`** / the REST `deleteCreds`
  swallow above.

**JAB-310 stays a module-parent.**

## Tests

A behavioral matrix that drives the update handler end to end:

- a first-time write then a failed persist **removes** the orphan (load-bearing);
- a pre-existing file is **NOT** removed on failure (load-bearing);
- a metadata-only update touches neither creds verb;
- a successful update removes nothing.

Plus a source-pin that `origHadCredsFile` is captured **before** the
`--clear-creds` block. The one scenario where that ordering matters — a
clear-then-rewrite in the same call, which would otherwise misread a cleared ref
as "no pre-existing file" and wrongly delete a file the surviving row still
references — cannot be exercised cleanly by the behavioral matrix (two
`creds_delete` sources), so it is pinned by source position instead.

The orphan-compensation and pre-existing-preservation guards were each falsified
— disabling the compensation drove the orphan test red; dropping the
`origHadCredsFile` gate drove the pre-existing test red — and the
capture-ordering pin was falsified by moving the capture after `--clear-creds`,
each reverted after confirming red. `go build ./...` / `vet` / `gofmt` clean;
`go test -race` green on `internal/api`.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
