### PR TITLE
fix(backup): honour stored auth on an sftp-password-only update (JAB-310)

### DIFF
--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -209,22 +209,6 @@ func buildReplacedSFTPBlock(host, user string, port int, path, auth, keyPath str
 	return url, raw, nil
 }
 
-// sftpPasswordWriteAllowed reports whether a --sftp-password update may write the
-// SSHPASS credential for a destination of the given kind and effective auth
-// (JAB-310 AC5). The password is an independent credential write (not a
-// structural block edit), but it must only land on an sftp destination whose
-// effective auth is "password": writing an SSHPASS to a key-auth destination is
-// meaningless, so it is rejected rather than silently stored.
-func sftpPasswordWriteAllowed(kind, effectiveAuth string) error {
-	if kind != models.BackupDestinationKindSFTP {
-		return fmt.Errorf("--sftp-password only applies to sftp destinations (kind=%s)", kind)
-	}
-	if effectiveAuth != models.SFTPAuthPassword {
-		return fmt.Errorf("--sftp-password requires the destination to use password auth (current auth=%q); pass --sftp-auth password with the full sftp block to switch", effectiveAuth)
-	}
-	return nil
-}
-
 func newBackupDestinationUpdateCmd() *cobra.Command {
 	var (
 		name        string
@@ -343,8 +327,10 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 				if s := d.ExtraOptionsTyped().SFTP; s != nil {
 					effAuth = s.Auth
 				}
-				if err := sftpPasswordWriteAllowed(d.Kind, effAuth); err != nil {
-					return err
+				if err := models.SFTPPasswordWriteAllowed(d.Kind, effAuth); err != nil {
+					// Append the CLI-specific remedy the shared (flag-agnostic)
+					// predicate deliberately omits, so the REST 400 detail stays clean.
+					return fmt.Errorf("%w; pass --sftp-auth password with the full sftp block to switch", err)
 				}
 				path, err := writeBackupDestinationCreds(ctx, sharedAgent.Call, d.ID, map[string]string{"SSHPASS": sftpPass})
 				if err != nil {

--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -328,9 +328,15 @@ func newBackupDestinationUpdateCmd() *cobra.Command {
 					effAuth = s.Auth
 				}
 				if err := models.SFTPPasswordWriteAllowed(d.Kind, effAuth); err != nil {
-					// Append the CLI-specific remedy the shared (flag-agnostic)
-					// predicate deliberately omits, so the REST 400 detail stays clean.
-					return fmt.Errorf("%w; pass --sftp-auth password with the full sftp block to switch", err)
+					// Append the CLI-specific remedy only for the auth-mismatch arm
+					// (kind is already sftp): a non-sftp kind cannot take --sftp-* at
+					// all, so "switch auth" is wrong advice there. The shared
+					// (flag-agnostic) predicate omits flag names so the REST 400 detail
+					// can surface it verbatim; the CLI adds the flag hint here.
+					if d.Kind == models.BackupDestinationKindSFTP {
+						err = fmt.Errorf("%w; pass --sftp-auth password with the full sftp block to switch", err)
+					}
+					return err
 				}
 				path, err := writeBackupDestinationCreds(ctx, sharedAgent.Call, d.ID, map[string]string{"SSHPASS": sftpPass})
 				if err != nil {

--- a/panel-api/cmd/server/backup_destination_parity_cmd_test.go
+++ b/panel-api/cmd/server/backup_destination_parity_cmd_test.go
@@ -69,23 +69,3 @@ func TestBuildReplacedSFTPBlock_RejectsPartialBlock(t *testing.T) {
 		t.Errorf("partial-block error must explain the whole-block requirement, got %v", err)
 	}
 }
-
-// TestSFTPPasswordWriteAllowed_GatesAuthAndKind pins the JAB-310 AC5 password
-// gate: --sftp-password is an independent credential write, but it must only
-// land on an sftp destination whose effective auth is "password". Writing an
-// SSHPASS to a key-auth (or non-sftp) destination is meaningless and must be
-// rejected, not silently stored.
-func TestSFTPPasswordWriteAllowed_GatesAuthAndKind(t *testing.T) {
-	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindSFTP, models.SFTPAuthPassword); err != nil {
-		t.Errorf("password write must be allowed for a password-auth sftp dest: %v", err)
-	}
-	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindSFTP, models.SFTPAuthKey); err == nil {
-		t.Error("password write must be rejected for a key-auth destination")
-	}
-	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindSFTP, ""); err == nil {
-		t.Error("password write must be rejected when auth is unset (defaults to key)")
-	}
-	if err := sftpPasswordWriteAllowed(models.BackupDestinationKindLocal, models.SFTPAuthPassword); err == nil {
-		t.Error("password write must be rejected for a non-sftp destination kind")
-	}
-}

--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -413,8 +413,25 @@ func (h *backupDestinationHandler) update(c *gin.Context) {
 		d.CredentialsRef = nil
 	}
 	credsEnv := req.CredentialsEnv
-	if d.Kind == models.BackupDestinationKindSFTP && req.SFTP != nil &&
-		req.SFTP.Auth == models.SFTPAuthPassword && req.SFTPPassword != "" {
+	// SFTP password (SSHPASS) is an independent credential write, gated on the
+	// destination's EFFECTIVE kind/auth — the block being set this request if the
+	// caller sent one (d.ExtraOptions was rewritten above), else the stored block.
+	// A password-only rotation (sftp_password with no sftp block) therefore lands
+	// on an already-password-auth destination, mirroring the CLI's --sftp-password
+	// affordance (JAB-310 AC5), instead of being silently dropped with a 200. The
+	// shared gate fails loud on a key-auth or non-sftp destination — including the
+	// req.SFTP=key-auth-block + sftp_password case, which used to be silently
+	// ignored. An empty sftp_password means "absent" (omitempty), so it is skipped,
+	// leaving any stored SSHPASS untouched (an unchanged-password edit).
+	if req.SFTPPassword != "" {
+		effAuth := ""
+		if s := d.ExtraOptionsTyped().SFTP; s != nil {
+			effAuth = s.Auth
+		}
+		if err := models.SFTPPasswordWriteAllowed(d.Kind, effAuth); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "sftp_password_not_applicable", "detail": err.Error()})
+			return
+		}
 		if credsEnv == nil {
 			credsEnv = map[string]string{}
 		}

