### PR TITLE
feat(shared-resources): reject grants to a non-existent grantee (JAB-339 AC4)

### DIFF
--- a/panel-api/cmd/server/shared_resource_cmd.go
+++ b/panel-api/cmd/server/shared_resource_cmd.go
@@ -25,6 +25,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sharedresourceops"
 )
 
 func sharedResourceRepoFromDB() repository.SharedResourceRepository {
@@ -168,6 +169,22 @@ func newSharedResourceGrantCmd() *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
+			// JAB-339 AC4: reject a grant to a non-existent grantee before any
+			// write — the shared owner with the REST handler. The inline flag
+			// checks above already caught a bad kind / empty id with a
+			// flag-specific message, so only the existence check fires here.
+			grantDeps := sharedresourceops.Deps{
+				Mailboxes:  mailboxRepoFromDB(),
+				MailGroups: repository.NewMailGroupRepository(sharedDB),
+			}
+			if err := sharedresourceops.ValidateGrants(ctx, grantDeps, []models.SharedResourceGrant{
+				{ResourceID: resourceID, GranteeKind: granteeKind, GranteeID: granteeID, Rights: rights},
+			}); err != nil {
+				if errors.Is(err, sharedresourceops.ErrGranteeNotFound) {
+					return fmt.Errorf("grantee not found: %s %s", granteeKind, granteeID)
+				}
+				return fmt.Errorf("validate grantee: %w", err)
+			}
 			repo := sharedResourceRepoFromDB()
 			grants, err := repo.ListGrants(ctx, resourceID)
 			if err != nil {

--- a/panel-api/cmd/server/shared_resource_ops_test.go
+++ b/panel-api/cmd/server/shared_resource_ops_test.go
@@ -186,6 +186,37 @@ func TestSharedResourceRemove_RoutesThroughLeafAndArmsAgent(t *testing.T) {
 	}
 }
 
+// TestSharedResourceGrant_ValidatesGranteeExistence source-pins JAB-339 AC4 in
+// the CLI grant subcommand: the grantee-existence gate must run through the
+// shared sharedresourceops.ValidateGrants owner (so REST and CLI cannot drift)
+// and it must run BEFORE ReplaceGrants — ordering is the load-bearing invariant.
+// The behavior is not cheaply testable (sharedDB is a concrete package global
+// the RunE dials directly), so the wiring is pinned at the source level, scoped
+// to the grant block so the revoke subcommand can't satisfy it.
+func TestSharedResourceGrant_ValidatesGranteeExistence(t *testing.T) {
+	cli := mustRead(t, "shared_resource_cmd.go")
+	marker := `Use:     "grant"`
+	i := strings.Index(cli, marker)
+	if i < 0 {
+		t.Fatal("grant subcommand not found")
+	}
+	block := cli[i:]
+	if j := strings.Index(block[len(marker):], "Use:"); j >= 0 {
+		block = block[:len(marker)+j]
+	}
+	vg := strings.Index(block, "sharedresourceops.ValidateGrants(")
+	if vg < 0 {
+		t.Error("CLI grant must validate grantee existence through sharedresourceops.ValidateGrants")
+	}
+	rg := strings.Index(block, "ReplaceGrants(")
+	if rg < 0 {
+		t.Error("CLI grant must call ReplaceGrants")
+	}
+	if vg >= 0 && rg >= 0 && vg > rg {
+		t.Error("ValidateGrants must run BEFORE ReplaceGrants, or a dangling grantee is written first")
+	}
+}
+
 func mustRead(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)

--- a/panel-api/internal/api/routes_m65.go
+++ b/panel-api/internal/api/routes_m65.go
@@ -13,6 +13,7 @@ type M65RouteDeps struct {
 	Agent           agent.AgentInterface
 	Domains         repository.DomainRepository
 	Mailboxes       repository.MailboxRepository
+	MailGroups      repository.MailGroupRepository
 	Autoresponders  repository.EmailAutoresponderRepository
 	Forwarders      repository.EmailForwarderRepository
 	MailboxShares   repository.MailboxShareRepository
@@ -101,8 +102,10 @@ func registerMailLogRoutes(g *gin.RouterGroup, deps M65RouteDeps) {
 // M52 (ADR-0133): standalone shared resources + grants.
 func registerSharedResourceRoutes(g *gin.RouterGroup, deps M65RouteDeps) {
 	RegisterSharedResourceRoutes(g, SharedResourceHandlerConfig{
-		Resources: deps.SharedResources,
-		Domains:   deps.Domains,
-		Agent:     deps.Agent,
+		Resources:  deps.SharedResources,
+		Domains:    deps.Domains,
+		Mailboxes:  deps.Mailboxes,
+		MailGroups: deps.MailGroups,
+		Agent:      deps.Agent,
 	})
 }

--- a/panel-api/internal/api/shared_resources.go
+++ b/panel-api/internal/api/shared_resources.go
@@ -30,9 +30,11 @@ var sharedResourceRights = map[string]bool{
 }
 
 type SharedResourceHandlerConfig struct {
-	Resources repository.SharedResourceRepository
-	Domains   repository.DomainRepository
-	Agent     agent.AgentInterface
+	Resources  repository.SharedResourceRepository
+	Domains    repository.DomainRepository
+	Mailboxes  repository.MailboxRepository
+	MailGroups repository.MailGroupRepository
+	Agent      agent.AgentInterface
 }
 
 type sharedResourceHandler struct{ cfg SharedResourceHandlerConfig }
@@ -206,14 +208,6 @@ func (h *sharedResourceHandler) setGrants(c *gin.Context) {
 	}
 	grants := make([]models.SharedResourceGrant, 0, len(req.Grants))
 	for _, g := range req.Grants {
-		if g.GranteeKind != "mailbox" && g.GranteeKind != "group" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grantee_kind"})
-			return
-		}
-		if g.GranteeID == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "missing_grantee_id"})
-			return
-		}
 		if !sharedResourceRights[g.Rights] {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_rights"})
 			return
@@ -224,6 +218,25 @@ func (h *sharedResourceHandler) setGrants(c *gin.Context) {
 			GranteeID:   g.GranteeID,
 			Rights:      g.Rights,
 		})
