### PR TITLE
fix(backup): race-specific message for a dual-init key/config mismatch (JAB-405)

### DIFF
--- a/panel-agent/internal/commands/backup_dest_testconn.go
+++ b/panel-agent/internal/commands/backup_dest_testconn.go
@@ -124,16 +124,40 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 				StdoutPreview: "reachable — restic repo initialized at destination",
 			}, nil
 		}
-		return backupDestTestResult{
-			Status: "error",
-			Detail: err.Error(),
-			Stderr: stderrStr,
-		}, nil
+		// Repo exists but the probe failed for a non-missing reason. Classify it
+		// so a repo that can't be opened (foreign/rotated password, or a
+		// concurrent-init key/config mismatch — JAB-405) gets the same actionable
+		// Detail as a real backup run, not a raw restic dump the operator can't
+		// act on.
+		return backupDestTestFailureResult(p.URL, backup.DefaultPasswordFile, stderrStr, err), nil
 	}
 	return backupDestTestResult{
 		Status:        "ok",
 		StdoutPreview: firstNonEmptyLine(string(stdout)),
 	}, nil
+}
+
+// backupDestTestFailureResult maps a non-missing probe failure to a test result.
+// A repository that exists but cannot be opened (repoProbeUnopenable /
+// repoProbeKeyConfigMismatch) gets the shared actionable message in Detail; any
+// other failure surfaces the raw error. The raw restic stderr is always kept in
+// Stderr. Pure — no restic call — so it is unit-testable from stderr fixtures.
+func backupDestTestFailureResult(url, passwordFile, stderrStr string, probeErr error) backupDestTestResult {
+	lower := strings.ToLower(stderrStr)
+	switch cls := classifyRepoProbe(lower); cls {
+	case repoProbeUnopenable, repoProbeKeyConfigMismatch:
+		return backupDestTestResult{
+			Status: "error",
+			Detail: repoUnopenableMessage(cls, url, passwordFile, lower),
+			Stderr: stderrStr,
+		}
+	default:
+		return backupDestTestResult{
+			Status: "error",
+			Detail: probeErr.Error(),
+			Stderr: stderrStr,
+		}
+	}
 }
 
 func firstNonEmptyLine(s string) string {

--- a/panel-agent/internal/commands/backup_dest_testconn_test.go
+++ b/panel-agent/internal/commands/backup_dest_testconn_test.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// JAB-405: the manual "test connection" path is the second door onto the same
+// restic probe as a real backup run. Before the split it returned the raw restic
+// error for anything but a missing repo, so an operator who hit "Test" on a
+// dual-init-corrupted destination saw "config or key <id> is damaged: ciphertext
+// verification failed" — the same unactionable dump that made GH #454 read as
+// "backups broken". backupDestTestFailureResult routes a repo-exists-but-unopenable
+// failure through the shared classifier + message so both doors give the same
+// actionable Detail. The raw stderr is always preserved in Stderr.
+
+func TestBackupDestTestFailureResult(t *testing.T) {
+	const (
+		url = "sftp:puzzle@host:/home/puzzle/jabali"
+		pw  = "/etc/jabali-panel/restic-repo.password"
+	)
+
+	t.Run("key/config mismatch gets the race message", func(t *testing.T) {
+		stderr := "Fatal: config or key abcd is damaged: ciphertext verification failed"
+		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"))
+		if res.Status != "error" {
+			t.Fatalf("status = %q, want error", res.Status)
+		}
+		// Detail must be the actionable mismatch message, NOT the raw probe error.
+		if !strings.Contains(res.Detail, "password is CORRECT") ||
+			!strings.Contains(res.Detail, "MORE THAN ONE") {
+			t.Errorf("Detail is not the mismatch message: %q", res.Detail)
+		}
+		if strings.Contains(res.Detail, "exit status 1") {
+			t.Errorf("Detail leaked the raw probe error instead of the actionable message: %q", res.Detail)
+		}
+		if res.Stderr != stderr {
+			t.Errorf("Stderr = %q, want the raw restic stderr %q", res.Stderr, stderr)
+		}
+	})
+
+	t.Run("wrong password gets the reinstall message", func(t *testing.T) {
+		stderr := "Fatal: wrong password or no key found"
+		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"))
+		if !strings.Contains(res.Detail, "reinstalled or regenerated") {
+			t.Errorf("Detail is not the wrong-password message: %q", res.Detail)
+		}
+		if strings.Contains(res.Detail, "MORE THAN ONE") {
+			t.Errorf("Detail leaked the mismatch recovery into the wrong-password case: %q", res.Detail)
+		}
+	})
+
+	t.Run("unknown failure surfaces the raw error", func(t *testing.T) {
+		stderr := "Fatal: unable to connect: connection refused"
+		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"))
+		if res.Detail != "snapshots: exit status 1" {
+			t.Errorf("Detail = %q, want the raw probe error for an unclassified failure", res.Detail)
+		}
+		if res.Stderr != stderr {
+			t.Errorf("Stderr = %q, want %q", res.Stderr, stderr)
+		}
+	})
+}
+
+// TestBackupDestTestHandlerRoutesUnopenable pins the wiring: the handler's
+// non-missing failure branch must delegate to backupDestTestFailureResult, not
+// re-inline a raw `Detail: err.Error()`. The behavioural test above proves the
+// helper is correct; this proves the handler actually calls it. A value test
+// can't cover the handler itself — it shells out to real restic and reads a
+// fixed /etc password file — so the source pin is the guard, same approach as
+// TestStageMarshalsForwardPasswordFile.
+func TestBackupDestTestHandlerRoutesUnopenable(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("backup_dest_testconn.go")
+	if err != nil {
+		t.Fatalf("read backup_dest_testconn.go: %v", err)
+	}
+	body := string(src)
+
+	start := strings.Index(body, "func backupDestTestHandler(")
+	if start < 0 {
+		t.Fatal("backupDestTestHandler not found — if it was renamed, update this test; " +
+			"the rule (route unopenable failures through the shared message) still applies")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	region := body[start:]
+	if end >= 0 {
+		region = body[start : start+1+end]
+	}
+
+	if !strings.Contains(region, "backupDestTestFailureResult(") {
+		t.Error("backupDestTestHandler must route a non-missing probe failure through " +
+			"backupDestTestFailureResult so a repo that exists but can't be opened gets the " +
+			"actionable message, not a raw restic dump")
+	}
+	if strings.Contains(region, "Detail: err.Error()") {
+		t.Error("backupDestTestHandler still returns a raw `Detail: err.Error()` for a probe " +
+			"failure — that is the pre-JAB-405 unactionable path; route it through backupDestTestFailureResult")
+	}
+}

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -159,23 +160,35 @@ func bkResticConfigWithPassword(repoURL, credentialsRef, passwordFile string, sf
 type repoProbeClass int
 
 const (
-	repoProbeOther      repoProbeClass = iota // unknown failure — surface raw
-	repoProbeMissing                          // no repo at the location → init
-	repoProbeUnopenable                       // repo exists but can't be decrypted/read
+	repoProbeOther             repoProbeClass = iota // unknown failure — surface raw
+	repoProbeMissing                                 // no repo at the location → init
+	repoProbeUnopenable                              // repo exists but no stored key matches the password (foreign/rotated) → GH #454
+	repoProbeKeyConfigMismatch                       // a key opened with the password but its master can't decrypt config → concurrent-init race (JAB-405) or corrupt config
 )
 
 // classifyRepoProbe maps a lowercased restic stderr to a repoProbeClass. Strings
-// are the verbatim messages restic 0.16 emits (captured against 0.16.4):
+// are the verbatim messages restic emits (captured against 0.16.4 and re-checked
+// on 0.18.0):
 //   - missing:    "unable to open config file: … no such file …" / "repository does not exist"
-//   - unopenable: "wrong password or no key found" (foreign/rotated password),
-//     "config or key <id> is damaged: ciphertext verification failed" (corrupt/foreign)
+//   - unopenable: "wrong password or no key found" — no stored key decrypts with
+//     the password (foreign/rotated password, e.g. a host reinstall).
+//   - key/config mismatch: "config or key <id> is damaged: ciphertext verification
+//     failed" — a key file DID open with the password (so the password is correct),
+//     but its master key can't decrypt `config`. That is the signature of two
+//     concurrent `restic init` on one empty repo (JAB-405), or a corrupt config —
+//     NOT a wrong password. The two never co-occur (verified: wrong-password vs an
+//     initialized repo yields the first string, the dual-key race yields the second),
+//     so they map to distinct classes and distinct recovery advice.
 //
-// Order matters: the missing case also contains "config file", so check the
-// unopenable signals (which never co-occur with a missing repo) first is not
-// required — the missing markers are specific — but we check missing explicitly.
+// Match the mismatch case on the specific "ciphertext verification failed" phrase,
+// not a bare "is damaged": restic also says "<thing> is damaged" for index/pack
+// corruption, which must keep the generic unopenable hint rather than the
+// "your password is fine, count your key files" guidance.
 func classifyRepoProbe(lowerStderr string) repoProbeClass {
+	if strings.Contains(lowerStderr, "ciphertext verification failed") {
+		return repoProbeKeyConfigMismatch
+	}
 	if strings.Contains(lowerStderr, "wrong password or no key found") ||
-		strings.Contains(lowerStderr, "ciphertext verification failed") ||
 		strings.Contains(lowerStderr, "is damaged") {
 		return repoProbeUnopenable
 	}
@@ -185,6 +198,35 @@ func classifyRepoProbe(lowerStderr string) repoProbeClass {
 		return repoProbeMissing
 	}
 	return repoProbeOther
+}
+
+// repoUnopenableMessage builds the operator-facing error for a repository that
+// EXISTS but cannot be opened. It is a single paragraph with no newlines: the
+// same text surfaces in a run-failure log AND in a short UI toast on the manual
+// "test connection" path, and a multi-line block is unreadable in the toast.
+// passwordFile is the restic password file the probe used (per-destination sealed
+// file or the shared default), named so the operator edits the right one.
+func repoUnopenableMessage(class repoProbeClass, repoURL, passwordFile, lowerStderr string) string {
+	switch class {
+	case repoProbeKeyConfigMismatch:
+		return fmt.Sprintf("backup repository at %q exists and a key file opened with the password at %s, "+
+			"so the password is CORRECT — do NOT restore or regenerate it. The failure (%s) is a key whose "+
+			"master does not match the repository config, which happens when two backups ran `restic init` on "+
+			"the same empty repository at once (leaving more than one key file and a single config), or the "+
+			"config is corrupt. To recover: if the repository's keys/ directory holds MORE THAN ONE file, move "+
+			"the key named in the error above out of keys/ and retry (restore it if that does not help); if keys/ "+
+			"holds exactly ONE file the config is corrupt — point this destination at a FRESH empty directory. "+
+			"The old snapshots stay on disk.",
+			repoURL, passwordFile, lowerStderr)
+	default: // repoProbeUnopenable
+		return fmt.Sprintf("backup repository at %q exists but this server cannot open it (%s). No stored key "+
+			"matches the password at %s — usually the server or that password file was reinstalled or regenerated "+
+			"while the repository directory was preserved, so the snapshots are sealed with a password this server "+
+			"no longer has. To recover: restore the ORIGINAL password file from before the reinstall, or point this "+
+			"destination at a FRESH empty directory to start a new repository — the old snapshots stay on disk but "+
+			"are unreadable without their original password.",
+			repoURL, lowerStderr, passwordFile)
+	}
 }
 
 // bkEnsureRepoReady probes the remote and runs mkdir -p (SFTP only) +
@@ -230,23 +272,22 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, p
 			return nil
 		}
 		lower := strings.ToLower(strings.TrimSpace(string(snapStderr)))
-		switch classifyRepoProbe(lower) {
-		case repoProbeUnopenable:
-			// A repository that EXISTS but cannot be opened (GH #454). Actionable
-			// message instead of the raw restic dump — see classifyRepoProbe.
-			return fmt.Errorf("backup repository at %q exists but this server cannot open it (%s).\n"+
-				"This usually means the server (or /etc/jabali-panel/restic-repo.password) was reinstalled or "+
-				"regenerated while the repository directory was preserved, so the snapshots are sealed with a "+
-				"password this server no longer has (or the repo's config/key files are corrupted). To recover: "+
-				"(a) restore the ORIGINAL /etc/jabali-panel/restic-repo.password from before the reinstall, or "+
-				"(b) point this backup destination at a FRESH empty directory to start a new repository — the old "+
-				"snapshots stay on disk but are unreadable without their original password.",
-				repoURL, lower)
+		switch cls := classifyRepoProbe(lower); cls {
+		case repoProbeMissing:
+			// Only an explicit missing-repo signal reaches `restic init` below.
+			// Fail-closed: any other class returns here, so a new class (or a
+			// dropped case) can never fall through to init an existing-but-broken
+			// repo — where "already initialized" is swallowed and the run proceeds
+			// to die later with a worse error.
 		case repoProbeOther:
 			// Not a missing-repo signal, not a known unopenable signal — surface raw.
 			return fmt.Errorf("snapshots probe: %w (stderr: %s)", snapErr, lower)
+		default:
+			// A repository that EXISTS but cannot be opened: a foreign/rotated
+			// password (GH #454) or a key/config mismatch from a concurrent-init
+			// race (JAB-405). Actionable message instead of the raw restic dump.
+			return errors.New(repoUnopenableMessage(cls, repoURL, pwFile, lower))
 		}
-		// repoProbeMissing → fall through to init below.
 		if destKind == "sftp" && sftp != nil && sftp.Host != "" {
 			if _, err := backup.MkdirRemoteSFTP(ctx, backup.SFTPInputs{
 				Host:    sftp.Host,

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -214,7 +214,7 @@ func repoUnopenableMessage(class repoProbeClass, repoURL, passwordFile, lowerStd
 			"master does not match the repository config, which happens when two backups ran `restic init` on "+
 			"the same empty repository at once (leaving more than one key file and a single config), or the "+
 			"config is corrupt. To recover: if the repository's keys/ directory holds MORE THAN ONE file, move "+
-			"the key named in the error above out of keys/ and retry (restore it if that does not help); if keys/ "+
+			"the key restic named in the error out of keys/ and retry (restore it if that does not help); if keys/ "+
 			"holds exactly ONE file the config is corrupt — point this destination at a FRESH empty directory. "+
 			"The old snapshots stay on disk.",
 			repoURL, passwordFile, lowerStderr)

--- a/panel-agent/internal/commands/backup_repo_probe_test.go
+++ b/panel-agent/internal/commands/backup_repo_probe_test.go
@@ -54,6 +54,8 @@ func TestClassifyRepoProbe(t *testing.T) {
 			// A bare "is damaged" without the ciphertext phrase (index/pack
 			// corruption) must NOT be mistaken for the key/config race — it keeps
 			// the generic unopenable hint, not the "count your key files" advice.
+			// (Synthetic fixture — pins classifier specificity, not a captured
+			// restic string, unlike the ciphertext case above.)
 			name:   "bare is-damaged (not ciphertext) stays unopenable",
 			stderr: "fatal: pack 1a2b3c is damaged: run `restic repair index`",
 			want:   repoProbeUnopenable,

--- a/panel-agent/internal/commands/backup_repo_probe_test.go
+++ b/panel-agent/internal/commands/backup_repo_probe_test.go
@@ -5,9 +5,22 @@ package commands
 // config/key files are corrupt) used to surface as a raw "snapshots probe:
 // exit status 1 (stderr: …)" that read as "backups are broken". classifyRepoProbe
 // separates that from a genuinely-missing repo (→ init) so the operator gets an
-// actionable recovery message. These strings are verbatim restic 0.16.4 output.
+// actionable recovery message. These strings are verbatim restic output
+// (captured against 0.16.4, re-checked on 0.18.0).
+//
+// JAB-405: the "config or key <id> is damaged: ciphertext verification failed"
+// signal is split out of the generic unopenable class into
+// repoProbeKeyConfigMismatch. A key opened with the password (so the password is
+// CORRECT) but its master can't decrypt config — the signature of two concurrent
+// `restic init` on one empty repo, NOT a wrong password. The two strings never
+// co-occur (verified: wrong-password vs an initialized repo yields
+// "wrong password or no key found"; the dual-key race yields the ciphertext
+// error), so they carry distinct recovery advice.
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestClassifyRepoProbe(t *testing.T) {
 	cases := []struct {
@@ -31,8 +44,18 @@ func TestClassifyRepoProbe(t *testing.T) {
 			want:   repoProbeUnopenable,
 		},
 		{
-			name:   "damaged config — the reporter's exact error",
+			// The dual-init race (JAB-405): a key opened but its master ≠ config.
+			// Distinct from a wrong password — password is correct here.
+			name:   "key/config mismatch — ciphertext verification failed",
 			stderr: "fatal: config or key eece3d748ff57531b620a3cd0441eb7cde4d1334762dab8c943efeba35c92397 is damaged: ciphertext verification failed",
+			want:   repoProbeKeyConfigMismatch,
+		},
+		{
+			// A bare "is damaged" without the ciphertext phrase (index/pack
+			// corruption) must NOT be mistaken for the key/config race — it keeps
+			// the generic unopenable hint, not the "count your key files" advice.
+			name:   "bare is-damaged (not ciphertext) stays unopenable",
+			stderr: "fatal: pack 1a2b3c is damaged: run `restic repair index`",
 			want:   repoProbeUnopenable,
 		},
 		{
@@ -47,5 +70,67 @@ func TestClassifyRepoProbe(t *testing.T) {
 				t.Errorf("classifyRepoProbe(%q) = %d, want %d", c.stderr, got, c.want)
 			}
 		})
+	}
+}
+
+// The key/config-mismatch message is the JAB-405 deliverable: it must tell the
+// operator the password is CORRECT (do not touch it) and give the key-file-count
+// recovery — and must NOT repeat the wrong-password "restore the ORIGINAL
+// password" advice, which is what shipped for this symptom before the split.
+func TestRepoUnopenableMessage_MismatchArm(t *testing.T) {
+	const pw = "/etc/jabali-panel/dest-7.password"
+	msg := repoUnopenableMessage(repoProbeKeyConfigMismatch,
+		"sftp:puzzle@host:/home/puzzle/jabali", pw,
+		"config or key abcd is damaged: ciphertext verification failed")
+
+	for _, want := range []string{
+		pw,               // names the exact password file — do not touch it
+		"CORRECT",        // password is correct
+		"do NOT restore", // anti-footgun: don't restore/regenerate the password
+		"keys/",          // recovery hinges on the key-file count
+		"MORE THAN ONE",  // >1 key → the race → move the named key aside
+		"exactly ONE",    // 1 key → genuine corruption → fresh dir
+		"FRESH empty",    // recovery destination for the corrupt-config path
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("mismatch message missing %q\ngot: %s", want, msg)
+		}
+	}
+	// Must NOT carry the wrong-password recovery — that advice destroys nothing
+	// but sends the operator to restore a password that is already correct.
+	for _, banned := range []string{"reinstalled or regenerated", "restore the ORIGINAL"} {
+		if strings.Contains(msg, banned) {
+			t.Errorf("mismatch message must not contain wrong-password advice %q\ngot: %s", banned, msg)
+		}
+	}
+	// Single paragraph — it also renders in a short UI toast.
+	if strings.Contains(msg, "\n") {
+		t.Errorf("mismatch message must be one line (no newline)\ngot: %s", msg)
+	}
+}
+
+func TestRepoUnopenableMessage_WrongPasswordArm(t *testing.T) {
+	const pw = "/etc/jabali-panel/restic-repo.password"
+	msg := repoUnopenableMessage(repoProbeUnopenable,
+		"/backups", pw, "wrong password or no key found")
+
+	for _, want := range []string{
+		pw, // names the password file to restore
+		"reinstalled or regenerated",
+		"restore the ORIGINAL",
+		"FRESH empty",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("wrong-password message missing %q\ngot: %s", want, msg)
+		}
+	}
+	// Must NOT carry the race-specific "count your key files" recovery.
+	for _, banned := range []string{"MORE THAN ONE", "password is CORRECT", "do NOT restore"} {
+		if strings.Contains(msg, banned) {
+			t.Errorf("wrong-password message must not contain mismatch advice %q\ngot: %s", banned, msg)
+		}
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("wrong-password message must be one line (no newline)\ngot: %s", msg)
 	}
 }


### PR DESCRIPTION
## What

`bkEnsureRepoReady` (and the manual "test connection" handler) classify a failed
restic probe so an unopenable repo gets an actionable recovery message instead of
a raw stderr dump. Until now `classifyRepoProbe` lumped two disjoint failures into
one `repoProbeUnopenable` class:

- `wrong password or no key found` — no stored key decrypts with the password
  (a host reinstall/rotation, GH #454).
- `config or key <id> is damaged: ciphertext verification failed` — a key file
  **did** open with the password (so the password is correct); its master key
  just can't decrypt `config`.

Both got the #454 hint: *"the password was reinstalled or regenerated — restore
the original."* For the second failure that advice is wrong: the password is
correct, and restoring it chases a file that was never the problem. That second
failure is the JAB-405 signature — two concurrent `restic init` on one empty repo
leave more than one key file and a single `config` only one key can decrypt
(prevented going forward by the per-destination init lock in #1676) — or a
genuinely corrupt `config`.

This is **Part 3 of JAB-405 (the diagnostic message)**.

## Change

- New `repoProbeKeyConfigMismatch` class. `classifyRepoProbe` matches the specific
  `ciphertext verification failed` phrase for it, and keeps a bare `is damaged`
  (index/pack corruption) on the generic unopenable hint.
- One shared, pure `repoUnopenableMessage(class, repoURL, passwordFile, stderr)`
  builder, used by **both doors**: the backup run (`bkEnsureRepoReady`) and the
  `backup.dest.test` handler, which previously returned the raw restic error.
  The mismatch arm: the password is correct — do not touch it; recovery hinges on
  the key-file count — if `keys/` holds more than one file, move the key restic
  named out of `keys/` and retry; if exactly one, the config is corrupt, point at
  a fresh empty directory.
- The `bkEnsureRepoReady` switch is now **fail-closed**: only an explicit
  `repoProbeMissing` continues to `restic init`; every other class returns. A
  future class (or a dropped case) can no longer fall through and init an
  existing-but-broken repo (where "already initialized" is swallowed and the run
  dies later with a worse error).
- The password path is now parametrized into both message arms (was hardcoded to
  the shared default), so a per-destination sealed password (M30.2.x) is named
  correctly.

## Why the wrong hint shipped

Verified empirically against restic 0.18.0: a wrong password on an **initialized**
repo yields `wrong password or no key found`; the dual-key race yields
`... is damaged: ciphertext verification failed`. **The two never co-occur** — a
plain reinstall does **not** produce the ciphertext error (to reach it a key must
open, which means the password is correct). Our own note that reinstall shows "the
same ciphertext symptom" was imprecise, and that conflation is why the #454
damaged-config reporter — and later puzzle — got the password-restore advice for a
symptom the password could not cause. (Internal memory corrected alongside this.)

## Surfaces / reviewer notes

- **Two doors, one message.** The `test connection` toast (`DestinationsTab`)
  renders `detail` via `feedback.message.error` (antd `message`, wraps, no
  truncation); it does **not** show the sibling `stderr` field. So the builder is
  a single paragraph with no newlines and quotes restic's stderr inline, and the
  recovery says "the key restic named in the error" (self-contained, not "see
  above"). The full text renders in the toast but is long — an operator may prefer
  to read it from the CLI (`jabali backup destination test`) or the job log.
  Switching that one error to a persistent `Alert` is a **UI follow-up**, not in
  this slice.
- The **wrong-password message went from five lines to one paragraph** — same
  content, no behavior change; it now shares the builder with the mismatch arm.
- The **fail-closed switch has no direct unit test** (it needs a live restic
  probe); it is covered structurally (only `case repoProbeMissing` continues), and
  the classifier + builder tests cover the message it emits.

## Tests

- `classifyRepoProbe`: ciphertext → mismatch; `wrong password` → unopenable;
  bare `is damaged` (synthetic fixture, labelled) → unopenable.
- Both message arms: required content present, the *other* arm's advice absent,
  single-line (no `\n`).
- `backupDestTestFailureResult` (extracted, pure): routes unopenable/mismatch
  through the shared message, keeps raw stderr, surfaces the raw error for an
  unclassified failure; plus a source-pin that the handler delegates to it.
- Five guards falsified against compiling neutralizations (classifier collapse;
  classifier over-broad on bare `is damaged`; mismatch arm content; helper
  routing; handler source-pin). No flag/route change → no golden regen. `go vet`
  clean; full `panel-agent/internal/commands` suite green.

## Not in this slice

**Part 2 of JAB-405 — automated repair** (move the mismatched key aside,
re-probe, confirm data is readable under the surviving key, else restore and fail
loud). It mutates remote key files on a live backup repo and is a separate,
box-verified slice.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
