### PR TITLE
fix(backups): surface the CLI destination delete creds_delete failure instead of swallowing it (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -392,10 +392,9 @@ func newBackupDestinationDeleteCmd() *cobra.Command {
 					return nil
 				}
 			}
-			if err := backupDestinationRepoFromDB().Delete(ctx, d.ID); err != nil {
-				return fmt.Errorf("delete destination: %w", err)
+			if err := deleteBackupDestinationDirect(ctx, sharedAgent.Call, backupDestinationRepoFromDB(), d, os.Stderr); err != nil {
+				return err
 			}
-			_, _ = sharedAgent.Call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID})
 			if jsonOutput {
 				return printJSON(map[string]string{"deleted": d.ID})
 			}

--- a/panel-api/cmd/server/backup_destination_ops.go
+++ b/panel-api/cmd/server/backup_destination_ops.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -80,6 +81,32 @@ func updateBackupDestinationDirect(ctx context.Context, call agentCaller, repo r
 			}
 		}
 		return fmt.Errorf("update destination: %w", err)
+	}
+	return nil
+}
+
+// deleteBackupDestinationDirect is the CLI testable core for the persist step of
+// `jabali destination delete`. It removes the row, then removes the destination's
+// Agent credential file. The credential removal is best-effort — the row is gone
+// regardless — but a failed cleanup is surfaced to errOut, never silently
+// swallowed (JAB-275), so an operator isn't blind to a leaked root:root 0600
+// secrets file (SSHPASS / cloud keys). This was the last swallowed creds_delete;
+// the create/update cores in this file already surface theirs.
+//
+// The creds_delete call is unconditional, matching the pre-existing RunE: the
+// Agent handler is idempotent (os.Remove tolerates a missing file), so a
+// destination that never had a credential file produces no spurious warning.
+// errOut is injected — its sibling cores hard-code os.Stderr — because the
+// surface, the warning on a cleanup failure, is the behavior under test here.
+// call is never a nil-pointer method value: the delete RunE runs under
+// requireDBAndAgent, so sharedAgent is initialised before the core is reached.
+func deleteBackupDestinationDirect(ctx context.Context, call agentCaller, repo repository.BackupDestinationRepository, d *models.BackupDestination, errOut io.Writer) error {
+	if err := repo.Delete(ctx, d.ID); err != nil {
+		return fmt.Errorf("delete destination: %w", err)
+	}
+	if _, derr := call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID}); derr != nil {
+		fmt.Fprintf(errOut, "warning: credential file cleanup failed for destination %s (%v); remove %s manually\n",
+			d.ID, derr, filepath.Join(credsDir, d.ID+".env"))
 	}
 	return nil
 }

