### PR TITLE
feat(nginx): admin web-template UI — management card + create picker (GH #1624, ADR-0169 Phase 3b)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -27,6 +27,9 @@ export type DomainCreateInput = {
   // GH #1175: reverse-proxy domain — the panel reserves a loopback port and
   // proxies the domain to it. The assigned port comes back on create.
   reverse_proxy?: boolean;
+  // GH #1624 / ADR-0169 Phase 3: an admin web (nginx) template to seed this
+  // domain's custom nginx directives from. Admin-only (this whole form is admin).
+  web_template_id?: string;
 };
 
 type DomainCreated = { id: string; reverse_proxy_port?: number };
@@ -59,6 +62,18 @@ export const DomainCreate = () => {
         "/users?page_size=500&is_admin=false",
       );
       return data.data ?? [];
+    },
+  });
+
+  // GH #1624 / ADR-0169 Phase 3: admin web (nginx) templates the admin may apply
+  // to seed the new domain's custom directives. Empty picker → no template.
+  const webTemplatesQ = useQuery({
+    queryKey: ["admin", "web-templates"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ templates: { id: string; name: string; description: string }[] }>(
+        "/admin/web-templates",
+      );
+      return data.templates ?? [];
     },
   });
 
@@ -134,6 +149,27 @@ export const DomainCreate = () => {
         >
           <Input placeholder="auto-generated if empty" />
         </Form.Item>
+
+        {/* GH #1624 / ADR-0169 Phase 3: apply an admin web (nginx) template to
+            seed this domain's custom nginx directives. Only shown when at least
+            one template exists (managed under Server Settings → Nginx). */}
+        {(webTemplatesQ.data?.length ?? 0) > 0 && (
+          <Form.Item
+            label="Nginx template"
+            name="web_template_id"
+            tooltip="Optional. Seed this domain's custom nginx directives from an admin web template. You can edit them afterward under the domain's settings."
+          >
+            <Select
+              allowClear
+              placeholder="None"
+              loading={webTemplatesQ.isLoading}
+              options={(webTemplatesQ.data ?? []).map((tmpl) => ({
+                value: tmpl.id,
+                label: tmpl.description ? `${tmpl.name} — ${tmpl.description}` : tmpl.name,
+              }))}
+            />
+          </Form.Item>
+        )}
 
         <Form.Item
           label={t("domaincreate.mail")}

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -71,6 +71,7 @@ import { CloudflareTokenCard } from "./CloudflareTokenCard";
 import { NspawnImagesCard } from "./NspawnImagesCard";
 import { SSOMaintenanceCard } from "./SSOMaintenanceCard";
 import { TenantDomainOptionsCard } from "./TenantDomainOptionsCard";
+import { WebTemplatesCard } from "./WebTemplatesCard";
 import { TenantNotificationsCard } from "./TenantNotificationsCard";
 import { NginxSettingsCard } from "./NginxSettingsCard";
 import { LogRetentionCard } from "./LogRetentionCard";
@@ -1071,6 +1072,7 @@ export const ServerSettingsPage = () => {
         <>
           <NginxSettingsCard />
           <TenantDomainOptionsCard />
+          <WebTemplatesCard />
         </>
       ),
     },

