### PR TITLE
fix(mail): refresh the per-domain mailbox list after create/update/delete (GH #1615)

### DIFF
--- a/panel-ui/src/hooks/useMailboxes.test.tsx
+++ b/panel-ui/src/hooks/useMailboxes.test.tsx
@@ -14,6 +14,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  perDomainMailboxesResource,
   useCreateMailbox,
   useDeleteMailbox,
   useDisableDomainEmail,
@@ -21,6 +22,7 @@ import {
   useEnableDomainEmail,
   useMailboxes,
   useRotateMailboxPassword,
+  useUpdateMailbox,
 } from "./useMailboxes";
 
 vi.mock("../apiClient", () => ({
@@ -194,6 +196,11 @@ describe("useCreateMailbox", () => {
     expect(resp?.password).toBe("gen123");
     const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidatedKeys).toContainEqual(["list", "mailboxes", "dom1"]);
+    // GH #1615: the per-domain Mailboxes drill-down (Mail Domains → domain →
+    // Mailboxes) is keyed ["list","domains/<id>/mailboxes",…] via useTableURL,
+    // NOT ["list","mailboxes",…] — so it must be invalidated by its own
+    // resource string or the new row never appears until a manual refresh.
+    expect(invalidatedKeys).toContainEqual(["list", perDomainMailboxesResource("dom1")]);
   });
 });
 
@@ -223,6 +230,34 @@ describe("useDeleteMailbox", () => {
       "dom1",
     ]);
     expect(invalidatedKeys).toContainEqual(["autoresponders", "by-domain", "dom1"]);
+    // GH #1615: same per-domain drill-down key as create/update — a deleted
+    // mailbox must vanish from the Mail Domains → domain → Mailboxes list too.
+    expect(invalidatedKeys).toContainEqual(["list", perDomainMailboxesResource("dom1")]);
+  });
+});
+
+describe("useUpdateMailbox", () => {
+  it("PATCHes /mailboxes/:id and invalidates every mailbox list, including the per-domain drill-down (GH #1615)", async () => {
+    mocked.patch.mockResolvedValue({
+      data: { id: "mb1", domain_id: "dom1", email: "alice@example.com", display_name: "New" },
+    });
+    const { qc, wrapper } = makeWrapper();
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateMailbox(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: "mb1", domainId: "dom1", display_name: "New" });
+    });
+
+    expect(mocked.patch).toHaveBeenCalledWith("/mailboxes/mb1", { display_name: "New" });
+    const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidatedKeys).toContainEqual(["list", "mailboxes", "dom1"]);
+    expect(invalidatedKeys).toContainEqual(["list", "admin/mailboxes"]);
+    expect(invalidatedKeys).toContainEqual(["list", "me/mailboxes"]);
+    // GH #1615 root cause: the edited mailbox never refreshed in the per-domain
+    // Mailboxes drill-down because this key was missing — the reason #1630's
+    // drawer-prefill fix couldn't work (the data feeding the form was stale).
+    expect(invalidatedKeys).toContainEqual(["list", perDomainMailboxesResource("dom1")]);
   });
 });
 

--- a/panel-ui/src/hooks/useMailboxes.ts
+++ b/panel-ui/src/hooks/useMailboxes.ts
@@ -112,6 +112,38 @@ function toQueryString(params: ListParams): string {
   return s ? `?${s}` : "";
 }
 
