### PR TITLE
fix(backups): defer the REST --clear-creds file removal until after the row persists (JAB-310)

### DIFF
--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -397,9 +397,18 @@ func (h *backupDestinationHandler) update(c *gin.Context) {
 	if req.Enabled != nil {
 		d.Enabled = *req.Enabled
 	}
+	// Clear stored credentials. Drop the reference here, but DEFER the on-disk
+	// file removal to after the row persists (the reap below): deleting it now,
+	// before persist, would leave a surviving row (failed persist) pointing at an
+	// already-deleted file — a dangling reference, the reverse of the orphan leak
+	// (JAB-310). Credential writes come AFTER this block, so under
+	// !origHadCredsFile a cleared reference cannot occur, and the fail-branch gate
+	// below needs no widening (the CLI adapter writes --sftp-password before its
+	// clear, so its gate does).
+	clearedCredsFile := false
 	if req.ClearCreds {
 		if d.CredentialsRef != nil {
-			h.deleteCreds(c.Request.Context(), d.ID)
+			clearedCredsFile = true
 		}
 		d.CredentialsRef = nil
 	}
@@ -434,6 +443,17 @@ func (h *backupDestinationHandler) update(c *gin.Context) {
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
 		return
+	}
+	// --clear-creds reap. The persist succeeded and the committed row no longer
+	// references a file (d.CredentialsRef nil), so remove the on-disk file now —
+	// AFTER the row that dropped the reference committed. Doing it here rather than
+	// in the clear block above keeps a failed persist from stranding the surviving
+	// row against a deleted file. The reap is skipped when a creds_write later in
+	// the same request re-created the file and re-set the reference (--clear-creds
+	// with new credentials): the committed row points at it, so it must stay.
+	// deleteCreds is best-effort and stays silent on failure by existing design.
+	if clearedCredsFile && d.CredentialsRef == nil {
+		h.deleteCreds(c.Request.Context(), d.ID)
 	}
 	c.JSON(http.StatusOK, toDestDTO(d))
 }

