### PR TITLE
feat(dns): re-enable + delete-domain affordances in the DNS Zone inventory (GH #1611)

### DIFF
--- a/panel-ui/src/components/dns/DNSDomainDeleteAction.tsx
+++ b/panel-ui/src/components/dns/DNSDomainDeleteAction.tsx
@@ -1,0 +1,77 @@
+// DNSDomainDeleteAction — controlled confirm modal that deletes an ENTIRE domain
+// from the DNS Zone inventory (GH #1611, johnnyq). This is deliberately separate
+// from DNSZoneDeleteAction: it is offered only for a DNS-only domain (web off,
+// mail off), whose DNS facet cannot be dropped on its own — DNS is the last
+// facet, so the backend refuses the zone delete and points here. Deleting it
+// removes the whole domain row via DELETE /domains/:id (userops.DeleteDomain),
+// not just the zone, so the copy and title say so plainly rather than reusing the
+// "Delete DNS zone" modal.
+import { useState } from "react";
+import { Alert, Modal, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+import type { DnsZoneRow } from "./DNSZoneInventory";
+
+interface DNSDomainDeleteActionProps {
+  zone: DnsZoneRow;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const DNSDomainDeleteAction = ({ zone, open, onClose }: DNSDomainDeleteActionProps) => {
+  const qc = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleDelete = async () => {
+    setIsLoading(true);
+    try {
+      // Full domain delete — no delete_files/delete_mail query params: this row is
+      // web-off + mail-off, so DNS is all that remains.
+      await apiClient.delete(`/domains/${encodeURIComponent(zone.id)}`);
+      feedback.message.success(`Deleted the domain "${zone.name}".`);
+      qc.invalidateQueries({ queryKey: ["list", "dns/zones"] });
+      onClose();
+    } catch (err: unknown) {
+      const errMsg =
+        (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data
+          ?.detail ??
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        (err instanceof Error ? err.message : "Delete domain failed");
+      feedback.message.error(errMsg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Delete domain"
+      open={open}
+      onCancel={onClose}
+      onOk={handleDelete}
+      okText="Delete domain"
+      okButtonProps={{ danger: true }}
+      confirmLoading={isLoading}
+      destroyOnHidden
+    >
+      <Typography.Paragraph>
+        <b>{zone.name}</b> has only DNS — no Web Domain and no Mail Domain. Deleting its zone
+        alone would leave an empty domain, so this removes the <b>whole domain</b>.
+      </Typography.Paragraph>
+      <Alert
+        type="warning"
+        showIcon
+        message="This deletes the domain entirely and can't be undone"
+        description={
+          <>
+            The domain, its DNS zone, and all {zone.record_count} of its records are removed. If
+            you host DNS for this domain elsewhere, this only removes it from the panel — but the
+            panel entry and any panel history for it are gone.
+          </>
+        }
+      />
+    </Modal>
+  );
+};

--- a/panel-ui/src/components/dns/DNSZoneEnableButton.tsx
+++ b/panel-ui/src/components/dns/DNSZoneEnableButton.tsx
@@ -1,0 +1,64 @@
+// DNSZoneEnableButton — re-enable panel-hosted DNS for a domain whose zone was
+// previously dropped (GH #1611, "host DNS here again"). POST /domains/:id/dns/zone
+// is admin-or-owner; it flips dns_disabled=false and the reconciler re-creates
+// the zone and its records on its next tick.
+//
+// This is the inverse of DNSZoneDeleteAction. It is non-destructive, so it uses a
+// short confirm rather than a full warning modal — the only caveat worth naming
+// is that the panel will start answering DNS for the domain again, which can
+// conflict with records the tenant published wherever they moved DNS.
+import { useState } from "react";
+import { Button } from "antd";
+import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import type { DnsZoneRow } from "./DNSZoneInventory";
+
+interface DNSZoneEnableButtonProps {
+  zone: DnsZoneRow;
+}
+
+export const DNSZoneEnableButton = ({ zone }: DNSZoneEnableButtonProps) => {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleEnable = () => {
+    feedback.modal.confirm({
+      title: `Enable DNS for "${zone.name}"?`,
+      content:
+        "The panel will host DNS for this domain again and re-create its zone " +
+        "with default records on the next sync. If you moved DNS elsewhere, the " +
+        "panel's records will now compete with it — remove the domain from your " +
+        "other DNS host first.",
+      okText: t("dnszonesoverviewpage.enable_dns"),
+      onOk: async () => {
+        setIsLoading(true);
+        try {
+          await apiClient.post(`/domains/${encodeURIComponent(zone.id)}/dns/zone`);
+          feedback.message.success(
+            `Re-enabled DNS for "${zone.name}". The zone is re-created within a minute.`,
+          );
+          qc.invalidateQueries({ queryKey: ["list", "dns/zones"] });
+        } catch (err: unknown) {
+          const errMsg =
+            (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data
+              ?.detail ??
+            (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+            (err instanceof Error ? err.message : "Enable DNS failed");
+          feedback.message.error(errMsg);
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    });
+  };
+
+  return (
+    <Button loading={isLoading} onClick={handleEnable}>
+      {t("dnszonesoverviewpage.enable_dns")}
+    </Button>
+  );
+};

--- a/panel-ui/src/components/dns/DNSZoneInventory.test.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.test.tsx
@@ -4,9 +4,10 @@
 // routes, and the DNSSEC tab receives the audience's owner-visibility policy
 // (AC4 / AC5). The common columns render the same values for both (AC3).
 import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   DnsZoneInventory,
@@ -56,16 +57,23 @@ const notProvisioned: DnsZoneRow = {
   registrar_expires_at: null,
 };
 
+// Mutable so a test can drive different row states (GH #1611 adds Enable /
+// Delete-domain branches). vi.hoisted lets the hoisted vi.mock factory read it.
+const table = vi.hoisted(() => ({ items: [] as DnsZoneRow[] }));
 vi.mock("../../hooks/useTableURL", () => ({
   useTableURL: () => ({
-    items: [provisioned, notProvisioned],
-    total: 2,
+    items: table.items,
+    total: table.items.length,
     isLoading: false,
     isError: false,
     params: { page: 1, pageSize: 20, q: "", sort: "name", order: "asc" },
     setParams: vi.fn(),
   }),
 }));
+
+beforeEach(() => {
+  table.items = [provisioned, notProvisioned];
+});
 
 const adminAudience: DnsZoneInventoryAudience = {
   showOwner: true,
@@ -85,11 +93,13 @@ const tenantAudience: DnsZoneInventoryAudience = {
 
 const renderPage = (audience: DnsZoneInventoryAudience) =>
   render(
-    <MemoryRouter>
-      <App>
-        <DnsZoneInventory audience={audience} />
-      </App>
-    </MemoryRouter>,
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter>
+        <App>
+          <DnsZoneInventory audience={audience} />
+        </App>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 
 describe("DnsZoneInventory audience policy (JAB-299)", () => {
@@ -153,5 +163,89 @@ describe("DnsZoneInventory audience policy (JAB-299)", () => {
     renderPage(tenantAudience);
     fireEvent.click(screen.getByText("DNSSEC"));
     expect(screen.getByTestId("dnssec-table").getAttribute("data-showowner")).toBe("false");
+  });
+});
+
+describe("DnsZoneInventory facet-state actions (GH #1611)", () => {
+  // dns_disabled: DNS deliberately dropped — no zone row (provisioned=false).
+  const dnsDropped: DnsZoneRow = {
+    id: "d3",
+    user_id: "u3",
+    username: "carol",
+    name: "dropped.tld",
+    provisioned: false,
+    record_count: 0,
+    effective_ttl: null,
+    dnssec_enabled: false,
+    registrar_expires_at: null,
+    dns_disabled: true,
+    web_disabled: false,
+    email_enabled: true,
+  };
+  // DNS-only: web off + mail off, zone provisioned. The zone can't be dropped
+  // alone (last facet), so the row offers a whole-domain delete.
+  const dnsOnly: DnsZoneRow = {
+    id: "d4",
+    user_id: "u4",
+    username: "dave",
+    name: "dnsonly.tld",
+    provisioned: true,
+    record_count: 5,
+    effective_ttl: 300,
+    dnssec_enabled: false,
+    registrar_expires_at: null,
+    dns_disabled: false,
+    web_disabled: true,
+    email_enabled: false,
+  };
+  // Ordinary multi-facet, provisioned, unsigned → an enabled zone delete.
+  const normalMulti: DnsZoneRow = {
+    id: "d5",
+    user_id: "u5",
+    username: "erin",
+    name: "multi.tld",
+    provisioned: true,
+    record_count: 4,
+    effective_ttl: 300,
+    dnssec_enabled: false,
+    registrar_expires_at: null,
+    dns_disabled: false,
+    web_disabled: false,
+    email_enabled: true,
+  };
+
+  it("a dropped-DNS row shows 'Hosted elsewhere' + Enable DNS and hides Manage Records", () => {
+    table.items = [dnsDropped];
+    renderPage(adminAudience);
+
+    expect(screen.getByText("dnszonesoverviewpage.dns_hosted_elsewhere")).toBeInTheDocument();
+    expect(screen.getByText("dnszonesoverviewpage.enable_dns")).toBeInTheDocument();
+    // No zone rows exist while DNS is dropped, so no "Manage Records" and no
+    // zone/domain delete on this row.
+    expect(screen.queryByText("Manage Records")).not.toBeInTheDocument();
+    expect(screen.queryByText("dnszonesoverviewpage.delete_zone")).not.toBeInTheDocument();
+    expect(screen.queryByText("dnszonesoverviewpage.delete_domain")).not.toBeInTheDocument();
+  });
+
+  it("a DNS-only row offers Delete domain, not a zone delete", () => {
+    table.items = [dnsOnly];
+    renderPage(adminAudience);
+
+    expect(screen.getByText("dnszonesoverviewpage.delete_domain")).toBeInTheDocument();
+    expect(screen.queryByText("dnszonesoverviewpage.delete_zone")).not.toBeInTheDocument();
+    // A DNS-only row still has a zone to manage.
+    expect(screen.getByText("Manage Records")).toBeInTheDocument();
+  });
+
+  it("an ordinary multi-facet row keeps the zone delete; the three states coexist", () => {
+    table.items = [dnsDropped, dnsOnly, normalMulti];
+    renderPage(adminAudience);
+
+    // Each state renders exactly its own action.
+    expect(screen.getAllByText("dnszonesoverviewpage.enable_dns")).toHaveLength(1);
+    expect(screen.getAllByText("dnszonesoverviewpage.delete_domain")).toHaveLength(1);
+    expect(screen.getAllByText("dnszonesoverviewpage.delete_zone")).toHaveLength(1);
+    // Manage Records on both provisioned/manageable rows, hidden on the dropped one.
+    expect(screen.getAllByText("Manage Records")).toHaveLength(2);
   });
 });

--- a/panel-ui/src/components/dns/DNSZoneInventory.tsx
+++ b/panel-ui/src/components/dns/DNSZoneInventory.tsx
@@ -20,6 +20,8 @@ import { useTabParam } from "../../hooks/useTabParam";
 import { columnSearchProps } from "../columnSearch";
 import { DNSSECTable } from "../dnssec/DNSSECTable";
 import { DNSZoneDeleteAction } from "./DNSZoneDeleteAction";
+import { DNSDomainDeleteAction } from "./DNSDomainDeleteAction";
+import { DNSZoneEnableButton } from "./DNSZoneEnableButton";
 import { SearchableTableStringQ } from "../SearchableTable";
 import { useTableURL } from "../../hooks/useTableURL";
 import { sorterToParams } from "../../utils/tableSorter";
@@ -39,6 +41,14 @@ export interface DnsZoneRow {
   effective_ttl?: number | null;
   dnssec_enabled?: boolean;
   registrar_expires_at?: string | null;
+  // GH #1611: facet state. dns_disabled distinguishes a deliberately-dropped
+  // zone ("host DNS elsewhere" → offer Enable DNS) from one the reconciler
+  // simply hasn't provisioned yet. web_disabled + email_enabled identify a
+  // DNS-only domain (both off) whose zone can't be dropped alone (last facet) —
+  // that row offers a whole-domain delete instead.
+  dns_disabled?: boolean;
+  web_disabled?: boolean;
+  email_enabled?: boolean;
 }
 
 // DnsZoneInventoryAudience is the per-screen policy. Admin passes the
@@ -77,6 +87,9 @@ const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
   // GH #1611: the row whose DNS zone is being deleted (null = closed). Admin +
   // tenant both get the action; the backend enforces admin-or-owner.
   const [deleteTarget, setDeleteTarget] = useState<DnsZoneRow | null>(null);
+  // GH #1611: the DNS-only row whose WHOLE domain is being deleted (its zone
+  // can't be dropped alone — DNS is the last facet).
+  const [deleteDomainTarget, setDeleteDomainTarget] = useState<DnsZoneRow | null>(null);
 
   // One batched request (JAB-377): the endpoint returns provisioning state +
   // record count + effective TTL per row, so there is no per-domain zone fetch
@@ -163,7 +176,12 @@ const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
           <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.zone_status")}
             render={(_, record) =>
-              record.provisioned ? (
+              record.dns_disabled ? (
+                // GH #1611: DNS was deliberately dropped — distinct from a zone
+                // the reconciler simply hasn't provisioned yet, which would
+                // otherwise read as the same "Not provisioned".
+                <Tag color="orange">{t("dnszonesoverviewpage.dns_hosted_elsewhere")}</Tag>
+              ) : record.provisioned ? (
                 <Tag color="green">Provisioned</Tag>
               ) : (
                 <Tag>Not provisioned</Tag>
@@ -202,28 +220,51 @@ const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
           />
           <Table.Column<DnsZoneRow>
             title={t("dnszonesoverviewpage.actions")}
-            render={(_, record) => (
-              <Space>
-                <Button type="primary" onClick={() => navigate(audience.manageRoute(record.id))}>
-                  Manage Records
-                </Button>
-                {/* GH #1611: delete the DNS zone (keep web + mail). Only for a
-                    panel-hosted zone; a DNSSEC-signed zone must be unsigned
-                    first (the backend refuses it too). */}
-                {record.provisioned &&
-                  (record.dnssec_enabled ? (
-                    <Tooltip title={t("dnszonesoverviewpage.delete_disabled_dnssec")}>
-                      <Button danger disabled>
+            render={(_, record) => {
+              // GH #1611: a DNS-only domain (web off + mail off) can't drop its
+              // zone alone — DNS is the last facet — so it offers a whole-domain
+              // delete instead of the zone delete the backend would refuse.
+              const dnsOnly = record.web_disabled === true && record.email_enabled !== true;
+              return (
+                <Space>
+                  {/* Managing records is meaningless while DNS is dropped (no
+                      zone rows exist), so hide it on those rows. */}
+                  {!record.dns_disabled && (
+                    <Button
+                      type="primary"
+                      onClick={() => navigate(audience.manageRoute(record.id))}
+                    >
+                      Manage Records
+                    </Button>
+                  )}
+                  {record.dns_disabled ? (
+                    // GH #1611: DNS was dropped ("host DNS elsewhere") — offer to
+                    // host it here again. The backend re-creates the zone.
+                    <DNSZoneEnableButton zone={record} />
+                  ) : dnsOnly ? (
+                    <Button danger onClick={() => setDeleteDomainTarget(record)}>
+                      {t("dnszonesoverviewpage.delete_domain")}
+                    </Button>
+                  ) : (
+                    // Delete the DNS zone (keep web + mail). Only for a
+                    // panel-hosted zone; a DNSSEC-signed zone must be unsigned
+                    // first (the backend refuses it too).
+                    record.provisioned &&
+                    (record.dnssec_enabled ? (
+                      <Tooltip title={t("dnszonesoverviewpage.delete_disabled_dnssec")}>
+                        <Button danger disabled>
+                          {t("dnszonesoverviewpage.delete_zone")}
+                        </Button>
+                      </Tooltip>
+                    ) : (
+                      <Button danger onClick={() => setDeleteTarget(record)}>
                         {t("dnszonesoverviewpage.delete_zone")}
                       </Button>
-                    </Tooltip>
-                  ) : (
-                    <Button danger onClick={() => setDeleteTarget(record)}>
-                      {t("dnszonesoverviewpage.delete_zone")}
-                    </Button>
-                  ))}
-              </Space>
-            )}
+                    ))
+                  )}
+                </Space>
+              );
+            }}
           />
         </SearchableTableStringQ>
       )}
@@ -232,6 +273,13 @@ const ZonesTab = ({ audience }: { audience: DnsZoneInventoryAudience }) => {
           zone={deleteTarget}
           open={deleteTarget != null}
           onClose={() => setDeleteTarget(null)}
+        />
+      )}
+      {deleteDomainTarget && (
+        <DNSDomainDeleteAction
+          zone={deleteDomainTarget}
+          open={deleteDomainTarget != null}
+          onClose={() => setDeleteDomainTarget(null)}
         />
       )}
     </>

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -379,7 +379,10 @@
   "dnszonesoverviewpage": {
     "actions": "Actions",
     "delete_zone": "Delete zone",
+    "delete_domain": "Delete domain",
     "delete_disabled_dnssec": "Disable DNSSEC before deleting this zone",
+    "dns_hosted_elsewhere": "Hosted elsewhere",
+    "enable_dns": "Enable DNS",
     "dns_zones_are_provisioned_automatically_when": "DNS zones are provisioned automatically when a domain is created. Nameservers are configured in Server Settings.",
     "dnssec": "DNSSEC",
     "domain_name": "Domain Name",


### PR DESCRIPTION
## What

UI half of the GH #1611 DNS-facet follow-ups. The backend/CLI/REST half landed in #1663 (merged) — that PR added `POST /domains/:id/dns/zone` and enriched the `GET /dns/zones` row with facet flags. This drives the DNS Zone inventory's row actions off those flags.

> Supersedes #1664, which GitHub auto-closed when its base branch (the #1663 branch) was deleted on merge. Same commit, rebased onto `main`.

The DNS Zone inventory listed every domain but had only one action beyond "Manage Records" — delete the DNS zone. Two states had no working affordance:

- A domain whose DNS was dropped ("host DNS elsewhere") reappeared as **"Not provisioned"**, indistinguishable from a zone the reconciler simply hadn't provisioned yet — under an alert promising zones provision automatically — with no way back to panel-hosted DNS except the new CLI.
- A **DNS-only** domain (web off, mail off) offered "Delete zone", which the backend refuses (DNS is the last facet) — a dead end.

Drive the row's action off the facet flags:

- **`dns_disabled`** → a "Hosted elsewhere" status tag and an **Enable DNS** button (`POST /domains/:id/dns/zone`; the reconciler re-creates the zone). Manage Records is hidden while DNS is dropped — there are no zone rows to manage.
- **DNS-only** (`web_disabled && !email_enabled`) → a **Delete domain** button that deletes the whole domain (`DELETE /domains/:id` → `userops.DeleteDomain`), with its own modal and copy ("This deletes the domain entirely…") — deliberately **not** the "Delete DNS zone" modal, so a zone-delete affordance can never quietly remove a domain.
- Otherwise unchanged: the existing zone delete (keeps web + mail), disabled for a DNSSEC-signed zone.

## Testing

- The `DNSZoneInventory` unit suite is extended with all three row states (Enable / Delete-domain / ordinary zone delete coexisting) — 9 tests, green after rebase onto merged `main`.
- `tsc` + `eslint` clean; the production `vite build` is green.
- No E2E role selectors reference the touched status text or buttons (checked `panel-ui/e2e/`). A live browser pass wasn't run — the branching is fully covered by the unit tests and the build is green; the change is standard antd table actions + two confirm modals.

## Screens

New row affordances in **DNS → Zones** (admin and tenant): "Enable DNS" on a hosted-elsewhere row, "Delete domain" on a DNS-only row.

GH #1611

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