--- a/panel-api/internal/api/backup_destinations_sftp_password_test.go
+++ b/panel-api/internal/api/backup_destinations_sftp_password_test.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// sftpPwAgent is a creds-write fake that captures the env payload of the last
+// backup.dest.creds_write, so a test can assert the stored-auth path writes THIS
+// SSHPASS value (not merely that a write fired) and leaks no other key.
+type sftpPwAgent struct {
+	writes  int
+	lastEnv map[string]string
+}
+
+func (a *sftpPwAgent) Call(_ context.Context, cmd string, args any) (json.RawMessage, error) {
+	if cmd == "backup.dest.creds_write" {
+		a.writes++
+		var p struct {
+			Env map[string]string `json:"env"`
+		}
+		raw, _ := json.Marshal(args)
+		_ = json.Unmarshal(raw, &p)
+		a.lastEnv = p.Env
+		return json.RawMessage(`{"path":"/etc/jabali-panel/restic-remotes/dst-1.env"}`), nil
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// sftpDestWithAuth returns a stored SFTP destination whose extra_options carry
+// the given auth ("key"|"password"), the shape the update handler reads to
+// derive effective auth when the request sends no fresh sftp block.
+func sftpDestWithAuth(id, auth string) *models.BackupDestination {
+	raw, _ := json.Marshal(models.BackupDestinationExtraOptions{
+		SFTP: &models.SFTPOptions{Host: "backup.example.com", User: "restic", Path: "/backups", Auth: auth},
+	})
+	return &models.BackupDestination{
+		ID: id, Name: "n", Kind: models.BackupDestinationKindSFTP, ExtraOptions: raw,
+	}
+}
+
+// A password-only rotation — sftp_password with NO sftp block — must land on a
+// destination whose STORED auth is already "password", writing exactly that
+// SSHPASS. This is the JAB-310 gap: the old handler coupled the SSHPASS write to
+// a present req.SFTP block, so this request was silently dropped with a 200.
+func TestSFTPPassword_PasswordOnlyRotation_HonoursStoredAuth(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: sftpDestWithAuth("dst-1", models.SFTPAuthPassword)}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"sftp_password": "newpass"})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	if ag.writes != 1 {
+		t.Fatalf("creds_write fired %d times, want 1", ag.writes)
+	}
+	if got := ag.lastEnv["SSHPASS"]; got != "newpass" {
+		t.Fatalf("SSHPASS = %q, want %q", got, "newpass")
+	}
+	if len(ag.lastEnv) != 1 {
+		t.Fatalf("creds env leaked extra keys: %v", ag.lastEnv)
+	}
+}
+
+// sftp_password against a stored KEY-auth destination is meaningless — it must
+// fail loud (400), never be silently stored.
+func TestSFTPPassword_KeyAuthDest_Rejected(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: sftpDestWithAuth("dst-1", models.SFTPAuthKey)}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"sftp_password": "x"})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "sftp_password_not_applicable") {
+		t.Fatalf("body = %s, want sftp_password_not_applicable", w.Body.String())
+	}
+	if ag.writes != 0 {
+		t.Fatalf("creds_write fired %d times, want 0", ag.writes)
+	}
+}
+
+// sftp_password against a non-sftp (local) destination must fail loud (400).
+func TestSFTPPassword_LocalDest_Rejected(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: &models.BackupDestination{
+		ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindLocal,
+	}}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"sftp_password": "x"})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if ag.writes != 0 {
+		t.Fatalf("creds_write fired %d times, want 0", ag.writes)
+	}
+}
+
+// The sibling silent drop: a FULL key-auth block plus sftp_password. The old
+// handler wrote SSHPASS only when req.SFTP.Auth == password, so a key-auth block
+// carrying a password silently dropped it (200). The effective-auth gate now
+// rejects it (400) — the same defect class in the same lines, fixed together.
+func TestSFTPPassword_KeyAuthBlockWithPassword_Rejected(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: sftpDestWithAuth("dst-1", models.SFTPAuthPassword)}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{
+		"sftp": map[string]any{
+			"host": "backup.example.com", "user": "restic", "path": "/backups", "auth": "key",
+		},
+		"sftp_password": "x",
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "sftp_password_not_applicable") {
+		t.Fatalf("body = %s, want sftp_password_not_applicable", w.Body.String())
+	}
+	if ag.writes != 0 {
+		t.Fatalf("creds_write fired %d times, want 0", ag.writes)
+	}
+}
+
+// An empty sftp_password means "absent" (omitempty) — a password-unchanged edit.
+// It must write nothing and leave any stored SSHPASS untouched, not 400.
+func TestSFTPPassword_Empty_NoOp(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: sftpDestWithAuth("dst-1", models.SFTPAuthPassword)}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"sftp_password": ""})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	if ag.writes != 0 {
+		t.Fatalf("creds_write fired %d times on empty password, want 0", ag.writes)
+	}
+}
+
+// Regression pin: the pre-existing working path — a full password-auth block
+// plus sftp_password in one request — must still write the SSHPASS.
+func TestSFTPPassword_FullPasswordBlock_StillWrites(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: sftpDestWithAuth("dst-1", models.SFTPAuthKey)}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{
+		"sftp": map[string]any{
+			"host": "backup.example.com", "user": "restic", "path": "/backups", "auth": "password",
+		},
+		"sftp_password": "secret",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	if ag.writes != 1 {
+		t.Fatalf("creds_write fired %d times, want 1", ag.writes)
+	}
+	if got := ag.lastEnv["SSHPASS"]; got != "secret" {
+		t.Fatalf("SSHPASS = %q, want %q", got, "secret")
+	}
+}
+
+// Corrupt stored extra_options plus a password-only request must fail closed
+// (400), never write: ExtraOptionsTyped yields an empty struct on bad JSON, so
+// effective auth is "" and the gate rejects — the client can always resend a
+// full block.
+func TestSFTPPassword_CorruptExtraOptions_FailClosed(t *testing.T) {
+	ag := &sftpPwAgent{}
+	repo := &updFakeDestRepo{getDest: &models.BackupDestination{
+		ID: "dst-1", Name: "n", Kind: models.BackupDestinationKindSFTP,
+		ExtraOptions: json.RawMessage(`{not json`),
+	}}
+	h := &backupDestinationHandler{repo: repo, agent: ag}
+
+	w := updDo(h, "dst-1", map[string]any{"sftp_password": "x"})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if ag.writes != 0 {
+		t.Fatalf("creds_write fired %d times, want 0", ag.writes)
+	}
+}

