### PR TITLE
fix(backups): record the CLI destination credential ref from the Agent's reply, not a locally-guessed path (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -21,6 +20,10 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
+// credsDir is only a hint path for operator-facing warnings (e.g. "remove X
+// manually" when Agent cleanup fails). The row's CredentialsRef is the Agent's
+// reported path, not a value computed from this const — see
+// writeBackupDestinationCreds in backup_destination_ops.go.
 const credsDir = "/etc/jabali-panel/restic-remotes"
 
 func backupDestinationRepoFromDB() repository.BackupDestinationRepository {
@@ -291,16 +294,11 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 				d.ExtraOptions = raw
 				changed = true
 				if opts.Auth == models.SFTPAuthPassword && cmd.Flags().Changed("sftp-password") {
-					if _, err := sharedAgent.Call(ctx, "backup.dest.creds_write", map[string]any{
-						"dest_id": d.ID,
-						"env":     map[string]string{"SSHPASS": sftpPass},
-					}); err != nil {
+					path, err := writeBackupDestinationCreds(ctx, sharedAgent.Call, d.ID, map[string]string{"SSHPASS": sftpPass})
+					if err != nil {
 						return fmt.Errorf("write sftp password: %w", err)
 					}
-					if d.CredentialsRef == nil {
-						ref := filepath.Join(credsDir, d.ID+".env")
-						d.CredentialsRef = &ref
-					}
+					d.CredentialsRef = &path
 				}
 			}
 			// Clear stored credential env (cloud secrets / sftp SSHPASS). Drop the
@@ -325,16 +323,11 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 					return err
 				}
 				if len(env) > 0 {
-					if _, err := sharedAgent.Call(ctx, "backup.dest.creds_write", map[string]any{
-						"dest_id": d.ID,
-						"env":     env,
-					}); err != nil {
+					path, err := writeBackupDestinationCreds(ctx, sharedAgent.Call, d.ID, env)
+					if err != nil {
 						return fmt.Errorf("write credentials: %w", err)
 					}
-					if d.CredentialsRef == nil {
-						ref := filepath.Join(credsDir, d.ID+".env")
-						d.CredentialsRef = &ref
-					}
+					d.CredentialsRef = &path
 					changed = true
 				}
 			}

--- a/panel-api/cmd/server/backup_destination_ops.go
+++ b/panel-api/cmd/server/backup_destination_ops.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +12,49 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
+
+// writeBackupDestinationCreds dispatches the credential-file write to the Agent
+// (root) and returns the on-disk path the Agent reports in its reply. The Agent
+// is the authoritative owner of that path: panel-api runs as the jabali user and
+// cannot see /etc/jabali-panel/, so the row's CredentialsRef must record what the
+// Agent actually wrote, not a path panel-api guessed locally. This mirrors the
+// REST handler's writeCreds (internal/api/backup_destinations.go), so both callers
+// materialize the same reference under a binary-version skew between panel and
+// Agent (JAB-310 AC5).
+//
+// One step further than REST's writeCreds: when the Agent replies without a
+// usable path (unparseable reply, or an empty "path"), the file is already on
+// disk but the row can never reference it — an orphan-in-waiting. The write is
+// idempotently compensated (creds_delete, ENOENT-tolerant on the Agent) before the
+// error returns, so a malformed reply leaves no unreferenced secrets file behind.
+// A failed compensation is surfaced on stderr, never silently swallowed (JAB-275);
+// bringing REST's writeCreds to this same standard is a named follow-up.
+func writeBackupDestinationCreds(ctx context.Context, call agentCaller, destID string, env map[string]string) (string, error) {
+	raw, err := call(ctx, "backup.dest.creds_write", map[string]any{
+		"dest_id": destID,
+		"env":     env,
+	})
+	if err != nil {
+		// Treated as not written: no compensation, matching REST's writeCreds.
+		// A reply lost after the Agent already completed the write is not
+		// distinguishable from a true write failure at this layer, so a rare
+		// orphan is possible on this path; it is out of scope for this change.
+		return "", err
+	}
+	var resp struct {
+		Path string `json:"path"`
+	}
+	if perr := json.Unmarshal(raw, &resp); perr != nil || resp.Path == "" {
+		if _, derr := call(ctx, "backup.dest.creds_delete", map[string]any{"dest_id": destID}); derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: credential file cleanup failed (%v); remove %s manually\n", derr, filepath.Join(credsDir, destID+".env"))
+		}
+		if perr != nil {
+			return "", fmt.Errorf("parse creds_write reply: %w", perr)
+		}
+		return "", errors.New("creds_write reply had no path")
+	}
+	return resp.Path, nil
+}
 
 // createBackupDestinationDirect is the CLI testable core for `jabali destination
 // create`. It writes the destination's Agent credential file (when the caller
