### PR TITLE
fix(dns): refuse records for a zone the reconciler never publishes (GH #1622)

### DIFF
--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -85,6 +85,15 @@ func dnsRecordAdd(ctx context.Context, zones repository.DNSZoneRepository, recs 
 	if err != nil {
 		return nil, err
 	}
+	// GH #1622: a disabled zone is never pushed to PowerDNS by the reconciler
+	// (reconcileDNSZone returns on !zone.IsEnabled), so a record added to it
+	// lands in the DB but never resolves. Refuse rather than accept a write that
+	// will never be published. (The REST create/update handlers apply the same
+	// gate, and additionally cover the DNS-hosted-elsewhere case at the domain
+	// level.)
+	if !zone.IsEnabled {
+		return nil, fmt.Errorf("DNS zone %q is disabled, so records added to it are not published to the nameservers — enable the zone first", zone.Name)
+	}
 	rec := &models.DNSRecord{
 		ID:        ids.NewULID(),
 		ZoneID:    zone.ID,

--- a/panel-api/cmd/server/dns_cmd_test.go
+++ b/panel-api/cmd/server/dns_cmd_test.go
@@ -140,6 +140,26 @@ func TestDNSRecordAdd_ValidDefaultsTTL(t *testing.T) {
 	}
 }
 
+// GH #1622: a disabled zone is never pushed to PowerDNS, so adding a record to
+// it would land in the DB but never resolve. The add path must refuse. Seed a
+// disabled zone; the add must error and persist nothing.
+func TestDNSRecordAdd_RefusesDisabledZone(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(&models.DNSZone{ID: "z-disabled", DomainID: "d1", Name: "example.com", IsEnabled: false})
+	recs := newMemDNSRecordRepo()
+	_, err := dnsRecordAdd(ctx, zones, recs, "example.com",
+		dnsRecordSpec{Name: "www", Type: "A", Content: "203.0.113.10", Enabled: true})
+	if err == nil {
+		t.Fatal("expected refusal for a disabled zone, got nil")
+	}
+	if !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("error should explain the zone is disabled, got: %v", err)
+	}
+	if len(recs.byID) != 0 {
+		t.Errorf("no record should be persisted for a disabled zone, got %d", len(recs.byID))
+	}
+}
+
 func TestDNSRecordAdd_RejectsUnknownZone(t *testing.T) {
 	ctx := context.Background()
 	zones := newMemDNSZoneRepo() // empty
@@ -312,6 +332,7 @@ func TestDNSCmd_Tree(t *testing.T) {
 	}
 }
 
-
 // ListByZoneIDs added for the JAB-374 batch interface method.
-func (m *memDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) { return nil, nil }
+func (m *memDNSRecordRepo) ListByZoneIDs(context.Context, []string) ([]models.DNSRecord, error) {
+	return nil, nil
+}

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -491,7 +491,8 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 	domainID := c.Param("id")
 
 	// Load and authorize domain
-	if h.loadDomainOwned(c, domainID) == nil {
+	domain := h.loadDomainOwned(c, domainID)
+	if domain == nil {
 		return
 	}
 
@@ -526,6 +527,15 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	// GH #1622: refuse records the reconciler will never push (DNS hosted
+	// elsewhere, or a disabled zone) instead of accepting one that lands in the
+	// DB but never reaches PowerDNS — the tenant otherwise sees it "added but not
+	// resolvable."
+	if reason := dnsZoneNotServedReason(domain, zone); reason != "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "dns_not_served", "detail": reason})
 		return
 	}
 
@@ -634,6 +644,14 @@ func (h *dnsHandler) updateRecord(c *gin.Context) {
 	// Check authorization
 	if !claims.IsAdmin && domain.UserID != claims.UserID {
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	// GH #1622: refuse edits the reconciler will never push (DNS hosted
+	// elsewhere, or a disabled zone), same as createRecord — an accepted edit
+	// that never reaches PowerDNS reads as "changed but not resolvable."
+	if reason := dnsZoneNotServedReason(domain, zone); reason != "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "dns_not_served", "detail": reason})
 		return
 	}
 
@@ -818,6 +836,29 @@ func (h *dnsHandler) deleteRecord(c *gin.Context) {
 	h.cfg.Reconciler.Schedule(zone.DomainID)
 
 	c.Status(http.StatusNoContent)
+}
+
+// dnsZoneNotServedReason returns a human-facing reason record writes to this
+// zone will not be published, or "" when the zone is served. It mirrors the two
+// early returns in the reconciler's reconcileDNSZone: it never pushes to
+// PowerDNS when domain.DNSDisabled (DNS hosted elsewhere, GH #1449) or when
+// !zone.IsEnabled (zone disabled, GH #1611).
+//
+// GH #1622: the record create/update handlers only checked that a zone ROW
+// existed (FindByDomainID returns disabled zones, and a domain toggled DNS-off
+// keeps its zone row), so they accepted records for an unserved zone and
+// returned 201/200. The reconciler then skipped the push and the tenant saw the
+// record "added but not resolvable" — for simple and dotted names alike. The
+// panel must refuse a write it knows will never be published rather than accept
+// it silently (fail-closed).
+func dnsZoneNotServedReason(domain *models.Domain, zone *models.DNSZone) string {
+	if domain.DNSDisabled {
+		return "DNS for this domain is hosted elsewhere (Jabali DNS is disabled for it), so records added here are never published to the nameservers. Enable Jabali DNS for the domain first, or manage the record at your DNS provider."
+	}
+	if !zone.IsEnabled {
+		return "This DNS zone is disabled, so record changes are not published to the nameservers. Enable the zone first."
+	}
+	return ""
 }
 
 // Validation helpers

--- a/panel-api/internal/api/dns_not_served_test.go
+++ b/panel-api/internal/api/dns_not_served_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -61,4 +63,40 @@ func TestCreateRecord_AllowsServedZone(t *testing.T) {
 	seedZoneWith(t, dr, zr, "user1", false, true)
 	w := postRecord(t, r, "A", "192.0.2.1")
 	require.Equal(t, http.StatusCreated, w.Code)
+}
+
+// TestUpdateRecord_RefusesDisabledZone pins the updateRecord half of the guard:
+// editing a record in a disabled zone (the reconciler never pushes it) is
+// refused 409, same as create. Without the guard the PATCH returned 200 and the
+// edit never reached PowerDNS — "changed but not resolvable." Uses dnsRouter
+// (not dnsRouterWithSettings) because the update path needs the record repo to
+// seed the row being edited; admin bypasses the GH #466 per-type policy gate.
+func TestUpdateRecord_RefusesDisabledZone(t *testing.T) {
+	r, dr, zr, rr, _ := dnsRouter("admin1", true)
+
+	dr.Create(context.Background(), &models.Domain{
+		ID: "test-domain-id", UserID: "user1", Name: "example.com",
+	})
+	zoneID := ids.NewULID()
+	zr.Create(context.Background(), &models.DNSZone{
+		ID: zoneID, DomainID: "test-domain-id", Name: "example.com",
+		Serial: 1, RefreshSeconds: 3600, RetrySeconds: 600, ExpireSeconds: 604800,
+		MinimumTTL: 3600, IsEnabled: false /*disabled*/, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	recordID := ids.NewULID()
+	rr.Create(context.Background(), &models.DNSRecord{
+		ID: recordID, ZoneID: zoneID, Name: "www", Type: "A", Content: "192.0.2.1",
+		TTL: 3600, IsEnabled: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+
+	body, _ := json.Marshal(map[string]any{"content": "192.0.2.2"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/dns/records/"+recordID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "dns_not_served", resp["error"])
 }

--- a/panel-api/internal/api/dns_not_served_test.go
+++ b/panel-api/internal/api/dns_not_served_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GH #1622: the record create/update handlers only checked that a zone ROW
+// existed, so they accepted records for a zone the reconciler never pushes to
+// PowerDNS (domain DNS-disabled, or the zone disabled) — the tenant saw the row
+// "added but not resolvable." These tests pin the fail-closed guard. They use an
+// admin so the per-type policy gate (GH #466) is bypassed and only the
+// not-served guard is under test.
+
+// seedZoneWith provisions the domain + zone with explicit DNS-disabled / zone-
+// enabled flags so the not-served guard can be exercised.
+func seedZoneWith(t *testing.T, dr *mockDomainRepo, zr *mockDNSZoneRepo, owner string, dnsDisabled, zoneEnabled bool) {
+	t.Helper()
+	dr.Create(context.Background(), &models.Domain{
+		ID: "test-domain-id", UserID: owner, Name: "example.com", DNSDisabled: dnsDisabled,
+	})
+	zr.Create(context.Background(), &models.DNSZone{
+		ID: ids.NewULID(), DomainID: "test-domain-id", Name: "example.com",
+		Serial: 1, RefreshSeconds: 3600, RetrySeconds: 600, ExpireSeconds: 604800,
+		MinimumTTL: 3600, IsEnabled: zoneEnabled, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+}
+
+func TestCreateRecord_RefusesDNSDisabledDomain(t *testing.T) {
+	r, dr, zr := dnsRouterWithSettings("admin1", true, &models.ServerSettings{ID: 1})
+	seedZoneWith(t, dr, zr, "user1", true /*dnsDisabled*/, true /*zoneEnabled*/)
+	w := postRecord(t, r, "A", "192.0.2.1")
+	require.Equal(t, http.StatusConflict, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "dns_not_served", resp["error"])
+}
+
+func TestCreateRecord_RefusesDisabledZone(t *testing.T) {
+	r, dr, zr := dnsRouterWithSettings("admin1", true, &models.ServerSettings{ID: 1})
+	seedZoneWith(t, dr, zr, "user1", false /*dnsDisabled*/, false /*zoneEnabled*/)
+	w := postRecord(t, r, "A", "192.0.2.1")
+	require.Equal(t, http.StatusConflict, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "dns_not_served", resp["error"])
+}
+
+// Control: a served zone still accepts the record — guards against the fix
+// over-blocking a normal domain.
+func TestCreateRecord_AllowsServedZone(t *testing.T) {
+	r, dr, zr := dnsRouterWithSettings("admin1", true, &models.ServerSettings{ID: 1})
+	seedZoneWith(t, dr, zr, "user1", false, true)
+	w := postRecord(t, r, "A", "192.0.2.1")
+	require.Equal(t, http.StatusCreated, w.Code)
+}


### PR DESCRIPTION
## Summary

GH #1622: adding a record to a DNS zone returned success but the record was
never resolvable. The create/update handlers only checked that a zone **row**
existed (`FindByDomainID`, which does not filter on `is_enabled`), so they
accepted and persisted the record with a 201/200 — but the reconciler then
skipped pushing the zone to PowerDNS, leaving the record stored yet unpublished:
"added but not resolvable."

The reconciler declines to push a zone in two cases:

- `domain.DNSDisabled` — DNS is hosted elsewhere for this domain (Jabali DNS
  disabled, GH #1449); `reconcileDNSZone` returns early at `reconciler.go:2499`.
- `!zone.IsEnabled` — the zone is disabled (GH #1611); early return at
  `reconciler.go:2576`.

Neither condition was checked at the write boundary, so a record could be
accepted for a zone that would never be served.

## Fix

Fail closed. `createRecord` and `updateRecord` now refuse with **409
`dns_not_served`** and a human-readable `detail` when the target zone is
not served, instead of accepting a write the reconciler will silently drop.
`deleteRecord` is intentionally left ungated — removing a record from an
unserved zone is harmless and should still work. The CLI `dns record add`
path gets the same refusal for a disabled zone.

## Reachability note

A domain disabled the normal way (`tearDownDNSFacet`, `dns_zone_delete.go`)
flips `dns_disabled=true` **and deletes the `dns_zones` row**, so a
properly-disabled domain has no zone row and `createRecord` already 404s. The
primary path that silently accepted before this change is a **disabled zone**
(`is_enabled=false`) whose row lingers (e.g. toggled off via the DNS Zone
inventory). The `DNSDisabled` branch of the guard remains as defense-in-depth
for the stale-row edge where a teardown left the row behind.

## Tests

`panel-api/internal/api/dns_not_served_test.go` (new):

- `TestCreateRecord_RefusesDNSDisabledDomain` — DNS-disabled domain → 409.
- `TestCreateRecord_RefusesDisabledZone` — disabled zone → 409.
- `TestUpdateRecord_RefusesDisabledZone` — edit in a disabled zone → 409.
- `TestCreateRecord_AllowsServedZone` — control: a served zone still accepts
  the record (201), so the guard does not over-block a normal domain.

`panel-api/cmd/server/dns_cmd_test.go`: `TestDNSRecordAdd_RefusesDisabledZone`.

Each refusal test was verified fail-on-unfixed: on the pre-guard handler the
create tests returned 201 and the update test returned 200; with the guard they
return 409.

## UI

No UI change needed — the DNS Records page already renders
`err.response.data.detail` in its error toast (`DNSRecordsPage.tsx`), so the
`dns_not_served` message surfaces to the tenant directly.

## Note for merge ordering

`panel-api/cmd/server/dns_cmd.go` is also touched by #1674 (orphan-sweep CLI) in
a different hunk. Whichever merges second needs a trivial rebase; no logical
conflict.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
