### PR TITLE
feat(dns): shared DNS-facet lifecycle leaf — CLI zone delete + re-enable (GH #1611)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1575,10 +1575,30 @@ jabali dns record update <domain> <record-id> [flags]
 
 #### `jabali dns zone`
 
-DNS zones: list / show
+DNS zones: list / show / delete / enable
 
 ```
 jabali dns zone
+```
+
+##### `jabali dns zone delete`
+
+Drop the DNS facet of a domain (host DNS elsewhere; keeps web + mail)
+
+```
+jabali dns zone delete <domain> [flags]
+```
+
+**Flags:**
+
+- `--force` — confirm dropping the zone
+
+##### `jabali dns zone enable`
+
+Re-enable DNS management for a domain (host DNS here again)
+
+```
+jabali dns zone enable <domain>
 ```
 
 ##### `jabali dns zone list`

--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnsops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -213,9 +214,98 @@ func newDNSCmd() *cobra.Command {
 }
 
 func newDNSZoneCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "zone", Short: "DNS zones: list / show"}
-	cmd.AddCommand(newDNSZoneListCmd(), newDNSZoneShowCmd())
+	cmd := &cobra.Command{Use: "zone", Short: "DNS zones: list / show / delete / enable"}
+	cmd.AddCommand(newDNSZoneListCmd(), newDNSZoneShowCmd(), newDNSZoneDeleteCmd(), newDNSZoneEnableCmd())
 	return cmd