--- a/panel-api/cmd/server/backup_destination_ops_test.go
+++ b/panel-api/cmd/server/backup_destination_ops_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,8 @@ type fakeBackupDestRepo struct {
 	createCalled int
 	updateErr    error
 	updateCalled int
+	deleteErr    error
+	deleteCalled int
 }
 
 func (f *fakeBackupDestRepo) Create(_ context.Context, d *models.BackupDestination) error {
@@ -31,6 +34,11 @@ func (f *fakeBackupDestRepo) Create(_ context.Context, d *models.BackupDestinati
 func (f *fakeBackupDestRepo) Update(_ context.Context, d *models.BackupDestination) error {
 	f.updateCalled++
 	return f.updateErr
+}
+
+func (f *fakeBackupDestRepo) Delete(_ context.Context, _ string) error {
+	f.deleteCalled++
+	return f.deleteErr
 }
 
 // recordingAgent records each agent command (and its params), and can be told to
@@ -265,6 +273,121 @@ func TestBackupDestinationUpdate_RoutesThroughCore(t *testing.T) {
 	}
 	if clearIdx < 0 || capIdx > clearIdx {
 		t.Error("origHadCredsFile must be captured BEFORE the --clear-creds branch mutates CredentialsRef")
+	}
+}
+
+// TestDeleteBackupDestinationDirect_SurfacesSwallowedCleanupFailure is the
+// load-bearing guard for this slice: a failed creds_delete after the row is gone
+// must NOT vanish. The delete still succeeds (returns nil — the row is deleted),
+// but the leftover root:root 0600 credential file is reported on errOut with the
+// dest id and the underlying error, matching the CLI create/update cores and the
+// REST twin #1665. Before this slice the RunE did `_, _ = sharedAgent.Call(...)`.
+func TestDeleteBackupDestinationDirect_SurfacesSwallowedCleanupFailure(t *testing.T) {
+	agent := &recordingAgent{failCmd: "backup.dest.creds_delete", failErr: errors.New("agent down")}
+	repo := &fakeBackupDestRepo{}
+	d := newDest()
+	var errOut bytes.Buffer
+
+	if err := deleteBackupDestinationDirect(context.Background(), agent.call, repo, d, &errOut); err != nil {
+		t.Fatalf("a cleanup failure must stay non-fatal to the delete, got %v", err)
+	}
+	if repo.deleteCalled != 1 {
+		t.Fatalf("row must be deleted exactly once, Delete called %d", repo.deleteCalled)
+	}
+	warn := errOut.String()
+	if !strings.Contains(warn, "cleanup failed") || !strings.Contains(warn, "dst-1") || !strings.Contains(warn, "agent down") {
+		t.Fatalf("failed creds_delete must be surfaced with dest id + error, got: %q", warn)
+	}
+}
+
+// TestDeleteBackupDestinationDirect_SuccessNoWarning: a creds_delete that
+// succeeds writes nothing to errOut — we only warn when a secrets file is
+// actually left behind.
+func TestDeleteBackupDestinationDirect_SuccessNoWarning(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{}
+	d := newDest()
+	ref := "/etc/jabali-panel/restic-remotes/dst-1.env"
+	d.CredentialsRef = &ref
+	var errOut bytes.Buffer
+
+	if err := deleteBackupDestinationDirect(context.Background(), agent.call, repo, d, &errOut); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.deleteCalled != 1 {
+		t.Fatalf("row must be deleted exactly once, Delete called %d", repo.deleteCalled)
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("creds_delete must fire on a successful delete")
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("no warning expected on a successful cleanup, got: %q", errOut.String())
+	}
+}
+
+// TestDeleteBackupDestinationDirect_DeleteFailsNoCredsDelete pins the ordering:
+// if the row delete fails the row survives, so its credential file must be left
+// in place (never delete a file behind a surviving row). The error wraps the
+// cause, and creds_delete never fires.
+func TestDeleteBackupDestinationDirect_DeleteFailsNoCredsDelete(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{deleteErr: errors.New("connection reset")}
+	d := newDest()
+	var errOut bytes.Buffer
+
+	err := deleteBackupDestinationDirect(context.Background(), agent.call, repo, d, &errOut)
+	if err == nil || !strings.Contains(err.Error(), "delete destination") {
+		t.Fatalf("want a delete-destination error, got %v", err)
+	}
+	if repo.deleteCalled != 1 {
+		t.Fatalf("Delete must have been attempted exactly once, called %d", repo.deleteCalled)
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatal("row delete failed (row survives) — its credential file must NOT be removed")
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("no cleanup warning expected when the row delete failed, got: %q", errOut.String())
+	}
+}
+
+// TestDeleteBackupDestinationDirect_CredsDeleteUnconditional pins that the
+// creds_delete call is NOT gated on CredentialsRef: even a destination that never
+// had a credential file still fires it once (the Agent handler is idempotent), so
+// no orphaned file is missed. A future --clear-creds/guard slice would change this
+// deliberately; this keeps the current unconditional behavior explicit.
+func TestDeleteBackupDestinationDirect_CredsDeleteUnconditional(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{}
+	d := newDest() // CredentialsRef nil
+	var errOut bytes.Buffer
+
+	if err := deleteBackupDestinationDirect(context.Background(), agent.call, repo, d, &errOut); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("creds_delete must fire unconditionally, even with no CredentialsRef")
+	}
+	if len(agent.cmds) != 1 {
+		t.Fatalf("creds_delete must fire exactly once, got %v", agent.cmds)
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("no warning expected, got: %q", errOut.String())
+	}
+}
+
+// TestBackupDestinationDelete_RoutesThroughCore source-pins that the delete RunE
+// hands the production agent caller to the core rather than swallowing the
+// creds_delete inline again (positive pin only — the create/update commands in
+// the same file legitimately call the same verbs, JAB-339 scar).
+func TestBackupDestinationDelete_RoutesThroughCore(t *testing.T) {
+	src := readOpsSource(t, "backup_destination_cmd.go")
+	start := strings.Index(src, "func newBackupDestinationDeleteCmd(")
+	if start < 0 {
+		t.Fatal("delete command not found")
+	}
+	body := src[start:]
+	if !strings.Contains(body, "deleteBackupDestinationDirect(ctx, sharedAgent.Call,") {
+		t.Error("delete RunE must route through deleteBackupDestinationDirect with the production agent caller")
 	}
 }
 