--- a/panel-ui/src/shells/admin/settings/WebTemplatesCard.test.tsx
+++ b/panel-ui/src/shells/admin/settings/WebTemplatesCard.test.tsx
@@ -1,0 +1,87 @@
+// WebTemplatesCard — GH #1624 / ADR-0169 Phase 3b. Admin CRUD for web (nginx)
+// templates. These tests cover the list render, the create round-trip, and the
+// key UX guarantee: when the API rejects a directive, the admin sees the exact
+// reason (the 400 `detail` from ValidateNginxDirectivesAdmin), not a generic
+// toast.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+const errorToast = vi.hoisted(() => vi.fn());
+vi.mock("../../../lib/feedback", () => ({
+  feedback: {
+    message: { success: vi.fn(), error: errorToast, warning: vi.fn() },
+    modal: { success: vi.fn(), confirm: vi.fn() },
+  },
+}));
+
+import { apiClient } from "../../../apiClient";
+import { WebTemplatesCard } from "./WebTemplatesCard";
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockPost = apiClient.post as ReturnType<typeof vi.fn>;
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <WebTemplatesCard />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGet.mockResolvedValue({
+    data: {
+      templates: [
+        { id: "t1", name: "WordPress", description: "WP rewrites", nginx_directives: "add_header X-A b;" },
+      ],
+    },
+  });
+});
+
+// Fill the create modal's required fields, then click Save.
+async function createTemplate(directives: string) {
+  fireEvent.click(screen.getByRole("button", { name: /new template/i }));
+  const dialog = await screen.findByRole("dialog");
+  const nameInput = await within(dialog).findByPlaceholderText("e.g. WordPress");
+  fireEvent.change(nameInput, { target: { value: "MyApp" } });
+  // The directives textarea placeholder carries a `proxy_pass` example.
+  const directivesInput = within(dialog).getByPlaceholderText(/proxy_pass/);
+  fireEvent.change(directivesInput, { target: { value: directives } });
+  // Let antd's Form commit both field values before validateFields runs on Save.
+  await waitFor(() => expect(within(dialog).getByDisplayValue("MyApp")).toBeInTheDocument());
+  fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+}
+
+describe("WebTemplatesCard", () => {
+  it("lists templates from the API", async () => {
+    renderCard();
+    expect(await screen.findByText("WordPress")).toBeInTheDocument();
+  });
+
+  it("creates a template via POST /admin/web-templates", async () => {
+    mockPost.mockResolvedValue({ data: { id: "t2", name: "MyApp" } });
+    renderCard();
+    await screen.findByText("WordPress");
+    await createTemplate("add_header X-B c;");
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost).toHaveBeenCalledWith(
+      "/admin/web-templates",
+      expect.objectContaining({ name: "MyApp", nginx_directives: "add_header X-B c;" }),
+    );
+  });
+
+  it("surfaces the API's rejection detail (not a generic toast)", async () => {
+    mockPost.mockRejectedValue({ response: { data: { detail: "forbidden directive: root" } } });
+    renderCard();
+    await screen.findByText("WordPress");
+    await createTemplate("root /etc/jabali-panel/;");
+    await waitFor(() => expect(errorToast).toHaveBeenCalledWith("forbidden directive: root"));
+  });
+});