+	}
+	// JAB-339 AC4: validate the grantee kind + id and reject a grant to a
+	// non-existent grantee BEFORE the write — the shared owner both the REST
+	// handler and the CLI call, so they cannot drift. A dangling grantee id
+	// would otherwise persist and be silently dropped by the reconciler on
+	// every pass.
+	grantDeps := sharedresourceops.Deps{Mailboxes: h.cfg.Mailboxes, MailGroups: h.cfg.MailGroups}
+	if err := sharedresourceops.ValidateGrants(c.Request.Context(), grantDeps, grants); err != nil {
+		switch {
+		case errors.Is(err, sharedresourceops.ErrGranteeInvalidKind):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grantee_kind"})
+		case errors.Is(err, sharedresourceops.ErrGranteeMissingID):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "missing_grantee_id"})
+		case errors.Is(err, sharedresourceops.ErrGranteeNotFound):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "grantee_not_found"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
+		return
 	}
 	if err := h.cfg.Resources.ReplaceGrants(c.Request.Context(), sr.ID, grants); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})

--- a/panel-api/internal/api/shared_resources_test.go
+++ b/panel-api/internal/api/shared_resources_test.go
@@ -78,7 +78,51 @@ func (f *srResFake) Delete(_ context.Context, id string) error {
 	return nil
 }
 
