### PR TITLE
feat(dns): one-time sweep of orphaned PowerDNS backend rows (GH #1620)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1500,6 +1500,18 @@ DNS zones and records (dns_zones / dns_records): list / add / update / delete
 jabali dns
 ```
 
+#### `jabali dns prune-orphan-records`
+
+Remove PowerDNS backend rows left behind by a pre-#1629 zone delete (GH #1620)
+
+```
+jabali dns prune-orphan-records [flags]
+```
+
+**Flags:**
+
+- `--apply` — actually delete (default is a dry run)
+
 #### `jabali dns prune-service-records`
 
 Remove imported cPanel service subdomains (cpanel/webmail/whm/…) from DNS

--- a/panel-agent/internal/commands/dns_reap_orphans.go
+++ b/panel-agent/internal/commands/dns_reap_orphans.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/pdns"
+)
+
+// dns.reap-orphans — GH #1620 one-time remediation.
+//
+// #1629 (DeleteZone) tears a zone's child rows down before the parent `domains`
+// row, so a zone delete no longer strands children. That is forward-only: a box
+// that deleted a domain BEFORE #1629 still carries the orphaned child rows
+// (records / domainmetadata / comments / cryptokeys with no parent `domains`
+// row). They can keep being served — from the backend or its caches — until the
+// rows are removed, and collide as "duplicate records" on re-add. This RPC
+// sweeps them.
+//
+// Dry-run by default (apply=false): report per-table orphan counts and the
+// affected record names, delete nothing. apply=true runs the transactional
+// sweep and then purges the pdns Auth + recursor caches for each affected name.
+
+type dnsReapOrphansParams struct {
+	// Apply=false (the default) is a dry run: report counts, delete nothing. A
+	// caller must opt in to deletion explicitly, mirroring the CLI's --apply.
+	Apply bool `json:"apply"`
+}
+
+type dnsReapOrphansResponse struct {
+	Applied bool           `json:"applied"`
+	Counts  map[string]int `json:"counts"`  // orphan rows per table (pre-delete)
+	Deleted map[string]int `json:"deleted"` // rows deleted per table (empty on a dry run)
+	Names   []string       `json:"names"`   // distinct record names affected (and purged on apply)
+}
+
+// orphanSweeper is the pdns surface this handler needs. The package-var seam
+// below lets tests substitute a fake without a live PowerDNS DB (mirrors
+// php_fpm_reap.go's osUserExists stub), so the safety guards — the empty-domains
+// refusal and "dry-run never deletes" — are testable.
+type orphanSweeper interface {
+	DomainsCount() (int, error)
+	OrphanCounts() (map[string]int, error)
+	OrphanRecordNames() ([]string, error)
+	ReapOrphans() (map[string]int, error)
+}
+
+// reapOrphansClient returns the sweeper the handler uses, or nil when the pdns
+// backend is unavailable. Overridable in tests. It must return an explicit nil
+// interface (not a typed nil *pdns.Client) so the handler's nil check works.
+var reapOrphansClient = func() orphanSweeper {
+	if cl := pdns.Default(); cl != nil {
+		return cl
+	}
+	return nil
+}
+
+func dnsReapOrphansHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dnsReapOrphansParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
+	cl := reapOrphansClient()
+	if cl == nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "powerdns backend not available"}
+	}
+
+	// Safety floor: an empty domains table would make the orphan predicate
+	// (`domain_id NOT IN (SELECT id FROM domains)`) true for EVERY record, so a
+	// misconfigured or mid-provision connection could wipe the whole backend.
+	// Refuse outright — the DNS analogue of php.pool.reap-orphans refusing a nil
+	// keep-list. A box with zero domains has nothing legitimate to reap anyway.
+	domains, err := cl.DomainsCount()
+	if err != nil {
+		return nil, err
+	}
+	if domains == 0 {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: "refusing to sweep: the pdns domains table is empty, which would make every record look orphaned — check the PowerDNS DB connection",
+		}
+	}
+
+	counts, err := cl.OrphanCounts()
+	if err != nil {
+		return nil, err
+	}
+	// Collect affected names BEFORE the delete — afterwards the rows are gone.
+	names, err := cl.OrphanRecordNames()
+	if err != nil {
+		return nil, err
+	}
+
+	if !p.Apply {
+		return dnsReapOrphansResponse{Applied: false, Counts: counts, Deleted: map[string]int{}, Names: names}, nil
+	}
+
+	deleted, err := cl.ReapOrphans()
+	if err != nil {
+		return nil, err
+	}
+	// Purge caches for each affected name. The row is gone from SQL but the pdns
+	// Auth packet cache and the recursor's forward cache would keep serving the
+	// stale answer for cache-ttl otherwise (GH #1620 "keeps resolving"). Same
+	// per-name purge dns.zone.delete does; best-effort. No NOTIFY — an orphan has
+	// no zone, so there is nothing to notify slaves about.
+	for _, n := range names {
+		_ = execCommandContext(ctx, "pdns_control", "purge", n+"$").Run()
+		_ = execCommandContext(ctx, "rec_control", "wipe-cache", n+"$").Run()
+	}
+	return dnsReapOrphansResponse{Applied: true, Counts: counts, Deleted: deleted, Names: names}, nil
+}
+
+func init() {
+	Default.Register("dns.reap-orphans", dnsReapOrphansHandler)
+}

--- a/panel-agent/internal/commands/dns_reap_orphans_test.go
+++ b/panel-agent/internal/commands/dns_reap_orphans_test.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// fakeOrphanSweeper is a no-DB stand-in for pdns.Client, so the dns.reap-orphans
+// safety guards can be tested without a live PowerDNS backend.
+type fakeOrphanSweeper struct {
+	domains    int
+	domainsErr error
+	counts     map[string]int
+	names      []string
+	deleted    map[string]int
+	reapCalls  int
+}
+
+func (f *fakeOrphanSweeper) DomainsCount() (int, error)            { return f.domains, f.domainsErr }
+func (f *fakeOrphanSweeper) OrphanCounts() (map[string]int, error) { return f.counts, nil }
+func (f *fakeOrphanSweeper) OrphanRecordNames() ([]string, error)  { return f.names, nil }
+func (f *fakeOrphanSweeper) ReapOrphans() (map[string]int, error) {
+	f.reapCalls++
+	return f.deleted, nil
+}
+
+func withFakeSweeper(t *testing.T, f orphanSweeper) {
+	t.Helper()
+	prev := reapOrphansClient
+	reapOrphansClient = func() orphanSweeper { return f }
+	t.Cleanup(func() { reapOrphansClient = prev })
+}
+
+func callReap(t *testing.T, apply bool) (dnsReapOrphansResponse, error) {
+	t.Helper()
+	params, _ := json.Marshal(map[string]any{"apply": apply})
+	out, err := dnsReapOrphansHandler(context.Background(), params)
+	if err != nil {
+		return dnsReapOrphansResponse{}, err
+	}
+	resp, ok := out.(dnsReapOrphansResponse)
+	if !ok {
+		t.Fatalf("response type = %T, want dnsReapOrphansResponse", out)
+	}
+	return resp, nil
+}
+
+// TestDNSReapOrphans_EmptyDomainsRefused is the load-bearing safety guard: an
+// empty domains table would make every record match the orphan predicate, so
+// the handler must refuse (failed_precondition) and never call ReapOrphans —
+// even with apply=true.
+func TestDNSReapOrphans_EmptyDomainsRefused(t *testing.T) {
+	f := &fakeOrphanSweeper{domains: 0, counts: map[string]int{"records": 999}, names: []string{"x"}}
+	withFakeSweeper(t, f)
+
+	_, err := callReap(t, true)
+	if err == nil {
+		t.Fatalf("expected refusal on empty domains table, got nil")
+	}
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeFailedPrecondition {
+		t.Fatalf("error = %v, want AgentError{failed_precondition}", err)
+	}
+	if f.reapCalls != 0 {
+		t.Fatalf("ReapOrphans called %d time(s) on refusal, want 0", f.reapCalls)
+	}
+}
+
+// TestDNSReapOrphans_DryRunNeverDeletes: apply=false reports counts + names but
+// must not call ReapOrphans and must return an empty Deleted map.
+func TestDNSReapOrphans_DryRunNeverDeletes(t *testing.T) {
+	f := &fakeOrphanSweeper{
+		domains: 5,
+		counts:  map[string]int{"records": 12, "domainmetadata": 3},
+		names:   []string{"gone.example.com", "www.gone.example.com"},
+		deleted: map[string]int{"records": 12, "domainmetadata": 3},
+	}
+	withFakeSweeper(t, f)
+
+	resp, err := callReap(t, false)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if resp.Applied {
+		t.Fatalf("Applied = true on dry run, want false")
+	}
+	if f.reapCalls != 0 {
+		t.Fatalf("ReapOrphans called %d time(s) on dry run, want 0", f.reapCalls)
+	}
+	if len(resp.Deleted) != 0 {
+		t.Fatalf("Deleted = %v on dry run, want empty", resp.Deleted)
+	}
+	if resp.Counts["records"] != 12 || len(resp.Names) != 2 {
+		t.Fatalf("dry run should still report counts/names: counts=%v names=%v", resp.Counts, resp.Names)
+	}
+}
+
+// TestDNSReapOrphans_ApplyDeletes: apply=true runs the sweep exactly once and
+// surfaces the per-table deleted counts. Empty names keep the cache-purge loop
+// (which shells out to pdns_control/rec_control) from running in the test.
+func TestDNSReapOrphans_ApplyDeletes(t *testing.T) {
+	f := &fakeOrphanSweeper{
+		domains: 5,
+		counts:  map[string]int{"records": 7},
+		names:   nil, // no purge shell-outs
+		deleted: map[string]int{"records": 7},
+	}
+	withFakeSweeper(t, f)
+
+	resp, err := callReap(t, true)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if !resp.Applied {
+		t.Fatalf("Applied = false on apply, want true")
+	}
+	if f.reapCalls != 1 {
+		t.Fatalf("ReapOrphans called %d time(s), want 1", f.reapCalls)
+	}
+	if resp.Deleted["records"] != 7 {
+		t.Fatalf("Deleted[records] = %d, want 7", resp.Deleted["records"])
+	}
+}

--- a/panel-agent/internal/pdns/client.go
+++ b/panel-agent/internal/pdns/client.go
@@ -318,3 +318,135 @@ func (c *Client) DeleteZone(name string) error {
 	}
 	return nil
 }
+
+// --- Orphan sweep (GH #1620) ------------------------------------------------
+//
+// DeleteZone (the #1629 fix) tears a zone's child rows down before its `domains`
+// row, so a zone delete no longer strands children. That is forward-only: a box
+// that deleted a domain BEFORE #1629 still carries the orphaned child rows —
+// records with no parent `domains` row. They can keep being served (from the
+// backend or its caches) until removed, and collide as "duplicate records" when
+// the domain is re-added. ReapOrphans is the one-time cleanup DeleteZone does
+// not do.
+
+// orphanWhere selects child rows whose parent `domains` row is gone. A
+// self-contained subquery, no bound args. A NULL domain_id yields NULL (not
+// TRUE) under NOT IN, so a null-parented row is left untouched — the safe
+// direction. Callers MUST refuse to run this when the domains table is empty
+// (see DomainsCount): an empty subquery makes NOT IN true for EVERY row.
+const orphanWhere = ` WHERE domain_id NOT IN (SELECT id FROM domains)`
+
+// orphanSweepStep is one statement in the orphan cleanup. Both SQL strings are
+// compile-time literals (table names cannot be bound parameters); nothing here
+// is built from runtime or caller data, so there is no injection surface.
+type orphanSweepStep struct {
+	table     string
+	deleteSQL string
+	countSQL  string
+}
+
+// orphanSweepPlan is zoneDeletePlan's counterpart with two deliberate
+// differences: the predicate is the orphan subquery (not a name-scoped one),
+// and there is NO `DELETE FROM domains` step — orphans are defined by the
+// absence of that parent, so the `domains` table is only ever read, never
+// written. present gates the optional tables exactly as zoneDeletePlan does.
+func orphanSweepPlan(present map[string]bool) []orphanSweepStep {
+	steps := []orphanSweepStep{
+		{"records", `DELETE FROM records` + orphanWhere, `SELECT COUNT(*) FROM records` + orphanWhere},
+		{"domainmetadata", `DELETE FROM domainmetadata` + orphanWhere, `SELECT COUNT(*) FROM domainmetadata` + orphanWhere},
+	}
+	if present["comments"] {
+		steps = append(steps, orphanSweepStep{"comments", `DELETE FROM comments` + orphanWhere, `SELECT COUNT(*) FROM comments` + orphanWhere})
+	}
+	if present["cryptokeys"] {
+		steps = append(steps, orphanSweepStep{"cryptokeys", `DELETE FROM cryptokeys` + orphanWhere, `SELECT COUNT(*) FROM cryptokeys` + orphanWhere})
+	}
+	return steps
+}
+
+// DomainsCount returns the number of rows in the pdns `domains` table. The
+// orphan sweep refuses to run when this is zero: an empty domains table turns
+// the orphan predicate true for every record, so a misconfigured or
+// mid-provision connection could otherwise wipe an entire backend. This is the
+// DNS analogue of php.pool.reap-orphans refusing a nil keep-list.
+func (c *Client) DomainsCount() (int, error) {
+	var n int
+	if err := c.db.QueryRow(`SELECT COUNT(*) FROM domains`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count domains: %w", err)
+	}
+	return n, nil
+}
+
+// OrphanCounts returns the number of orphan rows per child table — for the
+// dry-run report and to size a sweep before it runs. Only present tables are
+// probed.
+func (c *Client) OrphanCounts() (map[string]int, error) {
+	present, err := c.presentOptionalTables()
+	if err != nil {
+		return nil, fmt.Errorf("probe pdns tables: %w", err)
+	}
+	out := map[string]int{}
+	for _, s := range orphanSweepPlan(present) {
+		var n int
+		if err := c.db.QueryRow(s.countSQL).Scan(&n); err != nil {
+			return nil, fmt.Errorf("count orphan %s: %w", s.table, err)
+		}
+		out[s.table] = n
+	}
+	return out, nil
+}
+
+// OrphanRecordNames returns the DISTINCT names of orphan rows in `records` — the
+// names whose cached answers must be purged after a sweep. Deleting the row does
+// not evict the pdns Auth packet cache or the recursor's forward cache, which
+// would keep serving the stale answer for cache-ttl otherwise (the exact "keeps
+// resolving after delete" symptom in GH #1620). Collect these BEFORE the delete,
+// since afterwards the rows are gone.
+func (c *Client) OrphanRecordNames() ([]string, error) {
+	rows, err := c.db.Query(`SELECT DISTINCT name FROM records` + orphanWhere)
+	if err != nil {
+		return nil, fmt.Errorf("list orphan record names: %w", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n sql.NullString
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		if n.Valid && n.String != "" {
+			names = append(names, n.String)
+		}
+	}
+	return names, rows.Err()
+}
+
+// ReapOrphans deletes, in one transaction, every child row whose parent
+// `domains` row no longer exists (GH #1620) and returns the rows deleted per
+// table. It does NOT enforce the domains-nonempty floor itself; the caller MUST
+// refuse when DomainsCount() is zero. Cache purge is the caller's job too, since
+// only it knows the affected names (OrphanRecordNames, collected first).
+func (c *Client) ReapOrphans() (map[string]int, error) {
+	present, err := c.presentOptionalTables()
+	if err != nil {
+		return nil, fmt.Errorf("probe pdns tables: %w", err)
+	}
+	tx, err := c.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once committed
+	deleted := map[string]int{}
+	for _, s := range orphanSweepPlan(present) {
+		res, err := tx.Exec(s.deleteSQL)
+		if err != nil {
+			return nil, fmt.Errorf("delete orphan %s: %w", s.table, err)
+		}
+		n, _ := res.RowsAffected()
+		deleted[s.table] = int(n)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return deleted, nil
+}

--- a/panel-agent/internal/pdns/client_test.go
+++ b/panel-agent/internal/pdns/client_test.go
@@ -74,3 +74,70 @@ func TestZoneDeletePlan_OptionalTablesSkipped(t *testing.T) {
 		}
 	}
 }
+
+// TestOrphanSweepPlan_ShapeAndSafety pins the invariants of the GH #1620 sweep.
+// The single most important one: the plan must NEVER emit a `DELETE FROM
+// domains`. Orphans are defined by the absence of their parent `domains` row, so
+// the table is read-only here; a delete step would be catastrophic (it would
+// remove live zones). This is new code, so there is no "unfixed" version to fail
+// against — the test exists to guard that safety property against future edits.
+func TestOrphanSweepPlan_ShapeAndSafety(t *testing.T) {
+	all := orphanSweepPlan(map[string]bool{"comments": true, "cryptokeys": true})
+	wantTables := []string{"records", "domainmetadata", "comments", "cryptokeys"}
+	if len(all) != len(wantTables) {
+		t.Fatalf("plan len = %d, want %d: %+v", len(all), len(wantTables), all)
+	}
+	for i, w := range wantTables {
+		if all[i].table != w {
+			t.Fatalf("step %d table = %q, want %q", i, all[i].table, w)
+		}
+	}
+
+	for _, s := range all {
+		// Every step targets a CHILD table by the orphan predicate — never the
+		// parent `domains` row, and never a name-scoped delete.
+		if s.table == "domains" || strings.Contains(s.deleteSQL, "DELETE FROM domains") {
+			t.Fatalf("orphan sweep must never delete the parent domains row: %q", s.deleteSQL)
+		}
+		if !strings.Contains(s.deleteSQL, "domain_id NOT IN (SELECT id FROM domains)") {
+			t.Fatalf("step %s must scope by the orphan predicate, got %q", s.table, s.deleteSQL)
+		}
+		// The orphan predicate binds no args — it is a self-contained subquery.
+		if n := strings.Count(s.deleteSQL, "?"); n != 0 {
+			t.Fatalf("step %s must bind no args, got %d: %q", s.table, n, s.deleteSQL)
+		}
+		// The count statement counts the same table under the same predicate.
+		if !strings.HasPrefix(s.countSQL, "SELECT COUNT(*) FROM "+s.table+" ") {
+			t.Fatalf("step %s count must be COUNT(*) on the same table, got %q", s.table, s.countSQL)
+		}
+		if !strings.Contains(s.countSQL, "domain_id NOT IN (SELECT id FROM domains)") {
+			t.Fatalf("step %s count must use the orphan predicate, got %q", s.table, s.countSQL)
+		}
+	}
+}
+
+// TestOrphanSweepPlan_OptionalTablesSkipped verifies the optional tables are
+// gated exactly like zoneDeletePlan — absent tables produce no statement.
+func TestOrphanSweepPlan_OptionalTablesSkipped(t *testing.T) {
+	min := orphanSweepPlan(map[string]bool{})
+	want := []string{"records", "domainmetadata"}
+	if len(min) != len(want) {
+		t.Fatalf("minimal plan len = %d, want %d: %+v", len(min), len(want), min)
+	}
+	for i, w := range want {
+		if min[i].table != w {
+			t.Fatalf("minimal step %d = %q, want %q", i, min[i].table, w)
+		}
+	}
+
+	one := orphanSweepPlan(map[string]bool{"cryptokeys": true})
+	wantOne := []string{"records", "domainmetadata", "cryptokeys"}
+	if len(one) != len(wantOne) {
+		t.Fatalf("plan len = %d, want %d: %+v", len(one), len(wantOne), one)
+	}
+	for i, w := range wantOne {
+		if one[i].table != w {
+			t.Fatalf("step %d = %q, want %q", i, one[i].table, w)
+		}
+	}
+}

--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -209,7 +209,7 @@ func newDNSCmd() *cobra.Command {
 			"validation and conflict rules. Records are written to the DB; the reconciler pushes\n" +
 			"them into PowerDNS on its next tick.",
 	}
-	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd(), newDNSAcmeHookCmd(), newDNSPruneServiceCmd())
+	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd(), newDNSAcmeHookCmd(), newDNSPruneServiceCmd(), newDNSPruneOrphanRecordsCmd())
 	return cmd
 }
 