+// GH #1615: the per-domain Mailboxes drill-down (Mail Domains → domain →
+// Mailboxes, `MailboxesTab` in per-domain mode) lists rows via
+// useTableURL({ resource: `domains/${domainId}/mailboxes` }), so its cache key
+// is ["list", `domains/${domainId}/mailboxes`, …params] — a single resource
+// string, NOT ["list","mailboxes",domainId,…]. Any mutation that changes a
+// mailbox row must invalidate this key or that list stays stale until a manual
+// page refresh. Single-source the string here so the tab and the mutations
+// can't drift apart (they did — JAB-370 re-keyed the tab, the mutations were
+// left invalidating the old key).
+export const perDomainMailboxesResource = (domainId: string): string =>
+  `domains/${domainId}/mailboxes`;
+
+// invalidateMailboxLists busts every cache key that renders a mailbox list, so
+// a create / update / delete refreshes all of them: the legacy per-domain
+// useMailboxes key, the flat ["list","mailboxes"] fallback, both server-
+// paginated useTableURL directories (admin + tenant), and the per-domain
+// drill-down (GH #1615). Callers add any resource-specific keys of their own
+// (e.g. delete also busts group-membership + autoresponder panels).
+function invalidateMailboxLists(qc: ReturnType<typeof useQueryClient>, domainId?: string): void {
+  if (domainId) {
+    qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
+    qc.invalidateQueries({ queryKey: ["list", perDomainMailboxesResource(domainId)] });
+  }
+  qc.invalidateQueries({ queryKey: ["list", "mailboxes"] });
+  // JAB-370: the admin Mail tab is server-paginated via
+  // useTableURL({ resource: "admin/mailboxes" }), keyed ["list","admin/mailboxes",…].
+  qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
+  // JAB-370 Workspace: the flat tenant view uses useTableURL({ resource:
+  // "me/mailboxes" }), keyed ["list","me/mailboxes",…].
+  qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
+}
+
 // ---------------------------------------------------------------------------
 // Domain email (enable/disable state)
 // ---------------------------------------------------------------------------
@@ -229,17 +261,9 @@ export function useCreateMailbox(): UseMutationResult<
       return data;
     },
     onSuccess: (_data, { domainId }) => {
-      qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
-      // JAB-370: the admin Mail tab is now server-paginated via
-      // useTableURL({ resource: "admin/mailboxes" }), keyed ["list",
-      // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
-      // delete / create refreshes the visible page.
-      qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
-      // JAB-370 Workspace: the tenant Mailboxes tab is now server-paginated via
-      // useTableURL({ resource: "me/mailboxes" }), keyed ["list", "me/mailboxes",
-      // …params]. Prefix-invalidate it so a create/edit/delete refreshes the
-      // visible page instead of leaving a stale (or ghost) row.
-      qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
+      // GH #1615: refresh every mailbox list, including the per-domain
+      // drill-down (a newly created mailbox otherwise never appeared there).
+      invalidateMailboxLists(qc, domainId);
     },
   });
 }
@@ -255,17 +279,9 @@ export function useDeleteMailbox(): UseMutationResult<
       await apiClient.delete(`/mailboxes/${id}`);
     },
     onSuccess: (_data, { domainId }) => {
-      qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
-      // JAB-370: the admin Mail tab is now server-paginated via
-      // useTableURL({ resource: "admin/mailboxes" }), keyed ["list",
-      // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
-      // delete / create refreshes the visible page.
-      qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
-      // JAB-370 Workspace: the tenant Mailboxes tab is now server-paginated via
-      // useTableURL({ resource: "me/mailboxes" }), keyed ["list", "me/mailboxes",
-      // …params]. Prefix-invalidate it so a create/edit/delete refreshes the
-      // visible page instead of leaving a stale (or ghost) row.
-      qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
+      // GH #1615: refresh every mailbox list, including the per-domain
+      // drill-down (a deleted mailbox otherwise lingered there until refresh).
+      invalidateMailboxLists(qc, domainId);
       // JAB-333: a deleted mailbox also disappears from the tenant screen's
       // group-membership and autoresponder panels — invalidate those shared
       // keys so they don't render a ghost row until the next refetch.
@@ -330,20 +346,9 @@ export function useUpdateMailbox(): UseMutationResult<
       return data;
     },
     onSuccess: (_data, { domainId }) => {
-      if (domainId) {
-        qc.invalidateQueries({ queryKey: ["list", "mailboxes", domainId] });
-      }
-      qc.invalidateQueries({ queryKey: ["list", "mailboxes"] });
-      // JAB-370: the admin Mail tab is now server-paginated via
-      // useTableURL({ resource: "admin/mailboxes" }), keyed ["list",
-      // "admin/mailboxes", …params]. Prefix-invalidate that so an edit /
-      // delete / create refreshes the visible page.
-      qc.invalidateQueries({ queryKey: ["list", "admin/mailboxes"] });
-      // JAB-370 Workspace: the tenant Mailboxes tab is now server-paginated via
-      // useTableURL({ resource: "me/mailboxes" }), keyed ["list", "me/mailboxes",
-      // …params]. Prefix-invalidate it so a create/edit/delete refreshes the
-      // visible page instead of leaving a stale (or ghost) row.
-      qc.invalidateQueries({ queryKey: ["list", "me/mailboxes"] });
+      // GH #1615: refresh every mailbox list, including the per-domain
+      // drill-down that was previously left stale until a manual page refresh.
+      invalidateMailboxLists(qc, domainId);
     },
   });
 }

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -26,6 +26,7 @@ import { useForwarders } from "../../../../hooks/useForwarders";
 
 import { apiClient } from "../../../../apiClient";
 import {
+  perDomainMailboxesResource,
   useDeleteMailbox,
   type Mailbox,
 } from "../../../../hooks/useMailboxes";
