### PR TITLE
fix(backup): CLI SFTP destination update replaces the block, not overlays (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -179,6 +179,47 @@ func newBackupDestinationCreateCmd() *cobra.Command {
 	return cmd
 }
 
+// buildReplacedSFTPBlock builds the full-replace SFTP block for a destination
+// update (JAB-310 AC5) purely from the supplied flag values. It consults NO
+// stored value: an omitted field is cleared, not carried over — the same
+// replace-by-contract the REST update handler enforces by rebuilding
+// models.SFTPOptions from req.SFTP. validateSFTPOpts then requires the whole
+// block (host+user+path+auth), so a partial edit is rejected rather than
+// silently merged with stale stored values (the pre-JAB-310 CLI overlay bug).
+// Returns the composed restic URL and the marshalled extra_options JSON.
+func buildReplacedSFTPBlock(host, user string, port int, path, auth, keyPath string) (string, []byte, error) {
+	opts := &models.SFTPOptions{
+		Host:    host,
+		User:    user,
+		Port:    port,
+		Path:    path,
+		Auth:    auth,
+		KeyPath: keyPath,
+	}
+	if err := validateSFTPOpts(opts); err != nil {
+		return "", nil, err
+	}
+	url := internalbackup.ComposeSFTPURL(internalbackup.SFTPInputs{Host: opts.Host, User: opts.User, Path: opts.Path})
+	raw, _ := json.Marshal(models.BackupDestinationExtraOptions{SFTP: opts})
+	return url, raw, nil
+}
+
+// sftpPasswordWriteAllowed reports whether a --sftp-password update may write the
+// SSHPASS credential for a destination of the given kind and effective auth
+// (JAB-310 AC5). The password is an independent credential write (not a
+// structural block edit), but it must only land on an sftp destination whose
+// effective auth is "password": writing an SSHPASS to a key-auth destination is
+// meaningless, so it is rejected rather than silently stored.
+func sftpPasswordWriteAllowed(kind, effectiveAuth string) error {
+	if kind != models.BackupDestinationKindSFTP {
+		return fmt.Errorf("--sftp-password only applies to sftp destinations (kind=%s)", kind)
+	}
+	if effectiveAuth != models.SFTPAuthPassword {
+		return fmt.Errorf("--sftp-password requires the destination to use password auth (current auth=%q); pass --sftp-auth password with the full sftp block to switch", effectiveAuth)
+	}
+	return nil
+}
+
 func newBackupDestinationUpdateCmd() *cobra.Command {
 	var (
 		name        string
@@ -250,56 +291,62 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 				d.Enabled = false
 				changed = true
 			}
-			// Structured SFTP field edits (host/user/port/path/auth/key-path),
-			// overlaid on the existing block so unspecified fields survive.
-			// Same validation + URL/extra_options compose as the REST handler.
-			sftpTouched := false
-			for _, f := range []string{"sftp-host", "sftp-user", "sftp-port", "sftp-path", "sftp-auth", "sftp-key-path", "sftp-password"} {
+			// Structural SFTP field edits (host/user/port/path/auth/key-path)
+			// REPLACE the stored block wholesale — the same full-block-replace
+			// contract the REST update handler enforces (JAB-310 AC5). The block
+			// is built FRESH from the flags, not overlaid on the stored block, so
+			// an omitted field is cleared (a flag left off means "empty here"),
+			// exactly as REST rebuilds models.SFTPOptions purely from req.SFTP.
+			// validateSFTPOpts then forces the caller to supply the whole block
+			// (host+user+path+auth), mirroring the REST validateSFTPInputs gate.
+			//
+			// --sftp-password is deliberately NOT a structural field: it is a
+			// credential (SSHPASS) write, handled independently below, so a
+			// password rotation stays a single-flag operation and does not force
+			// the operator to resend the entire SFTP block. This is the one
+			// intentional CLI affordance beyond the REST handler, whose SSHPASS
+			// write is coupled to a present req.SFTP block.
+			sftpStructural := false
+			for _, f := range []string{"sftp-host", "sftp-user", "sftp-port", "sftp-path", "sftp-auth", "sftp-key-path"} {
 				if cmd.Flags().Changed(f) {
-					sftpTouched = true
+					sftpStructural = true
 					break
 				}
 			}
-			if sftpTouched {
+			if sftpStructural {
 				if d.Kind != models.BackupDestinationKindSFTP {
 					return fmt.Errorf("--sftp-* flags only apply to sftp destinations (kind=%s)", d.Kind)
 				}
-				opts := d.ExtraOptionsTyped().SFTP
-				if opts == nil {
-					opts = &models.SFTPOptions{}
-				}
-				if cmd.Flags().Changed("sftp-host") {
-					opts.Host = sftpHost
-				}
-				if cmd.Flags().Changed("sftp-user") {
-					opts.User = sftpUser
-				}
-				if cmd.Flags().Changed("sftp-port") {
-					opts.Port = sftpPort
-				}
-				if cmd.Flags().Changed("sftp-path") {
-					opts.Path = sftpPath
-				}
-				if cmd.Flags().Changed("sftp-auth") {
-					opts.Auth = sftpAuth
-				}
-				if cmd.Flags().Changed("sftp-key-path") {
-					opts.KeyPath = sftpKeyPath
-				}
-				if err := validateSFTPOpts(opts); err != nil {
+				// Full-block REPLACE built purely from the flags (buildReplacedSFTPBlock
+				// consults no stored value), so an omitted field is cleared, not carried.
+				newURL, raw, err := buildReplacedSFTPBlock(sftpHost, sftpUser, sftpPort, sftpPath, sftpAuth, sftpKeyPath)
+				if err != nil {
 					return err
 				}
-				d.URL = internalbackup.ComposeSFTPURL(internalbackup.SFTPInputs{Host: opts.Host, User: opts.User, Path: opts.Path})
-				raw, _ := json.Marshal(models.BackupDestinationExtraOptions{SFTP: opts})
+				d.URL = newURL
 				d.ExtraOptions = raw
 				changed = true
-				if opts.Auth == models.SFTPAuthPassword && cmd.Flags().Changed("sftp-password") {
-					path, err := writeBackupDestinationCreds(ctx, sharedAgent.Call, d.ID, map[string]string{"SSHPASS": sftpPass})
-					if err != nil {
-						return fmt.Errorf("write sftp password: %w", err)
-					}
-					d.CredentialsRef = &path
+			}
+			// SFTP password (SSHPASS) — an independent credential write, not a
+			// structural block edit. Rotates on --sftp-password alone; the block
+			// above is left untouched. The destination's effective auth must be
+			// "password" — either just set by a full block replace in this same
+			// command (d.ExtraOptions was rewritten above) or already stored —
+			// so a password cannot be written to a key-auth destination.
+			if cmd.Flags().Changed("sftp-password") {
+				effAuth := ""
+				if s := d.ExtraOptionsTyped().SFTP; s != nil {
+					effAuth = s.Auth
 				}
+				if err := sftpPasswordWriteAllowed(d.Kind, effAuth); err != nil {
+					return err
+				}
+				path, err := writeBackupDestinationCreds(ctx, sharedAgent.Call, d.ID, map[string]string{"SSHPASS": sftpPass})
+				if err != nil {
+					return fmt.Errorf("write sftp password: %w", err)
+				}
+				d.CredentialsRef = &path
+				changed = true
 			}
 			// Clear stored credential env (cloud secrets / sftp SSHPASS). Drop the
 			// reference here, but DEFER the on-disk file removal to after the row

--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -197,7 +197,12 @@ func buildReplacedSFTPBlock(host, user string, port int, path, auth, keyPath str
 		KeyPath: keyPath,
 	}
 	if err := validateSFTPOpts(opts); err != nil {
-		return "", nil, err
+		// A partial edit lands here: the block is built only from the flags, so a
+		// missing field is an incomplete block, not a typo. Name the new contract —
+		// the bare validator message ("sftp host and user are required") gives no
+		// hint that the CLI now needs the WHOLE block passed together, where the
+		// pre-JAB-310 overlay used to fill the rest from the stored row.
+		return "", nil, fmt.Errorf("--sftp-* flags replace the whole SFTP block; pass --sftp-host, --sftp-user, --sftp-path and --sftp-auth together: %w", err)
 	}
 	url := internalbackup.ComposeSFTPURL(internalbackup.SFTPInputs{Host: opts.Host, User: opts.User, Path: opts.Path})
 	raw, _ := json.Marshal(models.BackupDestinationExtraOptions{SFTP: opts})

--- a/panel-api/cmd/server/backup_destination_ops_test.go
+++ b/panel-api/cmd/server/backup_destination_ops_test.go
@@ -476,6 +476,47 @@ func TestBackupDestinationUpdate_RoutesThroughCore(t *testing.T) {
 	}
 }
 
+// TestBackupDestinationUpdate_SFTPBlockReplacesNotOverlays pins the JAB-310 AC5
+// full-block-replace WIRING in the update RunE (not unit-testable): the
+// structural SFTP edit builds a fresh block via buildReplacedSFTPBlock, never
+// overlays onto the stored block, and --sftp-password is not a structural field
+// (it is an independent credential write). Reverting to the pre-JAB-310 overlay
+// — `opts := d.ExtraOptionsTyped().SFTP` seeded from the stored row, or
+// re-adding sftp-password to the structural touch list — reddens this. The
+// behavior of the extracted helpers themselves is tested in
+// backup_destination_parity_cmd_test.go.
+func TestBackupDestinationUpdate_SFTPBlockReplacesNotOverlays(t *testing.T) {
+	src := readOpsSource(t, "backup_destination_cmd.go")
+	start := strings.Index(src, "func newBackupDestinationUpdateCmd(")
+	if start < 0 {
+		t.Fatal("update command not found")
+	}
+	body := src[start:]
+	if end := strings.Index(body, "\nfunc newBackupDestinationRotatePasswordCmd("); end > 0 {
+		body = body[:end]
+	}
+	if !strings.Contains(body, "buildReplacedSFTPBlock(sftpHost, sftpUser, sftpPort, sftpPath, sftpAuth, sftpKeyPath)") {
+		t.Error("structural SFTP edit must build a full-replace block via buildReplacedSFTPBlock (fresh from flags)")
+	}
+	// The structural branch must not seed opts from the stored block (the overlay).
+	// The password branch legitimately reads d.ExtraOptionsTyped().SFTP for its
+	// effective-auth gate (`s := d.ExtraOptionsTyped().SFTP`), so pin the exact
+	// overlay-seed spelling, not the accessor in general.
+	if strings.Contains(body, "opts := d.ExtraOptionsTyped().SFTP") {
+		t.Error("structural SFTP edit must not seed opts from the stored block (overlay); build fresh from flags")
+	}
+	// The structural touch list must exclude sftp-password.
+	tlStart := strings.Index(body, "sftpStructural := false")
+	if tlStart < 0 {
+		t.Fatal("structural touch list not found")
+	}
+	touchList := body[tlStart:]
+	touchList = touchList[:strings.Index(touchList, "}")]
+	if strings.Contains(touchList, "sftp-password") {
+		t.Error("--sftp-password must not be in the structural touch list; it is an independent credential write")
+	}
+}
+
 // TestDeleteBackupDestinationDirect_SurfacesSwallowedCleanupFailure is the
 // load-bearing guard for this slice: a failed creds_delete after the row is gone
 // must NOT vanish. The delete still succeeds (returns nil — the row is deleted),

--- a/panel-api/cmd/server/backup_destination_parity_cmd_test.go
+++ b/panel-api/cmd/server/backup_destination_parity_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -57,8 +58,15 @@ func TestBuildReplacedSFTPBlock_ReplacesFromFlagsOnly(t *testing.T) {
 // REJECTED by the full-block validator. Under the pre-JAB-310 overlay a lone
 // --sftp-host silently kept the stored user/path; now it is an error.
 func TestBuildReplacedSFTPBlock_RejectsPartialBlock(t *testing.T) {
-	if _, _, err := buildReplacedSFTPBlock("newhost.example.com", "", 0, "", "", ""); err == nil {
+	_, _, err := buildReplacedSFTPBlock("newhost.example.com", "", 0, "", "", "")
+	if err == nil {
 		t.Fatal("a block missing user+path must be rejected (full-block replace, not overlay)")
+	}
+	// The message must name the new contract — a partial edit used to work under
+	// the overlay, so the error has to explain the whole block is now required,
+	// not just echo the bare validator complaint.
+	if !strings.Contains(err.Error(), "replace the whole SFTP block") {
+		t.Errorf("partial-block error must explain the whole-block requirement, got %v", err)
 	}
 }
 

--- a/panel-api/cmd/server/backup_destination_parity_cmd_test.go
+++ b/panel-api/cmd/server/backup_destination_parity_cmd_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -20,5 +21,63 @@ func TestValidateSFTPOpts_RejectsUnsafeHostUser(t *testing.T) {
 	// A well-formed destination still validates.
 	if err := validateSFTPOpts(&models.SFTPOptions{Host: "backup.example.com", User: "restic", Path: "/backups"}); err != nil {
 		t.Errorf("a plain sftp destination must be accepted, got %v", err)
+	}
+}
+
+// TestBuildReplacedSFTPBlock_ReplacesFromFlagsOnly is the JAB-310 AC5 core: a
+// destination-update SFTP block is built VERBATIM from the flags and consults no
+// stored value. A full block round-trips to exactly the supplied fields —
+// nothing added, nothing defaulted — so an omitted field (port 0, empty
+// key-path) stays empty rather than inheriting a stale stored value, which is
+// the replace-by-contract that matches the REST update handler. The pre-JAB-310
+// CLI overlaid onto the stored block; this is the discriminator against it.
+func TestBuildReplacedSFTPBlock_ReplacesFromFlagsOnly(t *testing.T) {
+	url, raw, err := buildReplacedSFTPBlock("backup.example.com", "restic", 0, "/backups", models.SFTPAuthKey, "")
+	if err != nil {
+		t.Fatalf("a well-formed block must validate: %v", err)
+	}
+	if url == "" {
+		t.Fatal("composed restic URL must not be empty")
+	}
+	var got models.BackupDestinationExtraOptions
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("extra_options must unmarshal: %v", err)
+	}
+	if got.SFTP == nil {
+		t.Fatal("extra_options must carry an SFTP block")
+	}
+	want := models.SFTPOptions{Host: "backup.example.com", User: "restic", Port: 0, Path: "/backups", Auth: models.SFTPAuthKey, KeyPath: ""}
+	if *got.SFTP != want {
+		t.Fatalf("block not built verbatim from flags: got %+v want %+v", *got.SFTP, want)
+	}
+}
+
+// TestBuildReplacedSFTPBlock_RejectsPartialBlock: because the block is built only
+// from the flags (no overlay from the stored row), a partial edit must be
+// REJECTED by the full-block validator. Under the pre-JAB-310 overlay a lone
+// --sftp-host silently kept the stored user/path; now it is an error.
+func TestBuildReplacedSFTPBlock_RejectsPartialBlock(t *testing.T) {
+	if _, _, err := buildReplacedSFTPBlock("newhost.example.com", "", 0, "", "", ""); err == nil {
+		t.Fatal("a block missing user+path must be rejected (full-block replace, not overlay)")
+	}
+}
+
+// TestSFTPPasswordWriteAllowed_GatesAuthAndKind pins the JAB-310 AC5 password
+// gate: --sftp-password is an independent credential write, but it must only
+// land on an sftp destination whose effective auth is "password". Writing an
+// SSHPASS to a key-auth (or non-sftp) destination is meaningless and must be
+// rejected, not silently stored.
+func TestSFTPPasswordWriteAllowed_GatesAuthAndKind(t *testing.T) {
+	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindSFTP, models.SFTPAuthPassword); err != nil {
+		t.Errorf("password write must be allowed for a password-auth sftp dest: %v", err)
+	}
+	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindSFTP, models.SFTPAuthKey); err == nil {
+		t.Error("password write must be rejected for a key-auth destination")
+	}
+	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindSFTP, ""); err == nil {
+		t.Error("password write must be rejected when auth is unset (defaults to key)")
+	}
+	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindLocal, models.SFTPAuthPassword); err == nil {
+		t.Error("password write must be rejected for a non-sftp destination kind")
 	}
 }


### PR DESCRIPTION
## What

`jabali backup destination update` overlaid structural `--sftp-*` edits onto the
stored SFTP block — an omitted field kept its stored value. The REST update
handler instead rebuilds the block purely from the request (replace-by-contract:
an omitted field is cleared). The two adapters diverged on the same operation.

This makes the CLI match the REST contract (JAB-310 AC5, full-block replace):

- **Structural `--sftp-*` flags** (host/user/port/path/auth/key-path) now
  **replace** the block. It is built FRESH from the flags via
  `buildReplacedSFTPBlock` (consults no stored value) and validated by the same
  `validateSFTPOpts` full-block gate the REST handler uses. A partial edit is
  rejected instead of silently merged with stale values.
- **`--sftp-password` is no longer a structural field.** It is an independent
  credential (SSHPASS) write, so a password rotation stays a single-flag
  operation. `sftpPasswordWriteAllowed` gates it: the destination must be `sftp`
  kind with effective auth `password`, else the write is rejected rather than
  silently stored.

## Behavior change (operator-facing)

| Case | Before (overlay) | After (replace) |
|------|------------------|-----------------|
| Partial structural edit — `update X --sftp-port 2222` alone | Succeeded; host/user/path kept from stored row | **Rejected**: `--sftp-* flags replace the whole SFTP block; pass --sftp-host, --sftp-user, --sftp-path and --sftp-auth together: …` |
| Full structural edit | Only changed fields applied; rest kept | Whole block replaced from flags; an omitted field (e.g. `--sftp-port`) is cleared to its zero value — same as REST |
| Switch to password auth | `--sftp-auth password --sftp-password X` (2 flags) worked via overlay | Pass the **full block** + `--sftp-auth password --sftp-password X` |
| Standalone password rotation — `update X --sftp-password NEW` alone | Rewrote URL/extra_options to identical values, then wrote SSHPASS | **Still works**; block untouched (`extra_options` byte-identical), SSHPASS written; rejected if the dest isn't password-auth |

The one intentional CLI affordance beyond REST: REST couples its SSHPASS write to
a present `sftp` block (`req.SFTP != nil`); the CLI keeps standalone
`--sftp-password` rotation.

## Tests

- `buildReplacedSFTPBlock` — builds verbatim from flags (no defaulting: `--sftp-port` omitted → `0`, not `22`); rejects a partial block with the whole-block message.
- `sftpPasswordWriteAllowed` — allows password-auth sftp; rejects key-auth, unset-auth, and non-sftp kind.
- Source-pin on the (non-unit-testable) RunE wiring: structural edit routes through `buildReplacedSFTPBlock` (fresh build), no stored-block overlay, `sftp-password` out of the structural touch list.

All five guards falsified against compiling neutralizations (validator skip; port-defaulting; gate-open; overlay-revert; error-unwrap). No flag/help change → no CLI-reference golden regen.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
