### PR TITLE
fix(backups): commit the tenant schedule upsert row and memberships in one transaction (JAB-307)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -2257,16 +2257,14 @@ func (h *meBackupHandler) createSchedule(c *gin.Context) {
 		KeepMonthly: keepMonthly,
 		NextRunAt:   &next,
 	}
-	if err := h.cfg.Schedules.Create(c.Request.Context(), sched); err != nil {
+	// One transaction: the row and both membership sets commit together, or the
+	// whole create rolls back. The previous three sequential writes could leave a
+	// row with no or partial user/destination links if the second or third write
+	// failed (JAB-307). Same atomic repository primitive the admin and CLI paths
+	// use; the tenant surface keeps its own shape (Cadence/Content), so it calls
+	// the primitive directly rather than through the admin lifecycle leaf.
+	if err := h.cfg.Schedules.CreateWithMemberships(c.Request.Context(), sched, dests, []string{uid}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
-		return
-	}
-	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), id, []string{uid}); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
-		return
-	}
-	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), id, dests); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"status": "ok", "id": id})
@@ -2304,16 +2302,17 @@ func (h *meBackupHandler) updateSchedule(c *gin.Context) {
 	sched.Enabled = req.Enabled
 	sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly = keepDaily, keepWeekly, keepMonthly
 	sched.NextRunAt = &next
-	if err := h.cfg.Schedules.Update(c.Request.Context(), sched); err != nil {
+	// One transaction: the field changes and both membership sets commit together,
+	// or the whole update rolls back. The previous three sequential writes could
+	// leave the row on a new cadence while the destination or user set was only
+	// half-replaced (JAB-307). UpdateWithMemberships writes the same column set the
+	// old Update did, so field persistence is unchanged — it only wraps the two
+	// membership replacements into the same transaction. Same atomic repository
+	// primitive the admin and CLI paths use; called directly (not the admin
+	// lifecycle leaf) because the tenant surface keeps its own shape (Cadence/Content).
+	users := []string{uid}
+	if err := h.cfg.Schedules.UpdateWithMemberships(c.Request.Context(), sched, &dests, &users); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
-		return
-	}
-	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), sched.ID, []string{uid}); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
-		return
-	}
-	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), sched.ID, dests); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/panel-api/internal/api/backups_me_schedules_test.go
+++ b/panel-api/internal/api/backups_me_schedules_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -26,6 +27,17 @@ type schedStore struct {
 	rows  map[string]*models.BackupSchedule
 	dests map[string][]string
 	users map[string][]string
+
+	// Instrumentation for the tenant upsert-atomicity slice (JAB-307). The
+	// *Calls counters let a test prove the handler collapsed the three
+	// sequential writes into one atomic primitive; last*Dests/last*Users record
+	// the membership sets each primitive received (dests first, users second);
+	// failCWM/failUWM inject a persistence failure.
+	createCalls, updateCalls, replaceUsersCalls, replaceDestCalls int
+	cwmCalls, uwmCalls                                            int
+	lastCWMDests, lastCWMUsers                                    []string
+	lastUWMDests, lastUWMUsers                                    []string
+	failCWM, failUWM                                              error
 }
 
 func newSchedStore() *schedStore {
@@ -33,6 +45,7 @@ func newSchedStore() *schedStore {
 }
 
 func (s *schedStore) Create(_ context.Context, m *models.BackupSchedule) error {
+	s.createCalls++
 	cp := *m
 	s.rows[m.ID] = &cp
 	return nil
@@ -53,6 +66,7 @@ func (s *schedStore) ListForUser(_ context.Context, userID string) ([]models.Bac
 	return out, nil
 }
 func (s *schedStore) Update(_ context.Context, m *models.BackupSchedule) error {
+	s.updateCalls++
 	if _, ok := s.rows[m.ID]; !ok {
 		return repository.ErrNotFound
 	}
@@ -75,11 +89,53 @@ func (s *schedStore) GetDestinations(_ context.Context, id string) ([]models.Bac
 	return out, nil
 }
 func (s *schedStore) ReplaceDestinations(_ context.Context, id string, d []string) error {
+	s.replaceDestCalls++
 	s.dests[id] = d
 	return nil
 }
 func (s *schedStore) ReplaceUsers(_ context.Context, id string, u []string) error {
+	s.replaceUsersCalls++
 	s.users[id] = u
+	return nil
+}
+
+// CreateWithMemberships / UpdateWithMemberships are the atomic primitives the
+// tenant upsert handlers route through (JAB-307): row plus both membership sets
+// in one unit. destIDs is the first slot, userIDs the second.
+func (s *schedStore) CreateWithMemberships(_ context.Context, m *models.BackupSchedule, destIDs, userIDs []string) error {
+	s.cwmCalls++
+	s.lastCWMDests, s.lastCWMUsers = destIDs, userIDs
+	if s.failCWM != nil {
+		return s.failCWM
+	}
+	cp := *m
+	s.rows[m.ID] = &cp
+	s.dests[m.ID] = destIDs
+	s.users[m.ID] = userIDs
+	return nil
+}
+func (s *schedStore) UpdateWithMemberships(_ context.Context, m *models.BackupSchedule, destIDs, userIDs *[]string) error {
+	s.uwmCalls++
+	if destIDs != nil {
+		s.lastUWMDests = *destIDs
+	}
+	if userIDs != nil {
+		s.lastUWMUsers = *userIDs
+	}
+	if _, ok := s.rows[m.ID]; !ok {
+		return repository.ErrNotFound
+	}
+	if s.failUWM != nil {
+		return s.failUWM
+	}
+	cp := *m
+	s.rows[m.ID] = &cp
+	if destIDs != nil {
+		s.dests[m.ID] = *destIDs
+	}
+	if userIDs != nil {
+		s.users[m.ID] = *userIDs
+	}
 	return nil
 }
 
@@ -261,5 +317,151 @@ func TestMeSchedules_CrossTenantIsolation(t *testing.T) {
 	// The row must survive both cross-tenant attempts.
 	if _, ok := store.rows[aID]; !ok {
 		t.Error("userA's schedule was destroyed by a cross-tenant request")
+	}
+}
+
+// createSchedule must persist the row and both membership sets in ONE atomic
+// primitive, not three sequential writes (JAB-307). Also pins the (dests, users)
+// argument order: swapping the two slots reddens the slot assertions.
+func TestMeSchedules_CreateRoutesThroughAtomicMemberships(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	dest := &models.BackupDestination{ID: "d1", Kind: "local", Enabled: true}
+	h := newSchedHandler(store, users, schedTestPkg(3), dest)
+	r := newSchedRouter(h, "userA")
+
+	rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":true,"content":"full","cadence":"daily","destination_id":"d1"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.cwmCalls != 1 {
+		t.Fatalf("CreateWithMemberships calls = %d, want 1 (must route through the atomic primitive)", store.cwmCalls)
+	}
+	if store.createCalls != 0 || store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("three sequential writes not collapsed: create=%d replaceUsers=%d replaceDest=%d", store.createCalls, store.replaceUsersCalls, store.replaceDestCalls)
+	}
+	if len(store.lastCWMUsers) != 1 || store.lastCWMUsers[0] != "userA" {
+		t.Fatalf("users slot = %v, want [userA] (dests/users arg order swapped?)", store.lastCWMUsers)
+	}
+	if len(store.lastCWMDests) != 1 || store.lastCWMDests[0] != "d1" {
+		t.Fatalf("dests slot = %v, want [d1] (dests/users arg order swapped?)", store.lastCWMDests)
+	}
+}
+
+// updateSchedule must persist the field changes and both membership sets in ONE
+// atomic primitive, not three sequential writes (JAB-307). Also pins the
+// (dests, users) argument order.
+func TestMeSchedules_UpdateRoutesThroughAtomicMemberships(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	dest := &models.BackupDestination{ID: "d1", Kind: "local", Enabled: true}
+	h := newSchedHandler(store, users, schedTestPkg(3), dest)
+	r := newSchedRouter(h, "userA")
+
+	if rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":false,"content":"full","cadence":"daily"}`); rec.Code != http.StatusCreated {
+		t.Fatalf("seed create = %d", rec.Code)
+	}
+	var id string
+	for k := range store.rows {
+		id = k
+	}
+	// Reset counters so the update assertions are unambiguous about the PUT alone.
+	store.uwmCalls, store.updateCalls, store.replaceUsersCalls, store.replaceDestCalls = 0, 0, 0, 0
+
+	rec := doReq(t, r, http.MethodPut, "/me/backup-schedules/"+id, `{"enabled":true,"content":"database","cadence":"hourly","destination_id":"d1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.uwmCalls != 1 {
+		t.Fatalf("UpdateWithMemberships calls = %d, want 1", store.uwmCalls)
+	}
+	if store.updateCalls != 0 || store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("three sequential writes not collapsed: update=%d replaceUsers=%d replaceDest=%d", store.updateCalls, store.replaceUsersCalls, store.replaceDestCalls)
+	}
+	if len(store.lastUWMUsers) != 1 || store.lastUWMUsers[0] != "userA" {
+		t.Fatalf("users slot = %v, want [userA] (dests/users arg order swapped?)", store.lastUWMUsers)
+	}
+	if len(store.lastUWMDests) != 1 || store.lastUWMDests[0] != "d1" {
+		t.Fatalf("dests slot = %v, want [d1] (dests/users arg order swapped?)", store.lastUWMDests)
+	}
+}
+
+// A failed atomic persist must surface as 500 db_update and leave no separate
+// membership write to sneak in around it (JAB-307).
+func TestMeSchedules_UpdateAtomicFailReturns500(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	h := newSchedHandler(store, users, schedTestPkg(3), nil)
+	r := newSchedRouter(h, "userA")
+
+	if rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":false,"content":"full","cadence":"daily"}`); rec.Code != http.StatusCreated {
+		t.Fatalf("seed create = %d", rec.Code)
+	}
+	var id string
+	for k := range store.rows {
+		id = k
+	}
+	store.failUWM = repository.ErrConflict
+	store.replaceUsersCalls, store.replaceDestCalls = 0, 0
+
+	rec := doReq(t, r, http.MethodPut, "/me/backup-schedules/"+id, `{"enabled":false,"content":"database","cadence":"hourly"}`)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "db_update") {
+		t.Fatalf("atomic persist failure must 500 db_update: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("partial membership writes around a failed atomic update: replaceUsers=%d replaceDest=%d", store.replaceUsersCalls, store.replaceDestCalls)
+	}
+}
+
+// A failed atomic persist on create must surface as 500 db_create, leave no
+// separate membership write around it, and store no row (JAB-307).
+func TestMeSchedules_CreateAtomicFailReturns500(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	h := newSchedHandler(store, users, schedTestPkg(3), nil)
+	r := newSchedRouter(h, "userA")
+
+	store.failCWM = repository.ErrConflict
+	rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":false,"content":"full","cadence":"daily"}`)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "db_create") {
+		t.Fatalf("atomic persist failure must 500 db_create: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("partial membership writes around a failed atomic create: replaceUsers=%d replaceDest=%d", store.replaceUsersCalls, store.replaceDestCalls)
+	}
+	if len(store.rows) != 0 {
+		t.Fatalf("failed atomic create left %d rows", len(store.rows))
+	}
+}
+
+// Source-pin: each tenant upsert handler body routes through its atomic
+// primitive and no longer hand-rolls the three separate writes. Scoped to each
+// handler body (createSchedule still legitimately shares the file with the
+// legacy single-schedule upsert, so a file-wide check would over-reach).
+func TestMeSchedules_UpsertHandlersRouteThroughAtomicPrimitives_Source(t *testing.T) {
+	raw, err := os.ReadFile("backups.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	src := string(raw)
+
+	create := scheduleFuncBody(t, src, "func (h *meBackupHandler) createSchedule(")
+	if !strings.Contains(create, "CreateWithMemberships(") {
+		t.Error("createSchedule must route through CreateWithMemberships")
+	}
+	for _, bad := range []string{"Schedules.Create(", "ReplaceUsers(", "ReplaceDestinations("} {
+		if strings.Contains(create, bad) {
+			t.Errorf("createSchedule still calls %s (must be one atomic write)", bad)
+		}
+	}
+
+	update := scheduleFuncBody(t, src, "func (h *meBackupHandler) updateSchedule(")
+	if !strings.Contains(update, "UpdateWithMemberships(") {
+		t.Error("updateSchedule must route through UpdateWithMemberships")
+	}
+	for _, bad := range []string{"Schedules.Update(", "ReplaceUsers(", "ReplaceDestinations("} {
+		if strings.Contains(update, bad) {
+			t.Errorf("updateSchedule still calls %s (must be one atomic write)", bad)
+		}
 	}
 }


### PR DESCRIPTION
## What

The tenant self-service backup-schedule handlers — `POST /me/backup-schedules`
and `PUT /me/backup-schedules/:id` (the GH #454 "7B" tenant surface) — each
wrote the schedule row and then its user and destination links as three separate
repository calls (`Create`/`Update`, then `ReplaceUsers`, then
`ReplaceDestinations`). If the second or third write failed, the row was already
committed with no or partial memberships: a create could leave a schedule the
tenant owns that fans out to nothing, and an update could leave the row on a new
cadence while the destination or user set was only half-replaced.

This routes both handlers through the atomic repository primitives the admin and
operator-CLI paths already use (`CreateWithMemberships` / `UpdateWithMemberships`,
added in #1642 / #1654 / #1656). Each commits the row and both membership sets in
one transaction, or rolls the whole thing back.

## Why a direct repo call, not the lifecycle leaf

Unlike the admin and CLI adapters, this is a direct call to the repository
primitive, not a route through the `backupscheduleops` lifecycle leaf. The tenant
surface has its own request shape (Cadence/Content fields, an admin-owned window)
that does not fit the current leaf signature, so a tenant-shaped leaf op is
future module work, not this slice.

## Not a privilege change

This is an atomicity/consistency fix, not a security change. The tenant
membership is always the caller themselves (`[uid]`), so the "empty user set fans
out to every non-admin" concern that made the admin/CLI slices security-relevant
does not apply here.

`UpdateWithMemberships` writes the same twelve-column map the old `Update` did,
so field persistence is byte-for-byte unchanged; it only wraps the two membership
replacements into the same transaction. The distinct 500 sub-codes
(`db_link_users` / `db_link_destinations`) collapse into the single `db_create` /
`db_update` the atomic call returns — no panel-ui consumer distinguishes them.

## Out of scope (named)

The legacy single-schedule tenant upsert in the same file (findMeSchedule-based,
admin-owned cron window, shared membership tail) has the same three-write shape
but a different structure; it is a separate follow-up. Run-now (AC5) also remains.

## Tests

A behavioral matrix drives the handlers end to end through an instrumented fake
store:
- create and update each route through the atomic primitive exactly once, and the
  three legacy sequential writes are gone;
- the `(dests, users)` argument order is pinned (the users slot must carry the
  owner, the dests slot the selected destination);
- a failed atomic persist surfaces as 500 (`db_create` on create, `db_update` on
  update) with no separate membership write around it, and a failed create stores
  no row.

Plus a source-pin, scoped per handler body, that each body calls its
`*WithMemberships` primitive and no longer calls `Schedules.Create`/`Update`,
`ReplaceUsers`, or `ReplaceDestinations` (the legacy single-schedule upsert
legitimately still calls those, so the pin is per-body, not file-wide).

Four guards falsified red-then-reverted (both argument-order guards, the collapse
guard, and the create-fail 500 guard). `go build ./...` / `go vet ./...` green;
the test file is gofmt-clean; `go test ./internal/api/ -race` green. (`backups.go`
has a pre-existing gofmt misalignment in an unrelated struct that predates this
change and is left untouched.)

Part of JAB-307 (Backup Schedule Lifecycle module); the module parent stays open.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
