### PR TITLE
feat(appsec): ship DokuWiki sprintdoc 932120 as a built-in CRS exclusion (GH #1641)

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -389,6 +389,24 @@ SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599230,phase:1,pass,no
 # endpoints. All other rules still inspect both args (a real attack value
 # there is still caught), and 933120 stays active everywhere else.
 SecRule REQUEST_URI "@contains wc-ajax=" "id:9599300,phase:1,pass,nolog,ctl:ruleRemoveById=933120"
+#
+# 932120 vs DokuWiki sprintdoc icons (GH #1641, docs.itflow.org). The sprintdoc
+# template serves its UI icons through lib/tpl/sprintdoc/svg.php?svg=<name>, and
+# icon names like "format-list-bulleted-square" contain "format-list" — an entry
+# in windows-powershell-commands.data — so CRS 932120 ("Windows PowerShell
+# Command Found", RCE) fires on every page that renders that icon. Observed: 40
+# blocks across 10 distinct source IPs on that one asset path — the textbook
+# shape of a false positive, and it hands legit readers a ~4h AppSec ban.
+# This is a platform default, not a per-host exclusion: Jabali installs DokuWiki
+# itself (DefaultSubdirectory "wiki"), so without it an operator installs
+# DokuWiki + the common sprintdoc template and real users get banned with no clue
+# why. Safe to ship built-in: 932120 detects *Windows* PowerShell on a Linux/PHP
+# box, the target is a static-icon handler that executes nothing, and every other
+# rule still inspects the path. Drop ONLY 932120, ONLY on sprintdoc's svg.php.
+# The optional leading segment matches both a root install (/lib/tpl/...) and the
+# default /wiki/ subdir install (/wiki/lib/tpl/...); [^/?]+ is one path segment,
+# never crossing into a deeper path or the query string.
+SecRule REQUEST_URI "@rx ^(/[^/?]+)?/lib/tpl/sprintdoc/svg\.php" "id:9599310,phase:1,pass,nolog,ctl:ruleRemoveById=932120"
 `
 }
 

--- a/internal/appseccfg/crs_plugin_test.go
+++ b/internal/appseccfg/crs_plugin_test.go
@@ -23,6 +23,13 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 		// checkout FP was never actually fixed. ruleRemoveById is the only form
 		// that works, and "wc-ajax=" is narrow enough to contain it.
 		`ctl:ruleRemoveById=933120`,
+		// DokuWiki sprintdoc icons (GH #1641): svg.php?svg=format-list-* matches
+		// the "Format-List" cmdlet in windows-powershell-commands.data → 932120
+		// RCE FP. Built-in default (Jabali installs DokuWiki); optional leading
+		// segment covers root + the default /wiki/ subdir install.
+		`SecRule REQUEST_URI "@rx ^(/[^/?]+)?/lib/tpl/sprintdoc/svg\.php"`,
+		`id:9599310`,
+		`ctl:ruleRemoveById=932120`,
 		// text/plain must be an allowed request content type (sendBeacon
 		// default; jQuery contentType habit) — pre-seeded WITH the full CRS
 		// default list, not as a lone value, or 901162 skips its defaults and
@@ -60,6 +67,7 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 		"911100": true, "942550": true, "932370": true,
 		"933120": true, // wp-admin referer FP + WooCommerce checkout FP
 		"942100": true, // libinjection vs wp-admin/admin-ajax.php
+		"932120": true, // DokuWiki sprintdoc svg.php icons (GH #1641): Windows-PowerShell RCE FP on a Linux static-icon path
 	}
 	// Rules whose ctl sits on a chain's second line are URI-scoped by the
 	// chain's FIRST line; track that so the scoping check below stays honest.


### PR DESCRIPTION
## What

Follow-up to GH #1641 (CrowdSec banning legit users). The reporter's `jabali appsec explain` data showed two genuine false positives; this ships the DokuWiki one as a built-in default, which the reporter specifically asked for ("this exclusion should be added by default for everyone").

The **sprintdoc** DokuWiki template serves its UI icons through `lib/tpl/sprintdoc/svg.php?svg=<name>`. Icon names like `format-list-bulleted-square` contain `format-list` — an entry in `windows-powershell-commands.data` — so CRS **932120** ("Windows PowerShell Command Found", RCE) scores on every page that renders that icon. In the reporter's data: **40 blocks across 10 distinct source IPs on one asset path**, i.e. real readers handed a ~4h AppSec ban.

Add a built-in `CRSPluginBefore` drop (`id:9599310`) that removes **only 932120, only on sprintdoc's `svg.php`**:

```
SecRule REQUEST_URI "@rx ^(/[^/?]+)?/lib/tpl/sprintdoc/svg\.php" "id:9599310,phase:1,pass,nolog,ctl:ruleRemoveById=932120"
```

## Why a platform default (not a per-host exclusion)

My earlier take on the issue was that this should stay a per-host exclusion. The reporter pushed back — Jabali installs DokuWiki itself (`DefaultSubdirectory: "wiki"`), and sprintdoc is one of the most common templates, so an operator can install DokuWiki + sprintdoc and have real users banned with no idea why. That's right, and it's safe to ship built-in:

- **932120 detects _Windows_ PowerShell** on a Linux/PHP box, and the target is a **static-icon handler that executes nothing** — the whole-rule drop on this exact path removes essentially no real protection.
- It stays as narrow as the evidence: only rule 932120, only on `…/lib/tpl/sprintdoc/svg.php`. Every other rule still inspects the path, and 932120 stays fully active everywhere else.
- The optional leading segment `^(/[^/?]+)?` matches **both** a root install (`/lib/tpl/…`, the reporter's dedicated-subdomain case) and the default `/wiki/` subdir install (`/wiki/lib/tpl/…`); `[^/?]+` is exactly one path segment, so it never crosses into a deeper path or the query string.

Same proven construct as the shipped WordPress/WooCommerce drops (`ctl:ruleRemoveById` — the only removal form that actually works in Coraza; the target/tag-scoped forms are silent no-ops and are blocked by a separate guard test).

## Guard

`crs_plugin_test.go` gates every drop: each `ruleRemoveById` must be URI-scoped and its rule ID must be on the `allowedDrops` allowlist, or the test fails as a WAF hole. This adds **932120** to that allowlist deliberately (evidence-based) and asserts the new rule + its scoping.

## Delivery

`CRSPluginBefore` is single-sourced: the agent's boot render, `jabali appsec render-config`, and `install.sh` all emit it. So this lands on **new installs** and on **existing boxes at `jabali update`** (render-config rewrites the built-in file), with no operator action.

## Testing

- `internal/appseccfg`, `panel-agent/internal/commands`, and `panel-api/cmd/server` appsec suites + `go vet` — all green.
- On the `.60` test box: the new binary rendered the rule into `jabali-before.conf` and **`crowdsec -t` loaded the config cleanly (exit 0)** — the primary risk of a WAF-config edit (a malformed rule taking the whole before-file down) is retired. The box was restored afterward.
- The live 403→404 behavioral A/B **was not run**: that box's AppSec request path hangs uniformly on every path (excluded and control alike — a pre-existing box-health issue, not this rule). Behavioral correctness rests on the identical-shape parity with the shipped `911100/942550/932370/933120/942100` drops, the surgical guard, and the `-t` load.

## Not in scope

The second false positive — **Flarum, rule 920450** (X-HTTP-Method-Override on `/api/`) — is deliberately **not** a platform default. Dropping 920450 platform-wide would let any override-honoring app (Laravel/Symfony/…) smuggle PATCH/PUT/DELETE past the 911100 method policy — a WAF hole. It needs to be **host-scoped to each Flarum install**, tracked in #1650.

GH #1641

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