--- a/panel-api/internal/api/backup_destinations_update_compensation_test.go
+++ b/panel-api/internal/api/backup_destinations_update_compensation_test.go
@@ -49,6 +49,11 @@ type updFakeDestRepo struct {
 	repository.BackupDestinationRepository
 	getDest   *models.BackupDestination
 	updateErr error
+	// beforeUpdate, when set, runs at the instant Update is called — i.e. AFTER the
+	// handler mutated d and decided the credential file's fate but BEFORE persist
+	// returns. It lets a test snapshot agent state at persist time to prove the reap
+	// happens strictly after the row commits, not eagerly in the clear block.
+	beforeUpdate func()
 }
 
 func (r *updFakeDestRepo) Get(_ context.Context, _ string) (*models.BackupDestination, error) {
@@ -56,6 +61,9 @@ func (r *updFakeDestRepo) Get(_ context.Context, _ string) (*models.BackupDestin
 }
 
 func (r *updFakeDestRepo) Update(_ context.Context, _ *models.BackupDestination) error {
+	if r.beforeUpdate != nil {
+		r.beforeUpdate()
+	}
 	return r.updateErr
 }
 
@@ -181,5 +189,138 @@ func TestBackupDestinationUpdate_CapturesOrigRefBeforeClearCreds(t *testing.T) {
 	}
 	if capIdx > clearIdx {
 		t.Fatal("origHadCredsFile must be captured BEFORE the --clear-creds block")
+	}
+}
+
+// --clear-creds on a destination that HAS a credential file, with a persist that
+// then fails, must NOT remove the on-disk file: the surviving (unchanged) row
+// still references it, so deleting it before persist would strand the live
+// destination against a missing file — a dangling reference, the reverse of the
+// orphan leak. The removal is deferred to the post-persist reap, which never runs
+// on a failed persist. Load-bearing.
+func TestBackupDestinationUpdate_ClearCredsPreExistingNotDeletedOnFail(t *testing.T) {
+	ref := "/etc/jabali-panel/restic-remotes/dst-1.env"
+	ag := &credsRecordingAgent{}
+	repo := &updFakeDestRepo{
+		getDest:   &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3, CredentialsRef: &ref},
+		updateErr: errors.New("db down"),
+	}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"clear_credentials": true})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", w.Code)
+	}
+	if got := ag.count("backup.dest.creds_delete"); got != 0 {
+		t.Fatalf("--clear-creds deleted the file before a failed persist (dangling reference): creds_delete fired %d times, want 0", got)
+	}
+}
+
+// --clear-creds with a successful persist reaps the file exactly once, and the
+// reap happens strictly AFTER the row commits: beforeUpdate snapshots the delete
+// count at persist time and it must still be zero there. This distinguishes the
+// deferred reap from the old eager delete-in-clear-block, which would show a count
+// of one at persist time.
+func TestBackupDestinationUpdate_ClearCredsReapedAfterPersist(t *testing.T) {
+	ref := "/etc/jabali-panel/restic-remotes/dst-1.env"
+	ag := &credsRecordingAgent{}
+	atPersist := -1
+	repo := &updFakeDestRepo{
+		getDest: &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3, CredentialsRef: &ref},
+		// updateErr nil => persist succeeds
+	}
+	repo.beforeUpdate = func() { atPersist = ag.count("backup.dest.creds_delete") }
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"clear_credentials": true})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", w.Code)
+	}
+	if atPersist != 0 {
+		t.Fatalf("credential file removed BEFORE persist (eager, not deferred): creds_delete count at persist time = %d, want 0", atPersist)
+	}
+	if got := ag.count("backup.dest.creds_delete"); got != 1 {
+		t.Fatalf("--clear-creds did not reap the file after a successful persist: creds_delete fired %d times, want 1", got)
+	}
+}
+
+// --clear-creds together with new credentials in the SAME request re-creates the
+// file (creds_write) and re-sets the reference, so the committed row points at a
+// file that must stay: no reap. The reap gate keys on d.CredentialsRef ending nil,
+// which the rewrite prevents.
+func TestBackupDestinationUpdate_ClearThenRewriteNoReap(t *testing.T) {
+	ref := "/etc/jabali-panel/restic-remotes/dst-1.env"
+	ag := &credsRecordingAgent{}
+	repo := &updFakeDestRepo{
+		getDest: &models.BackupDestination{ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindS3, CredentialsRef: &ref},
+		// updateErr nil => persist succeeds
+	}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{
+		"clear_credentials": true,
+		"credentials_env":   map[string]string{"AWS_SECRET_ACCESS_KEY": "x"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", w.Code)
+	}
+	if wr := ag.count("backup.dest.creds_write"); wr != 1 {
+		t.Fatalf("rewrite must re-create the file: creds_write fired %d times, want 1", wr)
+	}
+	if del := ag.count("backup.dest.creds_delete"); del != 0 {
+		t.Fatalf("clear-then-rewrite must not reap the re-created file: creds_delete fired %d times, want 0", del)
+	}
+}
+
+// Source-pin: the credential WRITE must come AFTER the --clear-creds block in the
+// update handler. The persist-failure gate is deliberately left un-widened
+// (`!origHadCredsFile && d.CredentialsRef != nil`) precisely because a cleared
+// reference cannot coexist with !origHadCredsFile under this ordering. If a future
+// edit hoisted the write above the clear (the CLI adapter's shape), a
+// written-then-cleared file on a fileless destination would leak on a failed
+// persist and the gate would need widening. Pin the ordering so that regression is
+// caught here rather than in production. Scoped to the update handler body —
+// h.writeCreds also appears in create.
+func TestBackupDestinationUpdate_ClearBeforeWrite(t *testing.T) {
+	src, err := os.ReadFile("backup_destinations.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	body := string(src)
+	start := strings.Index(body, "func (h *backupDestinationHandler) update(")
+	if start < 0 {
+		t.Fatal("update handler not found")
+	}
+	end := strings.Index(body[start:], "\nfunc (h *backupDestinationHandler) delete(")
+	if end < 0 {
+		t.Fatal("delete handler (update body terminator) not found")
+	}
+	updBody := body[start : start+end]
+
+	clearIdx := strings.Index(updBody, "if req.ClearCreds {")
+	if clearIdx < 0 {
+		t.Fatal("--clear-creds block not found in the update handler")
+	}
+	writeIdx := strings.Index(updBody, "h.writeCreds(")
+	if writeIdx < 0 {
+		t.Fatal("credential write not found in the update handler")
+	}
+	if clearIdx > writeIdx {
+		t.Fatal("--clear-creds block must precede the credential write; the un-widened persist-failure gate depends on this ordering")
+	}
+
+	// The clear block itself must no longer delete the file inline (the reap moved
+	// to after persist). Scope to the clear block: from `if req.ClearCreds {` up to
+	// the credsEnv assignment that follows it.
+	clearBlockEnd := strings.Index(updBody[clearIdx:], "credsEnv := req.CredentialsEnv")
+	if clearBlockEnd < 0 {
+		t.Fatal("credsEnv assignment (clear-block terminator) not found")
+	}
+	clearBlock := updBody[clearIdx : clearIdx+clearBlockEnd]
+	if strings.Contains(clearBlock, "h.deleteCreds(") {
+		t.Fatal("--clear-creds block must not delete the file inline; the removal is deferred to the post-persist reap")
 	}
 }


### PR DESCRIPTION
## What

The admin REST update handler (`PATCH /api/v1/admin/backup-destinations/:id`)
removed a destination's on-disk credential file (SSHPASS / cloud secrets,
root:root 0600) through the agent inside the `clear_credentials` block and *then*
persisted the row with the reference dropped:

```go
if req.ClearCreds {
    if d.CredentialsRef != nil {
        h.deleteCreds(c.Request.Context(), d.ID)   // deletes the file HERE, before persist
    }
    d.CredentialsRef = nil
}
// ... later ...
h.repo.Update(ctx, d)   // if this fails, the file is already gone
```

If the persist failed, the file was already deleted but the DB row was unchanged —
it still referenced the now-missing file. The surviving destination was left
pointing at a credential file that no longer exists: a **dangling reference**, the
mirror image of the orphaned-file leak the create/update compensation already
guards (#1647 / #1659). This is the REST twin of the CLI fix (#1668), one adapter
per PR.

## How

Reorder to **persist-first**. The `clear_credentials` block now only drops the
in-memory reference and records that a file was cleared (`clearedCredsFile`); the
on-disk removal is deferred to a reap that runs only *after* the row that no
longer references it has committed. On a failed persist the file survives and the
surviving row still references it — consistent, no dangling reference. The reap is
skipped when a `creds_write` later in the same request re-created the file at the
deterministic path and re-set the reference (`clear_credentials` together with new
`credentials_env`): the committed row points at it, so it must stay.

## Why the persist-failure gate is NOT widened (the CLI/REST asymmetry)

The CLI adapter (#1668) had to widen its orphan gate to
`d.CredentialsRef != nil || clearedCredsFile`, because the CLI writes
`--sftp-password` *before* its clear — a file could be written then cleared on a
fileless destination, and on a persist failure that file needed compensating.

The REST handler orders the clear block **before** the credential writes. So under
`!origHadCredsFile` the reference is still nil when the clear block runs, and
`clearedCredsFile` can never be set in that state — the written-then-cleared case
is unreachable here. The existing gate `!origHadCredsFile && d.CredentialsRef != nil`
already covers every reachable orphan, and widening it would be dead code. A
scoped source-pin test (`_ClearBeforeWrite`) asserts the clear block keeps
preceding the write so this asymmetry cannot silently regress into the CLI's shape.

## Scope / honesty

This is **prevention**: the reorder removes the dangling-reference window outright,
it does not merely surface it.

**Visibility unchanged.** The REST `deleteCreds` helper is best-effort and stays
silent on a cleanup failure by existing design; the reap inherits that silence — a
failed reap leaves an orphan secrets file with no log line, exactly as the eager
path did before this PR. Making it loud is the separate open PR #1665; this PR does
not touch it.

**One observable behavior change:** clearing and rewriting credentials in the same
request (`clear_credentials` + new `credentials_env`) now overwrites the file in
place — one agent call (`creds_write`) — instead of a delete followed by a write
(two calls). The end state is identical.

**Closes no acceptance criterion.** AC4 is about a live *rekey* (a credential
WRITE) completing before persistence — the opposite operation with the opposite
safe ordering; this is a credential *delete*, only safe *after* persistence.
JAB-310 stays a module-parent. This completes the clear-creds persist-first reorder
on **both** adapters — the twin named as the follow-up in #1668.

## Tests

`backup_destinations_update_compensation_test.go`:

- **[LB]** a clear on a destination that HAS a file, with a failed persist, does
  NOT delete the file (the surviving row still references it) — the dangling
  reference is prevented;
- a clear with a successful persist reaps the file exactly once, and a
  `beforeUpdate` repo hook snapshots the delete count at persist time and asserts
  it is still zero there — proving the reap is deferred, not eager;
- a clear-then-rewrite in one request does not reap the re-created file;
- a scoped source-pin asserts the clear block precedes the write and no longer
  deletes the file inline.

All four guards were falsified with compiling neutralizations (eager delete
re-added; reap disabled; the reap's `d.CredentialsRef == nil` check dropped; the
write hoisted above the clear), each red then reverted. `go build ./...` /
`go vet ./internal/api/` green; gofmt-clean; `go test ./internal/api/ -race` green
(full package, unfiltered).

## Merge ordering

Off `fb590ac8c`. Touches `internal/api/backup_destinations.go`, which **overlaps
#1665** (loud `deleteCreds`: #1665 edits the struct / constructor / `deleteCreds`
body / the fail-branch comment; this edits the clear block and inserts the reap
before the `200`). No logic conflict, adjacent edits in the same handler; whichever
of #1665 / this merges second needs a rebase. No test-file conflict (#1665 added a
new file).

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