--- a/panel-api/cmd/server/dns_prune_orphans_cmd.go
+++ b/panel-api/cmd/server/dns_prune_orphans_cmd.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// dns_prune_orphans_cmd.go — GH #1620 remediation half.
+//
+// #1629 made DeleteZone tear the child rows (records, domainmetadata, comments,
+// cryptokeys) down before the parent `domains` row, so a zone delete no longer
+// strands children. That is forward-only: a box that deleted a domain BEFORE
+// #1629 still carries the orphaned child rows, and they can keep being served
+// (from the backend or its caches) and collide as "duplicate records" when the
+// domain is re-added.
+//
+// This is the one-time cleanup #1629 does not do. NOTE this is distinct from
+// `jabali domain prune-orphans` (nginx sites-enabled vs DB) and from
+// `jabali dns prune-service-records` (control-plane dns_records): those act on
+// panel state, this acts on the agent-side PowerDNS backend tables. The pdns DB
+// is agent-side, so the work runs in the agent (dns.reap-orphans), scoped
+// strictly to rows whose parent `domains` row is gone, with a cache purge after.
+
+// dnsReapOrphansResult mirrors the agent's dns.reap-orphans response.
+type dnsReapOrphansResult struct {
+	Applied bool           `json:"applied"`
+	Counts  map[string]int `json:"counts"`
+	Deleted map[string]int `json:"deleted"`
+	Names   []string       `json:"names"`
+}
+
+func newDNSPruneOrphanRecordsCmd() *cobra.Command {
+	var apply bool
+	cmd := &cobra.Command{
+		Use:   "prune-orphan-records",
+		Short: "Remove PowerDNS backend rows left behind by a pre-#1629 zone delete (GH #1620)",
+		Long: "Removes rows in the PowerDNS backend (records, domainmetadata, comments, cryptokeys)\n" +
+			"whose parent `domains` row no longer exists — orphans left behind when a domain was\n" +
+			"deleted BEFORE the #1629 teardown fix. They keep answering off the pdns caches and\n" +
+			"collide as duplicate records when the domain is re-added.\n\n" +
+			"This is NOT the same as `domain prune-orphans` (nginx vhosts) or `dns\n" +
+			"prune-service-records` (control-plane dns_records) — it operates on the agent-side\n" +
+			"PowerDNS tables.\n\n" +
+			"The sweep is scoped strictly to `domain_id NOT IN (SELECT id FROM domains)`; a\n" +
+			"re-added domain's records (which carry a new domain_id) are never touched. The agent\n" +
+			"refuses to run if the domains table is empty (that would make every record look\n" +
+			"orphaned). After deleting, it purges the pdns Auth + recursor caches for the affected\n" +
+			"names so they stop resolving immediately.\n\n" +
+			"Dry-run by default. Re-run with --apply to delete.",
+		Args:    cobra.NoArgs,
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+
+			raw, err := sharedAgent.Call(ctx, "dns.reap-orphans", map[string]any{"apply": apply})
+			if err != nil {
+				return fmt.Errorf("reap orphans: %w", err)
+			}
+			var resp dnsReapOrphansResult
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return fmt.Errorf("decode agent response: %w", err)
+			}
+
+			if jsonOutput {
+				return printJSON(resp)
+			}
+
+			total := 0
+			for _, n := range resp.Counts {
+				total += n
+			}
+			if total == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No orphaned PowerDNS rows found — nothing to prune.")
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(tw, "TABLE\tORPHAN ROWS")
+			for _, t := range sortedCountKeys(resp.Counts) {
+				fmt.Fprintf(tw, "%s\t%d\n", t, resp.Counts[t])
+			}
+			_ = tw.Flush()
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%d orphan row(s) across %d distinct record name(s).\n",
+				total, len(resp.Names))
+
+			if !resp.Applied {
+				fmt.Fprintln(cmd.OutOrStdout(),
+					"\nThis is a DRY RUN — nothing changed. Re-run with --apply to delete these rows\n"+
+						"and purge the pdns caches for the affected names.")
+				return nil
+			}
+
+			deleted := 0
+			for _, n := range resp.Deleted {
+				deleted += n
+			}
+			cliAuditOK(ctx, "dns.reap_orphans", "pdns_records", fmt.Sprintf("%d", deleted), nil)
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"\nremoved %d orphan row(s) and purged the pdns Auth + recursor caches for the\n"+
+					"%d affected name(s).\n", deleted, len(resp.Names))
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "actually delete (default is a dry run)")
+	return cmd
+}
+
+// sortedCountKeys returns the keys of a map[string]int in ascending order, for
+// stable report output.
+func sortedCountKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
## What

