### PR TITLE
feat(dns): opt-in hourly PowerDNS orphan-record auto-sweep (GH #1620)

### DIFF
--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -188,7 +188,10 @@ type updateServerSettingsRequest struct {
 	TenantNotificationsEnabled   *bool   `json:"tenant_notifications_enabled,omitempty"`
 	RootTerminalEnabled          *bool   `json:"root_terminal_enabled,omitempty"`
 	BandwidthQuotaEnforceEnabled *bool   `json:"bandwidth_quota_enforce_enabled,omitempty"`
-	UploadMaxSizeMB              *uint32 `json:"upload_max_size_mb,omitempty"`
+	// DNSOrphanAutosweepEnabled (GH #1620) — opt-in hourly PowerDNS
+	// orphan-record sweep, driven by the reconciler. Off by default.
+	DNSOrphanAutosweepEnabled *bool   `json:"dns_orphan_autosweep_enabled,omitempty"`
+	UploadMaxSizeMB           *uint32 `json:"upload_max_size_mb,omitempty"`
 	// TenantBackupCron (GH #454): the admin-owned cron time tenant scheduled
 	// backups run at. Tenants choose content + destination; only the admin sets
 	// the timing. Validated server-side via internalbackup.ParseCron.
@@ -616,6 +619,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.BandwidthQuotaEnforceEnabled != nil {
 		current.BandwidthQuotaEnforceEnabled = *req.BandwidthQuotaEnforceEnabled
+	}
+	if req.DNSOrphanAutosweepEnabled != nil {
+		current.DNSOrphanAutosweepEnabled = *req.DNSOrphanAutosweepEnabled
 	}
 	if req.UploadMaxSizeMB != nil {
 		current.UploadMaxSizeMB = *req.UploadMaxSizeMB

--- a/panel-api/internal/db/migrations/000295_dns_orphan_autosweep.down.sql
+++ b/panel-api/internal/db/migrations/000295_dns_orphan_autosweep.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN dns_orphan_autosweep_enabled;

--- a/panel-api/internal/db/migrations/000295_dns_orphan_autosweep.up.sql
+++ b/panel-api/internal/db/migrations/000295_dns_orphan_autosweep.up.sql
@@ -1,0 +1,15 @@
+-- GH #1620: opt-in automatic PowerDNS orphan-record sweep.
+--
+-- server_settings.dns_orphan_autosweep_enabled — global on/off toggle,
+-- OFF by default. When on, the reconciler fires the agent RPC
+-- `dns.reap-orphans` with apply=true at most once per hour, so every box
+-- self-removes PowerDNS backend rows whose parent domain is gone
+-- (records/domainmetadata/comments/cryptokeys with
+-- domain_id NOT IN (SELECT id FROM domains)). The agent refuses the
+-- sweep outright when its domains table is empty, so an enabled-but-
+-- misconfigured box deletes nothing. Manual operators keep the existing
+-- one-shot CLI (`jabali dns prune-orphan-records`) regardless of this
+-- toggle.
+
+ALTER TABLE server_settings
+    ADD COLUMN dns_orphan_autosweep_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -305,6 +305,15 @@ type ServerSettings struct {
 	// bytes ≥ BandwidthQuotaMB and re-enables when ≤ 80%. Off by default.
 	BandwidthQuotaEnforceEnabled bool `gorm:"column:bandwidth_quota_enforce_enabled;type:tinyint(1);not null;default:0" json:"bandwidth_quota_enforce_enabled"`
 
+	// DNS orphan-record auto-sweep toggle (GH #1620). When true, the
+	// reconciler fires the agent RPC `dns.reap-orphans` (apply=true) at
+	// most once per hour so each box self-removes PowerDNS backend rows
+	// whose parent domain is gone. Off by default; only takes effect when
+	// DNSEnabled is also true. The agent refuses on an empty domains
+	// table, so an enabled-but-misconfigured box deletes nothing. The
+	// one-shot CLI (`jabali dns prune-orphan-records`) is unaffected.
+	DNSOrphanAutosweepEnabled bool `gorm:"column:dns_orphan_autosweep_enabled;type:tinyint(1);not null;default:0" json:"dns_orphan_autosweep_enabled"`
+
 	// File-manager upload cap (MB). Enforced by panel-api at request
 	// time via http.MaxBytesReader; nginx vhost client_max_body_size
 	// is set to the static ceiling (1G) so this is the operator-tunable

--- a/panel-api/internal/reconciler/dns_orphan_sweep.go
+++ b/panel-api/internal/reconciler/dns_orphan_sweep.go
@@ -1,0 +1,96 @@
+// GH #1620 — opt-in automatic PowerDNS orphan-record sweep.
+//
+// When server_settings.dns_orphan_autosweep_enabled is true (and DNS is
+// enabled), the reconciler fires the agent RPC `dns.reap-orphans` with
+// apply=true at most once per hour. Each box then self-removes PowerDNS
+// backend rows whose parent domain no longer exists — the same rows the
+// one-shot operator CLI (`jabali dns prune-orphan-records`) targets,
+// stranded when a domain was deleted before #1629's teardown fix landed.
+//
+// Safety: the agent refuses the sweep outright (CodeFailedPrecondition)
+// when its own domains table is empty, so an enabled-but-misconfigured
+// box deletes nothing. A box with no PowerDNS backend answers
+// CodeInternal. Both mean "this box can't sweep" — logged and skipped,
+// not faults — because enabling the toggle fleet-wide hits non-DNS boxes.
+// The lastRun stamp is set BEFORE the call, so a refusing or failing box
+// waits a full hour instead of retrying every 60s tick.
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+// dnsOrphanSweepInterval bounds how often the sweep RPC fires. Orphans
+// only accrue when a domain is deleted, so an hour is ample; a faster
+// cadence just re-asks the agent to delete rows it already deleted.
+const dnsOrphanSweepInterval = time.Hour
+
+// reconcileDNSOrphanSweep is the per-tick DNS orphan sweep. Cheap noop
+// when the toggle is off, DNS is disabled, or a required dep is nil.
+func (r *Reconciler) reconcileDNSOrphanSweep(ctx context.Context) {
+	if r.serverSettings == nil || r.agent == nil {
+		return
+	}
+	srv, err := r.serverSettings.Get(ctx)
+	if err != nil || srv == nil || !srv.DNSOrphanAutosweepEnabled || !srv.DNSEnabled {
+		return
+	}
+
+	// Evaluate hourly, not every 60s tick. Orphans only appear on a
+	// domain delete; between deletes every call would ask the agent to
+	// re-delete an empty set. Set the stamp BEFORE the call so a refusing
+	// or failing box backs off a full hour instead of hammering the RPC.
+	r.dnsSweepMu.Lock()
+	if !r.dnsSweepLastRun.IsZero() && time.Since(r.dnsSweepLastRun) < dnsOrphanSweepInterval {
+		r.dnsSweepMu.Unlock()
+		return
+	}
+	r.dnsSweepLastRun = time.Now()
+	r.dnsSweepMu.Unlock()
+
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	raw, err := r.agent.Call(callCtx, "dns.reap-orphans", map[string]any{"apply": true})
+	if err != nil {
+		// CodeFailedPrecondition (empty domains table) and CodeInternal
+		// (no PowerDNS backend on this box) both mean "nothing to sweep
+		// here", not a fault — a fleet-wide toggle hits both on non-DNS
+		// boxes. Log at Info and move on; anything else is a real
+		// failure worth a Warn.
+		var ae *agent.AgentError
+		if errors.As(err, &ae) && (ae.Code == agent.CodeFailedPrecondition || ae.Code == agent.CodeInternal) {
+			r.log.Info("dns_orphan_sweep: skipped", "reason", ae.Message)
+			return
+		}
+		r.log.Warn("dns_orphan_sweep: agent call failed", "err", err)
+		return
+	}
+
+	var resp struct {
+		Applied bool           `json:"applied"`
+		Counts  map[string]int `json:"counts"`
+		Deleted map[string]int `json:"deleted"`
+		Names   []string       `json:"names"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		r.log.Warn("dns_orphan_sweep: parse agent reply failed", "err", err)
+		return
+	}
+
+	total := 0
+	for _, n := range resp.Deleted {
+		total += n
+	}
+	if total > 0 {
+		r.log.Info("dns_orphan_sweep: removed orphaned PowerDNS rows",
+			"deleted", resp.Deleted, "names", len(resp.Names))
+	} else {
+		r.log.Debug("dns_orphan_sweep: no orphans", "counts", resp.Counts)
+	}
+}

--- a/panel-api/internal/reconciler/dns_orphan_sweep_test.go
+++ b/panel-api/internal/reconciler/dns_orphan_sweep_test.go
@@ -1,0 +1,107 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// dnsSweepReconciler builds a reconciler whose only wired deps are the
+// agent and a server-settings repo carrying the two gate flags.
+func dnsSweepReconciler(ag *fakeAgent, autosweep, dnsEnabled bool) *Reconciler {
+	r := New(nil, nil, ag, slog.Default(), Config{})
+	r.serverSettings = &fakeServerSettingsRepo{settings: &models.ServerSettings{
+		DNSEnabled:                dnsEnabled,
+		DNSOrphanAutosweepEnabled: autosweep,
+	}}
+	return r
+}
+
+// reapCallsWithApply counts dns.reap-orphans calls whose params carried
+// apply == want.
+func reapCallsWithApply(ag *fakeAgent, want bool) int {
+	n := 0
+	for _, c := range ag.calls {
+		if c.method != "dns.reap-orphans" {
+			continue
+		}
+		p, ok := c.params.(map[string]any)
+		if ok && p["apply"] == want {
+			n++
+		}
+	}
+	return n
+}
+
+// okReply is a valid dns.reap-orphans apply response with one deleted row.
+func okReply() json.RawMessage {
+	return json.RawMessage(`{"applied":true,"counts":{"records":1},"deleted":{"records":1},"names":["stale.example.com"]}`)
+}
+
+// Toggle OFF: the sweep never calls the agent.
+func TestDNSOrphanSweep_OffMakesNoCall(t *testing.T) {
+	ag := &fakeAgent{resultByMethod: map[string]json.RawMessage{"dns.reap-orphans": okReply()}}
+	r := dnsSweepReconciler(ag, false, true)
+	r.reconcileDNSOrphanSweep(context.Background())
+	if len(ag.calls) != 0 {
+		t.Fatalf("toggle off issued agent calls: %v", ag.calls)
+	}
+}
+
+// Autosweep ON but DNS disabled on this box: still no call. Guards the
+// fleet-wide-enable case where non-DNS boxes must stay silent.
+func TestDNSOrphanSweep_DNSDisabledMakesNoCall(t *testing.T) {
+	ag := &fakeAgent{resultByMethod: map[string]json.RawMessage{"dns.reap-orphans": okReply()}}
+	r := dnsSweepReconciler(ag, true, false)
+	r.reconcileDNSOrphanSweep(context.Background())
+	if len(ag.calls) != 0 {
+		t.Fatalf("dns-disabled box issued agent calls: %v", ag.calls)
+	}
+}
+
+// Toggle ON + DNS enabled: exactly one dns.reap-orphans call, and it must
+// carry apply=true (a dry-run would delete nothing).
+func TestDNSOrphanSweep_OnCallsApply(t *testing.T) {
+	ag := &fakeAgent{resultByMethod: map[string]json.RawMessage{"dns.reap-orphans": okReply()}}
+	r := dnsSweepReconciler(ag, true, true)
+	r.reconcileDNSOrphanSweep(context.Background())
+	if n := reapCallsWithApply(ag, true); n != 1 {
+		t.Fatalf("apply=true reap calls = %d, want 1 (calls: %v)", n, ag.calls)
+	}
+	if n := reapCallsWithApply(ag, false); n != 0 {
+		t.Fatalf("sent a dry-run (apply=false) call: %d", n)
+	}
+}
+
+// Second invocation inside the hour is gated: still one call total.
+func TestDNSOrphanSweep_HourlyGate(t *testing.T) {
+	ag := &fakeAgent{resultByMethod: map[string]json.RawMessage{"dns.reap-orphans": okReply()}}
+	r := dnsSweepReconciler(ag, true, true)
+	r.reconcileDNSOrphanSweep(context.Background())
+	r.reconcileDNSOrphanSweep(context.Background())
+	if got := len(ag.calls); got != 1 {
+		t.Fatalf("reap calls after two ticks = %d, want 1 (hourly gate)", got)
+	}
+}
+
+// A CodeFailedPrecondition refusal (empty domains table) must not panic,
+// and must still advance the gate so the box backs off a full hour
+// instead of retrying every tick. This is the fail-soft discriminator.
+func TestDNSOrphanSweep_RefusalIsSoftAndAdvancesGate(t *testing.T) {
+	ag := &fakeAgent{errByMethod: map[string]error{
+		"dns.reap-orphans": &agent.AgentError{
+			Code:    agent.CodeFailedPrecondition,
+			Message: "refusing to sweep: the pdns domains table is empty",
+		},
+	}}
+	r := dnsSweepReconciler(ag, true, true)
+	r.reconcileDNSOrphanSweep(context.Background()) // refused
+	r.reconcileDNSOrphanSweep(context.Background()) // gated by lastRun set before the call
+	if got := len(ag.calls); got != 1 {
+		t.Fatalf("reap calls after refusal+retry = %d, want 1 (lastRun must be set before the call)", got)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -284,6 +284,13 @@ type Reconciler struct {
 	dbQuotaEnforceMu      sync.Mutex
 	dbQuotaEnforceLastRun time.Time
 
+	// GH #1620 DNS orphan-record auto-sweep (dns_orphan_sweep.go). Gated
+	// on server_settings.dns_orphan_autosweep_enabled; fires the agent
+	// `dns.reap-orphans` RPC at most hourly. Same hourly-gate rationale as
+	// the two enforce sweeps above.
+	dnsSweepMu      sync.Mutex
+	dnsSweepLastRun time.Time
+
 	// sshKeysDispatchCache: per-user hash of last-applied SSH keys +
 	// timestamp. Lets ReconcileSSHKeysForUser skip the agent IPC when
 	// the desired state hasn't changed since the last dispatch. Self-
@@ -925,6 +932,12 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 
 	// JAB-243 — DB storage quota enforcement (hourly inside).
 	r.reconcileDBQuotaEnforce(ctx)
+
+	// GH #1620 — opt-in PowerDNS orphan-record sweep (hourly inside).
+	// Cheap noop when the toggle is off; the agent refuses on an empty
+	// domains table. Runs before the domain.list call below so a failing
+	// list can't starve it.
+	r.reconcileDNSOrphanSweep(ctx)
 
 	// M18 rate-limit zone fragment MUST converge BEFORE the domain loop:
 	// domain.create on the agent writes each vhost then runs `nginx -t`.


### PR DESCRIPTION
## What

Opt-in, hourly, per-box automatic sweep of orphaned PowerDNS backend rows. GH #1620.

#1674 shipped the one-shot, operator-triggered sweep (the `dns.reap-orphans` agent RPC + the `jabali dns prune-orphan-records` CLI). This adds a way to run that same sweep automatically, so a fleet operator can enable it once and have every box remove its own orphans instead of running the CLI per host.

## How

- **Migration 000295** adds `server_settings.dns_orphan_autosweep_enabled` (`tinyint(1)`, default `0`).
- The reconciler gains `reconcileDNSOrphanSweep`, called from `ReconcileAll` right after the existing bandwidth / DB quota enforce sweeps. When the toggle is on it fires `dns.reap-orphans` with `apply=true`, at most once per hour via the same `sync.Mutex` + `lastRun` gate those two siblings use. Between hourly runs it is a cheap noop.

## Safety / fleet behaviour

- Acts only when **both** `dns_orphan_autosweep_enabled` **and** `dns_enabled` are true, so enabling it fleet-wide leaves non-DNS boxes silent.
- The agent already refuses the sweep (`CodeFailedPrecondition`) when its `domains` table is empty, so an enabled-but-misconfigured box deletes nothing. A box with no PowerDNS backend answers `CodeInternal`. Both are treated as "this box can't sweep": logged at Info and skipped, never a hard error.
- The hourly-gate stamp is set **before** the RPC, so a refusing or failing box backs off a full hour rather than retrying every 60s tick.
- Like the sibling enforce sweeps, the first `ReconcileAll` fires it once on every panel start (zero `lastRun`). Safe because the agent refuses on an empty `domains` table.

## Scope

- Default **OFF**. No behaviour change unless an operator enables the toggle.
- The one-shot operator CLI is untouched and works regardless of the toggle.
- The admin Server Settings **UI** control is a follow-up PR; the setting is already reachable via the settings API (`PATCH` `dns_orphan_autosweep_enabled`) in the meantime.

## Tests

`dns_orphan_sweep_test.go` covers the gate matrix (off / DNS-disabled / on), that the on-path sends exactly one `apply=true` call (no dry-run), the hourly gate, and that a refusal is soft and still advances the gate. The refusal test was verified fail-first: it fails if the `lastRun` stamp is moved to after the RPC.

`go build ./...`, `go vet`, and the full `internal/reconciler` + `internal/api` test packages pass.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