+// srMbFake / srMgFake are the grantee-existence lookups the grant handler now
+// consults (JAB-339 AC4). They embed the full repository interface but only
+// implement FindByID: a seeded id resolves, anything else is ErrNotFound, and a
+// non-nil err drives the fail-closed path.
+type srMbFake struct {
+	repository.MailboxRepository
+	ids map[string]bool
+	err error
+}
+
+func (f *srMbFake) FindByID(_ context.Context, id string) (*models.Mailbox, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.ids[id] {
+		return &models.Mailbox{ID: id}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type srMgFake struct {
+	repository.MailGroupRepository
+	ids map[string]bool
+	err error
+}
+
+func (f *srMgFake) FindByID(_ context.Context, id string) (*models.MailGroup, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.ids[id] {
+		return &models.MailGroup{ID: id}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// srRouter wires the default grantee lookups: mailbox "mb1" and group "grp1"
+// exist. Tests that need a missing or erroring grantee use srRouterFull.
 func srRouter(t *testing.T, res *srResFake, ag *srAgentFake) *gin.Engine {
+	return srRouterFull(t, res, ag,
+		&srMbFake{ids: map[string]bool{"mb1": true}},
+		&srMgFake{ids: map[string]bool{"grp1": true}})
+}
+
+func srRouterFull(t *testing.T, res *srResFake, ag *srAgentFake, mb *srMbFake, mg *srMgFake) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -88,7 +132,9 @@ func srRouter(t *testing.T, res *srResFake, ag *srAgentFake) *gin.Engine {
 		c.Next()
 	})
 	dom := &srDomFake{dom: &models.Domain{ID: "dom1", UserID: "user1", Name: "example.org", EmailEnabled: true}}
-	RegisterSharedResourceRoutes(v1, SharedResourceHandlerConfig{Resources: res, Domains: dom, Agent: ag})
+	RegisterSharedResourceRoutes(v1, SharedResourceHandlerConfig{
+		Resources: res, Domains: dom, Mailboxes: mb, MailGroups: mg, Agent: ag,
+	})
 	return r
 }
 
@@ -144,6 +190,48 @@ func TestSharedResource_SetGrants(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.Len(t, res.grantsSet["res1"], 1)
 	require.Equal(t, "readwrite", res.grantsSet["res1"][0].Rights)
+}
+
+// JAB-339 AC4: a grant to a non-existent mailbox grantee is rejected 400
+// grantee_not_found BEFORE the write — the dangling reference never persists.
+func TestSharedResource_SetGrants_GranteeNotFound(t *testing.T) {
+	res := &srResFake{byID: map[string]*models.SharedResource{
+		"res1": {ID: "res1", DomainID: "dom1", Kind: "calendar"},
+	}}
+	r := srRouter(t, res, &srAgentFake{}) // seeds mb1 / grp1 only
+	w := do(t, r, "PUT", "/api/v1/shared-resources/res1/grants",
+		map[string]any{"grants": []map[string]any{{"grantee_kind": "mailbox", "grantee_id": "ghost", "rights": "read"}}})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "grantee_not_found")
+	require.Nil(t, res.grantsSet, "ReplaceGrants must not run when a grantee is missing")
+}
+
+// A group grantee is checked against the mail-group lookup too.
+func TestSharedResource_SetGrants_GroupGranteeNotFound(t *testing.T) {
+	res := &srResFake{byID: map[string]*models.SharedResource{
+		"res1": {ID: "res1", DomainID: "dom1", Kind: "calendar"},
+	}}
+	r := srRouter(t, res, &srAgentFake{})
+	w := do(t, r, "PUT", "/api/v1/shared-resources/res1/grants",
+		map[string]any{"grants": []map[string]any{{"grantee_kind": "group", "grantee_id": "ghost", "rights": "read"}}})
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "grantee_not_found")
+	require.Nil(t, res.grantsSet)
+}
+
+// Fail-closed: a lookup that errors (not a clean not-found) is a 500, and the
+// grant is NOT written. A transient DB blip must never let a grant slip through.
+func TestSharedResource_SetGrants_LookupFailsClosed(t *testing.T) {
+	res := &srResFake{byID: map[string]*models.SharedResource{
+		"res1": {ID: "res1", DomainID: "dom1", Kind: "calendar"},
+	}}
+	r := srRouterFull(t, res, &srAgentFake{},
+		&srMbFake{err: errors.New("db down")},
+		&srMgFake{ids: map[string]bool{"grp1": true}})
+	w := do(t, r, "PUT", "/api/v1/shared-resources/res1/grants",
+		map[string]any{"grants": []map[string]any{{"grantee_kind": "mailbox", "grantee_id": "mb1", "rights": "read"}}})
+	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+	require.Nil(t, res.grantsSet, "ReplaceGrants must not run on a lookup error")
 }
 
 func TestSharedResource_Delete_Tombstones(t *testing.T) {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -899,6 +899,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			Agent:           deps.Agent,
 			Domains:         deps.Domains,
 			Mailboxes:       deps.Mailboxes,
+			MailGroups:      deps.MailGroups,
 			Autoresponders:  deps.Autoresponders,
 			Forwarders:      deps.Forwarders,
 			MailboxShares:   deps.MailboxShares,

--- a/panel-api/internal/sharedresourceops/sharedresourceops.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops.go
@@ -39,10 +39,34 @@ func ValidKind(kind string) bool { return kinds[kind] }
 // swallowed by the caller's implementation and never fail the create.
 type NotifyFunc func(ctx context.Context, cmd string, params any)
 
-// Deps carries the collaborators Create needs.
+// Deps carries the collaborators the operations need. Create and Delete use
+// Resources; ValidateGrants uses Mailboxes + MailGroups. Each operation guards
+// only the deps it needs, so an adapter wires whichever it calls.
 type Deps struct {
-	Resources repository.SharedResourceRepository
+	Resources  repository.SharedResourceRepository
+	Mailboxes  MailboxLookup
+	MailGroups MailGroupLookup
 }
+
+// MailboxLookup and MailGroupLookup are the narrow existence-lookup slices of
+// the mailbox and mail-group repositories that ValidateGrants needs — declared
+// consumer-side so the fakes stay small and the module does not pull in the
+// full repository interfaces. Both concrete repositories satisfy them.
+type MailboxLookup interface {
+	FindByID(ctx context.Context, id string) (*models.Mailbox, error)
+}
+type MailGroupLookup interface {
+	FindByID(ctx context.Context, id string) (*models.MailGroup, error)
+}
+
+// granteeKinds is the grant GranteeKind allowlist (a grant points at a mailbox
+// row or a mail-group row) — distinct from the resource kinds map above. It
+// matches the migration's grant ENUM('mailbox','group'). The REST handler and
+// the CLI used to keep two separate inline copies of this check.
+var granteeKinds = map[string]bool{"mailbox": true, "group": true}
+
+// ValidGranteeKind reports whether kind is an allowed grant grantee kind.
+func ValidGranteeKind(kind string) bool { return granteeKinds[kind] }
 
 // Sentinel errors. Adapters map these to their own transport (the HTTP handler
 // to specific status codes + body strings, the CLI to a returned error).
@@ -60,6 +84,14 @@ var (
 	ErrAddressTaken = errors.New("sharedresourceops: address already in use")
 	// ErrInternal means an unexpected data-access failure.
 	ErrInternal = errors.New("sharedresourceops: internal error")
+
+	// Grant validation (ValidateGrants). ErrGranteeInvalidKind means the
+	// GranteeKind is not in the allowlist; ErrGranteeMissingID means the
+	// GranteeID was empty; ErrGranteeNotFound means the id does not resolve to
+	// an existing mailbox / mail-group row.
+	ErrGranteeInvalidKind = errors.New("sharedresourceops: invalid grantee kind")
+	ErrGranteeMissingID   = errors.New("sharedresourceops: grantee id required")
+	ErrGranteeNotFound    = errors.New("sharedresourceops: grantee not found")
 )
 
 // CreateInput is one shared-resource creation. The domain is pre-loaded and
@@ -170,6 +202,64 @@ func Delete(ctx context.Context, d Deps, in DeleteInput, notify NotifyFunc) erro
 	}
 	if err := d.Resources.Delete(ctx, sr.ID); err != nil {
 		return fmt.Errorf("%w: delete: %v", ErrInternal, err)
+	}
+	return nil
+}
+
+// ValidateGrants is the JAB-339 AC4 grantee-existence gate the REST handler and
+// the operator CLI both run before ReplaceGrants. It checks every grant
+// references (1) an allowed grantee kind, (2) a non-empty grantee id, and (3) —
+// the gap this closes — an EXISTING mailbox / mail-group row.
+//
+// Why existence matters: a grant to a non-existent grantee id used to persist
+// with a 200 / success, and the reconciler discovers the dangling reference
+// only later — its grant loop `continue`s on a FindByID not-found, so the bad
+// grantee is silently dropped from the projected shareWith on every pass, with
+// no error surfaced anywhere. The reference is invisible until someone reads
+// the grant list back. Rejecting it at write time is the fail-loud fix.
+//
+// Lookup failures fail CLOSED: a not-found row is ErrGranteeNotFound (reject
+// the whole set — ReplaceGrants is an all-or-nothing replace), but any OTHER
+// data-access error is wrapped ErrInternal and propagated, never collapsed into
+// "not found". Collapsing would let a grant slip through on a transient DB
+// blip. Kind + id are folded in here too, so both adapters stop duplicating
+// them inline and share one owner.
+//
+// Domain / tenant scoping of the grantee is deliberately NOT enforced here: a
+// cross-domain grant is a sharing-scope policy question, not a privilege
+// escalation (the caller can only share a resource it already owns, and the
+// grantee gains nothing on its own tenant), and which domains a grantee may
+// come from is an open product decision. When that rule lands it belongs in
+// this same validator and MUST return ErrGranteeNotFound too — a grantee that
+// exists but is out of policy must be indistinguishable from a missing one, so
+// the error can never be used to enumerate rows across a tenant boundary.
+func ValidateGrants(ctx context.Context, d Deps, grants []models.SharedResourceGrant) error {
+	if d.Mailboxes == nil || d.MailGroups == nil {
+		return fmt.Errorf("%w: mailbox + mail-group lookups required", ErrDeps)
+	}
+	for _, g := range grants {
+		if !ValidGranteeKind(g.GranteeKind) {
+			return fmt.Errorf("%w: %s", ErrGranteeInvalidKind, g.GranteeKind)
+		}
+		if g.GranteeID == "" {
+			return ErrGranteeMissingID
+		}
+		switch g.GranteeKind {
+		case "mailbox":
+			if _, err := d.Mailboxes.FindByID(ctx, g.GranteeID); err != nil {
+				if errors.Is(err, repository.ErrNotFound) {
+					return fmt.Errorf("%w: mailbox %s", ErrGranteeNotFound, g.GranteeID)
+				}
+				return fmt.Errorf("%w: mailbox lookup %s: %v", ErrInternal, g.GranteeID, err)
+			}
+		case "group":
+			if _, err := d.MailGroups.FindByID(ctx, g.GranteeID); err != nil {
+				if errors.Is(err, repository.ErrNotFound) {
+					return fmt.Errorf("%w: group %s", ErrGranteeNotFound, g.GranteeID)
+				}
+				return fmt.Errorf("%w: group lookup %s: %v", ErrInternal, g.GranteeID, err)
+			}
+		}
 	}
 	return nil
 }

