### PR TITLE
fix(backups): defer the CLI --clear-creds file removal until after the row persists (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -303,12 +303,16 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 					}
 				}
 			}
-			// Clear stored credential env (cloud secrets / sftp SSHPASS).
+			// Clear stored credential env (cloud secrets / sftp SSHPASS). Drop the
+			// reference here, but DEFER the on-disk file removal to after the row
+			// persists (see updateBackupDestinationDirect): deleting it now, before
+			// persist, would leave a surviving row (failed persist) pointing at an
+			// already-deleted file — a dangling reference, the reverse of the orphan
+			// leak (JAB-310).
+			clearedCredsFile := false
 			if clearCreds {
 				if d.CredentialsRef != nil {
-					if _, err := sharedAgent.Call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID}); err != nil {
-						return fmt.Errorf("clear credentials: %w", err)
-					}
+					clearedCredsFile = true
 				}
 				d.CredentialsRef = nil
 				changed = true
@@ -337,10 +341,11 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 			if !changed {
 				return fmt.Errorf("no changes specified")
 			}
-			// Persist and, on failure, compensate a credential file this update
-			// newly wrote so a transient DB error can't orphan a secrets file
-			// behind a NULL row (JAB-310).
-			if err := updateBackupDestinationDirect(ctx, sharedAgent.Call, backupDestinationRepoFromDB(), d, origHadCredsFile); err != nil {
+			// Persist, then reconcile the on-disk credential file to the committed
+			// row: on failure compensate a file this update newly wrote (orphan),
+			// and on success reap a file --clear-creds dropped the reference to
+			// (dangling-ref reverse-class) — both handled in the core (JAB-310).
+			if err := updateBackupDestinationDirect(ctx, sharedAgent.Call, backupDestinationRepoFromDB(), d, origHadCredsFile, clearedCredsFile); err != nil {
 				return err
 			}
 			if jsonOutput {

--- a/panel-api/cmd/server/backup_destination_ops.go
+++ b/panel-api/cmd/server/backup_destination_ops.go
@@ -48,39 +48,62 @@ func createBackupDestinationDirect(ctx context.Context, call agentCaller, repo r
 }
 
 // updateBackupDestinationDirect is the CLI testable core for the persist step of
-// `jabali destination update`. It persists the mutated row and — when this update
-// wrote a BRAND-NEW credential file — removes that just-written file on ANY
-// persistence failure, so a transient DB error can't leave an orphaned root:root
-// 0600 secrets file (SSHPASS / cloud keys) behind a row that never got the
-// reference (JAB-310).
+// `jabali destination update`. It persists the mutated row and reconciles the
+// on-disk Agent credential file to the row that actually committed (JAB-310):
 //
-// The gate rests on an invariant of the update RunE: d.CredentialsRef only goes
-// nil -> non-nil inside a creds_write branch. So origHadCredsFile == false (the
-// DB row had no credential file before this call) together with
-// d.CredentialsRef != nil means exactly "we wrote a new file this call, and the
-// row that survives the failed persist references none" — a true orphan.
+//   - orphan compensation (persist FAILS): the surviving row is the unchanged
+//     original, so the on-disk file should exist iff origHadCredsFile. When
+//     origHadCredsFile == false, any root:root 0600 secrets file (SSHPASS / cloud
+//     keys) on disk was written by THIS call — either the reference still points
+//     at it (a plain creds_write) or a later --clear-creds in the same command
+//     nil'd the reference (clearedCredsFile, e.g. --sftp-password ...
+//     --clear-creds). Both are orphans behind a row that never got the reference,
+//     and both are removed. A PRE-EXISTING file (origHadCredsFile true) is
+//     deliberately LEFT in place: the surviving row still references it
+//     (deterministic path per dest_id), so deleting it would break the
+//     destination that remains in the DB.
 //
-// A PRE-EXISTING credential file (origHadCredsFile true) is deliberately LEFT in
-// place on failure: the surviving row still references it (the path is
-// deterministic per dest_id), so deleting it would break the destination that
-// remains in the DB. That reverse case — a --clear-creds followed by a failed
-// persist, leaving the row pointing at a now-missing file — is a separate class
-// (not a leak) and out of scope here.
+//   - clear-creds reap (persist SUCCEEDS): when --clear-creds dropped the
+//     reference (clearedCredsFile == true and d.CredentialsRef ends nil), the
+//     on-disk file is removed AFTER the row that no longer references it commits.
+//     The RunE must NOT delete the file before this call: on a failed persist that
+//     would leave the surviving row pointing at an already-deleted file — a
+//     dangling reference, the reverse of the orphan leak. The reap is skipped when
+//     d.CredentialsRef is non-nil, meaning a creds_write later in the same update
+//     re-created the file at the deterministic path (--clear-creds --env): the row
+//     references it, so it must stay.
+//
+// The invariant the core holds: after it returns, the on-disk credential file
+// exists iff the PERSISTED row references it — on failure the persisted row is the
+// unchanged original (file iff origHadCredsFile), on success it is d (file iff
+// d.CredentialsRef != nil). d.CredentialsRef only goes nil -> non-nil inside a
+// creds_write branch, so under !origHadCredsFile a reference that is set OR was
+// cleared this call both imply a file this call wrote.
 //
 // sharedAgent is *agent.Client (a pointer), so the call value is safe to build
-// even on the DB-only update paths where the agent was never initialised: the
-// compensation branch is the only caller and it is reached only after a
-// creds_write this call, which required the credential agent. Cleanup is
-// best-effort but a failed cleanup is surfaced, never silently swallowed
-// (JAB-275).
-func updateBackupDestinationDirect(ctx context.Context, call agentCaller, repo repository.BackupDestinationRepository, d *models.BackupDestination, origHadCredsFile bool) error {
+// even on DB-only update paths where the agent was never initialised: both agent
+// branches are reached only after a creds_write / --clear-creds this call, which
+// required the credential agent. Both cleanups are best-effort but surfaced,
+// never silently swallowed (JAB-275), and neither is fatal to a committed update.
+func updateBackupDestinationDirect(ctx context.Context, call agentCaller, repo repository.BackupDestinationRepository, d *models.BackupDestination, origHadCredsFile, clearedCredsFile bool) error {
 	if err := repo.Update(ctx, d); err != nil {
-		if !origHadCredsFile && d.CredentialsRef != nil {
+		// Orphan compensation. Under !origHadCredsFile the surviving (unchanged)
+		// row references no file, so any credential file on disk was written by
+		// THIS call and is now an orphan — whether the reference still points at it
+		// (a plain creds_write) or a later --clear-creds in the same command nil'd
+		// the reference (clearedCredsFile: e.g. --sftp-password ... --clear-creds).
+		// Both must be removed.
+		if !origHadCredsFile && (d.CredentialsRef != nil || clearedCredsFile) {
 			if _, derr := call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID}); derr != nil {
-				fmt.Fprintf(os.Stderr, "warning: credential file cleanup failed (%v); remove %s manually\n", derr, *d.CredentialsRef)
+				fmt.Fprintf(os.Stderr, "warning: credential file cleanup failed (%v); remove %s manually\n", derr, filepath.Join(credsDir, d.ID+".env"))
 			}
 		}
 		return fmt.Errorf("update destination: %w", err)
+	}
+	if clearedCredsFile && d.CredentialsRef == nil {
+		if _, derr := call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": d.ID}); derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: credential file cleanup after --clear-creds failed (%v); remove %s manually\n", derr, filepath.Join(credsDir, d.ID+".env"))
+		}
 	}
 	return nil
 }

