### PR TITLE
feat(nginx): admin web (nginx) templates, applied at domain create (GH #1624, ADR-0169 Phase 3, backend)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -205,6 +205,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		dnsZoneRepo := repository.NewDNSZoneRepository(sharedDB)
 		dnsRecordRepo := repository.NewDNSRecordRepository(sharedDB)
 		dnsTemplateRepo := repository.NewDNSTemplateRepository(sharedDB)
+		webTemplateRepo := repository.NewWebTemplateRepository(sharedDB) // GH #1624 Phase 3
 		sslCertRepo := repository.NewSSLCertificateRepository(sharedDB)
 		sharedCertRepo := repository.NewSharedCertificateRepository(sharedDB)
 		mailRBLStateRepo := repository.NewMailRBLStateRepository(sharedDB)
@@ -280,6 +281,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		deps.Packages = packageRepo
 		deps.Domains = domainRepo
 		deps.DNSTemplates = dnsTemplateRepo // GH #1627
+		deps.WebTemplates = webTemplateRepo // GH #1624 Phase 3
 		deps.DomainTeardowns = repository.NewDomainTeardownRepository(sharedDB)
 		deps.SSO = ssoService
 		// M37 Phase 4: Adminer SSO bridge — engine-aware mint + PG shadow.

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -64,6 +64,12 @@ type createDomainInput struct {
 	// every non-template create. Mutually exclusive with an explicit mail
 	// provider, and requires the panel to host DNS (DNSDisabled=false).
 	DNSTemplateID  string
+	// WebTemplateID (GH #1624 / ADR-0169 Phase 3) is an admin web (nginx)
+	// template selected at create. ADMIN-ONLY: a non-admin actor naming one is
+	// rejected (web_template_admin_only). When set, the template's directives are
+	// snapshot-copied onto the new domain's NginxCustomDirectives. Empty for every
+	// non-template create.
+	WebTemplateID  string
 	SSLMode        string // "" → le
 	CreateWWW      bool
 	TempURLEnabled bool
@@ -295,6 +301,42 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		mailProvider = models.MailProviderCustom
 		mailTemplateID = &tmplID
 	}
+
+	// GH #1624 / ADR-0169 Phase 3: an ADMIN may create a domain from a web
+	// (nginx) template — the template's raw directives are snapshot-copied onto
+	// the new domain's NginxCustomDirectives (a later template edit does NOT
+	// propagate; the admin edits the domain directly).
+	//
+	// ADMIN-ONLY: the GH #1580 admin denylist does not block proxy_pass, so
+	// letting a tenant pick a globally-visible template would let template B's
+	// `proxy_pass http://127.0.0.1:...` front a localhost service from tenant B's
+	// own domain — the ADR-0169 SSRF threat with the admin as unwitting author.
+	// A nil repo is fail-closed (503), never a silent skip. The directives are
+	// validated AGAIN here so a denylist tightened after the template was saved
+	// is enforced at apply.
+	var webTemplateID *string
+	var webTemplateDirectives string
+	if tmplID := strings.TrimSpace(in.WebTemplateID); tmplID != "" {
+		if !in.ActorIsAdmin {
+			return nil, &createDomainError{http.StatusForbidden, "web_template_admin_only", "web templates can be applied only by an administrator"}
+		}
+		if h.cfg.WebTemplates == nil {
+			return nil, &createDomainError{http.StatusServiceUnavailable, "web_templates_unavailable", "web templates are not enabled on this server"}
+		}
+		tmpl, terr := h.cfg.WebTemplates.FindByID(ctx, tmplID)
+		if terr != nil {
+			if errors.Is(terr, repository.ErrNotFound) {
+				return nil, &createDomainError{http.StatusBadRequest, "unknown_web_template", "the selected web template does not exist"}
+			}
+			return nil, &createDomainError{http.StatusInternalServerError, "web_template_lookup_failed", ""}
+		}
+		if msg := ValidateNginxDirectivesAdmin(tmpl.NginxDirectives); msg != "" {
+			return nil, &createDomainError{http.StatusBadRequest, "web_template_invalid", "web template " + tmpl.Name + ": " + msg}
+		}
+		webTemplateID = &tmplID
+		webTemplateDirectives = tmpl.NginxDirectives
+	}
+
 	// GH #1409: never enable Jabali mail on a domain when the mail module isn't
 	// installed — coerce to "none" so we don't provision mail that can't run.
 	// The GUI already defaults to None; this guards API / automation callers
@@ -363,6 +405,10 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		M365Onmicrosoft: strPtrOrNil(m365Tenant),
 		GoogleDKIM:      strPtrOrNil(googleDKIM),
 		MailTemplateID:  mailTemplateID, // GH #1627: nil unless a template was chosen
+		// GH #1624 Phase 3: nil / "" unless an admin chose a web template above,
+		// in which case its directives are snapshot-copied onto this domain.
+		WebTemplateID:         webTemplateID,
+		NginxCustomDirectives: strPtrOrNil(webTemplateDirectives),
 		EmailEnabled:    mailEnabled,
 		SkipAutoSAN:     mailSkipSAN,
 		CreateWWW:       in.CreateWWW,

--- a/panel-api/internal/api/domain_create_web_template_test.go
+++ b/panel-api/internal/api/domain_create_web_template_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeWebTemplates is a minimal WebTemplateRepository for the createDomainOp
+// gating tests — only FindByID is exercised.
+type fakeWebTemplates struct {
+	repository.WebTemplateRepository
+	byID map[string]*models.WebTemplate
+}
+
+func (f fakeWebTemplates) FindByID(_ context.Context, id string) (*models.WebTemplate, error) {
+	if t, ok := f.byID[id]; ok {
+		return t, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// GH #1624 / ADR-0169 Phase 3: an ADMIN may create a domain from a web (nginx)
+// template — its directives are snapshot-copied onto the new domain's
+// NginxCustomDirectives. ADMIN-ONLY (the admin denylist does not block
+// proxy_pass, so a tenant-pickable template would be an SSRF vector), validated
+// again at apply, and fail-closed on every misuse.
+func TestCreateDomainOp_WebTemplate(t *testing.T) {
+	uname := "alice"
+	owner := &models.User{ID: "u-alice", Email: "alice@example.com", Username: &uname}
+	const tmplID = "wtmpl-01"
+	const directives = `add_header X-From-Template "1" always;`
+
+	newH := func(withTemplates bool, tmpl *models.WebTemplate) *domainHandler {
+		cfg := DomainHandlerConfig{Users: newAbUsers(owner), Domains: newDCDomains()}
+		if withTemplates {
+			m := map[string]*models.WebTemplate{}
+			if tmpl != nil {
+				m[tmpl.ID] = tmpl
+			}
+			cfg.WebTemplates = fakeWebTemplates{byID: m}
+		}
+		return &domainHandler{cfg: cfg}
+	}
+	goodTmpl := &models.WebTemplate{ID: tmplID, Name: "WordPress", NginxDirectives: directives}
+
+	t.Run("admin: template directives snapshot-copied + web_template_id set", func(t *testing.T) {
+		d, oerr := createDomainOp(context.Background(), newH(true, goodTmpl), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "shop.example.com",
+			ActorIsAdmin:  true,
+			WebTemplateID: tmplID,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v (%s)", oerr.Code, oerr.Detail)
+		}
+		if d.NginxCustomDirectives == nil || *d.NginxCustomDirectives != directives {
+			t.Errorf("NginxCustomDirectives = %v, want %q", d.NginxCustomDirectives, directives)
+		}
+		if d.WebTemplateID == nil || *d.WebTemplateID != tmplID {
+			t.Errorf("WebTemplateID = %v, want %q", d.WebTemplateID, tmplID)
+		}
+	})
+
+	t.Run("non-admin: template rejected (web_template_admin_only)", func(t *testing.T) {
+		_, oerr := createDomainOp(context.Background(), newH(true, goodTmpl), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "b.example.com",
+			ActorIsAdmin:  false,
+			WebTemplateID: tmplID,
+		})
+		if oerr == nil || oerr.Code != "web_template_admin_only" {
+			t.Fatalf("want web_template_admin_only, got %v", oerr)
+		}
+		if oerr.Status != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", oerr.Status)
+		}
+	})
+
+	t.Run("unknown template id → 400 unknown_web_template", func(t *testing.T) {
+		_, oerr := createDomainOp(context.Background(), newH(true, goodTmpl), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "c.example.com",
+			ActorIsAdmin:  true,
+			WebTemplateID: "does-not-exist",
+		})
+		if oerr == nil || oerr.Code != "unknown_web_template" {
+			t.Fatalf("want unknown_web_template, got %v", oerr)
+		}
+	})
+
+	t.Run("repo unwired → 503 fail-closed", func(t *testing.T) {
+		_, oerr := createDomainOp(context.Background(), newH(false, nil), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "d.example.com",
+			ActorIsAdmin:  true,
+			WebTemplateID: tmplID,
+		})
+		if oerr == nil || oerr.Code != "web_templates_unavailable" {
+			t.Fatalf("want web_templates_unavailable, got %v", oerr)
+		}
+		if oerr.Status != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", oerr.Status)
+		}
+	})
+
+	t.Run("apply-time validation: a denylisted directive in a stored template → 400", func(t *testing.T) {
+		// A template whose directives bypassed save validation (denylist tightened
+		// after the template was saved, or a row inserted out-of-band). Apply-time
+		// ValidateNginxDirectivesAdmin must STILL reject it — fail-closed, not dead
+		// code.
+		badTmpl := &models.WebTemplate{ID: "wtmpl-bad", Name: "Bad", NginxDirectives: "root /etc/jabali-panel/;"}
+		_, oerr := createDomainOp(context.Background(), newH(true, badTmpl), createDomainInput{
+			OwnerID:       owner.ID,
+			Name:          "e.example.com",
+			ActorIsAdmin:  true,
+			WebTemplateID: "wtmpl-bad",
+		})
+		if oerr == nil || oerr.Code != "web_template_invalid" {
+			t.Fatalf("want web_template_invalid, got %v", oerr)
+		}
+	})
+
+	t.Run("no template → no directives, no template id (unchanged create)", func(t *testing.T) {
+		d, oerr := createDomainOp(context.Background(), newH(true, goodTmpl), createDomainInput{
+			OwnerID:      owner.ID,
+			Name:         "f.example.com",
+			ActorIsAdmin: true,
+		})
+		if oerr != nil {
+			t.Fatalf("unexpected error: %v (%s)", oerr.Code, oerr.Detail)
+		}
+		if d.NginxCustomDirectives != nil {
+			t.Errorf("NginxCustomDirectives = %v, want nil", d.NginxCustomDirectives)
+		}
+		if d.WebTemplateID != nil {
+			t.Errorf("WebTemplateID = %v, want nil", d.WebTemplateID)
+		}
+	})
+}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -96,6 +96,12 @@ type DomainHandlerConfig struct {
 	// a create that names a dns_template_id return 503 (fail-closed), never a
 	// silent skip.
 	DNSTemplates repository.DNSTemplateRepository
+	// WebTemplates (GH #1624 / ADR-0169 Phase 3) resolves an admin-selected web
+	// (nginx) template at create: it validates the template exists + its
+	// directives pass the admin denylist, then snapshot-copies them onto the new
+	// domain's nginx_custom_directives. Optional — nil makes a create that names a
+	// web_template_id return 503 (fail-closed), never a silent skip.
+	WebTemplates repository.WebTemplateRepository
 	// AppInstalls (GH #1238 chown) backs the change-owner refusal: a domain
 	// with an app install carries the current owner's DB creds in its config,
 	// so re-owning it would leak a live cross-tenant credential. REQUIRED for
@@ -174,6 +180,11 @@ type createDomainRequest struct {
 	// it needs a cert upload, set via PUT /domains/:id/ssl/custom after create.
 	// Empty defaults to 'le'.
 	SSLMode string `json:"ssl_mode"`
+	// WebTemplateID (GH #1624 / ADR-0169 Phase 3) is an admin web (nginx)
+	// template to seed this domain's nginx_custom_directives from. ADMIN-ONLY:
+	// the create op rejects it from a non-admin caller (web_template_admin_only).
+	// Empty/absent for every non-template create.
+	WebTemplateID string `json:"web_template_id"`
 	// WebEnabled / ManageDNS (GH #1449) are the "Add Web Domain" service
 	// checkboxes: both default ON (nil == checked == current behaviour), so a
 	// caller only sends false to OPT OUT. WebEnabled=false → no vhost/docroot/
@@ -863,6 +874,7 @@ func (h *domainHandler) create(c *gin.Context) {
 		M365Onmicrosoft:  req.M365Onmicrosoft,
 		GoogleDKIM:       req.GoogleDKIM,
 		SSLMode:          req.SSLMode,
+		WebTemplateID:    req.WebTemplateID, // GH #1624 Phase 3 (admin-only; enforced in the op)
 		CreateWWW:        req.CreateWWW,
 		TempURLEnabled:   req.TempURLEnabled,
 		ReverseProxy:     req.ReverseProxy,

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1082,6 +1082,75 @@ paths:
         "200": { description: Deleted }
         "404": { description: Not found }
 
+  /admin/web-templates:
+    get:
+      tags: [Web Templates]
+      summary: List admin web (nginx) templates (admin) (GH #1624)
+      responses: { "200": { description: OK } }
+    post:
+      tags: [Web Templates]
+      summary: Create an admin web (nginx) template (admin) (GH #1624)
+      description: |
+        A named preset of raw nginx directives. The directives are validated with
+        the same relaxed denylist the admin custom-directives PATCH uses
+        (ValidateNginxDirectivesAdmin). Admin-select-only: at Web Domain create an
+        ADMIN may select a template (web_template_id) to snapshot-copy its
+        directives onto the new domain — there is no tenant-facing route.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, nginx_directives]
+              properties:
+                name:             { type: string, maxLength: 120 }
+                description:      { type: string, maxLength: 500 }
+                nginx_directives: { type: string, maxLength: 16384 }
+      responses:
+        "201": { description: Created }
+        "400": { description: Invalid template or directives }
+        "409": { description: A template with that name already exists }
+
+  /admin/web-templates/{id}:
+    get:
+      tags: [Web Templates]
+      summary: Get one admin web (nginx) template (admin) (GH #1624)
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200": { description: OK }
+        "404": { description: Not found }
+    put:
+      tags: [Web Templates]
+      summary: Replace an admin web (nginx) template's fields (admin) (GH #1624)
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, nginx_directives]
+              properties:
+                name:             { type: string, maxLength: 120 }
+                description:      { type: string, maxLength: 500 }
+                nginx_directives: { type: string, maxLength: 16384 }
+      responses:
+        "200": { description: Updated }
+        "400": { description: Invalid template or directives }
+        "404": { description: Not found }
+        "409": { description: A template with that name already exists }
+    delete:
+      tags: [Web Templates]
+      summary: Delete an admin web (nginx) template (admin) (GH #1624)
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200": { description: Deleted }
+        "404": { description: Not found }
+
   # ----------------------------------------------- Admin: Server Settings ---
 
   /admin/settings/free-hostname/register:

--- a/panel-api/internal/api/web_templates.go
+++ b/panel-api/internal/api/web_templates.go
@@ -1,0 +1,184 @@
+// Admin web (nginx) templates (GH #1624 / ADR-0169 Phase 3).
+//
+// Admin routes (mounted under /api/v1/admin, RequireAdmin):
+//
+//	GET    /web-templates          list templates
+//	POST   /web-templates          create a template
+//	GET    /web-templates/:id      one template
+//	PUT    /web-templates/:id      replace a template's fields
+//	DELETE /web-templates/:id      delete a template
+//
+// A web template is a named preset of raw nginx directives an admin authors
+// once; at Web Domain create an ADMIN may select one (web_template_id) and its
+// directives are snapshot-copied onto the new domain's nginx_custom_directives.
+// The directives are validated with the SAME ValidateNginxDirectivesAdmin the
+// admin custom-directives PATCH uses, so a template can never carry a directive
+// that path would reject.
+//
+// There is deliberately NO tenant-facing route: admin-select-only in this phase.
+// The admin denylist does not block proxy_pass, so a globally-visible template a
+// tenant could pick is an SSRF vector with the admin as unwitting author.
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// WebTemplateHandlerConfig wires the routes. A nil Templates repo disables
+// registration (the feature is unwired).
+type WebTemplateHandlerConfig struct {
+	Templates repository.WebTemplateRepository
+}
+
+type webTemplateHandler struct{ cfg WebTemplateHandlerConfig }
+
+// RegisterAdminWebTemplateRoutes mounts the admin CRUD under an already
+// RequireAdmin-gated group.
+func RegisterAdminWebTemplateRoutes(admin *gin.RouterGroup, cfg WebTemplateHandlerConfig) {
+	if cfg.Templates == nil {
+		return
+	}
+	h := &webTemplateHandler{cfg: cfg}
+	g := admin.Group("/web-templates")
+	g.GET("", h.list)
+	g.POST("", h.create)
+	g.GET("/:id", h.get)
+	g.PUT("/:id", h.update)
+	g.DELETE("/:id", h.delete)
+}
+
+type webTemplateInput struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	NginxDirectives string `json:"nginx_directives"`
+}
+
+// webTemplateMaxDirectivesBytes caps the raw directive blob. 16 KiB is far more
+// than any real per-vhost snippet and keeps a template row bounded.
+const webTemplateMaxDirectivesBytes = 16 * 1024
+
+// buildWebTemplate validates the input and returns a populated (unsaved)
+// template with a fresh ID, or an (http status, code, detail) rejection. The
+// directives are validated with the SAME relaxed denylist the admin
+// custom-directives PATCH uses (ValidateNginxDirectivesAdmin).
+func buildWebTemplate(in webTemplateInput) (*models.WebTemplate, int, string, string) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return nil, http.StatusBadRequest, "name_required", "a template name is required"
+	}
+	if len(name) > 120 {
+		return nil, http.StatusBadRequest, "name_too_long", "template name exceeds 120 characters"
+	}
+	if len(in.Description) > 500 {
+		return nil, http.StatusBadRequest, "description_too_long", "template description exceeds 500 characters"
+	}
+	directives := strings.TrimSpace(in.NginxDirectives)
+	if directives == "" {
+		return nil, http.StatusBadRequest, "directives_required", "a template must carry at least one nginx directive"
+	}
+	if len(directives) > webTemplateMaxDirectivesBytes {
+		return nil, http.StatusBadRequest, "directives_too_long", "nginx directives exceed 16 KiB"
+	}
+	if msg := ValidateNginxDirectivesAdmin(directives); msg != "" {
+		return nil, http.StatusBadRequest, "invalid_directives", msg
+	}
+	return &models.WebTemplate{
+		ID:              ids.NewULID(),
+		Name:            name,
+		Description:     strings.TrimSpace(in.Description),
+		NginxDirectives: directives,
+	}, 0, "", ""
+}
+
+func (h *webTemplateHandler) create(c *gin.Context) {
+	var in webTemplateInput
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	tmpl, status, code, detail := buildWebTemplate(in)
+	if status != 0 {
+		c.JSON(status, gin.H{"error": code, "detail": detail})
+		return
+	}
+	if err := h.cfg.Templates.Create(c.Request.Context(), tmpl); err != nil {
+		if isDuplicateKeyErr(err) {
+			c.JSON(http.StatusConflict, gin.H{"error": "name_taken", "detail": "a template with that name already exists"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusCreated, tmpl)
+}
+
+func (h *webTemplateHandler) update(c *gin.Context) {
+	var in webTemplateInput
+	if err := c.ShouldBindJSON(&in); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	tmpl, status, code, detail := buildWebTemplate(in)
+	if status != 0 {
+		c.JSON(status, gin.H{"error": code, "detail": detail})
+		return
+	}
+	tmpl.ID = c.Param("id")
+	if err := h.cfg.Templates.Update(c.Request.Context(), tmpl); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		case isDuplicateKeyErr(err):
+			c.JSON(http.StatusConflict, gin.H{"error": "name_taken", "detail": "a template with that name already exists"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, tmpl)
+}
+
+func (h *webTemplateHandler) get(c *gin.Context) {
+	tmpl, err := h.cfg.Templates.FindByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, tmpl)
+}
+
+func (h *webTemplateHandler) list(c *gin.Context) {
+	tmpls, err := h.cfg.Templates.List(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if tmpls == nil {
+		tmpls = []models.WebTemplate{}
+	}
+	c.JSON(http.StatusOK, gin.H{"templates": tmpls})
+}
+
+func (h *webTemplateHandler) delete(c *gin.Context) {
+	if err := h.cfg.Templates.Delete(c.Request.Context(), c.Param("id")); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"deleted": true})
+}

--- a/panel-api/internal/api/web_templates_test.go
+++ b/panel-api/internal/api/web_templates_test.go
@@ -1,0 +1,55 @@
+package api
+
+import "testing"
+
+// GH #1624 / ADR-0169 Phase 3: buildWebTemplate validates admin web-template
+// input. Directives run through the SAME relaxed denylist the admin
+// custom-directives PATCH uses (ValidateNginxDirectivesAdmin).
+func TestBuildWebTemplate(t *testing.T) {
+	t.Run("name required", func(t *testing.T) {
+		_, _, code, _ := buildWebTemplate(webTemplateInput{NginxDirectives: "add_header X-A b;"})
+		if code != "name_required" {
+			t.Fatalf("code = %q, want name_required", code)
+		}
+	})
+
+	t.Run("directives required", func(t *testing.T) {
+		_, _, code, _ := buildWebTemplate(webTemplateInput{Name: "t"})
+		if code != "directives_required" {
+			t.Fatalf("code = %q, want directives_required", code)
+		}
+	})
+
+	t.Run("denylisted directive rejected", func(t *testing.T) {
+		_, _, code, _ := buildWebTemplate(webTemplateInput{Name: "t", NginxDirectives: "root /etc/jabali-panel/;"})
+		if code != "invalid_directives" {
+			t.Fatalf("code = %q, want invalid_directives", code)
+		}
+	})
+
+	// proxy_pass is NOT in the admin denylist — this is exactly why web templates
+	// are admin-select-only: a globally-visible template holding this, if a tenant
+	// could pick it, would front a localhost service from the tenant's own domain.
+	t.Run("proxy_pass accepted (admin denylist is relaxed)", func(t *testing.T) {
+		_, status, code, _ := buildWebTemplate(webTemplateInput{Name: "t", NginxDirectives: "proxy_pass http://127.0.0.1:9000;"})
+		if status != 0 {
+			t.Fatalf("proxy_pass rejected (code=%q); admin path allows it", code)
+		}
+	})
+
+	t.Run("valid template — trimmed + ID assigned", func(t *testing.T) {
+		tmpl, status, _, _ := buildWebTemplate(webTemplateInput{Name: "  WordPress  ", Description: "wp", NginxDirectives: "  add_header X-A b;  "})
+		if status != 0 {
+			t.Fatalf("valid template rejected, status = %d", status)
+		}
+		if tmpl.Name != "WordPress" {
+			t.Errorf("name = %q, want trimmed WordPress", tmpl.Name)
+		}
+		if tmpl.NginxDirectives != "add_header X-A b;" {
+			t.Errorf("directives = %q, want trimmed", tmpl.NginxDirectives)
+		}
+		if tmpl.ID == "" {
+			t.Error("no ID assigned")
+		}
+	})
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -67,6 +67,7 @@ type Deps struct {
 	DNSZones                  repository.DNSZoneRepository
 	DNSRecords                repository.DNSRecordRepository
 	DNSTemplates              repository.DNSTemplateRepository
+	WebTemplates              repository.WebTemplateRepository
 	SSLCerts                  repository.SSLCertificateRepository
 	SharedCerts               repository.SharedCertificateRepository
 	// MailRBLStates (M47 Wave 5) backs the curated-RBL eventsource
@@ -484,6 +485,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 					// GH #1627: resolve a tenant-selected custom DNS template on
 					// the JAB-233 automation create path (same as GUI create).
 					DNSTemplates:    deps.DNSTemplates,
+					WebTemplates:    deps.WebTemplates, // GH #1624 Phase 3 (admin-only apply at create)
 					ManagedIPs:      deps.ManagedIPs,
 					ServerSettings:  deps.ServerSettings,
 					BWDaily:         deps.BWDaily,
@@ -735,6 +737,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				DNSRecords: deps.DNSRecords,
 				// GH #1627: resolves a tenant-selected custom DNS template at create.
 				DNSTemplates: deps.DNSTemplates,
+				WebTemplates: deps.WebTemplates, // GH #1624 Phase 3 (admin-only apply at create)
 				BWDaily:      deps.BWDaily,
 				// M24: lets PATCH listen_ipv*_id resolve FK + family + the
 				// is_user_selectable check, and lets GET denormalize
@@ -1562,6 +1565,15 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			adminTmpl := v1.Group("/admin", middleware.RequireAdmin())
 			api.RegisterAdminDNSTemplateRoutes(adminTmpl, api.DNSTemplateHandlerConfig{Templates: deps.DNSTemplates})
 			api.RegisterDNSTemplateRoutes(v1, api.DNSTemplateHandlerConfig{Templates: deps.DNSTemplates})
+		}
+		// GH #1624 / ADR-0169 Phase 3: admin web (nginx) templates. Admin CRUD
+		// under the RequireAdmin group only — there is NO tenant-facing route
+		// (admin-select-only: the admin denylist does not block proxy_pass, so a
+		// tenant-pickable template would be an SSRF vector with the admin as
+		// unwitting author).
+		if deps.WebTemplates != nil {
+			adminWebTmpl := v1.Group("/admin", middleware.RequireAdmin())
+			api.RegisterAdminWebTemplateRoutes(adminWebTmpl, api.WebTemplateHandlerConfig{Templates: deps.WebTemplates})
 		}
 		// M44: Automation API token management. Admin mints + revokes
 		// HMAC-signed tokens; the matching public read-only routes

--- a/panel-api/internal/app/openapi_coverage_test.go
+++ b/panel-api/internal/app/openapi_coverage_test.go
@@ -54,6 +54,7 @@ func fullDeps() Deps {
 		DNSZones: repository.NewDNSZoneRepository(db),
 		DNSRecords: repository.NewDNSRecordRepository(db),
 		DNSTemplates: repository.NewDNSTemplateRepository(db),
+		WebTemplates: repository.NewWebTemplateRepository(db),
 		SSLCerts: repository.NewSSLCertificateRepository(db),
 		MailRBLStates: repository.NewMailRBLStateRepository(db),
 		DMARCAggregate: repository.NewDMARCAggregateRepository(db),

--- a/panel-api/internal/db/migrations/000296_web_templates.down.sql
+++ b/panel-api/internal/db/migrations/000296_web_templates.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE domains DROP COLUMN web_template_id;
+DROP TABLE IF EXISTS web_templates;

--- a/panel-api/internal/db/migrations/000296_web_templates.up.sql
+++ b/panel-api/internal/db/migrations/000296_web_templates.up.sql
@@ -1,0 +1,43 @@
+-- GH #1624 / ADR-0169 Phase 3: admin-managed web (nginx) templates.
+--
+-- A web template is a named, admin-defined preset of raw nginx directives — the
+-- "copy my working config" migration vehicle (@johnnyq, #1624). An admin authors
+-- the directives (validated by the same relaxed denylist the admin custom-
+-- directives PATCH uses, ValidateNginxDirectivesAdmin); at Web Domain create an
+-- ADMIN may select a template and its directives are snapshot-copied onto the
+-- new domain's nginx_custom_directives. Snapshot, not a live link: later template
+-- edits do not propagate; the admin edits the domain directly (or re-creates).
+--
+-- ADMIN-SELECT-ONLY in this phase. The admin denylist (root/alias/include/...)
+-- does NOT block proxy_pass, so a globally-visible template holding
+-- `proxy_pass http://127.0.0.1:...` picked by a different tenant would front a
+-- localhost service from that tenant's own domain — the ADR-0169 SSRF threat with
+-- the admin as unwitting author. Per-template tenant-selectable opt-in is a later
+-- phase.
+--
+-- Single table: nginx directives are one raw text blob, not N structured records
+-- like a DNS template (#1627), so there is no child table.
+--
+-- Migration-number note: 000295 (dns_orphan_autosweep) is the highest on main at
+-- authoring time. Whichever nginx/backup migration merges after this renumbers to
+-- the next free version at rebase — the embedded-migrations completeness test
+-- (contiguous, no duplicate version) catches a collision.
+
+CREATE TABLE web_templates (
+    id               CHAR(26)      NOT NULL PRIMARY KEY,
+    name             VARCHAR(120)  NOT NULL,
+    description      VARCHAR(500)  NOT NULL DEFAULT '',
+    nginx_directives TEXT          NOT NULL,
+    created_at       DATETIME(6)   NOT NULL,
+    updated_at       DATETIME(6)   NOT NULL,
+    UNIQUE INDEX ux_web_templates_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- The domain records WHICH web template it was created from (nullable),
+-- informational only — the directives are already snapshot-copied into
+-- nginx_custom_directives at create, so nothing reads this at reconcile.
+-- Deliberately NOT a foreign key (mirrors mail_template_id): a later template
+-- delete leaves a harmless dangling id, and the big domains table gains no
+-- cross-table constraint.
+ALTER TABLE domains
+    ADD COLUMN web_template_id CHAR(26) NULL;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -411,6 +411,13 @@ type Domain struct {
 	// never re-asserted). Nil for every non-template domain. Not a foreign key:
 	// a later template delete leaves a harmless dangling id (seeds nothing).
 	MailTemplateID *string    `gorm:"column:mail_template_id;type:char(26)" json:"mail_template_id,omitempty"`
+	// WebTemplateID (GH #1624 / ADR-0169 Phase 3) records which admin web (nginx)
+	// template this domain was created from. Informational only: the template's
+	// directives are snapshot-copied into NginxCustomDirectives at create, so
+	// nothing reads this at reconcile. Nil for every non-template domain. Not a
+	// foreign key (mirrors MailTemplateID): a later template delete leaves a
+	// harmless dangling id.
+	WebTemplateID  *string    `gorm:"column:web_template_id;type:char(26)" json:"web_template_id,omitempty"`
 	DkimSelector    *string    `gorm:"type:varchar(64)" json:"dkim_selector,omitempty"`
 	DkimPublicKey   *string    `gorm:"type:text" json:"dkim_public_key,omitempty"`
 	EmailEnabledAt  *time.Time `gorm:"type:datetime(6)" json:"email_enabled_at,omitempty"`

--- a/panel-api/internal/models/web_template.go
+++ b/panel-api/internal/models/web_template.go
@@ -1,0 +1,31 @@
+package models
+
+import "time"
+
+// WebTemplate (GH #1624 / ADR-0169 Phase 3) is an admin-defined, named preset of
+// raw nginx directives — the "copy my working config" migration vehicle
+// (@johnnyq, #1624). An admin authors the directives; at Web Domain create an
+// ADMIN may select a template and its NginxDirectives are snapshot-copied onto
+// the new domain's NginxCustomDirectives (Domain.NginxCustomDirectives).
+//
+// Snapshot, not a live link: later edits to a template do not propagate to
+// domains already created from it. The directives are validated at BOTH template
+// save AND create-apply with api.ValidateNginxDirectivesAdmin, so a template can
+// never carry a directive the admin custom-directives PATCH would reject.
+//
+// ADMIN-SELECT-ONLY in this phase (see the create-op gate): the admin denylist
+// does not block proxy_pass, so a globally-visible template a tenant could pick
+// is an SSRF vector with the admin as unwitting author. Global — every admin sees
+// every template; per-package / tenant-selectable assignment is a later phase.
+type WebTemplate struct {
+	ID              string    `gorm:"type:char(26);primaryKey" json:"id"`
+	Name            string    `gorm:"type:varchar(120);not null;uniqueIndex:ux_web_templates_name" json:"name"`
+	Description     string    `gorm:"type:varchar(500);not null;default:''" json:"description"`
+	NginxDirectives string    `gorm:"type:text;not null" json:"nginx_directives"`
+	CreatedAt       time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt       time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+}
+
+// TableName pins the table (GORM would pluralise to "web_templates" anyway;
+// pinned for clarity + rename safety, mirroring DNSTemplate).
+func (WebTemplate) TableName() string { return "web_templates" }

--- a/panel-api/internal/repository/web_template_repository.go
+++ b/panel-api/internal/repository/web_template_repository.go
@@ -1,0 +1,90 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// WebTemplateRepository persists admin-managed web (nginx) templates
+// (GH #1624 / ADR-0169 Phase 3). A template is a flat row — a name, a
+// description, and one raw nginx-directives blob — so, unlike
+// DNSTemplateRepository, there is no child record set to load.
+type WebTemplateRepository interface {
+	Create(ctx context.Context, tmpl *models.WebTemplate) error
+	FindByID(ctx context.Context, id string) (*models.WebTemplate, error)
+	List(ctx context.Context) ([]models.WebTemplate, error)
+	Update(ctx context.Context, tmpl *models.WebTemplate) error
+	Delete(ctx context.Context, id string) error
+}
+
+type webTemplateRepo struct{ db *gorm.DB }
+
+func NewWebTemplateRepository(db *gorm.DB) WebTemplateRepository {
+	return &webTemplateRepo{db: db}
+}
+
+func (r *webTemplateRepo) Create(ctx context.Context, tmpl *models.WebTemplate) error {
+	now := time.Now().UTC()
+	if tmpl.CreatedAt.IsZero() {
+		tmpl.CreatedAt = now
+	}
+	tmpl.UpdatedAt = now
+	return r.db.WithContext(ctx).Create(tmpl).Error
+}
+
+func (r *webTemplateRepo) FindByID(ctx context.Context, id string) (*models.WebTemplate, error) {
+	var tmpl models.WebTemplate
+	err := r.db.WithContext(ctx).First(&tmpl, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &tmpl, nil
+}
+
+func (r *webTemplateRepo) List(ctx context.Context) ([]models.WebTemplate, error) {
+	var tmpls []models.WebTemplate
+	if err := r.db.WithContext(ctx).Order("name asc").Find(&tmpls).Error; err != nil {
+		return nil, err
+	}
+	return tmpls, nil
+}
+
+// Update replaces the mutable fields via a column-scoped map so a cleared
+// description ('') is written (a struct update would skip the zero value).
+func (r *webTemplateRepo) Update(ctx context.Context, tmpl *models.WebTemplate) error {
+	tmpl.UpdatedAt = time.Now().UTC()
+	res := r.db.WithContext(ctx).Model(&models.WebTemplate{}).
+		Where("id = ?", tmpl.ID).
+		Updates(map[string]any{
+			"name":             tmpl.Name,
+			"description":      tmpl.Description,
+			"nginx_directives": tmpl.NginxDirectives,
+			"updated_at":       tmpl.UpdatedAt,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *webTemplateRepo) Delete(ctx context.Context, id string) error {
+	res := r.db.WithContext(ctx).Delete(&models.WebTemplate{}, "id = ?", id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
## What

ADR-0169 **Phase 3 (backend, 3a)** for GH #1624. An admin authors a named preset of raw nginx directives (a **web template**); at Web Domain create an **admin** may select one (`web_template_id`) and its directives are snapshot-copied onto the new domain's `nginx_custom_directives`.

This is the "copy my working config" migration vehicle @johnnyq asked for on #1624 — templates for WordPress / Nextcloud / Laravel etc. The admin authors the snippet, so it never passes through the untrusted-tenant path.

## Admin-select-only (deliberate departure from DNS-template parity)

@johnnyq's suggestion was to make templates tenant-pickable at create. This PR ships **admin-select-only** and names tenant-selectable as a follow-up, for a security reason:

The GH #1580 admin denylist (`root`/`alias`/`include`/…) does **not** block `proxy_pass` (there's a test in this PR asserting it's accepted). So a globally-visible template holding `proxy_pass http://127.0.0.1:8443;`, if a *different* tenant could pick it, would front panel-api (or tenant A's Gitea) from tenant B's own domain — the ADR-0169 SSRF threat, with the admin as unwitting author. A wrong DNS template damages only the picker's own zone; a wrong nginx template reaches the host. DNS parity breaks here for that reason.

So a non-admin create naming `web_template_id` → **403 `web_template_admin_only`**. Per-template tenant-selectable opt-in (default OFF) is a named follow-up.

## Design

| Decision | Choice |
|---|---|
| Table | Single `web_templates` (nginx directives are one raw blob, not N records like a DNS template — no child table). |
| Domain link | `domains.web_template_id CHAR(26) NULL`, **non-FK / dangling-safe**, mirrors `mail_template_id`. Informational — nothing reads it at reconcile. |
| Apply | Snapshot-copy onto `nginx_custom_directives`. Later template edits do **not** propagate. |
| Validation | `ValidateNginxDirectivesAdmin` (the admin custom-directives denylist) at template **save** AND again at **create-apply** — a denylist tightened after save is enforced; a bad template fails the create 400, never applies. |
| Routes | Admin REST CRUD under `/admin/web-templates` (RequireAdmin). **No tenant route.** |
| DI | Nil repo → 503 `web_templates_unavailable` (fail-closed), never a silent skip. |

## Scope re-read

ADR-0169's Phase 3 text ("Let Web Templates carry admin-authored nginx directive presets") assumed a *Web Template* entity that **did not exist** — only DNS templates (#1627) and page templates did. This PR builds the entity, mirroring the DNS-template ship shape (#1635: single backend PR, REST CRUD, no template-CRUD CLI). The ADR wording is now stale — third nit, batched for a docs-only PR after Phase 5 (with the line-33 "owner-settable" nit and the stale Phase 2 wording).

## This is the backend slice (3a)

The admin **Web Templates management UI** + the **create-drawer picker** are follow-up **3b**, branched off `main` (the React form references only the JSON keys `web_template_id` / `nginx_directives`, no Go types — no stacked-PR dependency).

## Not in this PR (named for follow-ups)

Tenant-selectable templates; typed `NginxRules` in templates (Phase 5 unifies the two stores); apply-to-existing-domains; an `nginx -t` syntax pre-check (the reconciler already backstops syntax for admin directives today).

## Tests (`panel-api/internal/api`)

- **`TestBuildWebTemplate`** — name/directives required; denylisted `root` → `invalid_directives`; `proxy_pass` **accepted** (documents the admin-select-only rationale); valid input trims + assigns an ID.
- **`TestCreateDomainOp_WebTemplate`** — admin apply snapshot-copies directives + sets `web_template_id`; non-admin → 403; unknown id → 400; nil repo → 503; **apply-time validation** rejects a denylisted directive in a *stored* template (one that bypassed save validation) → 400 (proves the second validation isn't dead code); no-template create unchanged.
- **Fail-first verified**: neutralizing the admin gate, the apply-time validation, or the snapshot copy each flips its matching subtest; restored → green.

## Verification

- `go build ./...` + `go vet` clean.
- `internal/api`, `internal/app` (OpenAPI-coverage golden), `internal/repository`, `internal/models` suites green.
- Migration completeness (000296 contiguous, singular) green. `openapi.yaml` documents the new routes.
- Migration number 000296 free at branch time (000295 highest on main; #1685 carries none). Re-audit at merge.
- `detect_changes` not run; scope hand-verified = exactly the 14 intended web-template files.

Held for `MERGE_APPROVED`.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5