--- a/panel-api/internal/sharedresourceops/sharedresourceops.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops.go
@@ -222,8 +222,9 @@ func Delete(ctx context.Context, d Deps, in DeleteInput, notify NotifyFunc) erro
 // the whole set — ReplaceGrants is an all-or-nothing replace), but any OTHER
 // data-access error is wrapped ErrInternal and propagated, never collapsed into
 // "not found". Collapsing would let a grant slip through on a transient DB
-// blip. Kind + id are folded in here too, so both adapters stop duplicating
-// them inline and share one owner.
+// blip. Kind + id are folded in here too: the REST handler drops its inline
+// copies, while the CLI keeps its flag-specific messages first and lets this
+// re-check them harmlessly — so one owner governs the policy for both.
 //
 // Domain / tenant scoping of the grantee is deliberately NOT enforced here: a
 // cross-domain grant is a sharing-scope policy question, not a privilege

--- a/panel-api/internal/sharedresourceops/sharedresourceops_test.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops_test.go
@@ -273,3 +273,105 @@ func TestDelete_NilDepsReturnsErrDeps(t *testing.T) {
 		t.Fatalf("nil resource: want ErrDeps, got %v", err)
 	}
 }
+
+// lookMb / lookMg are the narrow MailboxLookup / MailGroupLookup fakes. A seeded
+// id resolves; anything else is repository.ErrNotFound; a non-nil err short-
+// circuits every lookup (to exercise the fail-closed path).
+type lookMb struct {
+	ids map[string]bool
+	err error
+}
+
+func (l *lookMb) FindByID(_ context.Context, id string) (*models.Mailbox, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	if l.ids[id] {
+		return &models.Mailbox{ID: id}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type lookMg struct {
+	ids map[string]bool
+	err error
+}
+
+func (l *lookMg) FindByID(_ context.Context, id string) (*models.MailGroup, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	if l.ids[id] {
+		return &models.MailGroup{ID: id}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func grant(kind, id string) []models.SharedResourceGrant {
+	return []models.SharedResourceGrant{{GranteeKind: kind, GranteeID: id, Rights: "read"}}
+}
+
+// TestValidateGrants is the JAB-339 AC4 gate table: an existing grantee passes;
+// a missing mailbox / group id, a bad kind, an empty id, and missing deps each
+// fail with their own sentinel. Message content is not asserted — only the
+// nil / sentinel outcome — so the adapters own their transport wording.
+func TestValidateGrants(t *testing.T) {
+	d := Deps{
+		Mailboxes:  &lookMb{ids: map[string]bool{"mb1": true}},
+		MailGroups: &lookMg{ids: map[string]bool{"grp1": true}},
+	}
+	cases := []struct {
+		name    string
+		grants  []models.SharedResourceGrant
+		deps    Deps
+		wantErr error // nil = must pass
+	}{
+		{"mailbox exists", grant("mailbox", "mb1"), d, nil},
+		{"group exists", grant("group", "grp1"), d, nil},
+		{"mailbox missing", grant("mailbox", "ghost"), d, ErrGranteeNotFound},
+		{"group missing", grant("group", "ghost"), d, ErrGranteeNotFound},
+		{"bad kind", grant("user", "mb1"), d, ErrGranteeInvalidKind},
+		{"empty id", grant("mailbox", ""), d, ErrGranteeMissingID},
+		{"no deps", grant("mailbox", "mb1"), Deps{}, ErrDeps},
+		{"empty set passes", nil, d, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGrants(context.Background(), tc.deps, tc.grants)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("want nil, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestValidateGrants_LookupErrorFailsClosed proves a non-not-found data-access
+// error is propagated as ErrInternal and NEVER collapsed into ErrGranteeNotFound
+// — collapsing would let a grant through on a transient DB blip (fail open).
+func TestValidateGrants_LookupErrorFailsClosed(t *testing.T) {
+	dbErr := errors.New("db down")
+	for _, tc := range []struct {
+		name  string
+		deps  Deps
+		grant []models.SharedResourceGrant
+	}{
+		{"mailbox lookup error", Deps{Mailboxes: &lookMb{err: dbErr}, MailGroups: &lookMg{}}, grant("mailbox", "mb1")},
+		{"group lookup error", Deps{Mailboxes: &lookMb{}, MailGroups: &lookMg{err: dbErr}}, grant("group", "grp1")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGrants(context.Background(), tc.deps, tc.grant)
+			if !errors.Is(err, ErrInternal) {
+				t.Fatalf("want ErrInternal (fail closed), got %v", err)
+			}
+			if errors.Is(err, ErrGranteeNotFound) {
+				t.Fatal("a DB error must NOT be collapsed into ErrGranteeNotFound")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

A grant to a **non-existent** mailbox / mail-group id used to persist with a
`200` / success. The REST `setGrants` handler and the operator CLI `grant`
command validated only the grantee **kind** + a non-empty **id**, then wrote the
grant set — neither checked the id resolves to a real row.

The dangling reference is then invisible until someone reads the grant list
back. The reconciler's grant loop skips it silently — on a `FindByID`
not-found it just `continue`s:

```go
case "mailbox":
    mb, err := r.srMailboxes.FindByID(ctx, g.GranteeID)
    if err != nil {
        continue
    }
```

so the bad grantee is dropped from the projected Stalwart `shareWith` on every
pass, surfacing no error anywhere. JAB-339 AC4 asks for the grantee policy to be
**explicit** — so reject at write time (fail loud) instead of leaking a
reference the reconciler quietly discards.

## Fix — one shared owner

New `sharedresourceops.ValidateGrants(ctx, Deps, grants)`, the gate both adapters
run **before** `ReplaceGrants`, so REST and CLI cannot drift (the same
single-owner shape as `Create` / `Delete`). It checks, per grant:

1. an allowed grantee kind (`mailbox` / `group`);
2. a non-empty grantee id;
3. — the gap this closes — an **existing** mailbox / mail-group row.

- Existence is looked up through narrow `MailboxLookup` / `MailGroupLookup`
  interfaces declared consumer-side, so the module does not pull in the full
  repositories and the fakes stay small. Both concrete repositories satisfy them.
- **Fail closed.** A not-found row is `ErrGranteeNotFound` (reject the whole set —
  `ReplaceGrants` is an all-or-nothing replace). Any **other** data-access error
  is wrapped `ErrInternal` and propagated, never collapsed into "not found" —
  collapsing would let a grant slip through on a transient DB blip.

Kind + id are folded into the validator too. The REST handler drops its inline
copies; the CLI keeps its flag-specific up-front messages
(`--grantee-kind must be mailbox|group`) and lets the validator re-check them
harmlessly, so one owner governs the policy for both.

**Rights** are unchanged: both adapters already validated `read|readwrite|admin`
(REST `invalid_rights`, CLI `--rights must be …`). No gap there, so this does not
widen into rights.

## Wiring

`SharedResourceHandlerConfig` and `M65RouteDeps` gain the mailbox + mail-group
repositories — already constructed unconditionally in `serve.go` alongside every
other repo (`deps.Mailboxes` / `deps.MailGroups`), so this is passthrough only and
cannot nil-out a grant write in any deployment that can already serve one. The CLI
builds them from the shared DB.

REST maps the sentinels to `400 invalid_grantee_kind` / `missing_grantee_id`
(unchanged) / **`grantee_not_found`** (new); the CLI returns a flag-friendly
`grantee not found: <kind> <id>`.

## Domain / tenant policy — deliberately deferred (needs a product call)

This slice enforces grantee **existence** only. It does **not** restrict which
domain / tenant a grantee may come from. That is a sharing-scope policy, not a
security hole: `loadResourceWithAuth` still gates on the resource, so the grantor
can only share a resource it already owns and the grantee gains nothing on its
own tenant (the Google-Doc-shared-with-an-external-address shape).

Three options for the follow-up, **recommendation: same-owner tenant**:

- **same-domain** — tightest, but breaks a tenant that legitimately shares across
  its own multiple domains;
- **same-owner tenant (recommended)** — a grantee must belong to the resource
  owner's tenant (a `Domain.UserID` compare); the JAB-364 tenant-boundary shape,
  additive to this same validator;
- **any** — today's behavior, made explicit.

Whichever lands belongs in **this same validator** and must return
`grantee_not_found` for an out-of-policy grantee too — a grantee that exists but
is out of policy must be indistinguishable from a missing one, so the error can
never be used to enumerate rows across a tenant boundary.

## No schema / SPA change

Reads only (`mailboxes` / `mail_groups` via `FindByID`). No request/response
shape change — only a new error-code string value. No migration, no golden regen.

## Tests

- `sharedresourceops`: `ValidateGrants` table (mailbox / group present + missing,
  bad kind, empty id, missing deps, empty set) asserting only the sentinel
  outcome, plus a fail-closed test proving a lookup **DB error is propagated as
  `ErrInternal` and never collapsed into `ErrGranteeNotFound`**.
- REST (real handler + fake repo + grantee-lookup fakes): `grantee_not_found`
  (mailbox and group) and a lookup-error fail-closed case, each asserting
  `ReplaceGrants` does **not** run.
- CLI: source-pin that the grant block routes through `ValidateGrants` and runs
  it **before** `ReplaceGrants` (ordering is the load-bearing invariant).

**Four guards falsified against compiling neutralizations, each reverted:** the
existence gate itself, the fail-closed non-collapse, the REST
validate-before-write ordering, and the CLI routing pin. `gofmt` + `go vet` clean;
full `panel-api` suite green.

## No box-verify

REST handler + CLI + module only, fully covered by the real handler + fakes and
the ops table. No agent, reconciler, migration, or cert surface is touched, so
there is nothing a live box would exercise that the unit path does not (same
rationale as #1685).

## Not in this slice (pre-existing / unchanged)

- **Active-state, not just existence.** The mailbox / mail-group models are
  hard-delete (no `DeletedAt`), so a deleted grantee is gone and
  `PruneGranteeGrants` clears its grants on delete. A **suspended / disabled**
  grantee still has a row, so it passes this existence check — existence is not
  liveness. Unchanged here.
- The grantee domain/tenant policy above.
- Module extraction of the grant path into `sharedresourceops` beyond this
  validator.

Part of JAB-339 (shared-resource lifecycle); the parent stays open (the grantee
domain-policy half and the module extraction remain).

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
