### PR TITLE
fix(domains): show the service badge on the admin Web Domains list (GH #1606)

### DIFF
--- a/panel-ui/src/components/domains/domainColumns.test.tsx
+++ b/panel-ui/src/components/domains/domainColumns.test.tsx
@@ -2,7 +2,10 @@
 // the tenant Web Domains list gains it; the admin list (which edits from its
 // own Edit page and has a dedicated Applications list) must not.
 import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { buildDomainDataColumns, type DomainInventoryAudience } from "./domainColumns";
+import type { Domain } from "./types";
 
 const ctx = { t: (k: string) => k, query: { params: {}, setParams: vi.fn() } };
 const colKeys = (audience: DomainInventoryAudience) =>
@@ -15,5 +18,32 @@ describe("buildDomainDataColumns Application column (GH #1543)", () => {
 
   it("omits the Application column on the admin list", () => {
     expect(colKeys({ kind: "admin" })).not.toContain("application");
+  });
+});
+
+// GH #1606 / #1449: the service badge ("DNS only" / "Mail only" / "External
+// DNS") must render on the admin list too, not just the tenant one — an
+// operator reviewing a migration otherwise cannot tell a docroot-less DNS-only
+// zone from a real web domain. The admin name cell renders a plain anchor (no
+// react-router), so it renders in isolation without a Router wrapper.
+describe("service badge on the name column (GH #1606)", () => {
+  const nameCell = (audience: DomainInventoryAudience, record: Domain): ReactNode => {
+    const col = buildDomainDataColumns(audience, ctx).find((c) => c.key === "name");
+    const r = (col as { render: (v: unknown, rec: Domain, i: number) => ReactNode }).render;
+    return r("", record, 0);
+  };
+  const dnsOnly = { name: "dns.example.com", doc_root: "", web_disabled: true, email_enabled: false } as Domain;
+  const fullWeb = { name: "web.example.com", doc_root: "/home/u/web", web_disabled: false, dns_disabled: false, email_enabled: true } as Domain;
+
+  it("renders the DNS-only badge on the admin list", () => {
+    render(<>{nameCell({ kind: "admin", ownerId: "u1" }, dnsOnly)}</>);
+    expect(screen.getByText("DNS only")).toBeTruthy();
+  });
+
+  it("shows no badge for a full-service web domain on the admin list", () => {
+    render(<>{nameCell({ kind: "admin", ownerId: "u1" }, fullWeb)}</>);
+    expect(screen.queryByText("DNS only")).toBeNull();
+    expect(screen.queryByText("Mail only")).toBeNull();
+    expect(screen.queryByText("External DNS")).toBeNull();
   });
 });

--- a/panel-ui/src/components/domains/domainColumns.tsx
+++ b/panel-ui/src/components/domains/domainColumns.tsx
@@ -159,7 +159,13 @@ export const buildDomainDataColumns = (
         onSearch: (v) => query.setParams({ q: v, page: 1 }),
       }),
       render: (_name: string, record: Domain) => {
-        const svc = audience.kind === "tenant" ? serviceBadge(record) : null;
+        // GH #1606 / #1449: the service badge distinguishes DNS-only, Mail-only
+        // and External-DNS rows from ordinary full-service web domains. It is
+        // rendered for both audiences — the admin list shows every owner's
+        // domains, so an operator inspecting a Hestia/cPanel migration needs
+        // the same "DNS only" cue a tenant gets, or a docroot-less zone reads
+        // as an ordinary web domain.
+        const svc = serviceBadge(record);
         return (
           <>
             {renderDomainCell(record, audience)}


### PR DESCRIPTION
## What

Follow-up to GH #1606 (Hestia → Jabali migration). The reporter noted that DNS-only zones from the migration "appear under the Web Domains list" and read as ordinary web domains.

The provisioning is correct — a DNS-only zone imports with `WebDisabled=true` and gets no vhost, docroot, or web SSL (`restore_domains.go`, GH #1616). The problem is purely how the row is *labelled*: the "DNS only" / "Mail only" / "External DNS" service badge (GH #1449) that distinguishes a docroot-less row from a real web domain was rendered **only on the tenant** Web Domains list. On the **admin** list — the one an operator uses to review a migration — the badge was gated off, so a DNS-only zone showed with no indication at all.

## Change

`domainColumns.tsx`: render `serviceBadge(record)` for both audiences instead of tenant-only. One line, plus a comment explaining why the admin list needs the same cue.

The badge reads `web_disabled` / `dns_disabled` / `email_enabled`, which `GET /domains` already serializes for both audiences — no backend change.

This matches the show-relabeled model already shipped for the DNS Zones inventory in GH #1611 ("Hosted elsewhere" for external-DNS rows): the facet rows stay visible in the unified inventory, correctly badged, rather than being filtered out.

## Test

`domainColumns.test.tsx`: two render assertions on the admin name cell — a `web_disabled` row shows the "DNS only" badge, and a full-service web domain shows none. The admin name cell renders a plain anchor (no react-router), so it renders in isolation without a Router wrapper.

- `domainColumns.test.tsx` + `serviceBadge.test.ts`: 8 passed.
- `tsc --noEmit`: clean. `eslint` on both files: clean.

## Not in scope

Whether DNS-only zones should be **hidden entirely** from the Web Domains section (a strict per-facet split) rather than shown-and-badged is a product decision left to the issue — the tenant/admin inventories are unified-with-badges by design (GH #1449), and hiding would need a UI-level filter (the `/domains` API also feeds admin breadcrumbs / cross-links, #483) that would also apply to hand-created facet domains. Raised on the issue for the reporter to confirm.

GH #1606

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