+}
+
+// newDNSZoneDeleteCmd drops the DNS facet of a domain (keep web + mail) — the
+// CLI mirror of DELETE /domains/:id/dns/zone (GH #1611). It routes through the
+// same dnsops.DeleteZone leaf as the REST handler, so the panel-primary, DNSSEC,
+// and last-facet guards are enforced identically. Unlike the record commands
+// this DOES talk to the agent: the reconciler never touches a disabled zone, so
+// the PowerDNS zone is removed here, now, rather than on a later tick.
+func newDNSZoneDeleteCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:     "delete <domain>",
+		Short:   "Drop the DNS facet of a domain (host DNS elsewhere; keeps web + mail)",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !force {
+				return fmt.Errorf("re-run with --force to drop the DNS zone for %s", args[0])
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+			defer cancel()
+			dom, err := resolveDomainSpec(ctx, domainRepoFromDB(), args[0])
+			if err != nil {
+				return err
+			}
+			deps := dnsops.Deps{
+				Domains: domainRepoFromDB(),
+				Zones:   dnsZoneRepoFromDB(),
+				Records: dnsRecordRepoFromDB(),
+				Call:    sharedAgent.Call,
+			}
+			warnings, err := dnsops.DeleteZone(ctx, deps, dom)
+			if err != nil {
+				switch {
+				case errors.Is(err, dnsops.ErrLastFacet):
+					return fmt.Errorf("%s has only DNS (no web, no mail) — delete the whole domain instead: jabali domain delete %s", dom.Name, dom.Name)
+				case errors.Is(err, dnsops.ErrPanelPrimary):
+					return fmt.Errorf("%s is the panel's own primary domain and is protected", dom.Name)
+				case errors.Is(err, dnsops.ErrDNSSECEnabled):
+					return fmt.Errorf("%s is DNSSEC-signed — disable DNSSEC and remove the DS record at your registrar before deleting the zone", dom.Name)
+				default:
+					return err
+				}
+			}
+			cliAuditOK(ctx, "dns.zone.delete", "domain", dom.ID, &dom.UserID)
+			if jsonOutput {
+				return printJSON(map[string]any{"domain": dom.Name, "warnings": warnings})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Dropped the DNS zone for %s (web + mail kept).\n", dom.Name)
+			for _, w := range warnings {
+				fmt.Fprintf(cmd.OutOrStdout(), "  warning: %s\n", w)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "confirm dropping the zone")
+	return cmd
+}
+
+// newDNSZoneEnableCmd re-enables DNS management for a domain whose DNS facet was
+// dropped — the CLI mirror of POST /domains/:id/dns/zone (GH #1611). It only
+// flips dns_disabled=false; the running reconciler re-creates the zone row,
+// bootstraps its records, and pushes the zone into PowerDNS on its next tick
+// (same tick-based model as the record commands), so no agent is needed here.
+func newDNSZoneEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "enable <domain>",
+		Short:   "Re-enable DNS management for a domain (host DNS here again)",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			dom, err := resolveDomainSpec(ctx, domainRepoFromDB(), args[0])
+			if err != nil {
+				return err
+			}
+			if err := dnsops.EnableZone(ctx, dnsops.Deps{Domains: domainRepoFromDB()}, dom); err != nil {
+				return err
+			}
+			cliAuditOK(ctx, "dns.zone.enable", "domain", dom.ID, &dom.UserID)
+			if jsonOutput {
+				return printJSON(map[string]any{"domain": dom.Name, "dns_enabled": true})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"Re-enabled DNS for %s. The reconciler re-creates the zone and its records on its next tick.\n", dom.Name)
+			return nil
+		},
+	}
 }
 
 func newDNSZoneListCmd() *cobra.Command {

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -144,6 +144,14 @@ type dnsZoneInventoryRow struct {
 	EffectiveTTL       int        `json:"effective_ttl"`
 	DNSSECEnabled      bool       `json:"dnssec_enabled"`
 	RegistrarExpiresAt *time.Time `json:"registrar_expires_at,omitempty"`
+	// GH #1611: the domain's facet state, so the DNS Zone inventory can tell a
+	// deliberately-dropped zone (dns_disabled=true → offer "Enable DNS") from one
+	// the reconciler simply hasn't provisioned yet, and a DNS-only domain
+	// (web_disabled && !email_enabled → offer "Delete domain" instead of a zone
+	// delete the last-facet guard would refuse) from an ordinary multi-facet one.
+	DNSDisabled  bool `json:"dns_disabled"`
+	WebDisabled  bool `json:"web_disabled"`
+	EmailEnabled bool `json:"email_enabled"`
 }
 
 // listZoneInventory serves GET /dns/zones — the batched DNS Zone overview
@@ -199,6 +207,9 @@ func (h *dnsHandler) listZoneInventory(c *gin.Context) {
 			EffectiveTTL:       ttl,
 			DNSSECEnabled:      domains[i].DNSSECEnabled,
 			RegistrarExpiresAt: domains[i].RegistrarExpiresAt,
+			DNSDisabled:        domains[i].DNSDisabled,
+			WebDisabled:        domains[i].WebDisabled,
+			EmailEnabled:       domains[i].EmailEnabled,
 		}
 	}
 

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -48,6 +48,9 @@ func RegisterDNSRoutes(g *gin.RouterGroup, cfg DNSHandlerConfig) {
 	d.PATCH("/zone", h.updateZone)
 	// GH #1611: drop the DNS facet (keep web + mail) — "host DNS elsewhere".
 	d.DELETE("/zone", h.deleteZone)
+	// GH #1611: re-enable DNS management — "host DNS here again". The reconciler
+	// re-creates the zone + records on its next tick.
+	d.POST("/zone", h.enableZone)
 	d.GET("/records", h.listRecords)
 	d.POST("/records", h.createRecord)
 	// SOA + NS are auto-generated at compile time (never stored in

--- a/panel-api/internal/api/dns_zone_delete.go
+++ b/panel-api/internal/api/dns_zone_delete.go
@@ -1,82 +1,27 @@
-// DNS-zone delete — drop the DNS facet of a domain while keeping web + mail
-// (GH #1611, johnnyq). "Host DNS elsewhere": the panel stops hosting the zone,
-// but the Web Domain and Mail Domain keep working.
+// DNS-zone delete + re-enable — drop or restore the DNS facet of a domain while
+// keeping web + mail (GH #1611, johnnyq). "Host DNS elsewhere": the panel stops
+// hosting the zone, but the Web Domain and Mail Domain keep working; re-enabling
+// hands the zone back to the reconciler.
 //
-// A jabali "domain" is one row carrying web + mail + DNS facets. This is the
-// mirror image of the GH #1603 facet-preserving WEB delete: there the web facet
-// goes and mail/DNS may stay; here the DNS facet goes and web/mail stay. Both
-// share tearDownDNSFacet so the two paths can never drift on how a zone is torn
-// down.
+// A jabali "domain" is one row carrying web + mail + DNS facets. The delete is
+// the mirror image of the GH #1603 facet-preserving WEB delete: there the web
+// facet goes and mail/DNS may stay; here the DNS facet goes and web/mail stay.
+// Both share dnsops.TearDownFacet so the two paths can never drift on how a
+// zone is torn down, and the CLI shares dnsops.DeleteZone/EnableZone so the
+// operator surface enforces exactly the same guards.
 package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
-	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnsops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
-
-// tearDownDNSFacet drops the DNS facet of dom: flip dns_disabled=true, delete the
-// PowerDNS zone on the box, and remove the panel's dns_zones + dns_records rows so
-// the end-state is indistinguishable from a domain created with ManageDNS=false
-// (dns_disabled=1, no zone row — the reconciler never auto-creates one while
-// disabled). Shared by the GH #1603 web-facet delete and the GH #1611 DNS-zone
-// delete.
-//
-// Ordering is fail-closed: the flip runs FIRST and, if it fails, the function
-// returns immediately WITHOUT deleting anything on the box — dns_disabled is
-// still 0, so the reconciler still owns the zone and would resurrect whatever we
-// removed. flipErr is that (hard) failure; a zone-delete or row-cleanup problem
-// is non-fatal residue returned in warnings (the flag is already set, so a retry
-// of the same delete converges).
-func tearDownDNSFacet(
-	ctx context.Context,
-	domains repository.DomainRepository,
-	zones repository.DNSZoneRepository,
-	records repository.DNSRecordRepository,
-	ag agent.AgentInterface,
-	dom *models.Domain,
-) (warnings []string, flipErr error) {
-	// 1. dns_disabled=true BEFORE any teardown so the reconciler stops pushing
-	//    the zone. On failure the reconciler still owns it → do NOT delete it.
-	if err := domains.UpdateDNSDisabled(ctx, dom.ID, true); err != nil {
-		return nil, err
-	}
-
-	// 2. Delete the PowerDNS zone on the box. A box without the DNS module has no
-	//    PowerDNS backend; that is permanent, not a failure.
-	zctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	_, zerr := ag.Call(zctx, "dns.zone.delete", map[string]string{"zone": dom.Name})
-	cancel()
-	if zerr != nil && !strings.Contains(zerr.Error(), "powerdns backend not available") {
-		warnings = append(warnings, "DNS zone not removed on the server; remove it manually if it lingers")
-	}
-
-	// 3. Remove the panel's zone + records rows so the domain matches the
-	//    ManageDNS=false shape (no zone row). FindByDomainID → ErrNotFound simply
-	//    means there was never a row (created disabled) — nothing to clean. The
-	//    repos are optional (nil in a dev binary without DNS wired); a missing one
-	//    just leaves the rows in place, non-fatally.
-	if zones == nil || records == nil {
-		return warnings, nil
-	}
-	if z, err := zones.FindByDomainID(ctx, dom.ID); err == nil && z != nil {
-		if err := records.DeleteByZoneID(ctx, z.ID); err != nil {
-			warnings = append(warnings, "DNS records not cleared from the panel database")
-		}
-		if err := zones.Delete(ctx, z.ID); err != nil {
-			warnings = append(warnings, "DNS zone row not cleared from the panel database")
-		}
-	}
-	return warnings, nil
-}
 
 // tenantMayDeleteZone reports whether a non-admin tenant may delete an entire
 // zone under the server's per-type DNS record policy (GH #466). A zone delete
@@ -85,7 +30,7 @@ func tearDownDNSFacet(
 // locked delete on even one type (say MX), a tenant cannot drop the whole zone
 // out from under that restriction — they delete records within their allowance
 // instead. Mirrors the per-record delete gate in deleteRecord so the zone path
-// can't be used to bypass it wholesale.
+// can't be used to bypass it wholesale. REST-only: the CLI is admin context.
 func tenantMayDeleteZone(pol models.DNSUserRecordPolicy) bool {
 	for _, t := range models.UserManageableDNSTypes {
 		if !pol.Allows(t, "delete") {
@@ -95,13 +40,22 @@ func tenantMayDeleteZone(pol models.DNSUserRecordPolicy) bool {
 	return true
 }
 
+// dnsFacetDeps builds the dnsops.Deps for this handler's repositories. The
+// dnsHandler config uses Zones/Records (the domainHandler uses DNSZones/
+// DNSRecords), so each caller assembles its own Deps.
+func (h *dnsHandler) dnsFacetDeps() dnsops.Deps {
+	d := dnsops.Deps{Domains: h.cfg.Domains, Zones: h.cfg.Zones, Records: h.cfg.Records}
+	if h.cfg.Agent != nil {
+		d.Call = h.cfg.Agent.Call
+	}
+	return d
+}
+
 // deleteZone serves DELETE /domains/:id/dns/zone — drop the DNS facet, keep web
-// + mail. Admin or the domain's owner. Refuses (v1) rather than surprise:
-//   - the panel's own primary domain (its DNS underpins the panel);
-//   - a DNSSEC-signed zone (deleting it makes the domain bogus for validating
-//     resolvers while the DS still sits at the registrar);
-//   - the domain's LAST facet (web off + mail off): deleting DNS would leave an
-//     empty row — the caller should delete the whole domain instead.
+// + mail. Admin or the domain's owner. The transition guards (panel-primary,
+// DNSSEC, last-facet, idempotent-when-already-disabled) live in dnsops.DeleteZone
+// so the CLI enforces them identically; this adapter adds only the REST-specific
+// authorization and the GH #466 per-type policy gate.
 func (h *dnsHandler) deleteZone(c *gin.Context) {
 	ctx := c.Request.Context()
 
@@ -118,11 +72,6 @@ func (h *dnsHandler) deleteZone(c *gin.Context) {
 	}
 	claims := ginctx.Claims(c) // non-nil: loadDomainOwned already gated it.
 
-	if dom.IsPanelPrimary {
-		c.JSON(http.StatusForbidden, gin.H{"error": "panel_primary_protected"})
-		return
-	}
-
 	// Per-type DNS policy gate for non-admin tenants (GH #466). A zone delete is a
 	// delete of every record, so a tenant may drop the zone only if the policy
 	// permits delete on every user-manageable type; admins bypass. Same 403 shape
@@ -135,31 +84,28 @@ func (h *dnsHandler) deleteZone(c *gin.Context) {
 		return
 	}
 
-	// Transition guards only fire when DNS is currently managed. If it's already
-	// disabled the call is an idempotent cleanup (a retry after a partial run),
-	// so let tearDownDNSFacet mop up any lingering zone/rows and return 200.
-	if !dom.DNSDisabled {
-		if dom.DNSSECEnabled {
+	// The teardown must complete even if the client hangs up.
+	ctx = context.WithoutCancel(ctx)
+	warnings, err := dnsops.DeleteZone(ctx, h.dnsFacetDeps(), dom)
+	if err != nil {
+		switch {
+		case errors.Is(err, dnsops.ErrPanelPrimary):
+			c.JSON(http.StatusForbidden, gin.H{"error": "panel_primary_protected"})
+		case errors.Is(err, dnsops.ErrDNSSECEnabled):
 			c.JSON(http.StatusConflict, gin.H{
 				"error":  "dnssec_enabled",
 				"detail": "Disable DNSSEC and remove the DS record at your registrar before deleting the zone.",
 			})
-			return
-		}
-		if dom.WebDisabled && !dom.EmailEnabled {
+		case errors.Is(err, dnsops.ErrLastFacet):
 			c.JSON(http.StatusConflict, gin.H{
 				"error":  "last_facet",
 				"detail": "This domain has only DNS (no web, no mail). Delete the whole domain instead.",
 			})
-			return
+		case errors.Is(err, dnsops.ErrAgentUnavailable):
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dns_teardown_unavailable"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		}
-	}
-
-	// The teardown must complete even if the client hangs up.
-	ctx = context.WithoutCancel(ctx)
-	warnings, flipErr := tearDownDNSFacet(ctx, h.cfg.Domains, h.cfg.Zones, h.cfg.Records, h.cfg.Agent, dom)
-	if flipErr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
 	if h.cfg.Reconciler != nil {
@@ -169,4 +115,30 @@ func (h *dnsHandler) deleteZone(c *gin.Context) {
 		"kept":     gin.H{"web": !dom.WebDisabled, "mail": dom.EmailEnabled},
 		"warnings": warnings,
 	})
+}
+
+// enableZone serves POST /domains/:id/dns/zone — re-enable DNS management for a
+// domain whose DNS facet was previously dropped ("host DNS here again"). Admin
+// or the domain's owner. Flips dns_disabled=false and nudges the reconciler,
+// which re-creates the zone row, bootstraps its records, and pushes the zone
+// into PowerDNS on its next tick. No agent round-trip and no GH #466 gate: the
+// reconciler system-seeds the zone exactly as it does at domain create, so this
+// grants no ability to write an otherwise-forbidden record type. Idempotent for
+// a domain whose DNS is already enabled.
+func (h *dnsHandler) enableZone(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	dom := h.loadDomainOwned(c, c.Param("id"))
+	if dom == nil {
+		return
+	}
+
+	if err := dnsops.EnableZone(context.WithoutCancel(ctx), dnsops.Deps{Domains: h.cfg.Domains}, dom); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if h.cfg.Reconciler != nil {
+		h.cfg.Reconciler.Schedule(dom.ID)
+	}
+	c.JSON(http.StatusOK, gin.H{"dns_enabled": true})
 }

--- a/panel-api/internal/api/dns_zone_delete_test.go
+++ b/panel-api/internal/api/dns_zone_delete_test.go
@@ -236,3 +236,56 @@ func TestDeleteZone_AlreadyDisabled_Idempotent(t *testing.T) {
 	assert.Equal(t, 1, dr.flipCalls, "re-flip is idempotent")
 	assert.Equal(t, 1, ag.callCount, "pdns delete still attempted")
 }
+
+// --- GH #1611: re-enable DNS management (POST /domains/:id/dns/zone) ---
+
+func ezDo(h *dnsHandler, id, userID string, isAdmin bool) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/domains/"+id+"/dns/zone", nil)
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: isAdmin})
+	h.enableZone(c)
+	return w
+}
+
+func TestEnableZone_Flips_And_Returns200(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", DNSDisabled: true}
+	dr := &dzDomainRepo{dom: dom}
+	// No agent needed for enable — the reconciler re-creates the zone.
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr}}
+
+	w := ezDo(h, "d1", "u1", false)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "dns_enabled")
+	assert.Equal(t, 1, dr.flipCalls, "flipped once")
+	assert.False(t, dr.flippedTo, "flipped to enabled (dns_disabled=false)")
+}
+
+func TestEnableZone_AlreadyEnabled_Idempotent(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", DNSDisabled: false}
+	dr := &dzDomainRepo{dom: dom}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr}}
+
+	w := ezDo(h, "d1", "u1", false)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0, dr.flipCalls, "no write when DNS already enabled")
+}
+
+func TestEnableZone_NonOwner_Forbidden(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "owner", DNSDisabled: true}
+	dr := &dzDomainRepo{dom: dom}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr}}
+
+	w := ezDo(h, "d1", "someone-else", false)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, 0, dr.flipCalls, "no flip for a non-owner")
+}
+
+func TestEnableZone_NotFound(t *testing.T) {
+	dr := &dzDomainRepo{notFound: true}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr}}
+	w := ezDo(h, "nope", "u1", true)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/panel-api/internal/api/dns_zone_delete_test.go
+++ b/panel-api/internal/api/dns_zone_delete_test.go
@@ -17,9 +17,9 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// Fakes for the GH #1611 DNS-zone delete. Each embeds its repository interface so
-// only the methods deleteZone/tearDownDNSFacet touch are implemented; any other
-// call panics (guards against silent scope creep).
+// Fakes for the GH #1611 DNS-zone delete + re-enable. Each embeds its repository
+// interface so only the methods deleteZone/enableZone touch are implemented; any
+// other call panics (guards against silent scope creep).
 
 type dzDomainRepo struct {
 	repository.DomainRepository
@@ -168,7 +168,7 @@ func TestDeleteZone_NotFound(t *testing.T) {
 
 func TestDeleteZone_FlipFail_500_NoTeardown(t *testing.T) {
 	// The flip failing means dns_disabled is still 0 → the reconciler still owns
-	// the zone; tearDownDNSFacet must NOT delete it, and the caller returns 500.
+	// the zone; the teardown must NOT delete it, and the caller returns 500.
 	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true}
 	zone := &models.DNSZone{ID: "z1", DomainID: "d1"}
 	h, dr, zr, rr, ag := dzHandler(dom, zone)
@@ -227,7 +227,7 @@ func TestDeleteZone_TenantRestrictedByPolicy(t *testing.T) {
 
 func TestDeleteZone_AlreadyDisabled_Idempotent(t *testing.T) {
 	// A retry after a partial run: dns_disabled is already true and no zone row
-	// remains. The transition guards are skipped; tearDownDNSFacet re-flips
+	// remains. The transition guards are skipped; the teardown re-flips
 	// (idempotent), still calls the agent, finds no row to clean, returns 200.
 	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", EmailEnabled: true, DNSDisabled: true}
 	h, dr, _, _, ag := dzHandler(dom, nil) // nil zone → FindByDomainID ErrNotFound

--- a/panel-api/internal/api/dns_zone_inventory_test.go
+++ b/panel-api/internal/api/dns_zone_inventory_test.go
@@ -187,6 +187,32 @@ func TestZoneInventory_NotProvisioned(t *testing.T) {
 	require.EqualValues(t, 0, resp.Data[0].RecordCount)
 }
 
+// GH #1611: the facet flags project through so the DNS Zone inventory can tell a
+// deliberately-dropped zone (dns_disabled=true) from one merely pending, and a
+// DNS-only domain (web off + mail off) from a multi-facet one. A dropped zone
+// has no zone row, so it reports provisioned=false — the flags are what
+// distinguish it from a genuinely not-yet-provisioned domain.
+func TestZoneInventory_FacetFlags(t *testing.T) {
+	dr := &countingDomainRepo{domains: []models.Domain{
+		{ID: "d1", Name: "dropped.com", UserID: "u1", DNSDisabled: true, WebDisabled: true, EmailEnabled: false},
+	}}
+	zr := &noZoneRepo{}
+	h := &dnsHandler{cfg: DNSHandlerConfig{Domains: dr, Zones: zr, Records: &countingRecordRepo{}, ServerSettings: &countingSettingsRepo{}}}
+
+	w := invGet(h, "/dns/zones", "admin", true)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var resp struct {
+		Data []dnsZoneInventoryRow `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	require.False(t, resp.Data[0].Provisioned)
+	require.True(t, resp.Data[0].DNSDisabled, "dns_disabled projects through")
+	require.True(t, resp.Data[0].WebDisabled, "web_disabled projects through")
+	require.False(t, resp.Data[0].EmailEnabled, "email_enabled projects through")
+}
+
 type noZoneRepo struct {
 	repository.DNSZoneRepository
 }

--- a/panel-api/internal/api/domain_facet_delete.go
+++ b/panel-api/internal/api/domain_facet_delete.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"time"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnsops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
@@ -77,7 +78,11 @@ func (h *domainHandler) facetPreservingWebDelete(
 	//    delete the PowerDNS zone, and clear the panel's zone + records rows so
 	//    the domain matches the ManageDNS=false shape.
 	if deleteDNS {
-		w, flipErr := tearDownDNSFacet(ctx, h.cfg.Domains, h.cfg.DNSZones, h.cfg.DNSRecords, h.cfg.Agent, dom)
+		dnsDeps := dnsops.Deps{Domains: h.cfg.Domains, Zones: h.cfg.DNSZones, Records: h.cfg.DNSRecords}
+		if h.cfg.Agent != nil {
+			dnsDeps.Call = h.cfg.Agent.Call
+		}
+		w, flipErr := dnsops.TearDownFacet(ctx, dnsDeps, dom)
 		if flipErr != nil {
 			warnings = append(warnings, "DNS management flag not cleared in the database")
 		}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3197,6 +3197,7 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses:
         "200": { description: DNS re-enabled; the reconciler re-creates the zone }
+        "403": { description: Forbidden (not the domain's owner) }
         "404": { description: Domain not found }
     delete:
       tags: [Dns]

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3190,6 +3190,14 @@ paths:
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
+    post:
+      tags: [Dns]
+      summary: Re-enable DNS management (host DNS here again — GH #1611)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "200": { description: DNS re-enabled; the reconciler re-creates the zone }
+        "404": { description: Domain not found }
     delete:
       tags: [Dns]
       summary: Delete the DNS zone (drop DNS, keep web + mail — GH #1611)

--- a/panel-api/internal/dnsops/dnsops.go
+++ b/panel-api/internal/dnsops/dnsops.go
@@ -1,0 +1,177 @@
+// Package dnsops is the shared DNS-facet lifecycle (GH #1611): the tear-down
+// and re-enable operations the REST handlers and the operator CLI both route
+// through, so the fail-closed ordering, the transition guards, and the
+// PowerDNS/row cleanup have one owner and cannot drift between the two.
+//
+// A jabali "domain" is one row carrying web + mail + DNS facets. Dropping the
+// DNS facet flips dns_disabled=true, deletes the PowerDNS zone on the box, and
+// removes the panel's dns_zones + dns_records rows so the end-state is
+// indistinguishable from a domain created with ManageDNS=false. Re-enabling
+// flips dns_disabled=false; the reconciler then re-creates the zone row,
+// bootstraps its records, and pushes the zone into PowerDNS on its next tick
+// (the Schedule nudge stays a caller concern to avoid a reconciler import
+// cycle).
+//
+// Authorization stays an Adapter concern: every entry point takes an already-
+// loaded, already-authorized domain (the REST handler checks the caller's
+// claims and the GH #466 per-type policy; the operator CLI is admin-by-
+// construction). TearDownFacet is the UNGUARDED teardown shared with the GH
+// #1603 web-facet delete, which runs its own sequence; DeleteZone wraps it with
+// the transition guards the two zone-delete entry points (REST + CLI) share.
+package dnsops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// CallFunc is the hard agent call TearDownFacet uses to delete the PowerDNS
+// zone — its error is folded into warnings (the flag is already flipped, so a
+// retry converges), never a hard abort of the teardown.
+type CallFunc func(ctx context.Context, cmd string, params any) (json.RawMessage, error)
+
+// Deps carries the collaborators every operation needs. Zones/Records are
+// optional (nil in a dev binary without DNS wired): a nil pair just leaves the
+// rows in place, non-fatally. Call is required — a nil Call fails closed before
+// anything is flipped.
+type Deps struct {
+	Domains repository.DomainRepository
+	Zones   repository.DNSZoneRepository
+	Records repository.DNSRecordRepository
+	Call    CallFunc
+}
+
+var (
+	ErrDeps             = errors.New("dnsops: dependencies not wired")
+	ErrAgentUnavailable = errors.New("dnsops: agent not configured")
+	ErrPanelPrimary     = errors.New("dnsops: the panel's own primary domain is protected")
+	ErrDNSSECEnabled    = errors.New("dnsops: zone is DNSSEC-signed; disable DNSSEC and remove the DS record first")
+	ErrLastFacet        = errors.New("dnsops: DNS is the domain's only facet; delete the whole domain instead")
+)
+
+// TearDownFacet drops the DNS facet of dom: flip dns_disabled=true, delete the
+// PowerDNS zone on the box, and remove the panel's dns_zones + dns_records rows
+// so the end-state is indistinguishable from a domain created with
+// ManageDNS=false (dns_disabled=1, no zone row — the reconciler never
+// auto-creates one while disabled). Shared by the GH #1603 web-facet delete and
+// the GH #1611 DNS-zone delete, so the two paths can never drift on how a zone
+// is torn down.
+//
+// Ordering is fail-closed: the flip runs FIRST and, if it fails, the function
+// returns immediately WITHOUT deleting anything on the box — dns_disabled is
+// still 0, so the reconciler still owns the zone and would resurrect whatever
+// we removed. flipErr is that (hard) failure; a zone-delete or row-cleanup
+// problem is non-fatal residue returned in warnings (the flag is already set,
+// so a retry of the same delete converges). This carries NO transition guards:
+// the web-facet delete calls it directly after its own sequence.
+func TearDownFacet(ctx context.Context, d Deps, dom *models.Domain) (warnings []string, flipErr error) {
+	if d.Domains == nil || dom == nil {
+		return nil, ErrDeps
+	}
+	if d.Call == nil {
+		// Fail closed: without an agent we cannot delete the box zone, so do
+		// NOT flip the flag and strand the panel rows out of sync.
+		return nil, ErrAgentUnavailable
+	}
+
+	// 1. dns_disabled=true BEFORE any teardown so the reconciler stops pushing
+	//    the zone. On failure the reconciler still owns it → do NOT delete it.
+	if err := d.Domains.UpdateDNSDisabled(ctx, dom.ID, true); err != nil {
+		return nil, err
+	}
+
+	// 2. Delete the PowerDNS zone on the box. A box without the DNS module has
+	//    no PowerDNS backend; that is permanent, not a failure.
+	zctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	_, zerr := d.Call(zctx, "dns.zone.delete", map[string]string{"zone": dom.Name})
+	cancel()
+	if zerr != nil && !strings.Contains(zerr.Error(), "powerdns backend not available") {
+		warnings = append(warnings, "DNS zone not removed on the server; remove it manually if it lingers")
+	}
+
+	// 3. Remove the panel's zone + records rows so the domain matches the
+	//    ManageDNS=false shape (no zone row). FindByDomainID → ErrNotFound simply
+	//    means there was never a row (created disabled) — nothing to clean. The
+	//    repos are optional (nil in a dev binary without DNS wired); a missing
+	//    one just leaves the rows in place, non-fatally.
+	if d.Zones == nil || d.Records == nil {
+		return warnings, nil
+	}
+	if z, err := d.Zones.FindByDomainID(ctx, dom.ID); err == nil && z != nil {
+		if err := d.Records.DeleteByZoneID(ctx, z.ID); err != nil {
+			warnings = append(warnings, "DNS records not cleared from the panel database")
+		}
+		if err := d.Zones.Delete(ctx, z.ID); err != nil {
+			warnings = append(warnings, "DNS zone row not cleared from the panel database")
+		}
+	}
+	return warnings, nil
+}
+
+// DeleteZone is the guarded zone-delete entry point the REST handler and the
+// operator CLI share. It enforces the transition guards, then runs the shared
+// TearDownFacet. The guards fire only while DNS is currently managed: if
+// dns_disabled is already true the call is an idempotent cleanup (a retry after
+// a partial run), so it skips straight to TearDownFacet to mop up any lingering
+// zone/rows. Refuses (v1) rather than surprise:
+//   - the panel's own primary domain (its DNS underpins the panel);
+//   - a DNSSEC-signed zone (deleting it makes the domain bogus for validating
+//     resolvers while the DS still sits at the registrar);
+//   - the domain's LAST facet (web off + mail off): deleting DNS would leave an
+//     empty row — the caller should delete the whole domain instead.
+//
+// Authorization (owner-or-admin) and the GH #466 per-type policy gate stay with
+// the REST adapter; the CLI is admin-by-construction and skips them.
+func DeleteZone(ctx context.Context, d Deps, dom *models.Domain) (warnings []string, err error) {
+	if d.Domains == nil || dom == nil {
+		return nil, ErrDeps
+	}
+	if d.Call == nil {
+		return nil, ErrAgentUnavailable
+	}
+	// The panel's own primary domain is never facet-deleted, even as an
+	// idempotent retry — its DNS underpins the panel.
+	if dom.IsPanelPrimary {
+		return nil, ErrPanelPrimary
+	}
+	// Transition guards only fire when DNS is currently managed. If it is
+	// already disabled the call is an idempotent cleanup.
+	if !dom.DNSDisabled {
+		if dom.DNSSECEnabled {
+			return nil, ErrDNSSECEnabled
+		}
+		if dom.WebDisabled && !dom.EmailEnabled {
+			return nil, ErrLastFacet
+		}
+	}
+	return TearDownFacet(ctx, d, dom)
+}
+
+// EnableZone re-enables DNS management for dom by flipping dns_disabled=false.
+// It is the mirror of the DNS-facet delete: the reconciler owns everything
+// after the flip — on its next tick it re-creates the dns_zones row, bootstraps
+// the zone's records, and pushes the zone into PowerDNS (dns.zone.upsert
+// re-creates the box zone). The caller schedules that reconcile pass; the leaf
+// deliberately does not import the reconciler.
+//
+// Idempotent: a domain whose DNS is already enabled returns nil without a write.
+// Panel-primary domains are always DNS-enabled, so this is a no-op for them.
+func EnableZone(ctx context.Context, d Deps, dom *models.Domain) error {
+	if d.Domains == nil || dom == nil {
+		return ErrDeps
+	}
+	if !dom.DNSDisabled {
+		return nil // already enabled — nothing to flip
+	}
+	if err := d.Domains.UpdateDNSDisabled(ctx, dom.ID, false); err != nil {
+		return err
+	}
+	dom.DNSDisabled = false
+	return nil
+}

--- a/panel-api/internal/dnsops/dnsops_test.go
+++ b/panel-api/internal/dnsops/dnsops_test.go
@@ -1,0 +1,242 @@
+package dnsops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Fakes embed the repository interface so only the methods the leaf touches are
+// implemented; any other call panics (guards against silent scope creep).
+
+type fakeDomainRepo struct {
+	repository.DomainRepository
+	flipCalls int
+	flipErr   error
+	flippedTo bool
+}
+
+func (r *fakeDomainRepo) UpdateDNSDisabled(_ context.Context, _ string, disabled bool) error {
+	r.flipCalls++
+	if r.flipErr != nil {
+		return r.flipErr
+	}
+	r.flippedTo = disabled
+	return nil
+}
+
+type fakeZoneRepo struct {
+	repository.DNSZoneRepository
+	zone        *models.DNSZone
+	deletedZone string
+}
+
+func (r *fakeZoneRepo) FindByDomainID(_ context.Context, domainID string) (*models.DNSZone, error) {
+	if r.zone == nil || r.zone.DomainID != domainID {
+		return nil, repository.ErrNotFound
+	}
+	return r.zone, nil
+}
+func (r *fakeZoneRepo) Delete(_ context.Context, id string) error {
+	r.deletedZone = id
+	return nil
+}
+
+type fakeRecordRepo struct {
+	repository.DNSRecordRepository
+	deletedByZone string
+}
+
+func (r *fakeRecordRepo) DeleteByZoneID(_ context.Context, zoneID string) error {
+	r.deletedByZone = zoneID
+	return nil
+}
+
+// recordingCall is a CallFunc that records the last command and returns a
+// configurable error.
+type recordingCall struct {
+	count       int
+	lastCommand string
+	err         error
+}
+
+func (r *recordingCall) fn() CallFunc {
+	return func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		r.count++
+		r.lastCommand = cmd
+		return nil, r.err
+	}
+}
+
+func newDeps(dr *fakeDomainRepo, zr *fakeZoneRepo, rr *fakeRecordRepo, call *recordingCall) Deps {
+	d := Deps{Domains: dr, Zones: zr, Records: rr}
+	if call != nil {
+		d.Call = call.fn()
+	}
+	return d
+}
+
+func TestTearDownFacet_HappyPath(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	zr := &fakeZoneRepo{zone: &models.DNSZone{ID: "z1", DomainID: "d1"}}
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{}
+	dom := &models.Domain{ID: "d1", Name: "ex.com"}
+
+	warnings, err := TearDownFacet(context.Background(), newDeps(dr, zr, rr, call), dom)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, 1, dr.flipCalls)
+	assert.True(t, dr.flippedTo, "flipped to disabled")
+	assert.Equal(t, "dns.zone.delete", call.lastCommand)
+	assert.Equal(t, "z1", rr.deletedByZone, "records cleared")
+	assert.Equal(t, "z1", zr.deletedZone, "zone row cleared")
+}
+
+func TestTearDownFacet_FlipFail_NoTeardown(t *testing.T) {
+	dr := &fakeDomainRepo{flipErr: errors.New("db down")}
+	zr := &fakeZoneRepo{zone: &models.DNSZone{ID: "z1", DomainID: "d1"}}
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{}
+
+	_, err := TearDownFacet(context.Background(), newDeps(dr, zr, rr, call), &models.Domain{ID: "d1", Name: "ex.com"})
+	require.Error(t, err)
+	assert.Equal(t, 1, dr.flipCalls, "flip attempted")
+	assert.Equal(t, 0, call.count, "no pdns delete after a failed flip")
+	assert.Empty(t, zr.deletedZone, "zone row untouched")
+	assert.Empty(t, rr.deletedByZone, "records untouched")
+}
+
+func TestTearDownFacet_AgentNil_FailsClosed(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	_, err := TearDownFacet(context.Background(), Deps{Domains: dr}, &models.Domain{ID: "d1", Name: "ex.com"})
+	require.ErrorIs(t, err, ErrAgentUnavailable)
+	assert.Equal(t, 0, dr.flipCalls, "no flip when the teardown cannot run")
+}
+
+func TestTearDownFacet_PdnsBackendMissing_NoWarning(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	zr := &fakeZoneRepo{zone: &models.DNSZone{ID: "z1", DomainID: "d1"}}
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{err: errors.New("powerdns backend not available")}
+
+	warnings, err := TearDownFacet(context.Background(), newDeps(dr, zr, rr, call), &models.Domain{ID: "d1", Name: "ex.com"})
+	require.NoError(t, err)
+	assert.Empty(t, warnings, "a box without the DNS module is not a failure")
+	assert.Equal(t, "z1", zr.deletedZone, "rows still cleared")
+}
+
+func TestTearDownFacet_PdnsError_Warns(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	zr := &fakeZoneRepo{zone: &models.DNSZone{ID: "z1", DomainID: "d1"}}
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{err: errors.New("connection refused")}
+
+	warnings, err := TearDownFacet(context.Background(), newDeps(dr, zr, rr, call), &models.Domain{ID: "d1", Name: "ex.com"})
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "remove it manually")
+	assert.Equal(t, "z1", zr.deletedZone, "rows still cleared despite the pdns warning")
+}
+
+func TestTearDownFacet_NoZoneRow_NothingToClean(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	zr := &fakeZoneRepo{} // no zone → FindByDomainID ErrNotFound
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{}
+
+	warnings, err := TearDownFacet(context.Background(), newDeps(dr, zr, rr, call), &models.Domain{ID: "d1", Name: "ex.com"})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, 1, call.count, "pdns delete still attempted")
+	assert.Empty(t, zr.deletedZone)
+	assert.Empty(t, rr.deletedByZone)
+}
+
+func TestDeleteZone_Guards(t *testing.T) {
+	cases := []struct {
+		name string
+		dom  *models.Domain
+		want error
+	}{
+		{"panel primary", &models.Domain{ID: "d1", Name: "p", IsPanelPrimary: true, EmailEnabled: true}, ErrPanelPrimary},
+		{"dnssec signed", &models.Domain{ID: "d1", Name: "p", DNSSECEnabled: true, EmailEnabled: true}, ErrDNSSECEnabled},
+		{"last facet", &models.Domain{ID: "d1", Name: "p", WebDisabled: true, EmailEnabled: false}, ErrLastFacet},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dr := &fakeDomainRepo{}
+			call := &recordingCall{}
+			_, err := DeleteZone(context.Background(), newDeps(dr, &fakeZoneRepo{}, &fakeRecordRepo{}, call), tc.dom)
+			require.ErrorIs(t, err, tc.want)
+			assert.Equal(t, 0, dr.flipCalls, "no flip on a refused guard")
+			assert.Equal(t, 0, call.count, "no teardown on a refused guard")
+		})
+	}
+}
+
+func TestDeleteZone_HappyPath(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	zr := &fakeZoneRepo{zone: &models.DNSZone{ID: "z1", DomainID: "d1"}}
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{}
+	dom := &models.Domain{ID: "d1", Name: "ex.com", EmailEnabled: true}
+
+	warnings, err := DeleteZone(context.Background(), newDeps(dr, zr, rr, call), dom)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, 1, dr.flipCalls)
+	assert.Equal(t, "dns.zone.delete", call.lastCommand)
+}
+
+func TestDeleteZone_AlreadyDisabled_SkipsGuards(t *testing.T) {
+	// dns_disabled already true → the transition guards (here DNSSEC, which would
+	// otherwise refuse) are skipped and the idempotent teardown runs.
+	dr := &fakeDomainRepo{}
+	zr := &fakeZoneRepo{} // no row left
+	rr := &fakeRecordRepo{}
+	call := &recordingCall{}
+	dom := &models.Domain{ID: "d1", Name: "ex.com", DNSDisabled: true, DNSSECEnabled: true, WebDisabled: true}
+
+	_, err := DeleteZone(context.Background(), newDeps(dr, zr, rr, call), dom)
+	require.NoError(t, err)
+	assert.Equal(t, 1, dr.flipCalls, "idempotent re-flip")
+	assert.Equal(t, 1, call.count, "teardown runs")
+}
+
+func TestDeleteZone_AgentNil_FailsClosed(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	_, err := DeleteZone(context.Background(), Deps{Domains: dr}, &models.Domain{ID: "d1", Name: "ex.com", EmailEnabled: true})
+	require.ErrorIs(t, err, ErrAgentUnavailable)
+	assert.Equal(t, 0, dr.flipCalls)
+}
+
+func TestEnableZone_Flip(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	dom := &models.Domain{ID: "d1", Name: "ex.com", DNSDisabled: true}
+	require.NoError(t, EnableZone(context.Background(), Deps{Domains: dr}, dom))
+	assert.Equal(t, 1, dr.flipCalls)
+	assert.False(t, dr.flippedTo, "flipped to enabled (dns_disabled=false)")
+	assert.False(t, dom.DNSDisabled, "in-memory struct updated")
+}
+
+func TestEnableZone_Idempotent(t *testing.T) {
+	dr := &fakeDomainRepo{}
+	dom := &models.Domain{ID: "d1", Name: "ex.com", DNSDisabled: false}
+	require.NoError(t, EnableZone(context.Background(), Deps{Domains: dr}, dom))
+	assert.Equal(t, 0, dr.flipCalls, "already enabled → no write")
+}
+
+func TestEnableZone_FlipErr(t *testing.T) {
+	dr := &fakeDomainRepo{flipErr: errors.New("db down")}
+	dom := &models.Domain{ID: "d1", Name: "ex.com", DNSDisabled: true}
+	require.Error(t, EnableZone(context.Background(), Deps{Domains: dr}, dom))
+	assert.True(t, dom.DNSDisabled, "left disabled on write failure")
+}


### PR DESCRIPTION
## What

Follow-up to the GH #1611 "host DNS elsewhere" delete (shipped REST + UI in #1621). Two gaps remained: the operator CLI could not drop or restore a domain's DNS facet, and there was no way — CLI or REST — to re-enable DNS on a domain whose zone had been dropped.

Extract a `dnsops` lifecycle leaf (mirroring `userops`/`mailboxops`) that owns the DNS-facet operations, and route both the REST adapters and the operator CLI through it:

- **`dnsops.TearDownFacet`** — the unguarded teardown: flip `dns_disabled=true` (fail-closed, first), delete the PowerDNS zone on the box, clear the panel's `dns_zones` + `dns_records` rows. Shared with the GH #1603 web-facet delete, which runs its own sequence. Byte-identical to the old in-package `tearDownDNSFacet`.
- **`dnsops.DeleteZone`** — wraps it with the transition guards the two zone-delete entry points share: panel-primary protected, DNSSEC-signed refused, last-facet refused, idempotent when already disabled. Authorization + the GH #466 per-type policy gate stay with the REST adapter; the CLI is admin-by-construction.
- **`dnsops.EnableZone`** — flips `dns_disabled=false`; the reconciler then re-creates the zone row, bootstraps its records, and pushes the zone into PowerDNS (`dns.zone.upsert`) on its next tick.

## Surfaces

- **REST:** `DELETE /domains/:id/dns/zone` re-pointed onto the leaf (behavior unchanged); new **`POST /domains/:id/dns/zone`** re-enables DNS (owner-or-admin, no agent round-trip, no #466 gate — the reconciler system-seeds the zone exactly as at domain create).
- **CLI:** `jabali dns zone delete <domain>` (needs the agent — the reconciler never touches a disabled zone, so the PowerDNS zone is removed now, not on a later tick; a DNS-only domain is refused and pointed at `jabali domain delete`) and `jabali dns zone enable <domain>` (flag flip; reconciler re-creates on its next tick).
- **Inventory:** `GET /dns/zones` rows now carry `dns_disabled` / `web_disabled` / `email_enabled`, so the DNS Zone screen can tell a deliberately-dropped zone from one merely pending (previously both read as "Not provisioned") and a DNS-only domain from a multi-facet one. The follow-up UI PR consumes these.

## Testing

- New `dnsops` unit suite: guards, fail-closed ordering, pdns-missing vs pdns-error warnings, enable idempotency.
- HTTP-level tests for the new enable route; the existing zone-delete + web-facet-delete suites still pass (behavior identical).
- Inventory test that the facet flags project through.
- `openapi.yaml` documents the new route; `cli-reference` golden regenerated. `go test` + `go vet` green.

## Note

Not in scope here: the shared `TearDownFacet` still lets the #1603 web-facet delete tear down a DNSSEC-signed zone without the DS guard (that guard lives only in `DeleteZone`). Pre-existing; worth a separate look.

GH #1611

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