### PR DESCRIPTION
## What

`jabali destination delete` (operator CLI) deleted the destination row and then
removed its per-destination credential file through the agent
(`backup.dest.creds_delete`), but discarded the agent's result:

```go
_, _ = sharedAgent.Call(ctx, "backup.dest.creds_delete", ...)
```

When that removal failed, the root:root 0600 credential file (SSHPASS / cloud
keys) was left on disk with nothing recording it — a silent orphaned secret.
This was the last swallowed `creds_delete` across the two adapters: the REST twin
was fixed in #1665, and the CLI create/update cores already surface their
cleanup (#1647 / #1658).

## How

Extract a testable core, `deleteBackupDestinationDirect`, in
`backup_destination_ops.go` alongside the existing create/update cores, and route
the delete `RunE` through it. The core deletes the row, then removes the
credential file, and on a failed removal writes a warning to an injected
`io.Writer` (the `RunE` passes `os.Stderr`) carrying the destination id, the
underlying error, and the deterministic credential path so an operator can reap
the leftover file by hand.

The credential removal stays **unconditional**, exactly as the `RunE` did before:
the agent handler is idempotent (its `os.Remove` tolerates a missing file), so a
destination that never had a credential file produces no spurious warning.

Unlike its sibling cores — which hard-code `os.Stderr` and whose tests assert only
that `creds_delete` fired — this core takes the writer as a parameter, because the
surface (the warning on a cleanup failure) is the behavior under test here.

## Scope / honesty

This is **visibility, not prevention**: on a genuine removal failure the file is
still left behind; it is no longer silent. It **closes no acceptance criterion** —
it completes the `deleteCreds`-swallow follow-up on both adapters, the last named
instance — and JAB-310 stays a module-parent.

Still open on the parent: the `--clear-creds` reverse-class (a surviving row left
referencing a file a delete-before-persist removed) and AC3 / AC4 / AC5 + full
extraction.

## Tests

`backup_destination_ops_test.go` (extends the existing fakes with a `Delete`
method):

- a failed `creds_delete` still returns nil, deletes the row exactly once, and
  writes a warning carrying the dest id and error;
- a successful cleanup deletes the row once and writes nothing;
- a failed **row** delete returns the wrapped `delete destination` error, is
  attempted exactly once, and never calls `creds_delete` (a file behind a
  surviving row is never removed);
- `creds_delete` fires exactly once and unconditionally even with no
  `CredentialsRef`;
- a source-pin that the delete `RunE` routes through the core with the production
  agent caller.

The surface guard and the ordering guard were each falsified (compiling
neutralization → red → reverted). `go build ./...` / `go vet ./cmd/server/`
green; gofmt-clean; `go test ./cmd/server/ -race` green.

Base: `f7978649a`. Touches only `cmd/server/*`, disjoint from #1661
(`internal/api/backups.go`) and #1665 (`internal/api/backup_destinations.go`).

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