--- a/panel-api/internal/models/backup_destination.go
+++ b/panel-api/internal/models/backup_destination.go
@@ -118,6 +118,26 @@ func ValidateSFTPHostUser(host, user string) error {
 	return nil
 }
 
+// SFTPPasswordWriteAllowed reports whether an sftp password (SSHPASS) write may
+// land on a destination with this effective kind and auth. An SSHPASS is only
+// meaningful for an sftp destination whose auth is "password"; writing one to a
+// key-auth or non-sftp destination is a no-op that must fail loud, never be
+// silently dropped. effectiveAuth is the auth of the block being written this
+// request if the caller supplies one, else the stored block's auth.
+//
+// The single owner of this decision so the REST and CLI update paths cannot
+// drift (JAB-310 AC5), the same reason ValidateSFTPHostUser lives here. The
+// message names no CLI flags so a REST 400 detail can surface it verbatim.
+func SFTPPasswordWriteAllowed(kind, effectiveAuth string) error {
+	if kind != BackupDestinationKindSFTP {
+		return fmt.Errorf("sftp password only applies to sftp destinations (kind=%s)", kind)
+	}
+	if effectiveAuth != SFTPAuthPassword {
+		return fmt.Errorf("sftp password requires the destination to use password auth (current auth=%q)", effectiveAuth)
+	}
+	return nil
+}
+
 type BackupDestination struct {
 	ID             string  `gorm:"type:char(26);primaryKey" json:"id"`
 	Name           string  `gorm:"type:varchar(64);not null;uniqueIndex:uniq_backup_dest_name" json:"name"`

--- a/panel-api/internal/models/backup_destination_test.go
+++ b/panel-api/internal/models/backup_destination_test.go
@@ -1,0 +1,24 @@
+package models
+
+import "testing"
+
+// TestSFTPPasswordWriteAllowed_GatesAuthAndKind pins the JAB-310 AC5 password
+// gate, the single owner shared by the REST and CLI update paths: an sftp
+// password (SSHPASS) is an independent credential write, but it must only land
+// on an sftp destination whose effective auth is "password". Writing an SSHPASS
+// to a key-auth (or non-sftp) destination is meaningless and must be rejected,
+// not silently stored.
+func TestSFTPPasswordWriteAllowed_GatesAuthAndKind(t *testing.T) {
+	if err := SFTPPasswordWriteAllowed(BackupDestinationKindSFTP, SFTPAuthPassword); err != nil {
+		t.Errorf("password write must be allowed for a password-auth sftp dest: %v", err)
+	}
+	if err := SFTPPasswordWriteAllowed(BackupDestinationKindSFTP, SFTPAuthKey); err == nil {
+		t.Error("password write must be rejected for a key-auth destination")
+	}
+	if err := SFTPPasswordWriteAllowed(BackupDestinationKindSFTP, ""); err == nil {
+		t.Error("password write must be rejected when auth is unset (defaults to key)")
+	}
+	if err := SFTPPasswordWriteAllowed(BackupDestinationKindLocal, SFTPAuthPassword); err == nil {
+		t.Error("password write must be rejected for a non-sftp destination kind")
+	}
+}


### PR DESCRIPTION
## What

A `PATCH` to a backup destination carrying `sftp_password` but **no `sftp`
block** silently dropped the password and returned `200`. The update handler
wrote the SSHPASS only when `req.SFTP != nil && req.SFTP.Auth == "password"`, so
a **password-only rotation** — the exact shape needed to change just the SFTP
connection password — was a no-op with a success status.

`rotate-password` rotates the restic **repo** password (the sealed
`password_enc` column), not the SSHPASS, so there was no path at all to change
only the SFTP connection password. Silently dropping a credential is the
JAB-275 allowlist-silent-drop class: a credential write must land or fail loud,
never vanish behind a `200`.

## Fix — honour stored auth (parity with the CLI)

The SSHPASS write now gates on the destination's **effective** kind and auth —
the block being set this request if the caller sent one (`d.ExtraOptions` was
rewritten just above), else the **stored** block — mirroring the CLI's
`--sftp-password` affordance (JAB-310 AC5). So:

- `PATCH {sftp_password}` alone rotates the SSHPASS of an already-password-auth
  destination.
- Anything else fails loud with `400 sftp_password_not_applicable`:
  - a key-auth or non-sftp destination (an SSHPASS is meaningless there);
  - **the sibling silent drop** — a full **key-auth** block sent together with
    `sftp_password`. The old code wrote SSHPASS only when the block's auth was
    `password`, so a key-auth block carrying a password silently dropped it.
    Same defect class, same ten lines, fixed together.
- An empty `sftp_password` means "absent" (`omitempty`), so it is skipped and
  any stored SSHPASS is left untouched — an unchanged-password edit still works.
- Corrupt stored `extra_options` fail **closed**: `ExtraOptionsTyped` yields an
  empty struct on bad JSON, so effective auth is `""` and the gate rejects; the
  client can always resend a full block.

The kind/auth decision is lifted into `models.SFTPPasswordWriteAllowed`, the
single owner both the REST and CLI update paths now call so they cannot drift —
the same reason `ValidateSFTPHostUser` lives in `models`. Its message names no
CLI flags so a REST `400` detail can surface it verbatim; the CLI wraps it to
append the `--sftp-auth password` remedy, and only on the auth-mismatch arm (a
non-sftp kind gets no misleading "switch auth" advice). The AC5 gate test moves
to the `models` package as the canonical test.

## No SPA change

The admin destination Drawer (`DestinationsTab.tsx`) sets `body.sftp_password`
only under `sftp_auth === "password"` **and** a non-empty field, and always
sends the full `body.sftp` block:

```
if (values.sftp_auth === "password") {
  if (!values.sftp_password && !editing?.has_credentials) { error; return; }
  if (values.sftp_password) body.sftp_password = values.sftp_password;
}
```

So the new `400` is unreachable from the UI (it never sends `sftp_password` on
key auth, and never a password-only body), and the existing edit flow (full
block + `auth=password` + `sftp_password`) still passes the gate. A UI
affordance for a **password-only** rotation (no block) is a REST/CLI capability
today; a Drawer button can follow.

## No schema change

Same request/response fields (`sftp`, `sftp_password`); only a new error-code
string value. `TestCLIReferenceGolden` and the OpenAPI coverage test both pass
unchanged (run, not eyeballed) — no golden regen.

## Tests

`panel-api/internal/api` (REST, driven through the real `update` handler with a
fake repo + a payload-capturing agent fake):

- password-only rotation on a stored password-auth dest → `200`, writes exactly
  that SSHPASS and **no other key**;
- key-auth dest, local dest, and a **key-auth-block + password** → `400
  sftp_password_not_applicable`, zero `creds_write`;
- empty `sftp_password` → `200` no-op, zero `creds_write`;
- full password block + password → still writes (regression pin);
- corrupt `extra_options` + password → `400` fail-closed, zero `creds_write`.

The creds fake captures the write payload, so the assertion is the exact
password value, not merely that a write fired. `panel-api/internal/models`: the
AC5 kind/auth gate table.

**Four guards falsified against compiling neutralizations** (each reverted):
neutralize `SFTPPasswordWriteAllowed` → the four `400` tests + the models table
go RED; drop the stored-auth derivation → the two write tests go RED; break the
`!= ""` empty guard → the no-op test goes RED; write a wrong SSHPASS value → the
two payload-capture tests go RED. `gofmt` + `go vet` clean; full `panel-api`
suite green.

## No box-verify

REST handler behavior, fully covered by the real handler + fake repo +
payload-capturing agent fake. No agent, reconciler, migration, or cert surface
is touched, so there is nothing a live box would exercise that the unit path
does not.

## Not in this slice (pre-existing, unchanged)

- `credentials_env: {SSHPASS: …}` still bypasses this gate — it is the generic
  raw-env write, same on CLI `--env`. Out of scope.
- A full block switch to `auth=password` with **no** `sftp_password` leaves a
  password-auth dest with no SSHPASS. CREATE `400`s this
  (`sftp_password_required`); UPDATE and the CLI both do not. Pre-existing, both
  doors.
- The creds file is written before `repo.Update`. On a password-only rotation
  the path is deterministic per id and pre-existing, so a persist failure leaves
  the **new** password on disk behind a `500` — the same behavior as today's
  block path. Inherited ordering, not changed here.

Part of JAB-310 (backup destination lifecycle); the parent stays open (AC3
round-trip / AC4 rekey remain). Closes the unfiled `PATCH {sftp_password}`
silent-no-op follow-up noted on the last JAB-310 comment.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
