### PR TITLE
feat(nginx): surface tenant domain options to tenants and admins (GH #1624, ADR-0169 Phase 1)

### DIFF
--- a/docs/site/admin/server-settings.md
+++ b/docs/site/admin/server-settings.md
@@ -9,6 +9,8 @@
 - **Default IP pool** — the IP returned by zone creation when no per-domain override is set.
 - **Default package** — the package assigned to new users if the form is left blank.
 - **Locale** — default UI locale for new users; users may override per-account.
+- **Tenant domain options** — off by default. When on, non-admin domain owners get two extra tabs on their own domains: *Domain options* (a curated, safe set of nginx options — max upload size, HSTS, security headers, gzip — each rendered as a fixed, vetted directive) and *Rewrite rules* (structured `rewrite` and `custom_header` rules, each validated; a `rewrite` target is forced to a local path so it can't become an open redirect or proxy). Raw nginx directives, `proxy_pass`, IP access, and PHP settings stay admin-only regardless. Surfaced to tenants on the [Domains](../user/domains.md#nginx-options-and-rewrite-rules) page.
+- **Tenant document-root editing** — on by default. Lets non-admin owners repoint a domain's document root to a folder inside that domain's own tree (e.g. a framework's `public/` subdir); confined server-side so it can't escape the domain.
 
 ## Database
 

--- a/docs/site/user/domains.md
+++ b/docs/site/user/domains.md
@@ -38,6 +38,17 @@ You may change PHP version (from the subset your package allows), SSL on/off, DN
 
 The admin controls listen IP (selected from the [IP Manager](../admin/ip-addresses.md) pool), maximum domain count, and quota-related suspension. The admin may also pin SSL on or force a specific PHP version on a domain; in that case the relevant control is read-only on your side.
 
+## Nginx options and rewrite rules
+
+Two extra per-domain tabs — **Domain options** and **Rewrite rules** — appear only when your administrator has enabled *tenant domain options* for the server. Until then the tabs are hidden, and the domain's Overview shows a short note that your administrator can turn these controls on.
+
+When they are enabled you can, on your own domains:
+
+- **Domain options** — set a curated, safe set of nginx options: maximum upload size, HSTS, the common security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), and gzip. You supply values; each option renders to a fixed, vetted directive — never raw config.
+- **Rewrite rules** — add two kinds of structured rule. A `rewrite` rule whose target must be a local path (no scheme or host, so it can never become an open redirect or a proxy to another service), and a `custom_header` rule that adds one response header. Every rule is validated before it is applied.
+
+Raw nginx directives, reverse-proxy targets, IP access rules, and PHP settings stay admin-only whether or not tenant domain options are enabled. Your administrator turns the feature on under [Server Settings → General](../admin/server-settings.md#general).
+
 ## CLI
 
 If you have SSH access to the panel host (operators only — tenants do not have shell access), the same operations are available via `jabali domain list / create / enable / disable / delete`.

--- a/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
@@ -6,8 +6,9 @@ import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { apiClient } from "../../../apiClient";
 
 // TenantDomainOptionsCard — Server Settings → General: opt non-admin domain
-// owners into the curated safe nginx options (GH #307). Off by default; raw
-// nginx directives stay admin-only regardless.
+// owners into the curated safe nginx options plus the tenant-safe rewrite /
+// custom_header rule builder (GH #307, GH #1624). Off by default; raw nginx
+// directives (proxy_pass, IP access, PHP settings) stay admin-only regardless.
 export const TenantDomainOptionsCard = () => {
   const { t } = useTranslation();
   const [enabled, setEnabled] = useState(false);
@@ -66,9 +67,10 @@ export const TenantDomainOptionsCard = () => {
     <Card title={t("tenantdomainoptionscard.tenant_domain_options")} style={{ marginBottom: 16 }} loading={loading}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Let non-admin users set a curated, safe set of nginx options on their own
-        domains — max upload size, HSTS, security headers, and gzip. The panel
-        renders fixed directives; raw nginx directives and the rule builder stay
-        admin-only either way.
+        domains — max upload size, HSTS, security headers, and gzip — plus a
+        limited rewrite / custom-response-header rule builder. The panel validates
+        every rule and renders fixed directives; raw nginx directives, proxy_pass,
+        IP access, and PHP settings stay admin-only either way.
       </Typography.Paragraph>
       <Switch checked={enabled} loading={saving} onChange={onToggle} checkedChildren="On" unCheckedChildren="Off" />
       <Typography.Paragraph type="secondary" style={{ marginTop: 20, marginBottom: 8 }}>

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -246,6 +246,24 @@ describe("WebDomainPage (GH #1543)", () => {
     expect(screen.queryByText("options-pane:d1")).not.toBeInTheDocument();
   });
 
+  it("shows a discoverability hint on Overview when tenant domain options are off (GH #1624)", async () => {
+    // caps off (beforeEach default): the gated tabs are hidden, so the Overview
+    // pane invites the tenant to have the admin enable the feature.
+    renderAt("/jabali-panel/domains/d1");
+    expect(
+      await screen.findByText(/More domain controls are available on request/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the discoverability hint once tenant domain options are on (GH #1624)", async () => {
+    caps.value = { tenant_domain_options_enabled: true, tenant_docroot_editable: false };
+    renderAt("/jabali-panel/domains/d1");
+    await screen.findByText("Preview URL");
+    expect(
+      screen.queryByText(/More domain controls are available on request/),
+    ).not.toBeInTheDocument();
+  });
+
   it("surfaces an error when the domain can't be loaded", async () => {
     domainQ.value = { data: undefined, isLoading: false, isError: true };
     renderAt("/jabali-panel/domains/d1");

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -99,6 +99,12 @@ export const WebDomainPage = () => {
   // sees neither the menu item nor the tab (never a disabled stub).
   const optionsOn = caps?.tenant_domain_options_enabled === true;
   const docrootOn = caps?.tenant_docroot_editable === true;
+  // GH #1624: with the cap off the two gated tabs are hidden (never a disabled
+  // stub — see below), so a tenant has no way to learn the feature exists. Show
+  // a small note on the Overview pane inviting them to ask the admin to enable
+  // it. Gate on an explicit `false` (not `undefined`) so it doesn't flash while
+  // capabilities are still loading.
+  const showOptionsHint = caps?.tenant_domain_options_enabled === false;
   // DNS renders here as a tab (GH #1543). Gate on the same dns_enabled signal
   // the sidebar and the old row-menu item used — default-on while caps load.
   // The tenant DNS Zones overview page links straight into this tab to manage a
@@ -106,7 +112,23 @@ export const WebDomainPage = () => {
   const dnsOn = caps?.dns_enabled !== false;
 
   const tabs: { key: string; label: string; node: ReactNode }[] = [
-    { key: "overview", label: "Overview", node: <OverviewTab domain={domain} /> },
+    {
+      key: "overview",
+      label: "Overview",
+      node: (
+        <Space direction="vertical" size="large" style={{ width: "100%" }}>
+          <OverviewTab domain={domain} />
+          {showOptionsHint && (
+            <Alert
+              type="info"
+              showIcon
+              message="More domain controls are available on request"
+              description="When your administrator enables tenant domain options for this server, you get two extra tabs on your domains: a curated set of safe nginx options (max upload size, HSTS, security headers, gzip) and a limited rewrite / custom-response-header rule builder. Raw nginx directives stay admin-only."
+            />
+          )}
+        </Space>
+      ),
+    },
     // Logs is a read-only diagnostic view — the most-checked thing after
     // "is the site up" — so it sits second, before the editors. It exists for
     // every web domain, so it is not cap-gated.


### PR DESCRIPTION
## Summary

ADR-0169 **Phase 1** (surface + document) for GH #1624. Make the `TenantDomainOptionsEnabled` server setting discoverable and correctly documented. **No new trust surface** — the setting already gates the tenant `rewrite`/`custom_header` rule builder (`panel-api/internal/api/domains.go:1028`) and the curated `NginxSafeOptions` (`domains.go:1152`); this PR only surfaces and documents what already exists. Phases 2–5 (widening tenant rule types, unifying the structured builder with raw directives) remain separate and approval-gated.

## What changed

1. **`docs/site/user/domains.md`** — new "Nginx options and rewrite rules" section: what the *Domain options* and *Rewrite rules* tabs give a tenant, that they appear only when the admin enables tenant domain options, and what stays admin-only.
2. **`docs/site/admin/server-settings.md`** — document the **Tenant domain options** and **Tenant document-root editing** toggles under General.
3. **`WebDomainPage.tsx`** — when the cap is off, the Overview pane shows a small info note so a tenant can discover the feature and ask the admin to enable it. Informational only — still **no disabled tab stub** (the existing "never a disabled stub" behaviour is preserved). Covered by two tests, fail-first verified.
4. **`TenantDomainOptionsCard.tsx`** — **bug fix.** The admin help text said the rule builder *"stay[s] admin-only either way"*, which is wrong: this toggle is exactly what grants tenants the `rewrite`/`custom_header` rule builder. The misleading copy actively suppressed discoverability. It now names what the toggle unlocks and what genuinely stays admin-only (raw directives, `proxy_pass`, IP access, PHP settings).

## Noticed, not touched

ADR-0169 line 33 calls the safe options "owner-settable", but the code gates `NginxSafeOptions` on admin **or** `tenant_domain_options_enabled` (`domains.go:1152-1166`) — i.e. not owner-settable by default. A docs/ADR wording nit for a later phase, left as-is here.

## Tests

`panel-ui` vitest full suite: **733 passed**. The new `WebDomainPage` hint tests were verified fail-first (disabling the render fails the "hint shown when off" test). `tsc --noEmit` and `eslint` clean. No E2E selector collision (no spec queries `role="alert"` on the tenant domain page).

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