Adds a one-time remediation for the orphaned PowerDNS rows reported in GH #1620.

## Background

#1629 fixed `DeleteZone` so a zone teardown clears the child rows (`records`, `domainmetadata`, `comments`, `cryptokeys`) **before** the parent `domains` row. That stops *new* orphans — but it is forward-only. A box that deleted a domain **before** #1629 landed still carries the child rows whose parent `domains` row is now gone. Those rows:

- keep answering off the pdns Auth packet cache / recursor forward cache (the "records continue to resolve" symptom), and
- collide as "duplicate records" when the same domain is re-added (the re-added domain gets a new `domains.id`; the stale rows keep the old one).

#1629 does not touch them. This PR is the sweep that does.

## Change

**`pdns.Client` (agent-side):**
- `orphanSweepPlan(present)` — `zoneDeletePlan`'s counterpart. Two deliberate differences: the predicate is `domain_id NOT IN (SELECT id FROM domains)` (not name-scoped), and there is **no** `DELETE FROM domains` step. Orphans are defined by the *absence* of the parent, so `domains` is only ever read here — a delete step would be catastrophic.
- `ReapOrphans()` — runs the plan in one transaction, returns rows deleted per table.
- `OrphanCounts()` / `OrphanRecordNames()` — for the dry-run report and the post-sweep cache purge (names collected before the delete).
- `DomainsCount()` — the safety floor.

