### PR TITLE
feat(backup): count a corrupt repo's key files to sharpen the race message (JAB-405 Part 2a)

### DIFF
--- a/internal/backup/sftpls.go
+++ b/internal/backup/sftpls.go
@@ -1,0 +1,76 @@
+// Package backup — SFTP remote-ls helper for M30.1 destinations (JAB-405 Part 2a).
+//
+// A repository corrupted by a concurrent-init race (two `restic init` on one
+// empty repo → more than one key file but a single config only one key can
+// decrypt) cannot be opened by restic at all — `restic key list` itself dies
+// with the same `ciphertext verification failed`, because restic opens config
+// before it lists keys. So to tell an operator whether a key/config mismatch is
+// the race (move a key aside and retry) or a genuinely corrupt config (start
+// fresh), the agent counts the key files by listing the repository's keys/
+// directory DIRECTLY, below restic: `ssh user@host -- ls -1 <path>/keys` for an
+// SFTP repo, os.ReadDir for a local one.
+package backup
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// buildSSHConnArgs assembles the argv prefix shared by every remote ssh exec:
+// `[sshpass -e] ssh [-i KEY -o IdentitiesOnly=yes] -o StrictHostKeyChecking=...
+// [auth opts] [-p PORT] user@host`. The caller appends `--` and the remote
+// command. Extracted from buildSSHMkdirArgs so mkdir and ls share one auth path;
+// TestBuildSSHMkdirArgs_Pin holds the mkdir argv byte-for-byte across the
+// extraction.
+func buildSSHConnArgs(in SFTPInputs) []string {
+	parts := []string{}
+	if in.Auth == "password" {
+		parts = append(parts, "sshpass", "-e")
+	}
+	parts = append(parts, "ssh")
+	if in.Auth == "key" && in.KeyPath != "" {
+		parts = append(parts, "-i", in.KeyPath, "-o", "IdentitiesOnly=yes")
+	}
+	parts = append(parts, "-o", "StrictHostKeyChecking=accept-new")
+	if in.Auth == "password" {
+		parts = append(parts, "-o", "PreferredAuthentications=password",
+			"-o", "PubkeyAuthentication=no")
+	} else {
+		parts = append(parts, "-o", "BatchMode=yes")
+	}
+	if in.Port > 0 && in.Port != 22 {
+		parts = append(parts, "-p", fmt.Sprintf("%d", in.Port))
+	}
+	parts = append(parts, fmt.Sprintf("%s@%s", in.User, in.Host))
+	return parts
+}
+
+// buildSSHListArgs assembles the argv for `[conn] -- ls -1 <remotePath>`.
+// remotePath is passed as a single argv element (no shell), so spaces or shell
+// metacharacters in the repository path cannot split into extra arguments.
+func buildSSHListArgs(in SFTPInputs, remotePath string) []string {
+	return append(buildSSHConnArgs(in), "--", "ls", "-1", remotePath)
+}
+
+// ListRemoteSFTP runs `ssh user@host -- ls -1 <remotePath>` over the same auth
+// path restic's sftp.command uses (sshpass for password, `-i <key>` for key
+// auth, `-p N` for non-22 ports) and returns the raw combined output. It is
+// READ-ONLY — it never creates, moves, or deletes anything. Callers parse the
+// output for restic key-file names. On error the combined output is returned so
+// the caller can fold a short diagnostic into a fail-soft message.
+func ListRemoteSFTP(ctx context.Context, in SFTPInputs, remotePath string, extraEnv []string) ([]byte, error) {
+	if in.Host == "" || in.User == "" {
+		return nil, fmt.Errorf("sftp: host+user required")
+	}
+	args := buildSSHListArgs(in, remotePath)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = append(cmd.Environ(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("ssh ls -1 %s: %w (output: %s)",
+			remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}

--- a/internal/backup/sftpls_test.go
+++ b/internal/backup/sftpls_test.go
@@ -1,0 +1,102 @@
+package backup
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestBuildSSHMkdirArgs_Pin freezes the exact argv buildSSHMkdirArgs produces
+// for every auth mode BEFORE the shared-base refactor (JAB-405 Part 2a extracts
+// buildSSHConnArgs, shared with the new ls builder). If the extraction changes
+// any argv element — most importantly the `--` separator that stops ssh from
+// treating the remote command as more of its own options — this pin goes red.
+func TestBuildSSHMkdirArgs_Pin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   SFTPInputs
+		want []string
+	}{
+		{
+			name: "password auth",
+			in:   SFTPInputs{User: "u", Host: "h", Path: "/p", Auth: "password"},
+			want: []string{
+				"sshpass", "-e", "ssh",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "PreferredAuthentications=password",
+				"-o", "PubkeyAuthentication=no",
+				"u@h", "--", "mkdir", "-p", "/p",
+			},
+		},
+		{
+			name: "key auth with key path",
+			in:   SFTPInputs{User: "u", Host: "h", Path: "/p", Auth: "key", KeyPath: "/k"},
+			want: []string{
+				"ssh", "-i", "/k", "-o", "IdentitiesOnly=yes",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "BatchMode=yes",
+				"u@h", "--", "mkdir", "-p", "/p",
+			},
+		},
+		{
+			name: "default auth (no key, no password)",
+			in:   SFTPInputs{User: "u", Host: "h", Path: "/p"},
+			want: []string{
+				"ssh",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "BatchMode=yes",
+				"u@h", "--", "mkdir", "-p", "/p",
+			},
+		},
+		{
+			name: "non-22 port on key auth",
+			in:   SFTPInputs{User: "u", Host: "h", Path: "/p", Auth: "key", KeyPath: "/k", Port: 2222},
+			want: []string{
+				"ssh", "-i", "/k", "-o", "IdentitiesOnly=yes",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "BatchMode=yes",
+				"-p", "2222",
+				"u@h", "--", "mkdir", "-p", "/p",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildSSHMkdirArgs(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("argv mismatch\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildSSHListArgs pins the ls argv: the shared connection prefix, then a
+// `--` separator (so ssh stops parsing its own options), then `ls -1` and the
+// remote path as ONE argv element — a path with spaces or metacharacters can
+// never split into extra arguments. Falsify by dropping the `--`, or by joining
+// the remote command into a single string.
+func TestBuildSSHListArgs(t *testing.T) {
+	t.Parallel()
+
+	got := buildSSHListArgs(
+		SFTPInputs{User: "u", Host: "h", Auth: "key", KeyPath: "/k", Port: 2222},
+		"/home/puzzle/jabali/keys",
+	)
+	want := []string{
+		"ssh", "-i", "/k", "-o", "IdentitiesOnly=yes",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "BatchMode=yes",
+		"-p", "2222",
+		"u@h", "--", "ls", "-1", "/home/puzzle/jabali/keys",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ls argv mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+
+	// A path with a space stays a single argv element (argv exec, no shell).
+	spaced := buildSSHListArgs(SFTPInputs{User: "u", Host: "h"}, "/a b/keys")
+	if last := spaced[len(spaced)-1]; last != "/a b/keys" {
+		t.Errorf("remote path split into extra args: last argv element = %q", last)
+	}
+}

--- a/internal/backup/sftpmkdir.go
+++ b/internal/backup/sftpmkdir.go
@@ -45,27 +45,9 @@ func MkdirRemoteSFTP(ctx context.Context, in SFTPInputs, extraEnv []string) ([]b
 }
 
 // buildSSHMkdirArgs assembles the argv for `[sshpass -e] ssh [-i KEY]
-// [-p PORT] [-o ...] user@host mkdir -p PATH`.
+// [-p PORT] [-o ...] user@host -- mkdir -p PATH`. The connection prefix is
+// shared with the ls builder via buildSSHConnArgs (sftpls.go);
+// TestBuildSSHMkdirArgs_Pin freezes this argv unchanged across that extraction.
 func buildSSHMkdirArgs(in SFTPInputs) []string {
-	parts := []string{}
-	if in.Auth == "password" {
-		parts = append(parts, "sshpass", "-e")
-	}
-	parts = append(parts, "ssh")
-	if in.Auth == "key" && in.KeyPath != "" {
-		parts = append(parts, "-i", in.KeyPath, "-o", "IdentitiesOnly=yes")
-	}
-	parts = append(parts, "-o", "StrictHostKeyChecking=accept-new")
-	if in.Auth == "password" {
-		parts = append(parts, "-o", "PreferredAuthentications=password",
-			"-o", "PubkeyAuthentication=no")
-	} else {
-		parts = append(parts, "-o", "BatchMode=yes")
-	}
-	if in.Port > 0 && in.Port != 22 {
-		parts = append(parts, "-p", fmt.Sprintf("%d", in.Port))
-	}
-	parts = append(parts, fmt.Sprintf("%s@%s", in.User, in.Host))
-	parts = append(parts, "--", "mkdir", "-p", in.Path)
-	return parts
+	return append(buildSSHConnArgs(in), "--", "mkdir", "-p", in.Path)
 }

--- a/panel-agent/internal/commands/backup_dest_testconn.go
+++ b/panel-agent/internal/commands/backup_dest_testconn.go
@@ -129,7 +129,32 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 		// concurrent-init key/config mismatch — JAB-405) gets the same actionable
 		// Detail as a real backup run, not a raw restic dump the operator can't
 		// act on.
-		return backupDestTestFailureResult(p.URL, backup.DefaultPasswordFile, stderrStr, err), nil
+		//
+		// For the key/config mismatch, count the key files (below restic, which
+		// can't open the repo to list them) so the operator sees the exact key to
+		// move vs "config corrupt, start fresh" (JAB-405 Part 2a). This door has no
+		// destKind field, so infer it from the request: an SFTP block → sftp, an
+		// absolute URL → a local repo path, anything else unsupported. Read-only,
+		// fail-soft — a listing failure is folded into the message, never returned
+		// in its place. The door does NOT auto-repair (that is Part 2b); it only
+		// counts.
+		var keys *repoKeyListing
+		var listErr error
+		if classifyRepoProbe(lower) == repoProbeKeyConfigMismatch {
+			kind := ""
+			switch {
+			case p.SFTP != nil && p.SFTP.Host != "":
+				kind = backup.KindSFTP
+			case strings.HasPrefix(p.URL, "/"):
+				kind = backup.KindLocal
+			}
+			if ids, lerr := listRepoKeys(ctx, kind, p.URL, p.SFTP, extraEnv); lerr != nil {
+				listErr = lerr
+			} else {
+				keys = &repoKeyListing{ids: ids, named: mismatchKeyID(lower)}
+			}
+		}
+		return backupDestTestFailureResult(p.URL, backup.DefaultPasswordFile, stderrStr, err, keys, listErr), nil
 	}
 	return backupDestTestResult{
 		Status:        "ok",
@@ -142,13 +167,13 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 // repoProbeKeyConfigMismatch) gets the shared actionable message in Detail; any
 // other failure surfaces the raw error. The raw restic stderr is always kept in
 // Stderr. Pure — no restic call — so it is unit-testable from stderr fixtures.
-func backupDestTestFailureResult(url, passwordFile, stderrStr string, probeErr error) backupDestTestResult {
+func backupDestTestFailureResult(url, passwordFile, stderrStr string, probeErr error, keys *repoKeyListing, listErr error) backupDestTestResult {
 	lower := strings.ToLower(stderrStr)
 	switch cls := classifyRepoProbe(lower); cls {
 	case repoProbeUnopenable, repoProbeKeyConfigMismatch:
 		return backupDestTestResult{
 			Status: "error",
-			Detail: repoUnopenableMessage(cls, url, passwordFile, lower),
+			Detail: repoUnopenableMessage(cls, url, passwordFile, lower, keys, listErr),
 			Stderr: stderrStr,
 		}
 	default:

--- a/panel-agent/internal/commands/backup_dest_testconn.go
+++ b/panel-agent/internal/commands/backup_dest_testconn.go
@@ -147,6 +147,11 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 				kind = backup.KindSFTP
 			case strings.HasPrefix(p.URL, "/"):
 				kind = backup.KindLocal
+			default:
+				// s3:/b2:/rest:… — not a listable backend. Name the URL scheme so
+				// the fail-soft note reads honestly ("… for a \"s3\" backend")
+				// instead of an empty backend name.
+				kind, _, _ = strings.Cut(p.URL, ":")
 			}
 			if ids, lerr := listRepoKeys(ctx, kind, p.URL, p.SFTP, extraEnv); lerr != nil {
 				listErr = lerr

--- a/panel-agent/internal/commands/backup_dest_testconn_test.go
+++ b/panel-agent/internal/commands/backup_dest_testconn_test.go
@@ -24,7 +24,7 @@ func TestBackupDestTestFailureResult(t *testing.T) {
 
 	t.Run("key/config mismatch gets the race message", func(t *testing.T) {
 		stderr := "Fatal: config or key abcd is damaged: ciphertext verification failed"
-		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"))
+		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"), nil, nil)
 		if res.Status != "error" {
 			t.Fatalf("status = %q, want error", res.Status)
 		}
@@ -43,7 +43,7 @@ func TestBackupDestTestFailureResult(t *testing.T) {
 
 	t.Run("wrong password gets the reinstall message", func(t *testing.T) {
 		stderr := "Fatal: wrong password or no key found"
-		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"))
+		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"), nil, nil)
 		if !strings.Contains(res.Detail, "reinstalled or regenerated") {
 			t.Errorf("Detail is not the wrong-password message: %q", res.Detail)
 		}
@@ -54,7 +54,7 @@ func TestBackupDestTestFailureResult(t *testing.T) {
 
 	t.Run("unknown failure surfaces the raw error", func(t *testing.T) {
 		stderr := "Fatal: unable to connect: connection refused"
-		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"))
+		res := backupDestTestFailureResult(url, pw, stderr, errors.New("snapshots: exit status 1"), nil, nil)
 		if res.Detail != "snapshots: exit status 1" {
 			t.Errorf("Detail = %q, want the raw probe error for an unclassified failure", res.Detail)
 		}

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -200,24 +201,175 @@ func classifyRepoProbe(lowerStderr string) repoProbeClass {
 	return repoProbeOther
 }
 
+// resticKeyIDRE matches a restic key-file name: a 32-byte key id, hex-encoded to
+// 64 lowercase hex chars. Filtering keys/ entries on it counts real key files
+// only, dropping any stray (a moved-aside .jabali-* key, a lost+found).
+var resticKeyIDRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// mismatchKeyIDRE pulls the key id restic names in
+// "config or key <id> is damaged: ciphertext verification failed". The id is the
+// full 64-hex key-file name (verified against restic 0.18.0), so it matches a
+// keys/ entry exactly — the key whose master does not decrypt config.
+var mismatchKeyIDRE = regexp.MustCompile(`config or key ([0-9a-f]{64}) is damaged`)
+
+// repoKeyListing is the result of counting a repository's key files (JAB-405
+// Part 2a). It sharpens the key/config-mismatch message from "count the files
+// yourself" to a concrete count plus which key restic named. A nil *repoKeyListing
+// means the count was not available — an unsupported backend, or a listing that
+// failed (carried separately as listErr) — and the message falls back to the
+// generic count-it-yourself guidance.
+type repoKeyListing struct {
+	ids   []string // key-file names in keys/, each a 64-hex restic key id
+	named string   // the key id restic named in the ciphertext error, "" if unparsed
+}
+
+// namedPresent reports whether the key restic named in the error is actually one
+// of the listed key files. The move-aside recovery is only ever suggested when
+// this holds: if the named key is absent, the listing does not match the failure
+// and moving a file would be blind (the 2b safety invariant, surfaced as advice).
+func (l *repoKeyListing) namedPresent() bool {
+	if l == nil || l.named == "" {
+		return false
+	}
+	for _, id := range l.ids {
+		if id == l.named {
+			return true
+		}
+	}
+	return false
+}
+
+// parseKeyIDs extracts restic key-file names from `ls -1` output (one name per
+// line), keeping only 64-hex entries so a stray file never inflates the count.
+func parseKeyIDs(raw []byte) []string {
+	var ids []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		name := strings.TrimSpace(line)
+		if resticKeyIDRE.MatchString(name) {
+			ids = append(ids, name)
+		}
+	}
+	return ids
+}
+
+// mismatchKeyID returns the key id restic named in a lowered ciphertext-mismatch
+// stderr, or "" if the phrase is not present or the id can't be parsed.
+func mismatchKeyID(lowerStderr string) string {
+	if m := mismatchKeyIDRE.FindStringSubmatch(lowerStderr); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// listRepoKeysTimeout bounds the read-only keys/ listing that a mismatch failure
+// folds in for diagnostics. The probe already reached the repo (a ciphertext
+// error means ssh auth and reachability were fine), so a hang is unlikely; the
+// bound just guarantees the diagnostic never makes the failure materially slower.
+const listRepoKeysTimeout = 30 * time.Second
+
+// listRepoKeys lists the restic key-file names in a repository's keys/ directory
+// directly, BELOW restic — restic cannot open a config-mismatched repo to list
+// keys itself (`restic key list` dies with the same ciphertext error, since it
+// opens config first). SFTP → `ssh user@host -- ls -1 <path>/keys`; local →
+// os.ReadDir. Any other backend is unsupported and returns an error the caller
+// folds into a fail-soft message. Read-only — it never creates, moves, or
+// deletes anything.
+func listRepoKeys(ctx context.Context, destKind, repoURL string, sftp *backupSFTPInputs, extraEnv []string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, listRepoKeysTimeout)
+	defer cancel()
+
+	switch {
+	case destKind == backup.KindSFTP && sftp != nil && sftp.Host != "":
+		out, err := backup.ListRemoteSFTP(ctx, backup.SFTPInputs{
+			Host:    sftp.Host,
+			User:    sftp.User,
+			Port:    sftp.Port,
+			Path:    sftp.Path,
+			Auth:    sftp.Auth,
+			KeyPath: sftp.KeyPath,
+		}, path.Join(sftp.Path, "keys"), extraEnv)
+		if err != nil {
+			return nil, err
+		}
+		return parseKeyIDs(out), nil
+	case destKind == backup.KindLocal:
+		entries, err := os.ReadDir(filepath.Join(repoURL, "keys"))
+		if err != nil {
+			return nil, fmt.Errorf("read keys dir: %w", err)
+		}
+		var ids []string
+		for _, e := range entries {
+			if resticKeyIDRE.MatchString(e.Name()) {
+				ids = append(ids, e.Name())
+			}
+		}
+		return ids, nil
+	default:
+		return nil, fmt.Errorf("cannot list keys/ for a %q backend", destKind)
+	}
+}
+
 // repoUnopenableMessage builds the operator-facing error for a repository that
 // EXISTS but cannot be opened. It is a single paragraph with no newlines: the
 // same text surfaces in a run-failure log AND in a short UI toast on the manual
 // "test connection" path, and a multi-line block is unreadable in the toast.
 // passwordFile is the restic password file the probe used (per-destination sealed
 // file or the shared default), named so the operator edits the right one.
-func repoUnopenableMessage(class repoProbeClass, repoURL, passwordFile, lowerStderr string) string {
+//
+// For the key/config-mismatch class (JAB-405), keys carries a key-file count when
+// one is available (Part 2a): a known count turns the generic "count them
+// yourself" guidance into a concrete instruction — the race (≥2 keys incl. the
+// named one) vs a corrupt config (exactly 1) vs a listing that does not match the
+// error (do NOT move anything). keys nil with a non-nil listErr keeps the generic
+// guidance and appends why the count is missing (fail-soft: a listing failure
+// never masks the underlying mismatch). listErr is flattened to one line so the
+// toast stays a single paragraph.
+func repoUnopenableMessage(class repoProbeClass, repoURL, passwordFile, lowerStderr string, keys *repoKeyListing, listErr error) string {
 	switch class {
 	case repoProbeKeyConfigMismatch:
-		return fmt.Sprintf("backup repository at %q exists and a key file opened with the password at %s, "+
+		preamble := fmt.Sprintf("backup repository at %q exists and a key file opened with the password at %s, "+
 			"so the password is CORRECT — do NOT restore or regenerate it. The failure (%s) is a key whose "+
 			"master does not match the repository config, which happens when two backups ran `restic init` on "+
 			"the same empty repository at once (leaving more than one key file and a single config), or the "+
-			"config is corrupt. To recover: if the repository's keys/ directory holds MORE THAN ONE file, move "+
-			"the key restic named in the error out of keys/ and retry (restore it if that does not help); if keys/ "+
-			"holds exactly ONE file the config is corrupt — point this destination at a FRESH empty directory. "+
-			"The old snapshots stay on disk.",
+			"config is corrupt.",
 			repoURL, passwordFile, lowerStderr)
+
+		var recovery string
+		switch {
+		case keys != nil && len(keys.ids) >= 2 && keys.namedPresent():
+			// The race: more than one key file and the key restic named is one of
+			// them. Name the exact file to move so there is no guessing.
+			recovery = fmt.Sprintf(" To recover: the keys/ directory holds %d key files and one is the key restic "+
+				"named (%s), so this is the concurrent-init race — move keys/%s out of keys/ and retry (restore it "+
+				"if that does not help). The old snapshots stay on disk.",
+				len(keys.ids), keys.named, keys.named)
+		case keys != nil && len(keys.ids) == 1 && keys.namedPresent():
+			// One key file that still can't decrypt config: the config itself is
+			// corrupt, so there is nothing to move — start fresh.
+			recovery = " To recover: the keys/ directory holds exactly ONE key file, so the config itself is " +
+				"corrupt — point this destination at a FRESH empty directory. The old snapshots stay on disk."
+		case keys != nil:
+			// Listing succeeded but does not match the error (the named key is absent,
+			// or no key files parsed). Do NOT tell the operator to move anything — a
+			// blind move is exactly what the 2b safety invariant forbids.
+			recovery = fmt.Sprintf(" To recover: the keys/ directory holds %d key files but the key restic named "+
+				"in the error is not among them, so the listing does not match the failure — do NOT move any key "+
+				"file; treat the repository as corrupt and point this destination at a FRESH empty directory. The "+
+				"old snapshots stay on disk.",
+				len(keys.ids))
+		default:
+			// Count unavailable — keep the original count-it-yourself guidance, byte
+			// for byte, then say why the automatic count is missing if a list failed.
+			recovery = " To recover: if the repository's keys/ directory holds MORE THAN ONE file, move " +
+				"the key restic named in the error out of keys/ and retry (restore it if that does not help); if keys/ " +
+				"holds exactly ONE file the config is corrupt — point this destination at a FRESH empty directory. " +
+				"The old snapshots stay on disk."
+			if listErr != nil {
+				recovery += " (Could not list keys/ to count the key files automatically: " +
+					strings.Join(strings.Fields(listErr.Error()), " ") + ".)"
+			}
+		}
+		return preamble + recovery
 	default: // repoProbeUnopenable
 		return fmt.Sprintf("backup repository at %q exists but this server cannot open it (%s). No stored key "+
 			"matches the password at %s — usually the server or that password file was reinstalled or regenerated "+
@@ -286,7 +438,23 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, p
 			// A repository that EXISTS but cannot be opened: a foreign/rotated
 			// password (GH #454) or a key/config mismatch from a concurrent-init
 			// race (JAB-405). Actionable message instead of the raw restic dump.
-			return errors.New(repoUnopenableMessage(cls, repoURL, pwFile, lower))
+			//
+			// For the mismatch class, count the key files (below restic, which
+			// can't open the repo to list them) so the message can name the exact
+			// key to move vs "the config is corrupt, start fresh" (JAB-405 Part
+			// 2a). Read-only. Fail-soft: a listing error is folded into the message,
+			// never returned in place of the mismatch — the operator must still see
+			// why the backup failed.
+			var keys *repoKeyListing
+			var listErr error
+			if cls == repoProbeKeyConfigMismatch {
+				if ids, err := listRepoKeys(ctx, destKind, repoURL, sftp, extraEnv); err != nil {
+					listErr = err
+				} else {
+					keys = &repoKeyListing{ids: ids, named: mismatchKeyID(lower)}
+				}
+			}
+			return errors.New(repoUnopenableMessage(cls, repoURL, pwFile, lower, keys, listErr))
 		}
 		if destKind == "sftp" && sftp != nil && sftp.Host != "" {
 			if _, err := backup.MkdirRemoteSFTP(ctx, backup.SFTPInputs{

--- a/panel-agent/internal/commands/backup_repo_keys_test.go
+++ b/panel-agent/internal/commands/backup_repo_keys_test.go
@@ -1,0 +1,194 @@
+package commands
+
+// JAB-405 Part 2a: count a corrupt repo's key files below restic (which can't
+// open it to list them) so the key/config-mismatch message names the exact key
+// to move — the concurrent-init race (≥2 keys incl. the named one) vs a corrupt
+// config (exactly 1) vs a listing that does not match the error (move nothing).
+// Read-only, fail-soft: a listing failure never masks the mismatch itself.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+// Real 64-hex restic key ids captured from a reproduced dual-key/one-config repo.
+const (
+	keyA = "3c0bdcd033d53757bd511b5755967c0ab681e9d103ecc52aab4ba096d89f6f76"
+	keyB = "d14707bdd8fc5db506b23abc1253eeefeca7165070341525856db3a9cef2107e"
+	// A well-formed key id that is NOT in a two-key listing — the error names a
+	// key the listing does not contain.
+	keyGhost = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+)
+
+func TestParseKeyIDs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"two keys", keyA + "\n" + keyB + "\n", 2},
+		{"stray non-key file and blank line ignored", keyA + "\n" + keyB + "\n.jabali-quarantine-123\n\n", 2},
+		{"restic layout names are not keys", "config\ndata\nindex\nkeys\nsnapshots\n", 0},
+		{"empty output", "", 0},
+		{"trailing spaces trimmed", "  " + keyA + "  \n", 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := len(parseKeyIDs([]byte(c.raw))); got != c.want {
+				t.Errorf("parseKeyIDs(%q) counted %d, want %d", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMismatchKeyID(t *testing.T) {
+	t.Parallel()
+	// Verbatim restic 0.18.0 stderr, lowercased (classifyRepoProbe lowercases
+	// before this runs). The id is the full 64-hex key-file name.
+	lower := "fatal: config or key " + keyA + " is damaged: ciphertext verification failed"
+	if got := mismatchKeyID(lower); got != keyA {
+		t.Errorf("mismatchKeyID = %q, want %q", got, keyA)
+	}
+	// No ciphertext phrase → no id.
+	if got := mismatchKeyID("fatal: wrong password or no key found"); got != "" {
+		t.Errorf("mismatchKeyID on wrong-password stderr = %q, want empty", got)
+	}
+}
+
+func TestListRepoKeys_Local(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	keysDir := filepath.Join(repo, "keys")
+	if err := os.MkdirAll(keysDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{keyA, keyB, "not-a-key"} {
+		if err := os.WriteFile(filepath.Join(keysDir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ids, err := listRepoKeys(context.Background(), backup.KindLocal, repo, nil, nil)
+	if err != nil {
+		t.Fatalf("listRepoKeys: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Errorf("counted %d key files, want 2 (the stray 'not-a-key' must be filtered): %v", len(ids), ids)
+	}
+}
+
+func TestListRepoKeys_UnsupportedKind(t *testing.T) {
+	t.Parallel()
+	_, err := listRepoKeys(context.Background(), backup.KindS3, "s3:s3.amazonaws.com/bucket", nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for an unsupported backend, got nil")
+	}
+	if !strings.Contains(err.Error(), "backend") {
+		t.Errorf("error should name the unsupported backend: %v", err)
+	}
+}
+
+// The known-count arm turns "count the files yourself" into a concrete
+// instruction. Each branch must (a) keep the password-is-CORRECT preamble,
+// (b) give the right recovery, and (c) not carry the other branch's advice, and
+// stay a single paragraph (renders in a UI toast).
+func TestRepoUnopenableMessage_MismatchArm_KnownCount(t *testing.T) {
+	t.Parallel()
+	const (
+		url = "sftp:puzzle@host:/home/puzzle/jabali"
+		pw  = "/etc/jabali-panel/dest-7.password"
+		lo  = "config or key " + keyA + " is damaged: ciphertext verification failed"
+	)
+
+	t.Run("race: two keys incl. the named one -> move that key", func(t *testing.T) {
+		msg := repoUnopenableMessage(repoProbeKeyConfigMismatch, url, pw, lo,
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyA}, nil)
+		for _, want := range []string{"CORRECT", "do NOT restore", "holds 2 key files", "move keys/" + keyA} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("race message missing %q\ngot: %s", want, msg)
+			}
+		}
+		// The concrete count REPLACES the count-it-yourself hedge.
+		for _, banned := range []string{"MORE THAN ONE", "exactly ONE"} {
+			if strings.Contains(msg, banned) {
+				t.Errorf("race message still carries the unknown-count hedge %q\ngot: %s", banned, msg)
+			}
+		}
+		if strings.Contains(msg, "\n") {
+			t.Errorf("message must be one line\ngot: %s", msg)
+		}
+	})
+
+	t.Run("corrupt config: exactly one key -> fresh dir, move nothing", func(t *testing.T) {
+		msg := repoUnopenableMessage(repoProbeKeyConfigMismatch, url, pw, lo,
+			&repoKeyListing{ids: []string{keyA}, named: keyA}, nil)
+		for _, want := range []string{"exactly ONE", "FRESH empty"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("corrupt-config message missing %q\ngot: %s", want, msg)
+			}
+		}
+		if strings.Contains(msg, "move keys/") {
+			t.Errorf("corrupt-config message must not tell the operator to move a key\ngot: %s", msg)
+		}
+	})
+
+	t.Run("listing does not match: named key absent -> move nothing", func(t *testing.T) {
+		msg := repoUnopenableMessage(repoProbeKeyConfigMismatch, url, pw, lo,
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyGhost}, nil)
+		for _, want := range []string{"not among them", "do NOT move", "FRESH empty"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("listing-mismatch message missing %q\ngot: %s", want, msg)
+			}
+		}
+		// Must NOT name a key to move — the named key is not in the listing.
+		if strings.Contains(msg, "move keys/") {
+			t.Errorf("listing-mismatch message must not name a key to move\ngot: %s", msg)
+		}
+	})
+}
+
+// Fail-soft: if the listing itself fails, the operator still gets the mismatch
+// message (unknown-count guidance) plus a flattened note of why the count is
+// missing — a listing failure must never mask the underlying mismatch, and the
+// multi-line ssh error must not break the single-paragraph toast.
+func TestRepoUnopenableMessage_FailSoftSuffix(t *testing.T) {
+	t.Parallel()
+	listErr := errors.New("ssh ls -1 /p/keys: exit status 255 (output: Permission denied\nConnection closed by remote host)")
+	msg := repoUnopenableMessage(repoProbeKeyConfigMismatch,
+		"sftp:u@h:/p", "/etc/jabali-panel/restic-repo.password",
+		"config or key "+keyA+" is damaged: ciphertext verification failed", nil, listErr)
+
+	for _, want := range []string{"MORE THAN ONE", "Could not list keys/", "Permission denied"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("fail-soft message missing %q\ngot: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("fail-soft message must stay one paragraph — the multi-line ssh error was not flattened\ngot: %s", msg)
+	}
+}
+
+// The wrong-password (unopenable) arm must ignore a key listing entirely: an
+// operator on a foreign/rotated password must never be told about key counts.
+// Guards that a listing result cannot bleed across classes.
+func TestRepoUnopenableMessage_UnopenableIgnoresKeys(t *testing.T) {
+	t.Parallel()
+	msg := repoUnopenableMessage(repoProbeUnopenable,
+		"/backups", "/etc/jabali-panel/restic-repo.password", "wrong password or no key found",
+		&repoKeyListing{ids: []string{keyA, keyB}, named: keyA}, nil)
+
+	if !strings.Contains(msg, "reinstalled or regenerated") {
+		t.Errorf("unopenable arm lost its wrong-password advice\ngot: %s", msg)
+	}
+	for _, banned := range []string{"holds 2", "move keys/", "concurrent-init"} {
+		if strings.Contains(msg, banned) {
+			t.Errorf("unopenable arm leaked key-count advice %q — a listing bled across classes\ngot: %s", banned, msg)
+		}
+	}
+}

--- a/panel-agent/internal/commands/backup_repo_probe_test.go
+++ b/panel-agent/internal/commands/backup_repo_probe_test.go
@@ -83,7 +83,7 @@ func TestRepoUnopenableMessage_MismatchArm(t *testing.T) {
 	const pw = "/etc/jabali-panel/dest-7.password"
 	msg := repoUnopenableMessage(repoProbeKeyConfigMismatch,
 		"sftp:puzzle@host:/home/puzzle/jabali", pw,
-		"config or key abcd is damaged: ciphertext verification failed")
+		"config or key abcd is damaged: ciphertext verification failed", nil, nil)
 
 	for _, want := range []string{
 		pw,               // names the exact password file — do not touch it
@@ -114,7 +114,7 @@ func TestRepoUnopenableMessage_MismatchArm(t *testing.T) {
 func TestRepoUnopenableMessage_WrongPasswordArm(t *testing.T) {
 	const pw = "/etc/jabali-panel/restic-repo.password"
 	msg := repoUnopenableMessage(repoProbeUnopenable,
-		"/backups", pw, "wrong password or no key found")
+		"/backups", pw, "wrong password or no key found", nil, nil)
 
 	for _, want := range []string{
 		pw, // names the password file to restore


### PR DESCRIPTION
## What

When a restic repository fails to open with `config or key <id> is damaged:
ciphertext verification failed`, the operator's next move depends entirely on how
many key files `keys/` holds: **more than one** is the concurrent-init race (move
the key restic named aside and retry), **exactly one** is a corrupt config (start
fresh). Part 3 (#1680) could only tell the operator to count the files by hand,
because restic itself cannot count them — `restic key list` opens `config` first
and dies with the same ciphertext error.

This slice counts them **below restic**: `ssh user@host -- ls -1 <path>/keys` for
an SFTP repo, `os.ReadDir` for a local one, filtered to 64-hex restic key-file
names. The key/config-mismatch message then states the concrete count and, when
the key restic named is present in the listing, names the exact key to move.

This is **Part 2a of JAB-405** — the read-only half of the resilient-open work.
It ships the listing primitive that the Part 2b auto-repair will depend on, and
battle-tests it on its own before any code moves a key file.

## Change

- New `internal/backup/sftpls.go`: `ListRemoteSFTP` runs `ssh … -- ls -1
  <remotePath>` over the same auth path restic's `sftp.command` uses (sshpass /
  `-i key` / `-p port`). The ssh connection args are refactored into a shared
  `buildSSHConnArgs`, so mkdir (Part 1) and the new ls builder share one auth
  path. Read-only — it never creates, moves, or deletes anything.
- `listRepoKeys` (agent): SFTP → `ListRemoteSFTP` on `path.Join(sftp.Path,
  "keys")`; local → `os.ReadDir(<repoURL>/keys)`; any other backend is
  unsupported and returns an error. Bounded by a 30s context so a diagnostic
  never slows the failure path.
- `repoUnopenableMessage` gains an optional key-count. The mismatch arm now has
  three concrete branches — **race** (≥2 keys incl. the named one → move
  `keys/<id>`), **corrupt config** (exactly 1 → fresh dir), and **listing does
  not match** (named key absent → do NOT move anything, the safety invariant Part
  2b will enforce). When the count is unavailable the message is **byte-identical**
  to the Part 3 text (the merged Part 3 tests guard that).
- Both doors enrich the message: the backup run (`bkEnsureRepoReady`) and the
  manual `backup.dest.test` handler. The test-connection door only **counts**; it
  does not repair.
- **Fail-soft.** A listing failure (host unreachable, permission, an sftp-only
  jail, an unsupported backend) is folded into the message as a one-line note and
  **never masks the underlying mismatch** — the operator always sees why the
  backup failed. The ssh error is flattened to one line so the message stays a
  single paragraph (it also renders in the UI test-connection toast).

## Why below restic

`restic key list` on a config-mismatched repo dies with the very error we are
diagnosing — restic opens `config` before it lists keys. So the only way to count
key files on a repo whose config is undecryptable is to list `keys/` directly,
which is what the agent now does.

## Reviewer notes

- The `--` separator is load-bearing in both builders (it stops ssh from parsing
  the remote path as more of its own options); an exact-argv pin freezes the mkdir
  argv unchanged across the `buildSSHConnArgs` extraction, and a second pin fixes
  the ls argv.
- **sftp-only (internal-sftp / ForceCommand) targets reject `ssh -- ls`** — the
  same limitation Part 1's `ssh -- mkdir` already has, so such a target already
  can't auto-init. Both now take the fail-soft path consistently.
- The wrong-password (foreign/rotated) class ignores the key listing entirely — a
  key count must never leak into that message.

## Tests

- Shared/ls argv pins (both keep `--`); key-id parse filter; named-id extraction
  from the verbatim restic 0.18.0 stderr; local listing via a real temp repo;
  unsupported-backend error; the three count-aware message branches (race /
  corrupt-config / listing-does-not-match); fail-soft flattening of a multi-line
  ssh error into one paragraph; and that the wrong-password arm ignores a key
  listing. **Nine guards falsified** against compiling neutralizations. No flag /
  route change → no golden regen. `gofmt` + `go vet ./…` clean.

## Box-verify (.60, deployed 2a agent, restic 0.16.4)

Both doors were exercised end-to-end through the real agent RPC against fabricated
corrupt repos (foreign config → deterministic ciphertext error):

- **Positive (dual-key, 2 keys)** — `backup.dest.test` Detail: *"… the keys/
  directory holds 2 key files and one is the key restic named (578a2d0e…), so this
  is the concurrent-init race — move keys/578a2d0e… out of keys/ and retry …"* —
  real `ssh -- ls` exec, real parse, correct branch, single paragraph.
- **Negative (single-key, 1 key)** — Detail: *"… the keys/ directory holds exactly
  ONE key file, so the config itself is corrupt — point this destination at a
  FRESH empty directory."*
- **Fail-soft** — against the box's internal-sftp jail (`drfeed@…:8022`), `ssh --
  ls` returns *"This service allows sftp connections only."*, confirming the
  fail-soft branch on a hardened target.

`listRepoKeys` is called exactly once per probe (single call site, no loop);
both live runs returned in one round-trip.

## Not in this slice

**Part 2b of JAB-405 — automated move-aside repair** (move the named key out of
`keys/` inside the init lock, re-probe, confirm the surviving key opens config,
else restore and fail loud). It mutates remote key files on a live backup repo
and is a separate, box-verified slice built on this listing primitive. Part 1
(per-destination init lock, prevention) shipped #1676; Part 3 (the race-specific
message) shipped #1680.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
