### PR TITLE
feat(backup): auto-repair the concurrent-init key/config mismatch (JAB-405 Part 2b)

### DIFF
--- a/internal/backup/sftpls.go
+++ b/internal/backup/sftpls.go
@@ -74,3 +74,38 @@ func ListRemoteSFTP(ctx context.Context, in SFTPInputs, remotePath string, extra
 	}
 	return out, nil
 }
+
+// buildSSHRenameArgs assembles the argv for `[conn] -- mv -n <src> <dst>`. src
+// and dst are each a single argv element (no shell), so spaces or shell
+// metacharacters in the repository path cannot split into extra arguments. -n
+// (no-clobber) is belt-and-braces: the JAB-405 caller builds dst from a
+// nanosecond timestamp, so the destination never pre-exists.
+func buildSSHRenameArgs(in SFTPInputs, src, dst string) []string {
+	return append(buildSSHConnArgs(in), "--", "mv", "-n", src, dst)
+}
+
+// RenameRemoteSFTP runs `ssh user@host -- mv -n <src> <dst>` over the same auth
+// path restic's sftp.command uses. It renames a single file within the remote
+// repository — src and dst live on the same filesystem, so `mv` is an atomic
+// rename, never a copy+unlink. The JAB-405 Part 2b move-aside repair uses it to
+// move a mismatched key file OUT of keys/ (into the repository root, which restic
+// never scans for key candidates). It NEVER deletes: `mv` only renames, so the
+// moved key stays on disk and can be restored. On error the combined output is
+// returned so the caller can surface a diagnostic.
+func RenameRemoteSFTP(ctx context.Context, in SFTPInputs, src, dst string, extraEnv []string) ([]byte, error) {
+	if in.Host == "" || in.User == "" {
+		return nil, fmt.Errorf("sftp: host+user required")
+	}
+	if src == "" || dst == "" {
+		return nil, fmt.Errorf("sftp: src+dst required")
+	}
+	args := buildSSHRenameArgs(in, src, dst)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = append(cmd.Environ(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("ssh mv -n %s %s: %w (output: %s)",
+			src, dst, err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}

--- a/internal/backup/sftpls_test.go
+++ b/internal/backup/sftpls_test.go
@@ -100,3 +100,80 @@ func TestBuildSSHListArgs(t *testing.T) {
 		t.Errorf("remote path split into extra args: last argv element = %q", last)
 	}
 }
+
+// TestBuildSSHRenameArgs pins the move-aside argv (JAB-405 Part 2b): the shared
+// connection prefix, then `--` (so ssh stops parsing its own options), then
+// `mv -n` and src+dst as TWO separate argv elements. Falsify by dropping the
+// `--`, dropping `-n`, or joining the remote command into one string. src and dst
+// as distinct argv elements is what keeps a repository path with spaces from
+// splitting into extra `mv` operands.
+func TestBuildSSHRenameArgs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		src = "/home/puzzle/jabali/keys/3c0bdcd0"
+		dst = "/home/puzzle/jabali/3c0bdcd0.jabali-race-1"
+	)
+	cases := []struct {
+		name string
+		in   SFTPInputs
+		want []string
+	}{
+		{
+			name: "password auth",
+			in:   SFTPInputs{User: "u", Host: "h", Auth: "password"},
+			want: []string{
+				"sshpass", "-e", "ssh",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "PreferredAuthentications=password",
+				"-o", "PubkeyAuthentication=no",
+				"u@h", "--", "mv", "-n", src, dst,
+			},
+		},
+		{
+			name: "key auth with key path",
+			in:   SFTPInputs{User: "u", Host: "h", Auth: "key", KeyPath: "/k"},
+			want: []string{
+				"ssh", "-i", "/k", "-o", "IdentitiesOnly=yes",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "BatchMode=yes",
+				"u@h", "--", "mv", "-n", src, dst,
+			},
+		},
+		{
+			name: "default auth (no key, no password)",
+			in:   SFTPInputs{User: "u", Host: "h"},
+			want: []string{
+				"ssh",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "BatchMode=yes",
+				"u@h", "--", "mv", "-n", src, dst,
+			},
+		},
+		{
+			name: "non-22 port on key auth",
+			in:   SFTPInputs{User: "u", Host: "h", Auth: "key", KeyPath: "/k", Port: 2222},
+			want: []string{
+				"ssh", "-i", "/k", "-o", "IdentitiesOnly=yes",
+				"-o", "StrictHostKeyChecking=accept-new",
+				"-o", "BatchMode=yes",
+				"-p", "2222",
+				"u@h", "--", "mv", "-n", src, dst,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildSSHRenameArgs(tc.in, src, dst)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("rename argv mismatch\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+
+	// src and dst with spaces stay two distinct single argv elements.
+	spaced := buildSSHRenameArgs(SFTPInputs{User: "u", Host: "h"}, "/a b/keys/K", "/a b/K aside")
+	if spaced[len(spaced)-2] != "/a b/keys/K" || spaced[len(spaced)-1] != "/a b/K aside" {
+		t.Errorf("src/dst split into extra args: tail = %#v", spaced[len(spaced)-2:])
+	}
+}

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -323,6 +323,21 @@ func removeID(ids []string, id string) []string {
 	return out
 }
 
+// repairGateOpen reports whether the automated move-aside repair (JAB-405 Part 2b)
+// may run. It is the safety invariant, in one place: the failure must be the
+// key/config-mismatch class, the key listing must be available (a jailed or
+// unlistable target leaves keys nil) and hold ≥2 key files, and the key restic
+// named must be one of them. Only then is the concurrent-init race PROVEN and a
+// move safe; every other shape — a foreign-password class, no listing, a single
+// key (corrupt config), or a named key absent from the listing — keeps the gate
+// shut and the repository untouched.
+func repairGateOpen(cls repoProbeClass, keys *repoKeyListing) bool {
+	return cls == repoProbeKeyConfigMismatch &&
+		keys != nil &&
+		len(keys.ids) >= 2 &&
+		keys.namedPresent()
+}
+
 // moveKeyAside moves a mismatched restic key file OUT of the repository's keys/
 // directory into the repository ROOT, renaming it to <id>.jabali-race-<unixnano>
 // (JAB-405 Part 2b). The destination is deliberately the repo root, not a keys/
@@ -333,6 +348,14 @@ func removeID(ids []string, id string) []string {
 // never deletes (os.Rename local; `ssh -- mv -n` remote), so the moved key stays
 // on disk and can be restored. Returns the destination path it moved to.
 func moveKeyAside(ctx context.Context, destKind, repoURL string, sftp *backupSFTPInputs, extraEnv []string, named string) (string, error) {
+	// Refuse anything that is not a bare 64-hex restic key id BEFORE building any
+	// path. This is a hard clamp independent of the caller's gate: an empty or
+	// traversing named would make src collapse to keys/ itself (renaming the whole
+	// key directory) or escape the repository. The move-aside primitive must never
+	// touch more than the one named key file, no matter how it is called.
+	if !resticKeyIDRE.MatchString(named) {
+		return "", fmt.Errorf("refusing to move %q aside: not a restic key id", named)
+	}
 	dstName := fmt.Sprintf("%s.jabali-race-%d", named, time.Now().UnixNano())
 	switch {
 	case destKind == backup.KindSFTP && sftp != nil && sftp.Host != "":
@@ -581,7 +604,7 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, p
 			// a move. One move per call. This runs inside withRepoInitLock (the whole
 			// switch does), so a concurrent job cannot init or repair the same repo at
 			// once. Only the backup run repairs; the manual test-connection door counts.
-			if cls == repoProbeKeyConfigMismatch && keys != nil && len(keys.ids) >= 2 && keys.namedPresent() {
+			if repairGateOpen(cls, keys) {
 				move := func(ctx context.Context, named string) (string, error) {
 					return moveKeyAside(ctx, destKind, repoURL, sftp, extraEnv, named)
 				}

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path"
@@ -309,6 +310,123 @@ func listRepoKeys(ctx context.Context, destKind, repoURL string, sftp *backupSFT
 	}
 }
 
+// removeID returns ids with the first exact match of id dropped. Used to build
+// the "remaining key files" listing after one key was moved aside, so the
+// sharpened race message counts what is left without a second remote listing.
+func removeID(ids []string, id string) []string {
+	out := make([]string, 0, len(ids))
+	for _, x := range ids {
+		if x != id {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// moveKeyAside moves a mismatched restic key file OUT of the repository's keys/
+// directory into the repository ROOT, renaming it to <id>.jabali-race-<unixnano>
+// (JAB-405 Part 2b). The destination is deliberately the repo root, not a keys/
+// sub-name: restic enumerates key candidates ONLY from keys/ on every version, so
+// a file in the root is never re-tried as a key — the surviving key becomes the
+// only one restic opens. The .jabali-race-<ts> suffix is also not a valid 64-hex
+// key id, and the nanosecond timestamp makes the destination unique. It RENAMES,
+// never deletes (os.Rename local; `ssh -- mv -n` remote), so the moved key stays
+// on disk and can be restored. Returns the destination path it moved to.
+func moveKeyAside(ctx context.Context, destKind, repoURL string, sftp *backupSFTPInputs, extraEnv []string, named string) (string, error) {
+	dstName := fmt.Sprintf("%s.jabali-race-%d", named, time.Now().UnixNano())
+	switch {
+	case destKind == backup.KindSFTP && sftp != nil && sftp.Host != "":
+		src := path.Join(sftp.Path, "keys", named)
+		dst := path.Join(sftp.Path, dstName)
+		if _, err := backup.RenameRemoteSFTP(ctx, backup.SFTPInputs{
+			Host:    sftp.Host,
+			User:    sftp.User,
+			Port:    sftp.Port,
+			Path:    sftp.Path,
+			Auth:    sftp.Auth,
+			KeyPath: sftp.KeyPath,
+		}, src, dst, extraEnv); err != nil {
+			return "", err
+		}
+		return dst, nil
+	case destKind == backup.KindLocal:
+		src := filepath.Join(repoURL, "keys", named)
+		dst := filepath.Join(repoURL, dstName)
+		if err := os.Rename(src, dst); err != nil {
+			return "", fmt.Errorf("rename %s: %w", src, err)
+		}
+		return dst, nil
+	default:
+		return "", fmt.Errorf("cannot move a key aside for a %q backend", destKind)
+	}
+}
+
+// repairKeyMismatch performs the JAB-405 Part 2b automated move-aside repair for
+// a key/config mismatch caused by the concurrent-init race. It is called ONLY when
+// the safety gate holds — the mismatch class, ≥2 key files, and the key restic
+// named is present in the listing — so it never touches keys/ on a listing that
+// does not prove the race. It moves that ONE key aside, re-probes, and:
+//
+//   - repository opens → returns nil; the backup proceeds. The move is logged.
+//   - still a mismatch on a DIFFERENT present key → the move made progress (there
+//     were ≥3 key files). Returns the sharpened race message naming the next key,
+//     built from the remaining key files (original minus the one moved). The run
+//     still fails, but the next scheduled run's auto-repair clears the next key —
+//     convergent: N key files clear over N-1 runs, one move each.
+//   - anything else (the move itself failed, a non-mismatch failure, or the SAME
+//     key is still named) → fails loud with what happened and where the key went,
+//     so the operator can investigate or restore it. There is NO revert: the named
+//     key is one restic itself proved cannot decrypt this config, so leaving it
+//     moved is never wrong, and moving it back would only re-introduce a known-bad
+//     key.
+//
+// At most ONE move per call (no retry loop). move and reprobe are injected so the
+// decision table is unit-testable without a real backend.
+func repairKeyMismatch(
+	ctx context.Context,
+	keys *repoKeyListing,
+	repoURL, passwordFile, origStderr string,
+	move func(ctx context.Context, named string) (dst string, err error),
+	reprobe func(ctx context.Context) (lowerStderr string, err error),
+) error {
+	named := keys.named
+	dst, err := move(ctx, named)
+	if err != nil {
+		// The move failed, so the repository is UNTOUCHED — surface the exact 2a
+		// race guidance (move keys/<id> manually) plus why the automatic move could
+		// not run.
+		return fmt.Errorf("automatic key-mismatch repair could not move keys/%s aside (%v) — do it manually: %s",
+			named, err, repoUnopenableMessage(repoProbeKeyConfigMismatch, repoURL, passwordFile, origStderr, keys, nil))
+	}
+
+	lower, perr := reprobe(ctx)
+	if perr == nil {
+		slog.Warn("JAB-405: auto-repaired concurrent-init key mismatch — moved key aside; repository now opens",
+			"repo", repoURL, "moved_key", named, "moved_to", dst)
+		return nil
+	}
+
+	if newNamed := mismatchKeyID(lower); classifyRepoProbe(lower) == repoProbeKeyConfigMismatch &&
+		newNamed != "" && newNamed != named {
+		// Progress: another key still mismatches (there were ≥3 key files). Build the
+		// sharpened race message from the remaining key files so the operator — and
+		// the next run's auto-repair — targets the next key.
+		remaining := &repoKeyListing{ids: removeID(keys.ids, named), named: newNamed}
+		slog.Warn("JAB-405: moved a mismatched key aside but another key still mismatches — next scheduled run will repair it",
+			"repo", repoURL, "moved_key", named, "moved_to", dst, "next_key", newNamed)
+		return errors.New(repoUnopenableMessage(repoProbeKeyConfigMismatch, repoURL, passwordFile, lower, remaining, nil))
+	}
+
+	// The move did not fix it and did not leave a clean "another key" signature: the
+	// config is genuinely corrupt, or the state is unexpected. Fail loud with the raw
+	// error and where the key went, so the operator can restore it if needed.
+	slog.Warn("JAB-405: moved a mismatched key aside but the repository still does not open — treating as corrupt",
+		"repo", repoURL, "moved_key", named, "moved_to", dst, "stderr", lower)
+	return fmt.Errorf("automatic key-mismatch repair moved keys/%s to %s but the repository still does not open (%s) — "+
+		"restore that file if needed and treat the repository as corrupt; point this destination at a FRESH empty directory (the old snapshots stay on disk)",
+		named, dst, lower)
+}
+
 // repoUnopenableMessage builds the operator-facing error for a repository that
 // EXISTS but cannot be opened. It is a single paragraph with no newlines: the
 // same text surfaces in a run-failure log AND in a short UI toast on the manual
@@ -453,6 +571,25 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, p
 				} else {
 					keys = &repoKeyListing{ids: ids, named: mismatchKeyID(lower)}
 				}
+			}
+			// JAB-405 Part 2b: when the listing PROVES the concurrent-init race — the
+			// mismatch class, ≥2 key files, and the key restic named is one of them —
+			// attempt the automated move-aside repair (move that key out of keys/,
+			// re-probe, proceed if the surviving key opens config). SAFETY INVARIANT:
+			// never touch keys/ unless all three hold, so a jailed/unlistable target
+			// (keys == nil) or a listing that does not match the error can never trigger
+			// a move. One move per call. This runs inside withRepoInitLock (the whole
+			// switch does), so a concurrent job cannot init or repair the same repo at
+			// once. Only the backup run repairs; the manual test-connection door counts.
+			if cls == repoProbeKeyConfigMismatch && keys != nil && len(keys.ids) >= 2 && keys.namedPresent() {
+				move := func(ctx context.Context, named string) (string, error) {
+					return moveKeyAside(ctx, destKind, repoURL, sftp, extraEnv, named)
+				}
+				reprobe := func(ctx context.Context) (string, error) {
+					_, st, e := backup.SnapshotsRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
+					return strings.ToLower(strings.TrimSpace(string(st))), e
+				}
+				return repairKeyMismatch(ctx, keys, repoURL, pwFile, lower, move, reprobe)
 			}
 			return errors.New(repoUnopenableMessage(cls, repoURL, pwFile, lower, keys, listErr))
 		}

--- a/panel-agent/internal/commands/backup_repo_repair_test.go
+++ b/panel-agent/internal/commands/backup_repo_repair_test.go
@@ -1,0 +1,243 @@
+package commands
+
+// JAB-405 Part 2b: automated move-aside repair for the concurrent-init key/config
+// mismatch. When the listing PROVES the race (mismatch class, ≥2 key files, the
+// key restic named present), move that ONE key OUT of keys/ into the repository
+// root, re-probe, and proceed if the surviving key opens config. No revert; one
+// move per call; only the backup run repairs. keyA/keyB/keyGhost come from
+// backup_repo_keys_test.go (same package).
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+func TestRemoveID(t *testing.T) {
+	t.Parallel()
+	got := removeID([]string{keyA, keyB, keyGhost}, keyB)
+	if len(got) != 2 || got[0] != keyA || got[1] != keyGhost {
+		t.Errorf("removeID dropped the wrong element: %v", got)
+	}
+	// Removing an absent id is a no-op (keeps every element).
+	if got := removeID([]string{keyA}, keyB); len(got) != 1 || got[0] != keyA {
+		t.Errorf("removeID of an absent id must be a no-op: %v", got)
+	}
+}
+
+// TestMoveKeyAside_Local renames the mismatched key OUT of keys/ into the repo
+// ROOT, keeps the surviving key, and never deletes. The destination landing in the
+// root (not a keys/ sub-name) is load-bearing: restic enumerates key candidates
+// only from keys/, so a root file is never re-tried as a key.
+func TestMoveKeyAside_Local(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	keysDir := filepath.Join(repo, "keys")
+	if err := os.MkdirAll(keysDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{keyA, keyB} {
+		if err := os.WriteFile(filepath.Join(keysDir, name), []byte("k"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dst, err := moveKeyAside(context.Background(), backup.KindLocal, repo, nil, nil, keyA)
+	if err != nil {
+		t.Fatalf("moveKeyAside: %v", err)
+	}
+
+	// The moved key is gone from keys/, the surviving key stays.
+	if _, err := os.Stat(filepath.Join(keysDir, keyA)); !os.IsNotExist(err) {
+		t.Errorf("moved key must be gone from keys/, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(keysDir, keyB)); err != nil {
+		t.Errorf("surviving key must stay in keys/: %v", err)
+	}
+	// The moved-aside file lands in the repo ROOT, not keys/, and still exists
+	// (rename, never delete).
+	if filepath.Dir(dst) != repo {
+		t.Errorf("moved-aside file must land in the repo root, got dir %q (repo %q)", filepath.Dir(dst), repo)
+	}
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("moved-aside file must exist (rename, not delete): %v", err)
+	}
+	// Its name is NOT a valid 64-hex restic key id (so restic never re-tries it as
+	// a key) and carries the .jabali-race- marker.
+	base := filepath.Base(dst)
+	if resticKeyIDRE.MatchString(base) {
+		t.Errorf("moved-aside name must not be a 64-hex key id: %q", base)
+	}
+	if !strings.Contains(base, ".jabali-race-") {
+		t.Errorf("moved-aside name must carry the .jabali-race- marker: %q", base)
+	}
+}
+
+func TestMoveKeyAside_UnsupportedKind(t *testing.T) {
+	t.Parallel()
+	_, err := moveKeyAside(context.Background(), backup.KindS3, "s3:s3.amazonaws.com/bucket", nil, nil, keyA)
+	if err == nil || !strings.Contains(err.Error(), "backend") {
+		t.Fatalf("expected an unsupported-backend error, got: %v", err)
+	}
+}
+
+// TestRepairKeyMismatch exercises the decision table with injected move/reprobe
+// fakes — no real backend. Each outcome is falsifiable independently.
+func TestRepairKeyMismatch(t *testing.T) {
+	t.Parallel()
+
+	const (
+		url  = "sftp:u@h:/p"
+		pw   = "/etc/jabali-panel/dest-1.password"
+		orig = "config or key " + keyA + " is damaged: ciphertext verification failed"
+	)
+	mismatchOn := func(id string) string {
+		return "config or key " + id + " is damaged: ciphertext verification failed"
+	}
+
+	t.Run("move fixes it: repo opens -> nil, exactly one move, re-probed", func(t *testing.T) {
+		var moved []string
+		reprobed := false
+		move := func(_ context.Context, named string) (string, error) {
+			moved = append(moved, named)
+			return "/p/" + named + ".jabali-race-1", nil
+		}
+		reprobe := func(_ context.Context) (string, error) {
+			reprobed = true
+			return "", nil // opens
+		}
+		err := repairKeyMismatch(context.Background(),
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyA},
+			url, pw, orig, move, reprobe)
+		if err != nil {
+			t.Fatalf("expected nil (repo opened after the move), got: %v", err)
+		}
+		if len(moved) != 1 || moved[0] != keyA {
+			t.Errorf("expected exactly one move of keyA, got: %v", moved)
+		}
+		if !reprobed {
+			t.Error("expected a re-probe after the move")
+		}
+	})
+
+	t.Run("three keys: still mismatches on a different key -> sharpened race message, one move", func(t *testing.T) {
+		moves := 0
+		move := func(_ context.Context, named string) (string, error) {
+			moves++
+			if named != keyA {
+				t.Errorf("must move the key restic named (keyA), got %s", named)
+			}
+			return "/p/" + named + ".jabali-race-1", nil
+		}
+		reprobe := func(_ context.Context) (string, error) {
+			return mismatchOn(keyB), errors.New("exit status 1")
+		}
+		// Three key files: after moving keyA, two remain (keyB, keyGhost) and the
+		// re-probe now names keyB — the sharpened race message must target keyB.
+		err := repairKeyMismatch(context.Background(),
+			&repoKeyListing{ids: []string{keyA, keyB, keyGhost}, named: keyA},
+			url, pw, orig, move, reprobe)
+		if err == nil {
+			t.Fatal("expected a run failure (repo still not open this run)")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "holds 2 key files") || !strings.Contains(msg, "move keys/"+keyB) {
+			t.Errorf("expected sharpened race message naming keyB from the 2 remaining keys\ngot: %s", msg)
+		}
+		if moves != 1 {
+			t.Errorf("exactly one move per call, got %d", moves)
+		}
+	})
+
+	t.Run("two keys, config matches neither: one key left, still mismatched -> corrupt-config guidance", func(t *testing.T) {
+		move := func(_ context.Context, named string) (string, error) {
+			return "/p/" + named + ".jabali-race-1", nil
+		}
+		reprobe := func(_ context.Context) (string, error) {
+			return mismatchOn(keyB), errors.New("exit status 1")
+		}
+		// Only two key files: after moving keyA, one remains (keyB) and it still
+		// mismatches -> the config itself is corrupt, so the message must say ONE key
+		// left, fresh dir, and NOT tell the operator to move anything.
+		err := repairKeyMismatch(context.Background(),
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyA},
+			url, pw, orig, move, reprobe)
+		if err == nil {
+			t.Fatal("expected a run failure")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "exactly ONE") || !strings.Contains(msg, "FRESH empty") {
+			t.Errorf("expected corrupt-config guidance (one key left, still mismatched)\ngot: %s", msg)
+		}
+	})
+
+	t.Run("move itself fails: repo untouched -> manual 2a guidance, NO re-probe", func(t *testing.T) {
+		reprobed := false
+		move := func(_ context.Context, named string) (string, error) {
+			return "", errors.New("permission denied")
+		}
+		reprobe := func(_ context.Context) (string, error) {
+			reprobed = true
+			return "", nil
+		}
+		err := repairKeyMismatch(context.Background(),
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyA},
+			url, pw, orig, move, reprobe)
+		if err == nil {
+			t.Fatal("expected an error when the move fails")
+		}
+		if reprobed {
+			t.Error("must NOT re-probe when the move failed (repository untouched)")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "could not move keys/"+keyA) || !strings.Contains(msg, "permission denied") {
+			t.Errorf("expected the move-failure reason\ngot: %s", msg)
+		}
+		// Falls back to the exact 2a manual race guidance (move keyA by hand).
+		if !strings.Contains(msg, "move keys/"+keyA) {
+			t.Errorf("expected manual 2a race guidance after a move failure\ngot: %s", msg)
+		}
+	})
+
+	t.Run("still mismatched on the SAME key -> fail loud with the moved-aside path", func(t *testing.T) {
+		move := func(_ context.Context, named string) (string, error) {
+			return "/p/" + named + ".jabali-race-1", nil
+		}
+		reprobe := func(_ context.Context) (string, error) {
+			return mismatchOn(keyA), errors.New("exit status 1") // same key still named
+		}
+		err := repairKeyMismatch(context.Background(),
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyA},
+			url, pw, orig, move, reprobe)
+		if err == nil {
+			t.Fatal("expected fail-loud when the same key is still named after the move")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "still does not open") || !strings.Contains(msg, ".jabali-race-1") {
+			t.Errorf("expected fail-loud naming where the key went\ngot: %s", msg)
+		}
+	})
+
+	t.Run("non-mismatch failure after move -> fail loud, treat as corrupt", func(t *testing.T) {
+		move := func(_ context.Context, named string) (string, error) {
+			return "/p/" + named + ".jabali-race-1", nil
+		}
+		reprobe := func(_ context.Context) (string, error) {
+			return "wrong password or no key found", errors.New("exit status 1")
+		}
+		err := repairKeyMismatch(context.Background(),
+			&repoKeyListing{ids: []string{keyA, keyB}, named: keyA},
+			url, pw, orig, move, reprobe)
+		if err == nil {
+			t.Fatal("expected fail-loud on a non-mismatch failure after the move")
+		}
+		if !strings.Contains(err.Error(), "still does not open") {
+			t.Errorf("expected fail-loud\ngot: %s", err.Error())
+		}
+	})
+}

--- a/panel-agent/internal/commands/backup_repo_repair_test.go
+++ b/panel-agent/internal/commands/backup_repo_repair_test.go
@@ -86,6 +86,66 @@ func TestMoveKeyAside_UnsupportedKind(t *testing.T) {
 	}
 }
 
+// TestMoveKeyAside_RefusesNonKeyID is the hard clamp independent of the caller's
+// gate: a named that is not a bare 64-hex key id must be refused BEFORE any path is
+// built and BEFORE any rename runs. An empty named would otherwise collapse src to
+// keys/ itself (renaming the whole key directory); a traversing named would escape
+// the repository. Nothing on disk may change.
+func TestMoveKeyAside_RefusesNonKeyID(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{"", "../config", "not-a-key", keyA + "/../config", keyA + "x"} {
+		repo := t.TempDir()
+		keysDir := filepath.Join(repo, "keys")
+		if err := os.MkdirAll(keysDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(keysDir, keyA), []byte("k"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := moveKeyAside(context.Background(), backup.KindLocal, repo, nil, nil, bad)
+		if err == nil || !strings.Contains(err.Error(), "not a restic key id") {
+			t.Errorf("moveKeyAside(named=%q) must refuse with a key-id error, got: %v", bad, err)
+		}
+		// keys/ is untouched, and no stray move-aside file appeared in the root.
+		if _, statErr := os.Stat(filepath.Join(keysDir, keyA)); statErr != nil {
+			t.Errorf("named=%q: keys/ was disturbed by a refused move: %v", bad, statErr)
+		}
+		entries, _ := os.ReadDir(repo)
+		for _, e := range entries {
+			if strings.Contains(e.Name(), ".jabali-race-") {
+				t.Errorf("named=%q: a refused move still created a root file %q", bad, e.Name())
+			}
+		}
+	}
+}
+
+// TestRepairGateOpen falsifies each clause of the Part 2b safety invariant: the
+// repair may run ONLY for the mismatch class, with a listing present, holding ≥2
+// key files, whose named key is among them. Deleting any one clause of
+// repairGateOpen turns one of these false cases true.
+func TestRepairGateOpen(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cls  repoProbeClass
+		keys *repoKeyListing
+		want bool
+	}{
+		{"race proven: mismatch + 2 keys + named present", repoProbeKeyConfigMismatch, &repoKeyListing{ids: []string{keyA, keyB}, named: keyA}, true},
+		{"wrong class: unopenable never repairs", repoProbeUnopenable, &repoKeyListing{ids: []string{keyA, keyB}, named: keyA}, false},
+		{"no listing: jailed/unlistable target", repoProbeKeyConfigMismatch, nil, false},
+		{"one key: corrupt config, nothing to move", repoProbeKeyConfigMismatch, &repoKeyListing{ids: []string{keyA}, named: keyA}, false},
+		{"named absent: listing does not match the error", repoProbeKeyConfigMismatch, &repoKeyListing{ids: []string{keyA, keyB}, named: keyGhost}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := repairGateOpen(c.cls, c.keys); got != c.want {
+				t.Errorf("repairGateOpen = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 // TestRepairKeyMismatch exercises the decision table with injected move/reprobe
 // fakes — no real backend. Each outcome is falsifiable independently.
 func TestRepairKeyMismatch(t *testing.T) {


### PR DESCRIPTION
## What

When two backups run `restic init` on one empty repository at once, the repo is
left with **more than one key file but a single config** that only one key can
decrypt. restic can pick the mismatched key and die fatally — `config or key <id>
is damaged: ciphertext verification failed` — instead of falling through, so the
repository is permanently unopenable and every backup fails at "ensure repo".

Part 1 (#1676) stops new occurrences with a per-destination init lock; Part 3
(#1680) turned the failure into an actionable message; Part 2a (#1682) counted the
key files below restic so the message names the exact key to move. **This slice —
Part 2b — repairs an already-corrupted repo automatically.**

On the backup **run**, when the listing PROVES the race — the mismatch class, **≥2
key files, and the key restic named is one of them** — the agent moves that one key
out of `keys/` and re-probes. If the surviving key now opens `config`, the backup
proceeds; the move is logged at Warn with where the key went.

## Where the moved key goes — and why the repo root

The mismatched key is renamed **out of `keys/` into the repository ROOT**, as
`<id>.jabali-race-<unixnano>` — not a `keys/` sub-name. restic enumerates key
candidates **only** from `keys/` on every version, so a file in the root is never
re-tried as a key and the surviving key becomes the only one restic opens. This is
verified end-to-end on **restic 0.16.4 (the fleet version) and 0.18.0**: a
fabricated dual-key/one-config repo dies with the ciphertext error, and after the
root move `restic snapshots` opens (exit 0) and `restic check` reports no errors.

It **renames, never deletes** — `os.Rename` local, `ssh … -- mv -n` remote — so the
moved key stays on disk and can be restored by hand.

## Safety

- **Never touches `keys/` unless the race is proven.** The gate is a single pure
  function `repairGateOpen(class, keys)` — mismatch class AND a listing is present
  AND ≥2 key files AND the named key is among them. A jailed/unlistable target (the
  listing returns nil, e.g. an internal-sftp `ForceCommand` host) or a listing that
  does not match the error keeps the gate shut.
- **The move primitive refuses bad input on its own**, independent of the gate:
  `moveKeyAside` hard-clamps `named` to a bare 64-hex key id before it builds any
  path — an empty `named` would otherwise collapse the source to `keys/` itself and
  rename the whole key directory. Defense-in-depth so a future gate edit can never
  turn a key move into a directory move.
- **One move per call — no retry loop.** With more than two key files, the re-probe
  still fails naming the next key; the run returns the sharpened race message built
  from the remaining key files, and the next scheduled run repairs the next key.
  Convergent: N key files clear over N-1 runs, one move each. The two-key /
  matches-neither case converges too — after one move a single key remains, the gate
  closes, and the operator gets the corrupt-config guidance (fresh dir); it never
  loops.
- **No revert on failure.** The named key is one restic itself proved cannot decrypt
  this config, so leaving it moved is never wrong; moving it back would only
  re-introduce a known-bad key and add a second failure mode. A move that does not
  open the repo fails loud with the raw error and the moved-aside path.
- **Runs inside `withRepoInitLock`** (the whole probe→classify→repair switch does),
  so a concurrent job cannot init or repair the same repository at once.
- **Only the backup run repairs.** The manual `backup.dest.test` door references
  none of the repair/move/rename code — it stays count-only (Part 2a). A test
  connection can never mutate the repository.

## Product call: always-on, no flag (the ask)

This ships **always-on with no feature flag**: the ticket asks to make open
resilient, the repository is unopenable so there is no working state to protect, and
the operation is a rename, not a delete. If you would rather gate it, I can add a
`server_settings` opt-in as a follow-up — say the word at approval and I will file it.

## Change

- New `RenameRemoteSFTP` in `internal/backup/sftpls.go`: `ssh user@host -- mv -n
  <src> <dst>` over the same auth path restic's `sftp.command` uses (shared
  `buildSSHConnArgs`). src and dst are separate argv elements, so a repository path
  with spaces or shell metacharacters can never split into extra `mv` operands.
- `moveKeyAside` (agent): SFTP → `RenameRemoteSFTP`, local → `os.Rename`; unsupported
  backend errors. Refuses a non-key-id `named`.
- `repairKeyMismatch` (agent): the decision table above, with the move and re-probe
  injected so it is unit-tested without a real backend.
- `repairGateOpen` (agent): the safety invariant, extracted pure and unit-gated.
- `bkEnsureRepoReady`: the mismatch arm now attempts the repair when the gate is
  open, otherwise returns the Part 2a message unchanged.

## Reviewer notes

- **`mv -n` (no-clobber) safety.** The destination carries a nanosecond timestamp,
  so it never pre-exists. In the impossible event it did collide, `mv -n` leaves the
  source in place; the re-probe then names the **same** key again, which takes the
  fail-loud branch (same-key-still-named) — never a second, blind move.
- The `keys != nil` gate clause guards a real nil dereference on a jailed/unlistable
  target — its falsification test panics without it.
- The test door is unchanged; a grep confirms it references none of the repair path.

## Tests

Rename argv pin across all four auth modes (keeps `--`, `mv -n`, src+dst as two
elements); local move-aside (key leaves `keys/`, lands in the repo root, survivor
stays, never deleted, moved name is not a 64-hex key id); `moveKeyAside` refuses
`""`, `../config`, `not-a-key`, `<id>/../config`, `<id>x` and leaves `keys/`
untouched; unsupported-backend error; `repairGateOpen` table with a falsification
per clause; and the full decision table with injected fakes — repo opens after the
move, ≥3 keys still mismatched on a different key (sharpened message names the next),
two keys matching neither (corrupt-config guidance), the move itself failing (repo
untouched, no re-probe), the same key still named (fail loud), and a non-mismatch
failure after the move (fail loud). **13 guards falsified** against compiling
neutralizations. `gofmt` + `go vet` clean; no flag/route change → no golden regen.

## Box-verify (.60, restic 0.16.4 — the fleet version)

The one behavior units cannot reach is whether restic opens after the move on the
fleet restic version. Fabricated a dual-key/one-config repo on .60: baseline
`restic snapshots` fails `config or key <id> is damaged: ciphertext verification
failed`; after moving the mismatched key OUT of `keys/` into the repo root,
`snapshots` returns exit 0 and `restic check` reports "no errors were found". The
stray root file is tolerated.

**Not box-run:** the full deployed-agent scheduler run-door (it needs standing up a
schedule + account against a corrupt local repo on the shared test box). The agent
decision table is unit-tested with fakes, and the run-door plumbing
(`destKind`/`repoURL`/`sftp` → move) is the same path Part 2a already box-verified
through the deployed agent in #1682.

## Not in this slice

A `server_settings` opt-in flag (offered above as a follow-up if wanted). This is
the last planned part of JAB-405; the ticket stays open pending your call on
always-on vs opt-in.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