--- a/panel-api/cmd/server/backup_destination_ops_test.go
+++ b/panel-api/cmd/server/backup_destination_ops_test.go
@@ -182,7 +182,7 @@ func TestUpdateBackupDestinationDirect_CompensatesOrphanOnPersistFail(t *testing
 	ref := "/var/lib/jabali/creds/dst-1.env"
 	d.CredentialsRef = &ref // a creds_write earlier in this update set it
 
-	err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false)
+	err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false, false)
 	if err == nil {
 		t.Fatal("expected the update failure to propagate")
 	}
@@ -205,7 +205,7 @@ func TestUpdateBackupDestinationDirect_PreExistingRefNotDeletedOnFail(t *testing
 	ref := "/var/lib/jabali/creds/dst-1.env"
 	d.CredentialsRef = &ref
 
-	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, true); err == nil {
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, true, false); err == nil {
 		t.Fatal("expected the update failure to propagate")
 	}
 	if agent.fired("backup.dest.creds_delete") {
@@ -220,7 +220,7 @@ func TestUpdateBackupDestinationDirect_NoRefNoDelete(t *testing.T) {
 	repo := &fakeBackupDestRepo{updateErr: errors.New("boom")}
 	d := newDest() // CredentialsRef nil
 
-	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false); err == nil {
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false, false); err == nil {
 		t.Fatal("expected the update failure to propagate")
 	}
 	if agent.fired("backup.dest.creds_delete") {
@@ -237,7 +237,7 @@ func TestUpdateBackupDestinationDirect_SuccessNoCompensation(t *testing.T) {
 	ref := "/var/lib/jabali/creds/dst-1.env"
 	d.CredentialsRef = &ref
 
-	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false); err != nil {
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if repo.updateCalled != 1 {
@@ -248,11 +248,110 @@ func TestUpdateBackupDestinationDirect_SuccessNoCompensation(t *testing.T) {
 	}
 }
 
+// TestUpdateBackupDestinationDirect_ClearCredsReapDeferredNotDeletedOnFail is the
+// load-bearing guard for this slice: --clear-creds dropped the reference and the
+// persist then FAILED. The on-disk credential file must NOT be removed — the
+// surviving DB row still references it (the RunE only nil'd the in-memory copy),
+// so deleting it would leave a dangling reference (the reverse of the orphan
+// leak). Before this slice the RunE deleted the file BEFORE persisting, stranding
+// the row pointing at a missing file on exactly this path.
+func TestUpdateBackupDestinationDirect_ClearCredsReapDeferredNotDeletedOnFail(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{updateErr: errors.New("connection reset")}
+	d := newDest() // RunE nil'd CredentialsRef; the DB row still has the old file
+
+	// clearedCredsFile true (the row had a file), origHadCredsFile true (pre-existing).
+	err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, true, true)
+	if err == nil || !strings.Contains(err.Error(), "update destination") {
+		t.Fatalf("want a wrapped update-destination error, got %v", err)
+	}
+	if repo.updateCalled != 1 {
+		t.Fatalf("Update must have been attempted exactly once, called %d", repo.updateCalled)
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatal("persist failed — the file the surviving row still references must NOT be reaped (dangling ref)")
+	}
+}
+
+// TestUpdateBackupDestinationDirect_ClearCredsReapedOnSuccess: --clear-creds
+// dropped the reference and the persist SUCCEEDED — now (and only now) the on-disk
+// file is reaped, exactly once. The row that no longer references it has
+// committed, so the removal cannot strand a surviving reference.
+func TestUpdateBackupDestinationDirect_ClearCredsReapedOnSuccess(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{}
+	d := newDest() // CredentialsRef nil (RunE cleared it)
+
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, true, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.updateCalled != 1 {
+		t.Fatalf("Update called %d times, want 1", repo.updateCalled)
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("a cleared credential file must be reaped after a successful persist")
+	}
+	if len(agent.cmds) != 1 {
+		t.Fatalf("creds_delete must fire exactly once, got %v", agent.cmds)
+	}
+	if got := agent.params["backup.dest.creds_delete"]["dest_id"]; got != "dst-1" {
+		t.Fatalf("creds_delete dest_id = %v, want dst-1", got)
+	}
+}
+
+// TestUpdateBackupDestinationDirect_ClearThenRewriteNoReap: --clear-creds followed
+// by a creds_write in the SAME update (--clear-creds --env) re-creates the file at
+// the deterministic path and re-sets CredentialsRef. The reap must be skipped — the
+// committed row references the rewritten file, so removing it would break the live
+// destination. clearedCredsFile stays true, but a non-nil ref gates the reap off.
+func TestUpdateBackupDestinationDirect_ClearThenRewriteNoReap(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{}
+	d := newDest()
+	ref := "/etc/jabali-panel/restic-remotes/dst-1.env" // creds_write re-set it this update
+	d.CredentialsRef = &ref
+
+	if err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, true, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent.fired("backup.dest.creds_delete") {
+		t.Fatalf("a file re-written in the same update must NOT be reaped, got %v", agent.cmds)
+	}
+}
+
+// TestUpdateBackupDestinationDirect_WrittenThenClearedOrphanCompensatedOnFail
+// guards the interaction of the deferred reap with the orphan compensation:
+// --sftp-password/--env writes a credential file on a destination that had none
+// (origHadCredsFile false), then --clear-creds in the SAME command nil's the
+// reference (clearedCredsFile true), then the persist FAILS. The just-written
+// root:root 0600 file must still be removed — the surviving row references
+// nothing, so it is a true orphan. Deferring the reap must not open this leak;
+// the compensation gate widened to `d.CredentialsRef != nil || clearedCredsFile`
+// to cover it.
+func TestUpdateBackupDestinationDirect_WrittenThenClearedOrphanCompensatedOnFail(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{updateErr: errors.New("connection reset")}
+	d := newDest() // creds_write set a ref this call, then --clear-creds nil'd it
+
+	err := updateBackupDestinationDirect(context.Background(), agent.call, repo, d, false, true)
+	if err == nil || !strings.Contains(err.Error(), "update destination") {
+		t.Fatalf("want a wrapped update-destination error, got %v", err)
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("a file written this call then cleared must be compensated on persist failure (orphan leak)")
+	}
+	if got := agent.params["backup.dest.creds_delete"]["dest_id"]; got != "dst-1" {
+		t.Fatalf("creds_delete dest_id = %v, want dst-1", got)
+	}
+}
+
 // TestBackupDestinationUpdate_RoutesThroughCore source-pins that the update RunE
-// hands the production agent caller to the compensating core, and that it
-// captures origHadCredsFile BEFORE the --clear-creds branch — capturing it later
-// would misread a cleared ref as "no pre-existing file" and wrongly compensate a
-// file the surviving row still references.
+// hands the production agent caller to the compensating core, captures
+// origHadCredsFile BEFORE the --clear-creds branch (capturing it later would
+// misread a cleared ref as "no pre-existing file" and wrongly compensate a file
+// the surviving row still references), and — for this slice — does NOT eagerly
+// delete the credential file inside the --clear-creds branch (the reap is deferred
+// to the core, post-persist).
 func TestBackupDestinationUpdate_RoutesThroughCore(t *testing.T) {
 	src := readOpsSource(t, "backup_destination_cmd.go")
 	start := strings.Index(src, "func newBackupDestinationUpdateCmd(")
@@ -273,6 +372,20 @@ func TestBackupDestinationUpdate_RoutesThroughCore(t *testing.T) {
 	}
 	if clearIdx < 0 || capIdx > clearIdx {
 		t.Error("origHadCredsFile must be captured BEFORE the --clear-creds branch mutates CredentialsRef")
+	}
+
+	// The eager creds_delete must be GONE from the --clear-creds branch: the file
+	// removal is deferred to the core, post-persist (dangling-ref reverse-class).
+	// Scope the negative to the clear block only — from `if clearCreds {` to the
+	// creds-rewrite comment — because creds_write/creds_delete verbs legitimately
+	// appear elsewhere in this RunE (JAB-339 scar: never pin a literal a sibling
+	// branch shares).
+	rewriteIdx := strings.Index(body, "// Rewrite cloud/SFTP")
+	if rewriteIdx < 0 || clearIdx > rewriteIdx {
+		t.Fatal("clear-creds block boundaries not found")
+	}
+	if strings.Contains(body[clearIdx:rewriteIdx], "backup.dest.creds_delete") {
+		t.Error("--clear-creds must NOT delete the credential file before persist; the reap is deferred to updateBackupDestinationDirect (dangling-ref reverse-class)")
 	}
 }
 


### PR DESCRIPTION
## What

`jabali destination update --clear-creds` removed the destination's on-disk
credential file (SSHPASS / cloud secrets, root:root 0600) through the agent and
*then* persisted the row with the reference dropped:

```go
if clearCreds {
    if d.CredentialsRef != nil {
        // agent deletes the file HERE, before persist
        sharedAgent.Call(ctx, "backup.dest.creds_delete", ...)
    }
    d.CredentialsRef = nil
}
// ... later ...
repo.Update(ctx, d)   // if this fails, the file is already gone
```

If the persist failed, the file was already deleted but the DB row was unchanged —
it still referenced the now-missing file. The surviving destination was left
pointing at a credential file that no longer exists: a **dangling reference**, the
mirror image of the orphaned-file leak the create/update compensation already
guards (#1647 / #1658).

## How

Reorder to **persist-first**. The `--clear-creds` branch now only drops the
in-memory reference and records that a file was cleared; the on-disk removal is
deferred to the testable core `updateBackupDestinationDirect`, which reaps the
file only *after* the row that no longer references it has committed. On a failed
persist the file survives and the surviving row still references it — consistent,
no dangling reference. The reap is skipped when a creds_write later in the same
update (`--clear-creds --env`) re-created the file at the deterministic path and
re-set the reference: the committed row points at it, so it must stay.

The invariant the core now holds: **after it returns, the on-disk credential file
exists iff the persisted row references it.**

## Behavior change (please note at review)

Previously a failing agent during `--clear-creds` aborted the whole update — the
row was left unchanged and the command exited non-zero. Now the destructive file
removal happens *after* the commit, so it can no longer block an otherwise-valid
update: the row commits with the reference cleared, and a failed removal leaves a
**surfaced orphan** — a warning on stderr naming the leftover file, exit zero —
rather than aborting. This matches the delete core (#1666): a filesystem cleanup
never vetoes a committed DB state transition, and a failed cleanup is warned,
never silently swallowed (JAB-275).

## Scope / honesty

This is **prevention**: the reorder removes the dangling-reference window
outright, it does not merely surface it.

**Closes no acceptance criterion.** AC4 is about a live *rekey* (a credential
WRITE) completing before persistence — the opposite operation with the opposite
safe ordering; this is a credential *delete*, only safe *after* persistence.
JAB-310 stays a module-parent. The REST `update` handler has the same
delete-before-persist shape in its `--clear-creds` path
(`internal/api/backup_destinations.go`) — named as the follow-up twin, one adapter
per PR (matching #1665 / #1666).

One consequence of deferring the clear: a file written then cleared in the same
command (`--sftp-password X --clear-creds` on a destination that had no file) is
now still on disk when a persist fails, whereas the old eager delete had already
removed it. The orphan-compensation gate widens from `d.CredentialsRef != nil` to
`d.CredentialsRef != nil || clearedCredsFile` so that path is compensated too
(covered by a dedicated test).

## Merge ordering

Off `4023de5bf`. Touches `cmd/server/backup_destination_{ops,ops_test,cmd}.go`,
which **overlaps #1666** (also off an earlier main, appends `deleteBackupDestinationDirect`
after `updateBackupDestinationDirect` and adds tests after `RoutesThroughCore`).
Whichever of #1666 / this merges second needs a rebase — no logic conflict, just
adjacent edits in the same two files.

## Tests

`backup_destination_ops_test.go` — the core gained a `clearedCredsFile` parameter:

- **[LB]** a failed persist with the reference cleared does NOT reap the file (the
  surviving row still references it) and returns the wrapped error;
- a successful persist reaps the file exactly once;
- a clear-then-rewrite (non-nil ref) does not reap;
- **[LB]** a file written then cleared in the same command is still compensated as
  an orphan on a persist failure (the widened gate);
- the existing four update-compensation cases pass the new parameter unchanged;
- a scoped source-pin asserts the `--clear-creds` branch no longer deletes the
  file inline (reap moved to the core).

All five guards were falsified with compiling neutralizations (reap moved above
the persist; nil-gate dropped; reap disabled; widened compensation gate reverted;
eager call re-added), each red then reverted. `go build ./...` / `go vet
./cmd/server/` green; gofmt-clean; `go test ./cmd/server/ -race` green.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
