### PR TITLE
fix(backup): serialize restic repo init per destination to prevent a dual-key/one-config race (JAB-405)

### DIFF
--- a/panel-agent/internal/commands/backup_dest_testconn.go
+++ b/panel-agent/internal/commands/backup_dest_testconn.go
@@ -77,14 +77,30 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 					}, nil
 				}
 			}
-			_, initStderr, initErr := backup.InitRemote(
-				ctx,
-				nil,
-				p.URL,
-				backup.DefaultPasswordFile,
-				extraEnv,
-				bkResticOptions(p.SFTP),
-			)
+			// Serialize this init against the scheduler's per-account init
+			// (bkEnsureRepoReady) and any concurrent test-connection on the same
+			// destination — two restic inits on one empty repo corrupt it
+			// (JAB-405). The loser sees "already initialized" below.
+			var initStderr []byte
+			var initErr error
+			if lockErr := withRepoInitLock(ctx, p.URL, func() error {
+				_, initStderr, initErr = backup.InitRemote(
+					ctx,
+					nil,
+					p.URL,
+					backup.DefaultPasswordFile,
+					extraEnv,
+					bkResticOptions(p.SFTP),
+				)
+				return initErr
+			}); lockErr != nil && initErr == nil {
+				// The lock could not be acquired, so init never ran. Surface it
+				// rather than initialise unserialized.
+				return backupDestTestResult{
+					Status: "error",
+					Detail: "init_lock_failed: " + lockErr.Error(),
+				}, nil
+			}
 			if initErr != nil {
 				initErrStr := strings.TrimSpace(string(initStderr))
 				lowerInit := strings.ToLower(initErrStr)

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -2,10 +2,15 @@ package commands
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
+	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
@@ -186,6 +191,18 @@ func classifyRepoProbe(lowerStderr string) repoProbeClass {
 // `restic init` if the repo doesn't exist yet. Idempotent — succeeds
 // on already-initialized repos. Local destinations get the parent dir
 // created if missing; failures bubble up.
+//
+// The probe→init is serialized per destination via a file lock (JAB-405):
+// a schedule's first run against a brand-new destination fans out several
+// per-account jobs concurrently, and without serialization each one probes
+// the empty repo, classifies it "missing", and runs `restic init`. Two
+// simultaneous inits on the same empty repo leave two key files but a single
+// `config`, whose master key matches only one of them; a later open can pick
+// the mismatched key and fail fatally ("config or key <id> is damaged:
+// ciphertext verification failed") instead of falling through — the repo is
+// then permanently unopenable and every backup fails at "ensure repo". The
+// lock makes the loser re-probe after the winner's init and short-circuit on
+// the now-existing repo.
 func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, passwordFile string, sftp *backupSFTPInputs) error {
 	if repoURL == "" {
 		return nil
@@ -207,51 +224,119 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, p
 		}
 		extraEnv = env
 	}
-	_, snapStderr, snapErr := backup.SnapshotsRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
-	if snapErr == nil {
-		return nil
-	}
-	lower := strings.ToLower(strings.TrimSpace(string(snapStderr)))
-	switch classifyRepoProbe(lower) {
-	case repoProbeUnopenable:
-		// A repository that EXISTS but cannot be opened (GH #454). Actionable
-		// message instead of the raw restic dump — see classifyRepoProbe.
-		return fmt.Errorf("backup repository at %q exists but this server cannot open it (%s).\n"+
-			"This usually means the server (or /etc/jabali-panel/restic-repo.password) was reinstalled or "+
-			"regenerated while the repository directory was preserved, so the snapshots are sealed with a "+
-			"password this server no longer has (or the repo's config/key files are corrupted). To recover: "+
-			"(a) restore the ORIGINAL /etc/jabali-panel/restic-repo.password from before the reinstall, or "+
-			"(b) point this backup destination at a FRESH empty directory to start a new repository — the old "+
-			"snapshots stay on disk but are unreadable without their original password.",
-			repoURL, lower)
-	case repoProbeOther:
-		// Not a missing-repo signal, not a known unopenable signal — surface raw.
-		return fmt.Errorf("snapshots probe: %w (stderr: %s)", snapErr, lower)
-	}
-	// repoProbeMissing → fall through to init below.
-	if destKind == "sftp" && sftp != nil && sftp.Host != "" {
-		if _, err := backup.MkdirRemoteSFTP(ctx, backup.SFTPInputs{
-			Host:    sftp.Host,
-			User:    sftp.User,
-			Port:    sftp.Port,
-			Path:    sftp.Path,
-			Auth:    sftp.Auth,
-			KeyPath: sftp.KeyPath,
-		}, extraEnv); err != nil {
-			return fmt.Errorf("ssh mkdir: %w", err)
-		}
-	}
-	// Init with the SAME password the probe used: a fresh repo for a
-	// destination that carries its own sealed password must be created under
-	// that password, or every later open fails.
-	_, initStderr, initErr := backup.InitRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
-	if initErr != nil {
-		ls := strings.ToLower(strings.TrimSpace(string(initStderr)))
-		if strings.Contains(ls, "already initialized") ||
-			strings.Contains(ls, "config file already exists") {
+	return withRepoInitLock(ctx, repoURL, func() error {
+		_, snapStderr, snapErr := backup.SnapshotsRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
+		if snapErr == nil {
 			return nil
 		}
-		return fmt.Errorf("restic init: %w (stderr: %s)", initErr, ls)
+		lower := strings.ToLower(strings.TrimSpace(string(snapStderr)))
+		switch classifyRepoProbe(lower) {
+		case repoProbeUnopenable:
+			// A repository that EXISTS but cannot be opened (GH #454). Actionable
+			// message instead of the raw restic dump — see classifyRepoProbe.
+			return fmt.Errorf("backup repository at %q exists but this server cannot open it (%s).\n"+
+				"This usually means the server (or /etc/jabali-panel/restic-repo.password) was reinstalled or "+
+				"regenerated while the repository directory was preserved, so the snapshots are sealed with a "+
+				"password this server no longer has (or the repo's config/key files are corrupted). To recover: "+
+				"(a) restore the ORIGINAL /etc/jabali-panel/restic-repo.password from before the reinstall, or "+
+				"(b) point this backup destination at a FRESH empty directory to start a new repository — the old "+
+				"snapshots stay on disk but are unreadable without their original password.",
+				repoURL, lower)
+		case repoProbeOther:
+			// Not a missing-repo signal, not a known unopenable signal — surface raw.
+			return fmt.Errorf("snapshots probe: %w (stderr: %s)", snapErr, lower)
+		}
+		// repoProbeMissing → fall through to init below.
+		if destKind == "sftp" && sftp != nil && sftp.Host != "" {
+			if _, err := backup.MkdirRemoteSFTP(ctx, backup.SFTPInputs{
+				Host:    sftp.Host,
+				User:    sftp.User,
+				Port:    sftp.Port,
+				Path:    sftp.Path,
+				Auth:    sftp.Auth,
+				KeyPath: sftp.KeyPath,
+			}, extraEnv); err != nil {
+				return fmt.Errorf("ssh mkdir: %w", err)
+			}
+		}
+		// Init with the SAME password the probe used: a fresh repo for a
+		// destination that carries its own sealed password must be created under
+		// that password, or every later open fails.
+		_, initStderr, initErr := backup.InitRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
+		if initErr != nil {
+			ls := strings.ToLower(strings.TrimSpace(string(initStderr)))
+			if strings.Contains(ls, "already initialized") ||
+				strings.Contains(ls, "config file already exists") {
+				return nil
+			}
+			return fmt.Errorf("restic init: %w (stderr: %s)", initErr, ls)
+		}
+		return nil
+	})
+}
+
+// repoInitLockDir is the directory the per-destination repo-init locks live in.
+// It defaults to the same directory as the restore flock (which the agent
+// already mkdir's and writes to, so no new permission surface). A var, not a
+// const, so tests can redirect it to a temp dir.
+var repoInitLockDir = filepath.Dir(restoreLockPath)
+
+const (
+	// repoInitLockMaxWait bounds how long a job waits for another job's
+	// probe→init on the SAME destination. init is seconds; this is generous.
+	// Without a bound, a job could sit behind a hung SFTP init for the whole
+	// orchestrator deadline (90m account / 6h system).
+	repoInitLockMaxWait = 5 * time.Minute
+	// repoInitLockPoll is the retry interval while the lock is contended.
+	repoInitLockPoll = 200 * time.Millisecond
+)
+
+// withRepoInitLock runs fn while holding an exclusive advisory file lock scoped
+// to one destination (keyed by the repo URL), so concurrent first-run jobs
+// cannot both `restic init` the same empty repo (JAB-405). Different
+// destinations hash to different lock files and never contend; the lock is held
+// only across the short probe+init, then released.
+//
+// syscall.Flock has no context support, so a bare blocking LOCK_EX would ignore
+// the caller's deadline and could park behind a hung init. Instead this polls
+// LOCK_EX|LOCK_NB, honouring ctx and repoInitLockMaxWait, and fails loud rather
+// than proceeding without the lock — running init unserialized is exactly the
+// bug this prevents.
+func withRepoInitLock(ctx context.Context, repoURL string, fn func() error) error {
+	if err := os.MkdirAll(repoInitLockDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir repo-init lock dir: %w", err)
 	}
-	return nil
+	// Key on the exact repo URL string (not a normalized form): two jobs for
+	// the same destination carry the byte-identical URL, and re-pointing a
+	// destination to a fresh directory (the JAB-405 workaround) is a different
+	// URL that correctly gets its own lock.
+	sum := sha256.Sum256([]byte(repoURL))
+	lockPath := filepath.Join(repoInitLockDir, fmt.Sprintf(".init-%x.lock", sum[:16]))
+	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o640)
+	if err != nil {
+		return fmt.Errorf("open repo-init lock %q: %w", lockPath, err)
+	}
+	defer lf.Close()
+
+	deadline := time.Now().Add(repoInitLockMaxWait)
+	for {
+		flockErr := syscall.Flock(int(lf.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if flockErr == nil {
+			break
+		}
+		if flockErr != syscall.EWOULDBLOCK {
+			return fmt.Errorf("acquire repo-init lock %q: %w", lockPath, flockErr)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("repo-init lock %q still held by another job after %s — the holding job is probably stuck probing or initialising this destination; check its job log",
+				lockPath, repoInitLockMaxWait)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("repo-init lock %q: %w", lockPath, ctx.Err())
+		case <-time.After(repoInitLockPoll):
+		}
+	}
+	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN)
+	return fn()
 }

--- a/panel-agent/internal/commands/backup_repo_init_lock_test.go
+++ b/panel-agent/internal/commands/backup_repo_init_lock_test.go
@@ -1,0 +1,186 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// setRepoInitLockDir redirects the package-global lock dir to a temp dir for the
+// duration of one test and restores it afterwards. Tests that touch it must not
+// run in parallel with each other.
+func setRepoInitLockDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := repoInitLockDir
+	repoInitLockDir = dir
+	t.Cleanup(func() { repoInitLockDir = prev })
+}
+
+// TestWithRepoInitLock_SerializesSameRepo is the JAB-405 guarantee: concurrent
+// jobs for the SAME destination never run their probe→init bodies at the same
+// time, so two `restic init` calls can't race on one empty repo. An atomic
+// in-flight counter records any overlap; removing the flock reddens this.
+func TestWithRepoInitLock_SerializesSameRepo(t *testing.T) {
+	setRepoInitLockDir(t, t.TempDir())
+	const n = 20
+	var active, violations int32
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = withRepoInitLock(context.Background(), "sftp:user@host:/repo", func() error {
+				if atomic.AddInt32(&active, 1) > 1 {
+					atomic.AddInt32(&violations, 1)
+				}
+				time.Sleep(5 * time.Millisecond)
+				atomic.AddInt32(&active, -1)
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+	if violations != 0 {
+		t.Fatalf("init not serialized for one destination: %d overlapping runs", violations)
+	}
+}
+
+// TestWithRepoInitLock_DistinctReposDoNotBlock is the discriminator against a
+// single global lock: a second destination must be able to run its body while a
+// first destination still holds its lock. Keying the lock file on a constant
+// (instead of the repo URL) reddens this.
+func TestWithRepoInitLock_DistinctReposDoNotBlock(t *testing.T) {
+	setRepoInitLockDir(t, t.TempDir())
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = withRepoInitLock(context.Background(), "repo-A", func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held // repo-A is now holding its lock
+
+	ranB := make(chan struct{})
+	go func() {
+		_ = withRepoInitLock(context.Background(), "repo-B", func() error {
+			close(ranB)
+			return nil
+		})
+	}()
+	select {
+	case <-ranB: // repo-B ran while repo-A held its lock → per-destination
+	case <-time.After(3 * time.Second):
+		close(release)
+		t.Fatal("repo-B blocked while repo-A held its lock — lock is global, not per-destination")
+	}
+	close(release)
+}
+
+// TestWithRepoInitLock_OpenErrorFailsLoud: a lock that cannot be created must
+// return an error and NOT run fn — running init unserialized is the bug. A
+// read-only lock dir makes OpenFile fail; swallowing that error reddens this.
+func TestWithRepoInitLock_OpenErrorFailsLoud(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions, so O_CREATE would succeed")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil { // r-x: no write, so O_CREATE fails
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) // let TempDir cleanup remove it
+	setRepoInitLockDir(t, dir)
+
+	ran := false
+	err := withRepoInitLock(context.Background(), "repo", func() error {
+		ran = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an error when the lock file cannot be opened in a read-only dir")
+	}
+	// Pin the open-error branch specifically: an open failure that is swallowed
+	// falls through to the flock attempt on a nil file (a different error), so
+	// asserting the identity of the message — not merely "some error" — is what
+	// keeps this branch honest.
+	if !strings.Contains(err.Error(), "open repo-init lock") {
+		t.Fatalf("want the open-lock error surfaced, got %v", err)
+	}
+	if ran {
+		t.Fatal("fn must not run when the lock could not be acquired")
+	}
+}
+
+// TestWithRepoInitLock_CtxCancelWhileHeld: while another job holds the lock, a
+// caller whose ctx is cancelled must return promptly with a ctx error rather
+// than block for the whole max-wait — flock has no ctx support, so the poll
+// loop must select on ctx.Done(). Deleting that select arm reddens this.
+func TestWithRepoInitLock_CtxCancelWhileHeld(t *testing.T) {
+	setRepoInitLockDir(t, t.TempDir())
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = withRepoInitLock(context.Background(), "repo", func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held // the lock is held by another job
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before we try to acquire
+	done := make(chan error, 1)
+	ran := make(chan struct{}, 1)
+	go func() {
+		done <- withRepoInitLock(ctx, "repo", func() error {
+			ran <- struct{}{}
+			return nil
+		})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a ctx error while the lock was held by another job")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want a context.Canceled error, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		close(release)
+		t.Fatal("withRepoInitLock ignored ctx cancellation while the lock was held")
+	}
+	select {
+	case <-ran:
+		t.Fatal("fn must not run when acquisition was cancelled")
+	default:
+	}
+	close(release)
+}
+
+// TestBackupDestTestConn_InitSerialized pins that the backup.dest.test handler's
+// auto-init is routed through withRepoInitLock (JAB-405): it is a second init
+// door that a scheduled first-run can race, and its behavior is not cheaply
+// testable (it shells out to real restic), so the wiring is pinned at the source
+// level. Reverting to a bare backup.InitRemote reddens this.
+func TestBackupDestTestConn_InitSerialized(t *testing.T) {
+	b, err := os.ReadFile("backup_dest_testconn.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	src := string(b)
+	wrap := strings.Index(src, "withRepoInitLock(ctx, p.URL")
+	if wrap < 0 {
+		t.Fatal("backup.dest.test init must be serialized through withRepoInitLock (JAB-405)")
+	}
+	initIdx := strings.Index(src, "backup.InitRemote(")
+	if initIdx < 0 || initIdx < wrap {
+		t.Fatal("backup.InitRemote must sit inside the withRepoInitLock closure, not before it")
+	}
+}


### PR DESCRIPTION
## What

A backup schedule's first run against a brand-new destination fans out several
per-account jobs concurrently. `defaultJobSlots` keys on user+repo, so different
per-account users targeting the SAME repo do not serialize — each job probes the
empty repo, classifies it "missing", and runs `restic init`. Two concurrent
inits on one empty repo leave two key files but a single `config` whose master
key matches only one of them; a later open can pick the mismatched key and fail
fatally ("config or key <id> is damaged: ciphertext verification failed")
instead of falling through. The repo is then permanently unopenable and every
backup fails at "ensure repo" — silently, forever.

Observed in production on the puzzle offsite destination: two keys created 49 ms
apart, zero snapshots ever, all jobs failing since the first run. A side effect
of each failed retry SSHing to the backup host is how it surfaced (a flood of
host login-alert emails).

## How

Serialize every agent-side `restic init` per destination behind an advisory file
lock. There are two init doors in the agent and both now route through one
helper, `withRepoInitLock`:

- `bkEnsureRepoReady` — the account and system backup orchestrators; this is
  where the fan-out race lands. The probe→init runs inside the lock, so the loser
  re-probes after the winner's init and short-circuits on the now-existing repo.
- `backup.dest.test` — auto-inits a reachable-but-empty destination on a
  test-connection. Outside the lock it could race a scheduled first run (or a
  double-clicked test); the loser's `restic init` now returns "already
  initialized" and reports success. (`(*backup.Client).Init` has no agent
  callers, so these are the only two doors.)

The lock is keyed on a sha256 of the exact repo URL, so different destinations
never contend and a re-pointed URL (the puzzle workaround) correctly gets its
own lock. It lives in the same directory the restore flock already uses
(`/var/lib/jabali-backups`), which the agent already creates and writes to from
this same process — no new permission surface.

`syscall.Flock` is not context-aware, so a bare blocking `LOCK_EX` would ignore
the job's deadline and could park behind a hung SFTP init for the whole
orchestrator timeout (90m account / 6h system). The helper instead polls
`LOCK_EX|LOCK_NB`, honouring ctx cancellation and an internal 5-minute max-wait,
and fails loud (returns an error, never runs the body) if the lock cannot be
created or acquired — running init unserialized is the exact bug this prevents.

## Cost / behavior

Same-destination jobs now serialize on the probe every run; a healthy probe is
seconds, bounded further by the per-destination slot cap (JAB-361). The
dead-destination case improves: a waiting job fails in 5 minutes instead of
burning a 4h slot.

## Why agent-side, not panel-side init-at-create

Agent-side covers every init caller — including a re-pointed URL — from one
choke point, and it is disjoint from the backup-destination PRs in panel-api.

## Scope

Prevention half of JAB-405; the ticket stays open. Remaining (parts 2/3): make
open resilient to an already-corrupted repo (skip a key whose master can't
decrypt `config` instead of fatal-erroring), and detect the ">1 key, one config"
corruption to emit a race-specific error in place of the current
"reinstalled/regenerated password" hint, which is wrong for this race and sends
operators down the wrong recovery path. The repo-password rotate path can't race
an init (init only on an empty repo, rotate only on an existing one), so it is
not a gap.

## Tests

`panel-agent/internal/commands/backup_repo_init_lock_test.go`:
- **SerializesSameRepo** — 20 concurrent callers for one destination never run
  their bodies at once (atomic in-flight counter asserts zero overlap): the core
  guarantee.
- **DistinctReposDoNotBlock** — a second destination runs while a first still
  holds its lock (discriminator against a single global lock).
- **OpenErrorFailsLoud** — a lock file that can't be created returns an error and
  never runs the body. The assertion pins the open-error *message*: a swallowed
  open error falls through to a nil-file flock that fails with a *different*
  error, so a "some error" check would pass both ways. Skipped under root.
- **CtxCancelWhileHeld** — a caller whose ctx is cancelled while the lock is held
  returns promptly with a ctx error rather than blocking for the max-wait.
- **BackupDestTestConn_InitSerialized** — source-pin that the test-connection
  init is wrapped in the lock (it shells out to real restic, so it's pinned at
  the source level).

All five new guards were falsified with compiling neutralizations (no real
flock; a constant lock path; swallowed open error; ctx select arm removed;
test-connection init reverted to bare), each red then reverted. `go build ./...`
/ `go vet` green; gofmt-clean; `go test -race` green on the full
`panel-agent/internal/commands` package. `bkEnsureRepoReady`'s signature is
unchanged (the existing password-threading pin still passes).

## Verification split

The serialization is proven deterministically by the unit tests. A pre-merge
smoke on the .60 test box (deploy the agent, run one backup, confirm the lock
file appears under `/var/lib/jabali-backups` and the job succeeds) is a
regression check on the hot path — not a correctness check, since the lock dir's
writability is already proven by the restore flock writing to the same dir from
the same process. Reproducing the race itself on the box is not attempted (it
needs a fresh empty repo + a fan-out >= 2).

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
