### PR TITLE
feat(nginx): deny tenant override of panel-managed response headers (GH #1624, ADR-0169 Phase 2)

### DIFF
--- a/docs/site/user/domains.md
+++ b/docs/site/user/domains.md
@@ -45,7 +45,7 @@ Two extra per-domain tabs — **Domain options** and **Rewrite rules** — appea
 When they are enabled you can, on your own domains:
 
 - **Domain options** — set a curated, safe set of nginx options: maximum upload size, HSTS, the common security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), and gzip. You supply values; each option renders to a fixed, vetted directive — never raw config.
-- **Rewrite rules** — add two kinds of structured rule. A `rewrite` rule whose target must be a local path (no scheme or host, so it can never become an open redirect or a proxy to another service), and a `custom_header` rule that adds one response header. Every rule is validated before it is applied.
+- **Rewrite rules** — add two kinds of structured rule. A `rewrite` rule whose target must be a local path (no scheme or host, so it can never become an open redirect or a proxy to another service), and a `custom_header` rule that adds one response header. Every rule is validated before it is applied. The headers the panel manages for security — `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` — can't be set here; use **Domain options** for HSTS and the security headers instead.
 
 Raw nginx directives, reverse-proxy targets, IP access rules, and PHP settings stay admin-only whether or not tenant domain options are enabled. Your administrator turns the feature on under [Server Settings → General](../admin/server-settings.md#general).
 

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -2032,10 +2032,38 @@ var tenantSafeNginxRuleTypes = map[string]struct{}{
 	"custom_header": {},
 }
 
+// tenantManagedResponseHeaders are response-header names a tenant custom_header
+// rule may NOT set (ADR-0169 Phase 2). Both classes are a value-independent name
+// hazard, so this is a denylist on the name — not a value grammar:
+//
+//   - The four security headers the panel renders itself: NginxSafeOptions.Render
+//     (models/nginx_safe_options.go) emits them at server scope, and the agent
+//     vhost template re-declares three of them per PHP location (JAB-70, because
+//     a location's own add_header suppresses inherited server-scope ones). A
+//     tenant custom_header lands at server scope (nginxrules.Compile), so a
+//     tenant add_header here duplicates or weakens panel-managed hardening — e.g.
+//     `Strict-Transport-Security: max-age=0` voids HSTS. The panel owns these
+//     names; a tenant "strengthening" value is still wrong (duplicate headers).
+//   - Content-Length / Transfer-Encoding: add_header with either produces a
+//     malformed response nginx will still emit (request-smuggling-adjacent).
+//
+// Not denied: Set-Cookie / Content-Security-Policy / Cache-Control — the tenant's
+// own domain, the tenant's call. Names are lower-cased; header names are
+// case-insensitive, so we match case- and surrounding-whitespace-insensitively.
+var tenantManagedResponseHeaders = map[string]struct{}{
+	"strict-transport-security": {},
+	"x-frame-options":           {},
+	"x-content-type-options":    {},
+	"referrer-policy":           {},
+	"content-length":            {},
+	"transfer-encoding":         {},
+}
+
 // validateTenantNginxRules enforces the tenant-safe subset on top of the full
-// structural validateNginxRules: only rewrite + custom_header, and a rewrite
+// structural validateNginxRules: only rewrite + custom_header, a rewrite
 // replacement must be a LOCAL path (no scheme or host) so it can never become
-// an open redirect or a proxy to an internal service.
+// an open redirect or a proxy to an internal service, and a custom_header may
+// not override a panel-managed response header (ADR-0169 Phase 2).
 func validateTenantNginxRules(rules models.NginxRules) error {
 	for i, r := range rules {
 		if _, ok := tenantSafeNginxRuleTypes[r.Type]; !ok {
@@ -2049,6 +2077,12 @@ func validateTenantNginxRules(rules models.NginxRules) error {
 			// JAB-72: tenants get a stricter pattern length cap than admins.
 			if err := validateRewritePattern(r.Pattern, 128); err != nil {
 				return fmt.Errorf("rule %d: %v", i, err)
+			}
+		}
+		if r.Type == "custom_header" {
+			name := strings.ToLower(strings.TrimSpace(r.Name))
+			if _, denied := tenantManagedResponseHeaders[name]; denied {
+				return fmt.Errorf("rule %d: response header %q is managed by the panel and can't be set here", i, r.Name)
 			}
 		}
 	}

--- a/panel-api/internal/api/domains_tenant_nginx_rules_test.go
+++ b/panel-api/internal/api/domains_tenant_nginx_rules_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
@@ -26,7 +28,10 @@ func patchNginxRules(t *testing.T, r interface {
 }
 
 func TestDomainPatch_TenantNginxRules(t *testing.T) {
-	const safeRewrite = `{"nginx_rules":[{"type":"rewrite","pattern":"^/old$","replacement":"/new","flag":"last"},{"type":"custom_header","name":"X-Frame-Options","value":"DENY"}]}`
+	// X-Robots-Tag is a benign, tenant-settable response header. (A panel-managed
+	// header like X-Frame-Options is NOT tenant-settable — see
+	// TestDomainPatch_TenantManagedHeadersDenied, ADR-0169 Phase 2.)
+	const safeRewrite = `{"nginx_rules":[{"type":"rewrite","pattern":"^/old$","replacement":"/new","flag":"last"},{"type":"custom_header","name":"X-Robots-Tag","value":"noindex"}]}`
 
 	t.Run("owner opt-in OFF: dropped", func(t *testing.T) {
 		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com"}
@@ -78,6 +83,63 @@ func TestDomainPatch_TenantNginxRules(t *testing.T) {
 		}
 		if len(repo.domains["d1"].NginxRules) != 1 {
 			t.Errorf("admin nginx_rules not applied: %+v", repo.domains["d1"].NginxRules)
+		}
+	})
+}
+
+// ADR-0169 Phase 2: a tenant custom_header may not set a response header the
+// panel manages — the four security headers it renders (Strict-Transport-
+// Security / X-Frame-Options / X-Content-Type-Options / Referrer-Policy), which
+// a tenant server-scope add_header would duplicate or weaken, plus the two
+// structural names (Content-Length / Transfer-Encoding) that make a malformed
+// response. Header names are case-insensitive, so each is denied in every
+// casing. The gate is tenant-only: an admin may still set these.
+func TestDomainPatch_TenantManagedHeadersDenied(t *testing.T) {
+	managed := []string{
+		"Strict-Transport-Security",
+		"X-Frame-Options",
+		"X-Content-Type-Options",
+		"Referrer-Policy",
+		"Content-Length",
+		"Transfer-Encoding",
+	}
+	for _, h := range managed {
+		for _, name := range []string{h, strings.ToLower(h), strings.ToUpper(h)} {
+			t.Run("tenant denied: "+name, func(t *testing.T) {
+				dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com"}
+				r, repo := buildSafeOptionsRouter(&auth.AccessClaims{UserID: "u1"}, true, dom)
+				body := fmt.Sprintf(`{"nginx_rules":[{"type":"custom_header","name":%q,"value":"x"}]}`, name)
+				if code := patchNginxRules(t, r, body); code != http.StatusBadRequest {
+					t.Fatalf("managed header %q should be 400 for tenant, got %d", name, code)
+				}
+				if len(repo.domains["d1"].NginxRules) != 0 {
+					t.Errorf("managed header %q applied despite reject: %+v", name, repo.domains["d1"].NginxRules)
+				}
+			})
+		}
+	}
+
+	t.Run("tenant: benign custom header applied", func(t *testing.T) {
+		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com"}
+		r, repo := buildSafeOptionsRouter(&auth.AccessClaims{UserID: "u1"}, true, dom)
+		body := `{"nginx_rules":[{"type":"custom_header","name":"X-Robots-Tag","value":"noindex"}]}`
+		if code := patchNginxRules(t, r, body); code != http.StatusOK {
+			t.Fatalf("benign header status %d", code)
+		}
+		if len(repo.domains["d1"].NginxRules) != 1 {
+			t.Errorf("benign header not applied: %+v", repo.domains["d1"].NginxRules)
+		}
+	})
+
+	t.Run("admin: managed header applied (gate is tenant-only)", func(t *testing.T) {
+		dom := &models.Domain{ID: "d1", UserID: "u1", Name: "x.com"}
+		r, repo := buildSafeOptionsRouter(&auth.AccessClaims{UserID: "admin", IsAdmin: true}, true, dom)
+		body := `{"nginx_rules":[{"type":"custom_header","name":"X-Frame-Options","value":"DENY"}]}`
+		if code := patchNginxRules(t, r, body); code != http.StatusOK {
+			t.Fatalf("admin managed header status %d", code)
+		}
+		if len(repo.domains["d1"].NginxRules) != 1 {
+			t.Errorf("admin managed header not applied: %+v", repo.domains["d1"].NginxRules)
 		}
 	})
 }


### PR DESCRIPTION
## What

ADR-0169 **Phase 2** for GH #1624. Deny a tenant `custom_header` rule from setting a response header the panel manages.

A tenant `custom_header` renders `add_header NAME VALUE [always];` at **server scope** (`nginxrules.Compile`). The panel already renders four security headers itself — `NginxSafeOptions.Render` at server scope, and the agent vhost template re-declares three of them per PHP `location` (JAB-70, because a location's own `add_header` suppresses inherited server-scope ones). So today a tenant with domain-options enabled can set:

```
Strict-Transport-Security: max-age=0
```

and duplicate or void panel-managed hardening. This PR closes that gap.

**Denied for tenant `custom_header` (case- and whitespace-insensitive):**

| Header | Why |
|---|---|
| `Strict-Transport-Security` | panel-managed (HSTS) — tenant value can void it |
| `X-Frame-Options` | panel-managed security header |
| `X-Content-Type-Options` | panel-managed security header |
| `Referrer-Policy` | panel-managed security header |
| `Content-Length` | structural: `add_header` here yields a malformed response |
| `Transfer-Encoding` | structural: request-smuggling-adjacent, nginx emits it anyway |

**Not denied** — `Set-Cookie`, `Content-Security-Policy`, `Cache-Control`: the tenant's own domain, the tenant's call.

## Why this is a denylist, not an allowlist / not a value grammar

The hazard is the **name** (a value-independent collision with panel-managed hardening, and two structurally-invalid names), not the value. `add_header` is already structurally safe here — control chars and whitespace-in-name are rejected upstream in `validateNginxRules`, and the value is `quoteNginxString`-escaped. Allowlisting header names would regress current tenant capability for no security gain. Header names are case-insensitive, so the match normalizes `strings.ToLower(strings.TrimSpace(name))`.

## Scope note — the ADR Phase 2 re-read

ADR-0169's Phase 2 text names "redirects + a vetted response-header set." On reading the code, the **redirect** half is already delivered:

- `page_redirects` (typed per-path) and `redirect_all_to` / `redirect_all_type` (whole-domain) render as `return 301/302/307/308` — first-class tenant redirects, editable in `DomainRedirectsPanel`.
- The tenant `rewrite` rule already supports `redirect` / `permanent` flags with the local-path guard (no scheme/host).

Adding a "redirect" rule kind would duplicate those. And no other typed rule kind is safe to widen to tenants (`proxy_pass` = SSRF to localhost services, `ip_access` / `php_setting` / `static_alias` = admin surface / covered by `nginx_safe_options`). So Phase 2's real content is the **response-header constraint** — a hardening, not a widening. (Follow-up: the ADR Phase 2 wording is now stale; batched with the line-33 "owner-settable" nit for a docs-only PR after Phase 5.)

## Gate placement

The check lives in `validateTenantNginxRules` **only**. The admin path (`validateNginxRules`, called directly for admins at `domains.go:993`) is untouched — an admin may still set any of these headers.

## UI

No UI change. `TenantNginxRulesPanel` already surfaces the 400 `detail` in its error toast (`DomainSettingsButton.tsx:1279`), so a tenant sees exactly why the header was rejected. `allowedTypes` stays `["rewrite", "custom_header"]`.

## Backwards compatibility

Stored rules are **not** retro-validated. A tenant with an existing `X-Frame-Options` custom_header rule keeps it until they next edit their rules. (With `tenant_domain_options_enabled` off, tenant behaviour is exactly as before.)

## Tests

`panel-api/internal/api/domains_tenant_nginx_rules_test.go` — new `TestDomainPatch_TenantManagedHeadersDenied`:
- 6 managed names × 3 casings (canonical / lower / upper) → **400**, rule not applied.
- benign `X-Robots-Tag` → **200**, applied.
- admin sets `X-Frame-Options` with the toggle on → **200**, applied (proves the gate is tenant-only).

The existing `safeRewrite` fixture used `X-Frame-Options` as a "safe" tenant header — now updated to `X-Robots-Tag`, since that header is exactly what this PR forbids for tenants.

**Fail-first verified**: neutralizing the denylist check makes all 18 denied-header subtests return 200 instead of 400; restored → full `internal/api` suite green.

## Verification

- `go vet ./internal/api/` clean; `go build ./...` green.
- `go test ./internal/api/` green (full package, 6.0s).

Held for `MERGE_APPROVED`.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5