### PR TITLE
fix(shared-resources): persist a durable tombstone before teardown via a shared delete leaf (JAB-339)

### DIFF
--- a/panel-api/cmd/server/shared_resource_cmd.go
+++ b/panel-api/cmd/server/shared_resource_cmd.go
@@ -242,28 +242,35 @@ func newSharedResourceRevokeCmd() *cobra.Command {
 func newSharedResourceRemoveCmd() *cobra.Command {
 	var resourceID string
 	cmd := &cobra.Command{
-		Use:     "remove",
-		Short:   "Delete a shared resource (reconciler tears down the host principal)",
-		PreRunE: requireDB,
+		Use:   "remove",
+		Short: "Delete a shared resource (reconciler tears down the host principal)",
+		// requireDBAndAgent, not requireDB: requireDB never calls initAgent, so
+		// sharedAgent stays nil and the instant host destroy never fires (the
+		// reconciler still converges from the tombstone, just not instantly).
+		// initAgent only constructs the client — a down socket does not fail the
+		// command — so this is safe. Same fix the create subcommand carries.
+		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if resourceID == "" {
 				return errors.New("--resource <id> required")
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 			defer cancel()
-			repo := sharedResourceRepoFromDB()
-			// Tear down the Stalwart host principal first (mirrors the REST
-			// delete handler). The reconciler does NOT garbage-collect orphaned
-			// hosts, so the row delete alone would leave the principal behind.
-			if sr, err := repo.FindByID(ctx, resourceID); err == nil && sr.EmailCached != nil && *sr.EmailCached != "" {
-				_ = repo.AddTombstone(ctx, *sr.EmailCached) // durable backstop for the reconciler GC
-				if sharedAgent != nil {
-					if _, derr := sharedAgent.Call(ctx, "sharedresource.destroy", map[string]any{"email": *sr.EmailCached}); derr != nil {
-						fmt.Fprintf(os.Stderr, "warning: host teardown failed (%v); reconciler will retry\n", derr)
-					}
+			// Best-effort host teardown that SURFACES a failure — not the shared
+			// notifyAgentSharedResource, which swallows. An operator running a
+			// manual remove should see a destroy that did not land; the
+			// reconciler GC still retries from the durable tombstone.
+			notify := func(nctx context.Context, agentCmd string, params any) {
+				if sharedAgent == nil {
+					return
+				}
+				agentCtx, acancel := context.WithTimeout(nctx, cliSharedResourceAgentTimeout)
+				defer acancel()
+				if _, derr := sharedAgent.Call(agentCtx, agentCmd, params); derr != nil {
+					fmt.Fprintf(os.Stderr, "warning: host teardown failed (%v); reconciler will retry\n", derr)
 				}
 			}
-			if err := repo.Delete(ctx, resourceID); err != nil {
+			if err := deleteSharedResourceDirect(ctx, sharedResourceRepoFromDB(), notify, resourceID); err != nil {
 				return fmt.Errorf("delete: %w", err)
 			}
 			cliAuditOK(ctx, "shared_resource.remove", "shared_resource", resourceID, nil)

--- a/panel-api/cmd/server/shared_resource_ops.go
+++ b/panel-api/cmd/server/shared_resource_ops.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -22,6 +23,22 @@ func createSharedResourceDirect(ctx context.Context, repo repository.SharedResou
 		Kind:        kind,
 		Name:        name,
 		DisplayName: displayName,
+	}, sharedresourceops.NotifyFunc(notify))
+}
+
+// deleteSharedResourceDirect mirrors DELETE /shared-resources/:rid: it loads the
+// resource, then routes the durable-tombstone-before-best-effort-destroy
+// teardown through sharedresourceops.Delete so the CLI and REST tear a resource
+// down identically (JAB-339 AC5). A load error is returned rather than swallowed
+// — the old CLI skipped teardown on a FindByID error yet still deleted the row,
+// orphaning the Stalwart host principal with no tombstone for the reconciler GC.
+func deleteSharedResourceDirect(ctx context.Context, repo repository.SharedResourceRepository, notify agentNotifier, resourceID string) error {
+	sr, err := repo.FindByID(ctx, resourceID)
+	if err != nil {
+		return fmt.Errorf("load resource: %w", err)
+	}
+	return sharedresourceops.Delete(ctx, sharedresourceops.Deps{Resources: repo}, sharedresourceops.DeleteInput{
+		Resource: sr,
 	}, sharedresourceops.NotifyFunc(notify))
 }
 

--- a/panel-api/cmd/server/shared_resource_ops_test.go
+++ b/panel-api/cmd/server/shared_resource_ops_test.go
@@ -149,6 +149,43 @@ func TestSharedResourceAdapters_RouteThroughLeaf(t *testing.T) {
 	}
 }
 
+// TestSharedResourceRemove_RoutesThroughLeafAndArmsAgent source-pins the remove
+// subcommand. Its behavior is not cheaply testable — sharedAgent / sharedDB are
+// concrete package globals the RunE dials directly — so the wiring is pinned at
+// the source level (same rationale as the create routing pin). Scoped to the
+// remove block so the create subcommand's own requireDBAndAgent doesn't satisfy
+// the check.
+func TestSharedResourceRemove_RoutesThroughLeafAndArmsAgent(t *testing.T) {
+	cli := mustRead(t, "shared_resource_cmd.go")
+	marker := `Use:   "remove"`
+	i := strings.Index(cli, marker)
+	if i < 0 {
+		t.Fatal("remove subcommand not found")
+	}
+	block := cli[i:]
+	if j := strings.Index(block[len(marker):], "Use:"); j >= 0 {
+		block = block[:len(marker)+j]
+	}
+	if !strings.Contains(block, "deleteSharedResourceDirect(") {
+		t.Error("CLI remove must route the teardown through deleteSharedResourceDirect")
+	}
+	// Pin the field assignment, not the bare word: the block's own comment
+	// mentions requireDBAndAgent, so a Contains on the word alone would still
+	// pass if PreRunE silently reverted to requireDB.
+	if !strings.Contains(block, "PreRunE: requireDBAndAgent") {
+		t.Error("CLI remove must use requireDBAndAgent, or the instant destroy never fires (sharedAgent stays nil)")
+	}
+	if !strings.Contains(block, "warning: host teardown failed") {
+		t.Error("CLI remove must surface a teardown failure on stderr, not swallow it")
+	}
+	// The old bypass loaded with `FindByID(...); err == nil && ...`, skipping
+	// teardown on a load error yet still deleting the row. The leaf now loads and
+	// returns the error, so this shape must be gone.
+	if strings.Contains(block, "err == nil &&") {
+		t.Error("CLI remove must not skip teardown on a FindByID error and delete the row anyway")
+	}
+}
+
 func mustRead(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)

--- a/panel-api/internal/api/shared_resources.go
+++ b/panel-api/internal/api/shared_resources.go
@@ -239,14 +239,14 @@ func (h *sharedResourceHandler) delete(c *gin.Context) {
 	if !ok {
 		return
 	}
-	ctx := c.Request.Context()
-	if sr.EmailCached != nil && *sr.EmailCached != "" {
-		// Tombstone first (durable teardown), then best-effort instant destroy.
-		// The reconciler GC retries destroy until it succeeds, then clears it.
-		_ = h.cfg.Resources.AddTombstone(ctx, *sr.EmailCached)
-		h.notifyAgent(ctx, "sharedresource.destroy", map[string]any{"email": *sr.EmailCached})
-	}
-	if err := h.cfg.Resources.Delete(ctx, sr.ID); err != nil {
+	// The durable-tombstone-before-best-effort-destroy teardown lives in
+	// sharedresourceops so the operator CLI tears down identically (JAB-339
+	// AC5). A tombstone that cannot be persisted now keeps the row (500) rather
+	// than deleting it into a host principal the reconciler GC can never reach.
+	if err := sharedresourceops.Delete(c.Request.Context(),
+		sharedresourceops.Deps{Resources: h.cfg.Resources},
+		sharedresourceops.DeleteInput{Resource: sr},
+		h.notifyAgent); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}

--- a/panel-api/internal/api/shared_resources_test.go
+++ b/panel-api/internal/api/shared_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,6 +39,8 @@ type srResFake struct {
 	created    []*models.SharedResource
 	grantsSet  map[string][]models.SharedResourceGrant
 	tombstones []string
+	tombErr    error
+	deleted    []string
 	byID       map[string]*models.SharedResource
 }
 
@@ -68,9 +71,12 @@ func (f *srResFake) ReplaceGrants(_ context.Context, id string, g []models.Share
 }
 func (f *srResFake) AddTombstone(_ context.Context, e string) error {
 	f.tombstones = append(f.tombstones, e)
+	return f.tombErr
+}
+func (f *srResFake) Delete(_ context.Context, id string) error {
+	f.deleted = append(f.deleted, id)
 	return nil
 }
-func (f *srResFake) Delete(context.Context, string) error { return nil }
 
 func srRouter(t *testing.T, res *srResFake, ag *srAgentFake) *gin.Engine {
 	t.Helper()
@@ -150,6 +156,25 @@ func TestSharedResource_Delete_Tombstones(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.Equal(t, []string{"teamcal@example.org"}, res.tombstones)
 	require.Contains(t, ag.calls, "sharedresource.destroy")
+	require.Equal(t, []string{"res1"}, res.deleted)
+}
+
+// AC5: a tombstone that cannot be persisted must NOT delete the row — deleting
+// it would strand the Stalwart host principal with no handle for the reconciler
+// GC. Was 200 + row deleted (the swallowed-tombstone bug); now 500 + row kept.
+func TestSharedResource_Delete_TombstoneFailureKeepsRow(t *testing.T) {
+	res := &srResFake{
+		tombErr: errors.New("db down"),
+		byID: map[string]*models.SharedResource{
+			"res1": {ID: "res1", DomainID: "dom1", Kind: "calendar", EmailCached: strptr("teamcal@example.org")},
+		},
+	}
+	ag := &srAgentFake{}
+	r := srRouter(t, res, ag)
+	w := do(t, r, "DELETE", "/api/v1/shared-resources/res1", nil)
+	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+	require.Empty(t, res.deleted, "row must not be deleted when the tombstone fails")
+	require.NotContains(t, ag.calls, "sharedresource.destroy", "destroy must not fire when the tombstone fails")
 }
 
 func strptr(s string) *string { return &s }

--- a/panel-api/internal/sharedresourceops/sharedresourceops.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops.go
@@ -131,3 +131,45 @@ func Create(ctx context.Context, d Deps, in CreateInput, notify NotifyFunc) (*mo
 	}
 	return sr, nil
 }
+
+// DeleteInput is one shared-resource deletion. The resource is pre-loaded and
+// pre-authorized by the adapter (the REST handler checks the caller's claims;
+// the operator CLI is admin-by-construction), mirroring CreateInput's
+// pre-loaded domain.
+type DeleteInput struct {
+	Resource *models.SharedResource
+}
+
+// Delete tears a shared resource down in the order AC5 requires: it records a
+// DURABLE tombstone first, then fires the best-effort agent destroy, then
+// deletes the row.
+//
+// The tombstone is the reconciler GC's only handle on the Stalwart host
+// principal — the reconciler does not scan for orphaned hosts — so if the
+// tombstone cannot be persisted the row is LEFT in place (ErrInternal) instead
+// of deleted: deleting it would strand the principal with no path to ever
+// reclaim it. This is stricter than the handlers it replaces, which swallowed
+// the tombstone error and deleted the row regardless. AddTombstone is
+// idempotent (OnConflict DoNothing), so retrying after a later failure re-adds
+// the same tombstone harmlessly.
+//
+// A resource with no cached address (EmailCached empty) has no host principal
+// to tear down, so it skips straight to the row delete.
+func Delete(ctx context.Context, d Deps, in DeleteInput, notify NotifyFunc) error {
+	if d.Resources == nil || in.Resource == nil {
+		return fmt.Errorf("%w: resources repo + resource required", ErrDeps)
+	}
+	sr := in.Resource
+	if sr.EmailCached != nil && *sr.EmailCached != "" {
+		if err := d.Resources.AddTombstone(ctx, *sr.EmailCached); err != nil {
+			return fmt.Errorf("%w: tombstone: %v", ErrInternal, err)
+		}
+		if notify != nil {
+			notify(ctx, "sharedresource.destroy", map[string]any{"email": *sr.EmailCached})
+		}
+	}
+	if err := d.Resources.Delete(ctx, sr.ID); err != nil {
+		return fmt.Errorf("%w: delete: %v", ErrInternal, err)
+	}
+	return nil
+}

--- a/panel-api/internal/sharedresourceops/sharedresourceops_test.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // fakeResRepo implements repository.SharedResourceRepository. Only ExistsByEmail
@@ -166,5 +167,109 @@ func TestCreate_NilNotifyDoesNotPanic(t *testing.T) {
 		Domain: emailDomain(), Kind: "files", Name: "teamfiles",
 	}, nil); err != nil {
 		t.Fatalf("nil notify happy path: %v", err)
+	}
+}
+
+// seqResRepo records the tombstone/delete call order and can force either to
+// fail. It embeds the interface so Delete's unused methods are never reached.
+type seqResRepo struct {
+	repository.SharedResourceRepository
+	ops       *[]string
+	tombErr   error
+	deleteErr error
+}
+
+func (r *seqResRepo) AddTombstone(_ context.Context, _ string) error {
+	*r.ops = append(*r.ops, "tombstone")
+	return r.tombErr
+}
+func (r *seqResRepo) Delete(_ context.Context, _ string) error {
+	*r.ops = append(*r.ops, "delete")
+	return r.deleteErr
+}
+
+func resWithEmail() *models.SharedResource {
+	e := "teamcal@example.org"
+	return &models.SharedResource{ID: "res1", EmailCached: &e}
+}
+
+// TestDelete_TombstoneFailKeepsRow is the AC5 guarantee: a tombstone that cannot
+// be persisted must NOT delete the row (that would orphan the host principal),
+// and the destroy must not fire.
+func TestDelete_TombstoneFailKeepsRow(t *testing.T) {
+	ops := []string{}
+	repo := &seqResRepo{ops: &ops, tombErr: errors.New("db down")}
+	fired := false
+	err := Delete(context.Background(), Deps{Resources: repo}, DeleteInput{Resource: resWithEmail()},
+		func(context.Context, string, any) { fired = true })
+	if !errors.Is(err, ErrInternal) {
+		t.Fatalf("want ErrInternal, got %v", err)
+	}
+	if len(ops) != 1 || ops[0] != "tombstone" {
+		t.Fatalf("row must not be deleted when the tombstone fails; ops=%v", ops)
+	}
+	if fired {
+		t.Fatal("destroy must not fire when the tombstone fails")
+	}
+}
+
+func TestDelete_HappyPathOrder(t *testing.T) {
+	ops := []string{}
+	repo := &seqResRepo{ops: &ops}
+	var gotCmd string
+	var gotParams map[string]any
+	notify := func(_ context.Context, cmd string, params any) {
+		ops = append(ops, "destroy")
+		gotCmd = cmd
+		if m, ok := params.(map[string]any); ok {
+			gotParams = m
+		}
+	}
+	if err := Delete(context.Background(), Deps{Resources: repo}, DeleteInput{Resource: resWithEmail()}, notify); err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if len(ops) != 3 || ops[0] != "tombstone" || ops[1] != "destroy" || ops[2] != "delete" {
+		t.Fatalf("want tombstone,destroy,delete in order; ops=%v", ops)
+	}
+	if gotCmd != "sharedresource.destroy" || gotParams["email"] != "teamcal@example.org" {
+		t.Fatalf("destroy call wrong: cmd=%q params=%#v", gotCmd, gotParams)
+	}
+}
+
+func TestDelete_NoEmailSkipsTeardown(t *testing.T) {
+	ops := []string{}
+	repo := &seqResRepo{ops: &ops}
+	fired := false
+	if err := Delete(context.Background(), Deps{Resources: repo},
+		DeleteInput{Resource: &models.SharedResource{ID: "res1"}},
+		func(context.Context, string, any) { fired = true }); err != nil {
+		t.Fatalf("no-email delete: %v", err)
+	}
+	if len(ops) != 1 || ops[0] != "delete" {
+		t.Fatalf("no cached address means no tombstone/destroy, just delete; ops=%v", ops)
+	}
+	if fired {
+		t.Fatal("destroy must not fire with no cached address")
+	}
+}
+
+func TestDelete_NilNotifyNoPanic(t *testing.T) {
+	ops := []string{}
+	repo := &seqResRepo{ops: &ops}
+	if err := Delete(context.Background(), Deps{Resources: repo}, DeleteInput{Resource: resWithEmail()}, nil); err != nil {
+		t.Fatalf("nil notify: %v", err)
+	}
+	if len(ops) != 2 || ops[0] != "tombstone" || ops[1] != "delete" {
+		t.Fatalf("nil notify: tombstone then delete; ops=%v", ops)
+	}
+}
+
+func TestDelete_NilDepsReturnsErrDeps(t *testing.T) {
+	if err := Delete(context.Background(), Deps{}, DeleteInput{Resource: resWithEmail()}, nil); !errors.Is(err, ErrDeps) {
+		t.Fatalf("nil repo: want ErrDeps, got %v", err)
+	}
+	ops := []string{}
+	if err := Delete(context.Background(), Deps{Resources: &seqResRepo{ops: &ops}}, DeleteInput{Resource: nil}, nil); !errors.Is(err, ErrDeps) {
+		t.Fatalf("nil resource: want ErrDeps, got %v", err)
 	}
 }


### PR DESCRIPTION
## What

Shared-resource delete was implemented twice — in the REST handler and in the
operator CLI — and the two had drifted. Neither guaranteed the tombstone the
teardown depends on: both wrote it with the error swallowed
(`_ = repo.AddTombstone(...)`) and then deleted the row regardless.

The tombstone is the reconciler GC's *only* handle on the Stalwart host
principal — the reconciler does not scan for orphaned hosts. So a tombstone
that failed to persist, followed by the row delete, stranded the principal with
no way to ever reclaim it. That principal keeps accepting mail / DAV for a
resource the panel reports as deleted. JAB-339 AC5 requires a durable tombstone
*before* the best-effort destroy, precisely to close that window.

The CLI had a second, separate defect on the same path. It loaded the resource
with `if sr, err := repo.FindByID(...); err == nil && ...`, so a transient load
error silently skipped the whole teardown yet still ran `repo.Delete` — deleting
the row with no tombstone and no destroy. (A *missing* resource errored before
and still errors: the repo's `Delete` maps zero rows affected to `ErrNotFound`,
and the leaf now surfaces the same `ErrNotFound` from the load. Only the
transient-load-error case changed.)

And the CLI's `remove` subcommand used `requireDB` as its `PreRunE`, which never
calls `initAgent`, so `sharedAgent` stayed nil and the `if sharedAgent != nil`
destroy was dead code — the CLI has never once fired `sharedresource.destroy`.

## How

Add a `Delete` operation to the existing `sharedresourceops` leaf (the twin of
the `Create` leaf from #1644) and route both adapters through it. `Delete` takes
an already-loaded, already-authorized resource — authorization stays an adapter
concern, exactly as `Create` takes a pre-loaded domain — and tears down in the
AC5 order:

1. `AddTombstone` first, and **fail loud**: a tombstone that cannot be persisted
   returns an error and leaves the row in place, rather than deleting it into an
   un-reclaimable orphan.
2. best-effort agent destroy.
3. row delete.

`AddTombstone` is idempotent (`OnConflict DoNothing`), so a retry after a later
failure re-adds the same tombstone harmlessly — fail-loud is safe here. A
resource with no cached address has no host principal to tear down, so it skips
straight to the row delete.

## Behavior changes (both stricter, called out)

- **REST**: a tombstone-persist failure was `200` with the row deleted (the
  orphan); now `500` with the row kept and the operation retryable.
- **CLI**: a `FindByID` error was a silent teardown-skip that still deleted the
  row; now it returns the error and deletes nothing.
- **CLI**: `remove`'s `PreRunE` switched from `requireDB` to `requireDBAndAgent`
  — the same fix the `create` subcommand already carries. `initAgent` only
  constructs the agent client (it does not dial), so a down socket does not fail
  the command. The CLI keeps surfacing a destroy failure on stderr by passing
  its own warning closure rather than the shared notifier, which swallows.

## Scope

Closes AC5 on both adapters and completes AC3 (identical CLI/REST projection)
for delete as well as create. AC4 (explicit grantee existence / domain policy
on the grant path) and the full Module abstraction remain, so JAB-339 stays a
module-parent in Backlog.

## Tests

- `sharedresourceops`: a sequence-recording fake asserts the order is
  tombstone -> destroy -> delete; that a tombstone failure returns `ErrInternal`
  with the row NOT deleted and the destroy NOT fired (the AC5 guarantee); that a
  resource with no cached address skips straight to the row delete; that a nil
  notify does not panic; and that nil deps return `ErrDeps`.
- `internal/api`: the existing happy-path delete test is extended to assert the
  row is deleted; a new test drives a tombstone failure and asserts `500` + row
  kept + destroy not fired.
- `cmd/server`: a source-pin (the `RunE` dials concrete package globals, so its
  behavior is not cheaply testable) checks the `remove` block routes through
  `deleteSharedResourceDirect`, uses `PreRunE: requireDBAndAgent` (pinned at the
  field, not the bare word, so the block's own comment can't satisfy it), keeps
  the stderr warning, and no longer carries the `err == nil &&` load-then-delete
  bypass.
- Four new guards were falsified with compiling neutralizations (tombstone-return
  gated off; destroy/tombstone order swapped; empty-address guard dropped;
  `PreRunE` reverted to `requireDB`), each red then reverted. `go build ./...` /
  `go vet` green; gofmt-clean; `go test -race` green on `sharedresourceops`,
  `internal/api`, and `cmd/server`.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
