### PR TITLE
fix(backups): log the REST destination creds_delete failure instead of swallowing it (JAB-310)

### DIFF
--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -44,7 +45,7 @@ func RegisterBackupDestinationRoutes(rg *gin.RouterGroup, cfg BackupDestinations
 	if cfg.Repo == nil {
 		return
 	}
-	h := &backupDestinationHandler{repo: cfg.Repo, agent: cfg.Agent, ssoKey: cfg.SSOKey}
+	h := &backupDestinationHandler{repo: cfg.Repo, agent: cfg.Agent, ssoKey: cfg.SSOKey, log: slog.Default()}
 	admin := rg.Group("/admin", middleware.RequireAdmin())
 	admin.GET("/backup-destinations", h.list)
 	admin.GET("/backup-destinations/:id", h.get)
@@ -62,6 +63,7 @@ type backupDestinationHandler struct {
 	repo   repository.BackupDestinationRepository
 	agent  agent.AgentInterface
 	ssoKey *ssokey.Key
+	log    *slog.Logger
 }
 
 // writeCreds dispatches the env-file write to the agent (root). panel-api
@@ -86,16 +88,26 @@ func (h *backupDestinationHandler) writeCreds(ctx context.Context, destID string
 	return resp.Path, nil
 }
 
-// deleteCreds dispatches the file removal to the agent. Best-effort —
-// caller treats errors as non-fatal because the row is being deleted
-// regardless.
+// deleteCreds dispatches the file removal to the agent. The removal is
+// non-fatal to the caller (the row is being deleted or has already been
+// persisted regardless), but a failure is no longer swallowed: it leaves a
+// root:root 0600 credentials file (SSHPASS / cloud keys) on disk with no row
+// referencing it, so we log it at error level for an operator to reap. This
+// brings the REST path to the no-swallow posture the CLI cores already have.
 func (h *backupDestinationHandler) deleteCreds(ctx context.Context, destID string) {
 	if h.agent == nil {
 		return
 	}
-	_, _ = h.agent.Call(ctx, "backup.dest.creds_delete", map[string]any{
+	if _, err := h.agent.Call(ctx, "backup.dest.creds_delete", map[string]any{
 		"dest_id": destID,
-	})
+	}); err != nil {
+		lg := h.log
+		if lg == nil {
+			lg = slog.Default()
+		}
+		lg.ErrorContext(ctx, "backup dest creds_delete failed — a root:root 0600 credentials file may be left behind on disk",
+			"dest_id", destID, "err", err)
+	}
 }
 
 type backupDestinationDTO struct {
@@ -415,8 +427,8 @@ func (h *backupDestinationHandler) update(c *gin.Context) {
 		// compensates above and the CLI update path fixed under JAB-310. A PRE-EXISTING
 		// file is deliberately left in place: the surviving row still references
 		// it (the path is deterministic per id), so deleting it would break the
-		// live destination. deleteCreds is best-effort and, unlike the CLI, stays
-		// silent on a cleanup failure by existing design (a separate follow-up).
+		// live destination. deleteCreds is non-fatal here (we already return
+		// db_update) but logs at error level if the cleanup itself fails.
 		if !origHadCredsFile && d.CredentialsRef != nil {
 			h.deleteCreds(c.Request.Context(), d.ID)
 		}

--- a/panel-api/internal/api/backup_destinations_delete_creds_log_test.go
+++ b/panel-api/internal/api/backup_destinations_delete_creds_log_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// delLogAgent records every agent command and can fail a chosen one, so a test
+// can drive deleteCreds down its error branch.
+type delLogAgent struct {
+	calls   []string
+	failCmd string
+	failErr error
+}
+
+func (a *delLogAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	a.calls = append(a.calls, cmd)
+	if a.failCmd != "" && cmd == a.failCmd {
+		return nil, a.failErr
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func (a *delLogAgent) count(cmd string) int {
+	n := 0
+	for _, c := range a.calls {
+		if c == cmd {
+			n++
+		}
+	}
+	return n
+}
+
+// delFakeDestRepo returns a preset destination from Get and a preset error from
+// Delete. The delete handler calls only Get and Delete; every other method is
+// promoted from the embedded nil interface and panics if called.
+type delFakeDestRepo struct {
+	repository.BackupDestinationRepository
+	getDest   *models.BackupDestination
+	deleteErr error
+}
+
+func (r *delFakeDestRepo) Get(_ context.Context, _ string) (*models.BackupDestination, error) {
+	return r.getDest, nil
+}
+
+func (r *delFakeDestRepo) Delete(_ context.Context, _ string) error {
+	return r.deleteErr
+}
+
+// delDo drives backupDestinationHandler.delete directly (skipping the admin
+// middleware) with an :id param.
+func delDo(h *backupDestinationHandler, id string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/admin/backup-destinations/"+id, nil)
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	h.delete(c)
+	return w
+}
+
+func delBufLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func destWithCreds(id string) *models.BackupDestination {
+	p := CredentialsDir + "/" + id + ".env"
+	return &models.BackupDestination{ID: id, Name: "n", Kind: models.BackupDestinationKindS3, CredentialsRef: &p}
+}
+
+// A failed creds_delete no longer vanishes: the row is gone (200) but the
+// leftover root:root 0600 credentials file is recorded at error level with its
+// dest id and the underlying error, so an operator can reap it. Load-bearing —
+// this is the whole point of the slice (visibility of the leak, not prevention).
+func TestBackupDestinationDelete_LogsSwallowedCredsDeleteFailure(t *testing.T) {
+	var buf bytes.Buffer
+	ag := &delLogAgent{failCmd: "backup.dest.creds_delete", failErr: errors.New("agent boom")}
+	h := &backupDestinationHandler{
+		repo:  &delFakeDestRepo{getDest: destWithCreds("dst-1")},
+		agent: ag,
+		log:   delBufLogger(&buf),
+	}
+
+	w := delDo(h, "dst-1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete code = %d, want 200 (a cleanup failure must stay non-fatal to the delete)", w.Code)
+	}
+	if ag.count("backup.dest.creds_delete") != 1 {
+		t.Fatalf("creds_delete calls = %d, want 1", ag.count("backup.dest.creds_delete"))
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "creds_delete") || !strings.Contains(logged, "dst-1") || !strings.Contains(logged, "agent boom") {
+		t.Fatalf("failed creds_delete must be logged with dest id + error, got: %q", logged)
+	}
+}
+
+// A creds_delete that succeeds emits no error log — we only shout when a
+// secrets file is actually left behind.
+func TestBackupDestinationDelete_NoLogWhenCredsDeleteSucceeds(t *testing.T) {
+	var buf bytes.Buffer
+	ag := &delLogAgent{}
+	h := &backupDestinationHandler{
+		repo:  &delFakeDestRepo{getDest: destWithCreds("dst-1")},
+		agent: ag,
+		log:   delBufLogger(&buf),
+	}
+
+	w := delDo(h, "dst-1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete code = %d, want 200", w.Code)
+	}
+	if ag.count("backup.dest.creds_delete") != 1 {
+		t.Fatalf("creds_delete calls = %d, want 1", ag.count("backup.dest.creds_delete"))
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("no error log expected on a successful cleanup, got: %q", buf.String())
+	}
+}
+
+// A destination with no credential file triggers no creds_delete and no log.
+func TestBackupDestinationDelete_NoCredsRefNoCallNoLog(t *testing.T) {
+	var buf bytes.Buffer
+	ag := &delLogAgent{failCmd: "backup.dest.creds_delete", failErr: errors.New("agent boom")}
+	h := &backupDestinationHandler{
+		repo:  &delFakeDestRepo{getDest: &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3}},
+		agent: ag,
+		log:   delBufLogger(&buf),
+	}
+
+	w := delDo(h, "dst-1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete code = %d, want 200", w.Code)
+	}
+	if ag.count("backup.dest.creds_delete") != 0 {
+		t.Fatalf("creds_delete must not fire when the row has no credential file: calls = %d", ag.count("backup.dest.creds_delete"))
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("no error log expected when nothing was cleaned up, got: %q", buf.String())
+	}
+}
+
+// A nil agent keeps deleteCreds a no-op: no panic, no log (pins the existing
+// early return).
+func TestBackupDestinationDelete_NilAgentNoPanicNoLog(t *testing.T) {
+	var buf bytes.Buffer
+	h := &backupDestinationHandler{
+		repo:  &delFakeDestRepo{getDest: destWithCreds("dst-1")},
+		agent: nil,
+		log:   delBufLogger(&buf),
+	}
+
+	w := delDo(h, "dst-1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete code = %d, want 200", w.Code)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("no error log expected with a nil agent, got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## What

The admin REST backup-destination handler's `deleteCreds` helper removes a
destination's credential file (SSHPASS / cloud keys, root:root 0600) through the
agent (`backup.dest.creds_delete`). It discarded the agent's result —
`_, _ = h.agent.Call(...)` — so when the removal failed the file was left on disk
with nothing recording it. That happens on four paths: a destination delete (row
gone), a `--clear-creds` update (ref cleared), and the create / update
persist-failure compensations.

## Change

`deleteCreds` now logs a failed `creds_delete` at error level with the
destination id and the underlying error, mirroring the "rollback left an orphan"
logging the app install/delete paths already do (`applications.go` /
`app_delete.go`). A `*slog.Logger` is added to the handler, set to
`slog.Default()` in the constructor (captured after the server has already called
`slog.SetDefault`, so it is the configured logger, matching `admin_services.go`)
and nil-guarded inside `deleteCreds` so a struct-literal handler in a test still
logs to the default.

## Visibility, not prevention

This does not stop the leak: the file is still left behind (the agent removal
genuinely failed). It stops the leak from being *silent* — an operator can now
find and reap the file. It brings the REST path to the no-swallow posture the CLI
create/update cores already have (#1647 / #1658), and closes the "REST
`deleteCreds` swallows its own cleanup failure" follow-up those PRs named. **It
closes no acceptance criterion** — JAB-310's ACs are the shared validator,
create-compensation, and AC3/AC4/AC5 + full extraction. The module parent stays
Backlog.

## Unchanged

The change is confined to `deleteCreds`. All four call sites, every response
code, and the wire contract are untouched: destination delete still returns 200,
`--clear-creds` still proceeds, and the create/update compensations still return
`db_create` / `db_update`. Two stale comments — the `deleteCreds` doc and the
update-compensation comment, both of which described the swallow as intended and
named this exact work as a future follow-up — are rewritten.

## Out of scope (named)

- The operator CLI `jabali destination delete` command
  (`backup_destination_cmd.go:398`) discards its own `creds_delete` result the
  same way (the CLI *update* path already surfaces it via its core, #1658) — one
  adapter per PR, matching #1658 / #1659.
- The `--clear-creds` reverse-class (a row left referencing a file a
  delete-before-persist removed) and AC3 / AC4 / AC5 + full extraction remain.

## Tests

A behavioral matrix drives the delete handler end to end through an instrumented
fake agent and repo, capturing the handler's `slog` output in a buffer:
- a failed `creds_delete` still returns 200 and logs the dest id and the error;
- a successful cleanup logs nothing;
- a destination with no credential file never calls `creds_delete` and logs
  nothing;
- a nil agent is a no-op with no panic (pins the existing early return).

The log guard was falsified (neutralized so it never logs, red, then reverted).
`go build ./...` / `go vet ./...` green; gofmt-clean; `go test ./internal/api/
-race` green.

Part of JAB-310 (Backup Destination Lifecycle module); the module parent stays
open.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