@@ -70,7 +71,7 @@ export const MailboxesTab = ({ domainId }: { domainId?: string } = {}) => {
   // embedded in the Mail Domains drill-down (domainId set). This replaces the
   // one-request-per-domain fan-out that capped each domain at 200 rows and never
   // paginated across domains. Search/sort/pagination are all server-authoritative.
-  const resource = domainId ? `domains/${domainId}/mailboxes` : "me/mailboxes";
+  const resource = domainId ? perDomainMailboxesResource(domainId) : "me/mailboxes";
   const query = useTableURL<Mailbox & { domain_name?: string }>({
     resource,
     defaultSort: "email",


### PR DESCRIPTION
## What

Fixes GH #1615 — editing (and creating/deleting) a mailbox did not update the UI until a manual page refresh, and reopening the Edit drawer showed stale data.

## Root cause

The per-domain **Mailboxes** drill-down (Mail Domains → a domain → Mailboxes tab) lists its rows via `useTableURL({ resource: `domains/${domainId}/mailboxes` })`, so its TanStack-query cache key is:

```
["list", "domains/<domainId>/mailboxes", { …params }]
```

The mailbox mutations only invalidated `["list","mailboxes",…]`, `["list","admin/mailboxes"]` and `["list","me/mailboxes"]` — **none of which prefix-match** that key (element `[1]` is the single string `"domains/<id>/mailboxes"`, not `"mailboxes"`). So the drill-down list never refetched after an edit. JAB-370 re-keyed this tab onto `useTableURL` but left the mutations invalidating the old key.

Because that list never refreshed, the row object it hands to `EditMailboxModal` stayed stale too — which is why the earlier drawer-prefill fix (#1630) couldn't resolve the report: the form's `initialValues` were correct, but the data feeding them was never refreshed.

This is tenant-only: the admin server-wide Mail page (`admin/mailboxes`) and the admin per-domain `DomainMailboxesSection` (`["list","mailboxes",domainId]`) were already invalidated correctly.

## Change

- Add `invalidateMailboxLists(qc, domainId)` covering every mailbox-list key, including the per-domain drill-down, and route `useCreateMailbox` / `useUpdateMailbox` / `useDeleteMailbox` through it. Delete keeps its extra group-membership + autoresponder invalidations. (Create and delete had the same gap, so this fixes those on the drill-down too, not just edit.)
- Export `perDomainMailboxesResource(domainId)` and use it in **both** `MailboxesTab` (the query) and the invalidations, so the tab's key and the mutations can no longer drift apart.

## Test

`useMailboxes.test.tsx` now asserts each of the three mutations invalidates `["list", perDomainMailboxesResource("dom1")]`.

These three assertions **fail on the code before this change and pass after** — verified by running them against the unfixed hook first (3 failed / 7 passed), then after the fix (10 passed). That is the discriminator #1630 lacked: its drawer test passed on both sides of its fix because jsdom mounts overlay children synchronously and can't reproduce the browser-only symptom. A hook-level cache-key test has no such blind spot.

- `useMailboxes.test.tsx`: 10 passed. Adjacent mail tests (`EditMailboxModal.reopen`, `mailboxInventorySurfaces.wiring`, `MailDomainsPage`): 18 passed.
- `tsc --noEmit`: clean. `eslint` on all three files: clean.

GH #1615

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