@@ -24,14 +69,11 @@ import (
 // select the conflict-specific message via errors.Is(err, repository.ErrConflict).
 func createBackupDestinationDirect(ctx context.Context, call agentCaller, repo repository.BackupDestinationRepository, d *models.BackupDestination, env map[string]string) error {
 	if len(env) > 0 {
-		if _, err := call(ctx, "backup.dest.creds_write", map[string]any{
-			"dest_id": d.ID,
-			"env":     env,
-		}); err != nil {
+		path, err := writeBackupDestinationCreds(ctx, call, d.ID, env)
+		if err != nil {
 			return fmt.Errorf("write credentials: %w", err)
 		}
-		ref := filepath.Join(credsDir, d.ID+".env")
-		d.CredentialsRef = &ref
+		d.CredentialsRef = &path
 	}
 	if err := repo.Create(ctx, d); err != nil {
 		// Compensate on EVERY failure, not just a name-conflict. Best-effort, but

--- a/panel-api/cmd/server/backup_destination_ops_test.go
+++ b/panel-api/cmd/server/backup_destination_ops_test.go
@@ -41,6 +41,13 @@ func (f *fakeBackupDestRepo) Delete(_ context.Context, _ string) error {
 	return f.deleteErr
 }
 
+// agentCredsPath is the on-disk path the fake Agent reports in its creds_write
+// reply. It is deliberately NOT filepath.Join(credsDir, "dst-1.env"): the core
+// must record the path the Agent returns, not one it computes locally, so a test
+// that sees this exact value proves the reply — not a local guess — set the row's
+// CredentialsRef (JAB-310 AC5).
+const agentCredsPath = "/agent/says/dst-1.env"
+
 // recordingAgent records each agent command (and its params), and can be told to
 // fail a specific command.
 type recordingAgent struct {
@@ -48,6 +55,10 @@ type recordingAgent struct {
 	params  map[string]map[string]any
 	failCmd string
 	failErr error
+	// credsWriteNoPath, when true, makes the creds_write reply omit "path"
+	// (a malformed Agent reply): the file is on disk but has no referenceable
+	// path, which the write helper must treat as a failure and compensate.
+	credsWriteNoPath bool
 }
 
 func (r *recordingAgent) call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
@@ -60,6 +71,9 @@ func (r *recordingAgent) call(_ context.Context, cmd string, params any) (json.R
 	}
 	if cmd == r.failCmd {
 		return nil, r.failErr
+	}
+	if cmd == "backup.dest.creds_write" && !r.credsWriteNoPath {
+		return json.RawMessage(`{"path":"` + agentCredsPath + `"}`), nil
 	}
 	return json.RawMessage(`{}`), nil
 }
@@ -151,6 +165,79 @@ func TestCreateBackupDestinationDirect_CredsWriteFailsBeforePersist(t *testing.T
 	}
 	if agent.fired("backup.dest.creds_delete") {
 		t.Fatal("nothing was written, so nothing must be deleted")
+	}
+}
+
+// TestCreateBackupDestinationDirect_RefFromAgentReply is the discriminator for
+// this slice: the row's CredentialsRef must be the path the Agent returned in its
+// creds_write reply, not a path panel-api computed locally from credsDir. The
+// Agent owns /etc/jabali-panel/ and is authoritative for the path, so under a
+// panel/Agent binary-version skew the two must not disagree (JAB-310 AC5). The
+// fake returns a deliberately non-local path.
+func TestCreateBackupDestinationDirect_RefFromAgentReply(t *testing.T) {
+	agent := &recordingAgent{}
+	repo := &fakeBackupDestRepo{} // persist succeeds
+	d := newDest()
+
+	if err := createBackupDestinationDirect(context.Background(), agent.call, repo, d, map[string]string{"AWS_SECRET_ACCESS_KEY": "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.createCalled != 1 {
+		t.Fatalf("Create called %d times, want 1", repo.createCalled)
+	}
+	if d.CredentialsRef == nil {
+		t.Fatal("CredentialsRef must be set from the Agent reply")
+	}
+	if *d.CredentialsRef != agentCredsPath {
+		t.Fatalf("CredentialsRef = %q, want the Agent-reported path %q (not a locally-computed one)", *d.CredentialsRef, agentCredsPath)
+	}
+}
+
+// TestWriteBackupDestinationCreds_MissingPathCompensates is load-bearing: when the
+// Agent write succeeds but the reply carries no usable path, the file is on disk
+// yet the row can never reference it. The helper must compensate (creds_delete)
+// and return an error rather than persist a row that points nowhere — driven here
+// through the create core, which must then NOT persist.
+func TestWriteBackupDestinationCreds_MissingPathCompensates(t *testing.T) {
+	agent := &recordingAgent{credsWriteNoPath: true}
+	repo := &fakeBackupDestRepo{} // would succeed if reached
+	d := newDest()
+
+	err := createBackupDestinationDirect(context.Background(), agent.call, repo, d, map[string]string{"AWS_SECRET_ACCESS_KEY": "x"})
+	if err == nil {
+		t.Fatal("a creds_write reply with no path must return an error")
+	}
+	if !agent.fired("backup.dest.creds_delete") {
+		t.Fatal("the on-disk file left by a path-less reply was NOT compensated (orphan)")
+	}
+	if repo.createCalled != 0 {
+		t.Fatalf("row must NOT be persisted when no referenceable path came back, Create called %d", repo.createCalled)
+	}
+	if d.CredentialsRef != nil {
+		t.Fatalf("CredentialsRef must stay nil when the reply had no path, got %q", *d.CredentialsRef)
+	}
+}
+
+// TestBackupDestinationUpdate_WritesRouteThroughHelper source-pins that the update
+// RunE's two credential-write sites (sftp-password and --env) go through
+// writeBackupDestinationCreds and no longer compute the ref locally from credsDir.
+// The RunE is not unit-testable, so pin the migration by source: the local
+// filepath.Join(credsDir ... computation must be gone from the update command.
+func TestBackupDestinationUpdate_WritesRouteThroughHelper(t *testing.T) {
+	src := readOpsSource(t, "backup_destination_cmd.go")
+	start := strings.Index(src, "func newBackupDestinationUpdateCmd(")
+	if start < 0 {
+		t.Fatal("update command not found")
+	}
+	body := src[start:]
+	if end := strings.Index(body, "\nfunc newBackupDestinationRotatePasswordCmd("); end > 0 {
+		body = body[:end]
+	}
+	if !strings.Contains(body, "writeBackupDestinationCreds(ctx, sharedAgent.Call,") {
+		t.Error("update RunE credential writes must route through writeBackupDestinationCreds")
+	}
+	if strings.Contains(body, "filepath.Join(credsDir") {
+		t.Error("update RunE must not compute CredentialsRef locally from credsDir; use the Agent reply path")
 	}
 }
 


### PR DESCRIPTION
## What

The `jabali destination` CLI wrote the credential file through the Agent and then
set the row's `CredentialsRef` to a path it computed **locally**
(`filepath.Join(credsDir, id+".env")`), discarding the path the Agent actually
reported in its `backup.dest.creds_write` reply. The REST handler already does the
right thing — it stores `resp.Path` from that same reply.

The Agent owns `/etc/jabali-panel/` and is authoritative for where the file lands;
panel-api runs as the `jabali` user and cannot see that directory. Same DB column,
two materialization strategies. Under a binary-version skew between the panel and
Agent (they deploy separately), a locally-guessed path could disagree with where
the file really is. This is the "local-vs-agent credential-path computation"
divergence named under JAB-310 AC5 — every caller should materialize the
destination's parameters identically. REST is the reference; the CLI is the outlier.

## Change

Extract `writeBackupDestinationCreds(ctx, call, destID, env) (string, error)` — the
CLI twin of REST's `writeCreds`: it dispatches the write and returns the path from
the Agent reply. All three CLI write sites now route through it and set
`CredentialsRef` from that returned path: the create core, plus the update RunE's
sftp-password and `--env` sites. The `if d.CredentialsRef == nil` guards at the
update sites are dropped — the reply is authoritative, so it should also correct a
stale reference rather than leave it.

### Behavior change (observable only under a malformed reply)

Previously, a path-less or unparseable `creds_write` reply was silently ignored and
the CLI succeeded using its local guess. Now the CLI **fails loud and compensates**:
when the Agent write succeeds but the reply carries no usable path (unparseable, or
an empty `"path"`), the file is on disk yet the row can never reference it — an
orphan-in-waiting. The helper idempotently deletes it (`creds_delete`,
ENOENT-tolerant on the Agent) before returning the error, so a malformed reply
leaves no unreferenced secrets file behind. A failed compensation is surfaced on
stderr, never silently swallowed (JAB-275). This is one step further than REST's
`writeCreds`, following the #1647 precedent of the CLI going beyond REST on cleanup.

The path is deterministic today, so there is **no observable change to a healthy
write** — the fix removes a skew-time hazard and unifies the two adapters.

### No fleet-skew hazard from the new strictness

Verified the Agent's `creds_write` handler returns `credsWriteResult{Path: final}`
— the reply always carries `path`. That field was added in `d28aa7fcc` (m30.1), the
**same** commit that first introduced the agent-delegated creds-file ops. So any
Agent old enough to lack `path` in its reply is also too old to serve
`backup.dest.creds_write` at all. The new fail-loud path cannot be tripped by an
older fleet Agent; no minimum Agent version beyond the command's own introduction.

## Scope

Closes no acceptance criterion on its own. AC5 is the broader "every caller
materializes identical destination parameters" invariant; this closes the
credential-path half on the CLI adapter. JAB-310 stays a module-parent (Backlog).

The SFTP-options half of AC5 remains divergent and is an open **product question**
(below) — not fixed here.

## Tests (`backup_destination_ops_test.go`)

- The fake Agent now returns a deliberately non-local path
  (`/agent/says/dst-1.env`) in its `creds_write` reply.
- `TestCreateBackupDestinationDirect_RefFromAgentReply` — create success asserts
  `CredentialsRef` equals that Agent-reported path (the whole slice in one
  assertion; a local computation would yield the `credsDir` path and go red).
- `TestWriteBackupDestinationCreds_MissingPathCompensates` (load-bearing) — a
  path-less reply through the create core: file compensated (`creds_delete`), row
  NOT persisted, `CredentialsRef` stays nil, create not called.
- `TestBackupDestinationUpdate_WritesRouteThroughHelper` (source-pin) — the update
  RunE routes writes through the helper and no longer joins `credsDir` locally.
- The three new guards were each falsified with a compiling neutralization (restore
  local computation; disable in-helper compensation; revert an update site to local
  computation) — red then reverted.
- Existing create/update compensation tests unchanged; the fake's default reply now
  carries a path, so they exercise the same flow. `go build ./...` /
  `go vet ./cmd/server/` green; gofmt-clean; `go test ./cmd/server/ -race` green
  (full package).

## Merge ordering

Off `origin/main` `fb590ac8c`. Touches
`cmd/server/backup_destination_{ops,ops_test,cmd}.go`, which is now **three-deep**
with two open PRs in the same files: #1666 (CLI delete) -> #1668 (CLI --clear-creds)
-> this. Adjacent regions, no logic conflict; whichever merges last rebases
(mechanical). **A merge pass on the `cmd/server` stack is due before any further
`cmd/server` slice.** (`backup_destinations.go` is separately two-deep: #1665 <->
#1670.)

## Named follow-ups (not built here — one adapter per PR)

- **REST `writeCreds` has two gaps**, both this class: (1) a parse failure returns
  500 with no compensation (same defect this PR closes on the CLI); (2) it accepts
  an empty `path` and would store `""` as `CredentialsRef`. A REST follow-up.
- **REST `CredentialsDir`** (`internal/api/backup_destinations.go`) is a dead
  exported const (unused repo-wide).
- **Agent-internal `credsDir`** (`panel-agent/.../backup_dest_creds.go`) vs
  `resticRemoteEnvDir` (`docker_app_backup.go`) — the writer and the docker reader
  in the same Agent binary derive the same directory from two separate consts.
  Agent-only PR.

## Open product question (for the parent, not this PR)

SFTP-options materialization is still divergent: the CLI update **overlays** onto
the stored SFTP block via `ExtraOptionsTyped().SFTP` + `cmd.Flags().Changed()`,
while REST update builds a **fresh** `models.SFTPOptions{}` from the request alone
(wholesale replace). The REST `sftpRequestOptions` fields are plain values with no
presence tracking, so a partial SFTP PATCH would need pointer wire fields. Should
REST PATCH `sftp` support partial blocks (pointer wire fields), or is
full-block-by-contract the intended behavior? Answer decides whether AC5's SFTP half
is a bug or by-design.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