--- a/panel-ui/src/shells/admin/settings/WebTemplatesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/WebTemplatesCard.tsx
@@ -1,0 +1,232 @@
+// WebTemplatesCard — GH #1624 / ADR-0169 Phase 3b. Admin CRUD for web (nginx)
+// templates: a named preset of raw nginx directives an admin can apply to a new
+// domain at create (admin-select-only — see DomainCreate's picker). Mirrors the
+// PageTemplatesCard list+modal shape, but backed by a real REST entity
+// (POST/PUT/DELETE /admin/web-templates) rather than the settings-patch that
+// page templates use.
+import { useState } from "react";
+import { Button, Card, Form, Input, List, Modal, Popconfirm, Space, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@icons";
+import { apiClient } from "../../../apiClient";
+
+type WebTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  nginx_directives: string;
+  updated_at?: string;
+};
+
+type WebTemplateForm = {
+  name: string;
+  description?: string;
+  nginx_directives: string;
+};
+
+const LIST_KEY = ["admin", "web-templates"] as const;
+// Mirrors the API cap (webTemplateMaxDirectivesBytes) so the form rejects an
+// over-long blob before the round-trip.
+const MAX_BYTES = 16 * 1024;
+
+// pickDetail surfaces the API's `detail` (e.g. the exact rejected directive from
+// ValidateNginxDirectivesAdmin) instead of a generic axios message.
+const pickDetail = (err: unknown, fallback: string): string => {
+  const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+  if (detail) return detail;
+  return err instanceof Error ? err.message : fallback;
+};
+
+export const WebTemplatesCard = () => {
+  const qc = useQueryClient();
+  const [form] = Form.useForm<WebTemplateForm>();
+  const [editing, setEditing] = useState<WebTemplate | null>(null);
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const list = useQuery<{ templates: WebTemplate[] }>({
+    queryKey: LIST_KEY,
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ templates: WebTemplate[] }>("/admin/web-templates");
+      return data;
+    },
+  });
+
+  const openCreate = () => {
+    setEditing(null);
+    setOpen(true);
+    form.resetFields();
+  };
+
+  const openEdit = (row: WebTemplate) => {
+    setEditing(row);
+    setOpen(true);
+    form.setFieldsValue({
+      name: row.name,
+      description: row.description,
+      nginx_directives: row.nginx_directives,
+    });
+  };
+
+  const close = () => {
+    setOpen(false);
+    setEditing(null);
+    form.resetFields();
+  };
+
+  const save = async () => {
+    let values: WebTemplateForm;
+    try {
+      values = await form.validateFields();
+    } catch {
+      return; // antd renders the field errors
+    }
+    setSaving(true);
+    try {
+      if (editing) {
+        await apiClient.put(`/admin/web-templates/${editing.id}`, values);
+        feedback.message.success(`${values.name} saved`);
+      } else {
+        await apiClient.post("/admin/web-templates", values);
+        feedback.message.success(`${values.name} created`);
+      }
+      qc.invalidateQueries({ queryKey: LIST_KEY });
+      close();
+    } catch (err) {
+      feedback.message.error(pickDetail(err, "Save failed"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (row: WebTemplate) => {
+    try {
+      await apiClient.delete(`/admin/web-templates/${row.id}`);
+      qc.invalidateQueries({ queryKey: LIST_KEY });
+      feedback.message.success(`${row.name} deleted`);
+    } catch (err) {
+      feedback.message.error(pickDetail(err, "Delete failed"));
+    }
+  };
+
+  return (
+    <>
+      <Card
+        title="Web templates (nginx)"
+        style={{ marginBottom: 16 }}
+        extra={
+          <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+            New template
+          </Button>
+        }
+      >
+        <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+          Named presets of raw nginx directives. When you create a Web Domain you
+          can apply a template to seed its custom directives — the "copy my working
+          config" shortcut for common apps (WordPress, Nextcloud, …). Templates are
+          admin-authored and validated with the same rules as a domain's own custom
+          directives, and can only be applied by an admin at domain create.
+        </Typography.Paragraph>
+        <List<WebTemplate>
+          loading={list.isLoading}
+          dataSource={list.data?.templates ?? []}
+          rowKey="id"
+          locale={{ emptyText: "No web templates yet" }}
+          renderItem={(row) => (
+            <List.Item
+              actions={[
+                <Button key="edit" icon={<EditOutlined />} onClick={() => openEdit(row)}>
+                  Edit
+                </Button>,
+                <Popconfirm
+                  key="del"
+                  title={`Delete ${row.name}?`}
+                  okText="Delete"
+                  okButtonProps={{ danger: true }}
+                  onConfirm={() => remove(row)}
+                >
+                  <Button danger icon={<DeleteOutlined />}>
+                    Delete
+                  </Button>
+                </Popconfirm>,
+              ]}
+            >
+              <List.Item.Meta
+                title={
+                  <Space>
+                    <Typography.Text strong>{row.name}</Typography.Text>
+                    <Tag color="blue">nginx</Tag>
+                  </Space>
+                }
+                description={
+                  row.description || (
+                    <Typography.Text type="secondary">No description</Typography.Text>
+                  )
+                }
+              />
+            </List.Item>
+          )}
+        />
+      </Card>
+
+      <Modal
+        open={open}
+        title={editing ? `Edit — ${editing.name}` : "New web template"}
+        onCancel={close}
+        width={900}
+        confirmLoading={saving}
+        onOk={save}
+        okText="Save"
+        destroyOnClose
+      >
+        <Form<WebTemplateForm> form={form} layout="vertical">
+          <Form.Item
+            label="Name"
+            name="name"
+            rules={[
+              { required: true, message: "A name is required" },
+              { max: 120, message: "Name cannot exceed 120 characters" },
+            ]}
+          >
+            <Input placeholder="e.g. WordPress" />
+          </Form.Item>
+          <Form.Item
+            label="Description"
+            name="description"
+            rules={[{ max: 500, message: "Description cannot exceed 500 characters" }]}
+          >
+            <Input placeholder="Optional" />
+          </Form.Item>
+          <Form.Item
+            label="Nginx directives"
+            name="nginx_directives"
+            rules={[
+              { required: true, message: "At least one nginx directive is required" },
+              {
+                validator: (_, v: string) =>
+                  new TextEncoder().encode(v ?? "").length > MAX_BYTES
+                    ? Promise.reject(new Error(`Directives exceed ${Math.round(MAX_BYTES / 1024)} KB`))
+                    : Promise.resolve(),
+              },
+            ]}
+            extra="Raw nginx config injected into the server block. Validated on save: rewrites, headers, proxy_pass and the like are allowed; dangerous directives (root, alias, include, access_log off, auth_basic off) are rejected."
+          >
+            <Input.TextArea
+              spellCheck={false}
+              autoSize={{ minRows: 10 }}
+              styles={{
+                textarea: {
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+                  fontSize: 13,
+                  lineHeight: 1.5,
+                },
+              }}
+              placeholder={"location /api/ {\n    proxy_pass http://127.0.0.1:9000;\n}"}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};


### PR DESCRIPTION
## What

The panel-ui half of ADR-0169 **Phase 3** for GH #1624. Backend is **PR #1687** (3a). Two admin surfaces:

### 1. WebTemplatesCard — Server Settings → Nginx tab
List + create / edit / delete CRUD for web (nginx) templates against `/admin/web-templates`. Name, description, and a monospace nginx-directives textarea. It surfaces the API's 400 `detail` — the exact rejected directive from `ValidateNginxDirectivesAdmin` — in the error toast, so an admin sees *why* a directive was refused, not a generic message. Placed next to `TenantDomainOptionsCard` (the Phase-1 nginx card).

### 2. DomainCreate — an optional "Nginx template" picker
On the admin Create Domain form, a picker shown only when at least one template exists. The whole form is **admin-only** (admin route), which matches 3a's admin-select-only gate: a tenant never sees this, and the tenant create drawer (`UserDomainDrawer`) is **untouched**. The selected `web_template_id` flows through the existing create payload; the backend snapshot-copies the template's directives onto the new domain.

## Design

Mirrors the `PageTemplatesCard` list+modal shape, but backed by a real REST entity (POST/PUT/DELETE) rather than the settings-patch page templates use. No new i18n keys (hardcoded English, consistent with `TenantDomainOptionsCard`). The form caps directives at 16 KiB client-side, mirroring the API's `webTemplateMaxDirectivesBytes`.

## Tests (`WebTemplatesCard.test.tsx`)

- Lists templates from the API.
- Creates a template via `POST /admin/web-templates` with the entered values.
- **Surfaces the API rejection `detail`** (not a generic toast) — **fail-first verified**: neutralizing the `detail` branch flips the assertion to a generic "Save failed".

## Verification

- `tsc --noEmit` + `eslint` clean.
- Full panel-ui vitest **736 passed** (was 733 + 3 new).

## Merge ordering

This UI calls `/admin/web-templates`, which lands in **3a (#1687)** — so the card 404s until #1687 merges. **Hold this PR's `MERGE_APPROVED` until #1687 has merged.** (No code dependency — the React refs only the JSON keys — so it's a plain PR off `main`, not stacked.)

Held for `MERGE_APPROVED`.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5