**Agent RPC `dns.reap-orphans`:**
- Dry-run by default (`apply=false`): reports per-table orphan counts + affected names, deletes nothing.
- `apply=true`: runs the sweep, then purges the pdns Auth + recursor caches for each affected name (`pdns_control purge <name>$`, `rec_control wipe-cache <name>$`) — same purge `dns.zone.delete` does. No NOTIFY: an orphan has no zone.
- **Refuses outright when the `domains` table is empty** — that would make the orphan predicate true for every record. This is the DNS analogue of `php.pool.reap-orphans` refusing a nil keep-list.

**CLI `jabali dns prune-orphan-records`:**
- Drives the RPC. Dry-run by default, `--apply` to delete, CLI-audited.
- Named to be unambiguous against the two existing prune commands, which operate on different state: `domain prune-orphans` (nginx sites-enabled vs DB) and `dns prune-service-records` (control-plane `dns_records`). This one acts on the agent-side PowerDNS backend tables.

## Safety

- Scope is strictly `domain_id NOT IN (SELECT id FROM domains)`; a re-added domain's records carry a new `domain_id` and are never touched.
- Dry-run default at both the RPC and CLI layers; deletion is explicit opt-in.
- Empty-`domains` refusal guards the "every record looks orphaned" failure mode.
- A `NULL` `domain_id` yields `NULL` (not `TRUE`) under `NOT IN`, so null-parented rows are left untouched.

## Test

- `TestOrphanSweepPlan_ShapeAndSafety` pins the load-bearing invariant: the plan can **never** emit a `DELETE FROM domains`, every step scopes by the orphan predicate and binds no args, and each count statement matches its delete. `TestOrphanSweepPlan_OptionalTablesSkipped` mirrors the zone-delete optional-table gating.
- The two handler guards that make up the PR's safety story are tested through a fake sweeper (no live DB, mirroring `php_fpm_reap`'s stub): `TestDNSReapOrphans_EmptyDomainsRefused` (empty `domains` ⇒ `failed_precondition`, `ReapOrphans` never called even with `apply=true`) and `TestDNSReapOrphans_DryRunNeverDeletes` (`apply=false` reports but never calls `ReapOrphans`, `Deleted` empty). `TestDNSReapOrphans_ApplyDeletes` confirms `apply=true` sweeps exactly once.
- `panel-agent/internal/pdns` + `internal/commands` + `panel-api/cmd/server`: all green. `go vet` clean on all three. CLI reference golden regenerated.

## Does this fix the stale rows already on a box?

No — that is exactly what this PR is *for*. #1629 stops new orphans; existing ones need this sweep run once (dry-run first). See the note on the issue.

GH #1620

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
