### PR TITLE
fix(shared-resources): keep last-known shares when a grantee lookup errors (JAB-339)

### DIFF
--- a/panel-api/internal/reconciler/shared_resource_reconcile.go
+++ b/panel-api/internal/reconciler/shared_resource_reconcile.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -132,17 +133,34 @@ func (r *Reconciler) reconcileOneSharedResource(ctx context.Context, res *models
 		case "mailbox":
 			mb, err := r.srMailboxes.FindByID(ctx, g.GranteeID)
 			if err != nil {
-				continue
+				if errors.Is(err, repository.ErrNotFound) {
+					continue // grantee gone (e.g. deleted before its grants were pruned) — inert, drop it
+				}
+				// A data-access error is NOT proof the grantee is gone. Pushing a
+				// map built from a partial lookup would wrongly revoke this grantee
+				// in Stalwart on a transient DB blip, so skip the push and keep the
+				// last-known shareWith until the next pass (same rule as the
+				// ListGrants failure above).
+				slog.WarnContext(ctx, "shared_resources: resolve mailbox grantee; skip share push to keep last-known state", "resource", res.ID, "grantee", g.GranteeID, "err", err)
+				return
 			}
 			dom, err := r.domains.FindByID(ctx, mb.DomainID)
 			if err != nil {
-				continue
+				if errors.Is(err, repository.ErrNotFound) {
+					continue // dangling domain reference — inert, drop it
+				}
+				slog.WarnContext(ctx, "shared_resources: resolve grantee domain; skip share push to keep last-known state", "resource", res.ID, "domain", mb.DomainID, "err", err)
+				return
 			}
 			shares[mb.LocalPart+"@"+dom.Name] = g.Rights
 		case "group":
 			emails, err := r.srMailGroups.ListMemberEmails(ctx, g.GranteeID)
 			if err != nil {
-				continue
+				// ListMemberEmails has no not-found case: a missing or empty group
+				// returns no rows + a nil error, so any error here is a data-access
+				// failure. Skip the push and keep last-known state, as above.
+				slog.WarnContext(ctx, "shared_resources: list group members; skip share push to keep last-known state", "resource", res.ID, "grantee", g.GranteeID, "err", err)
+				return
 			}
 			for _, e := range emails {
 				if _, exists := shares[e]; !exists {

--- a/panel-api/internal/reconciler/shared_resource_reconcile_test.go
+++ b/panel-api/internal/reconciler/shared_resource_reconcile_test.go
@@ -2,8 +2,9 @@ package reconciler
 
 import (
 	"context"
-	"os"
+	"errors"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -44,28 +45,46 @@ func (f *srFake) DeleteTombstone(_ context.Context, e string) error {
 type mbFake struct {
 	repository.MailboxRepository
 	byID map[string]*models.Mailbox
+	err  error // if set, every FindByID returns this (a data-access failure, not not-found)
 }
 
 func (f *mbFake) FindByID(_ context.Context, id string) (*models.Mailbox, error) {
-	return f.byID[id], nil
+	if f.err != nil {
+		return nil, f.err
+	}
+	if m, ok := f.byID[id]; ok {
+		return m, nil
+	}
+	return nil, repository.ErrNotFound // mirror the real repo (not a nil,nil)
 }
 
 type mgFake struct {
 	repository.MailGroupRepository
 	members map[string][]string
+	err     error // if set, every ListMemberEmails returns this
 }
 
 func (f *mgFake) ListMemberEmails(_ context.Context, id string) ([]string, error) {
-	return f.members[id], nil
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.members[id], nil // a missing/empty group is no rows + nil err, like the real repo
 }
 
 type domFake struct {
 	repository.DomainRepository
 	byID map[string]*models.Domain
+	err  error // if set, every FindByID returns this (a data-access failure, not not-found)
 }
 
 func (f *domFake) FindByID(_ context.Context, id string) (*models.Domain, error) {
-	return f.byID[id], nil
+	if f.err != nil {
+		return nil, f.err
+	}
+	if d, ok := f.byID[id]; ok {
+		return d, nil
+	}
+	return nil, repository.ErrNotFound // mirror the real repo
 }
 
 func sptr(s string) *string { return &s }
@@ -141,4 +160,160 @@ func TestReconcileSharedResources_TombstoneRetainedOnAgentFailure(t *testing.T) 
 	r := newSRReconciler(t, ag, sr, &mbFake{}, &mgFake{}, &domFake{})
 	r.reconcileSharedResources(context.Background())
 	require.Empty(t, sr.tombKilled, "tombstone kept when destroy fails (retry next pass)")
+}
+
+// --- JAB-339 AC3: grantee-lookup fail-closed (keep last-known shareWith) ---
+
+// calendarShareSet returns the first calendar.share_set push (nil if none).
+func calendarShareSet(ag *fakeAgent) *fakeCall {
+	for i := range ag.calls {
+		if ag.calls[i].method == "calendar.share_set" {
+			return &ag.calls[i]
+		}
+	}
+	return nil
+}
+
+// shareSetCount counts calendar.share_set pushes across all resources in a pass.
+func shareSetCount(ag *fakeAgent) int {
+	n := 0
+	for _, c := range ag.calls {
+		if c.method == "calendar.share_set" {
+			n++
+		}
+	}
+	return n
+}
+
+func calRes(id, email string) models.SharedResource {
+	return models.SharedResource{
+		ID: id, DomainID: "dom1", Kind: "calendar", EmailCached: sptr(email),
+		DisplayName: "Cal " + id, HostAccountID: "h-" + id, // non-empty: skip the apply step
+	}
+}
+
+// A genuine not-found mailbox grantee stays inert: it is dropped and the push
+// still runs for the remaining grantees (unchanged behavior, pinned).
+func TestReconcileSharedResources_MissingMailboxGranteeInert_PushProceeds(t *testing.T) {
+	sr := &srFake{
+		res: []models.SharedResource{calRes("res1", "teamcal@example.org")},
+		grants: map[string][]models.SharedResourceGrant{
+			"res1": {
+				{ResourceID: "res1", GranteeKind: "mailbox", GranteeID: "ghost", Rights: "read"},
+				{ResourceID: "res1", GranteeKind: "mailbox", GranteeID: "mb1", Rights: "readwrite"},
+			},
+		},
+	}
+	mb := &mbFake{byID: map[string]*models.Mailbox{"mb1": {ID: "mb1", LocalPart: "alice", DomainID: "dom1"}}}
+	dom := &domFake{byID: map[string]*models.Domain{"dom1": {ID: "dom1", Name: "example.org"}}}
+	ag := &fakeAgent{}
+
+	r := newSRReconciler(t, ag, sr, mb, &mgFake{}, dom)
+	r.reconcileSharedResources(context.Background())
+
+	cs := calendarShareSet(ag)
+	require.NotNil(t, cs, "missing grantee is inert — push still runs for the rest")
+	shares := cs.params.(map[string]any)["shares"].(map[string]string)
+	require.Equal(t, map[string]string{"alice@example.org": "readwrite"}, shares,
+		"missing grantee dropped; resolvable grantee still shared")
+}
+
+// A mailbox whose DomainID dangles (domain not-found) is likewise inert.
+func TestReconcileSharedResources_MissingDomainInert_PushProceeds(t *testing.T) {
+	sr := &srFake{
+		res: []models.SharedResource{calRes("res1", "teamcal@example.org")},
+		grants: map[string][]models.SharedResourceGrant{
+			"res1": {
+				{ResourceID: "res1", GranteeKind: "mailbox", GranteeID: "mb1", Rights: "read"},
+				{ResourceID: "res1", GranteeKind: "group", GranteeID: "grp1", Rights: "read"},
+			},
+		},
+	}
+	mb := &mbFake{byID: map[string]*models.Mailbox{"mb1": {ID: "mb1", LocalPart: "alice", DomainID: "dom_gone"}}}
+	mg := &mgFake{members: map[string][]string{"grp1": {"bob@example.org"}}}
+	dom := &domFake{byID: map[string]*models.Domain{}} // dom_gone absent → ErrNotFound
+
+	ag := &fakeAgent{}
+	r := newSRReconciler(t, ag, sr, mb, mg, dom)
+	r.reconcileSharedResources(context.Background())
+
+	cs := calendarShareSet(ag)
+	require.NotNil(t, cs, "dangling domain is inert — push still runs")
+	shares := cs.params.(map[string]any)["shares"].(map[string]string)
+	require.Equal(t, map[string]string{"bob@example.org": "read"}, shares,
+		"mailbox with dangling domain dropped; group grantee survives")
+}
+
+// A data-access error (NOT not-found) resolving a mailbox grantee must skip the
+// whole push, so Stalwart keeps last-known shareWith rather than losing the
+// grantee on a transient DB blip.
+func TestReconcileSharedResources_MailboxLookupDBError_SkipsPush(t *testing.T) {
+	sr := &srFake{
+		res: []models.SharedResource{calRes("res1", "teamcal@example.org")},
+		grants: map[string][]models.SharedResourceGrant{
+			"res1": {{ResourceID: "res1", GranteeKind: "mailbox", GranteeID: "mb1", Rights: "read"}},
+		},
+	}
+	ag := &fakeAgent{}
+	r := newSRReconciler(t, ag, sr, &mbFake{err: errors.New("db down")}, &mgFake{}, &domFake{})
+	r.reconcileSharedResources(context.Background())
+
+	require.Nil(t, calendarShareSet(ag),
+		"mailbox lookup DB error must skip the push (keep last-known state)")
+}
+
+func TestReconcileSharedResources_DomainLookupDBError_SkipsPush(t *testing.T) {
+	sr := &srFake{
+		res: []models.SharedResource{calRes("res1", "teamcal@example.org")},
+		grants: map[string][]models.SharedResourceGrant{
+			"res1": {{ResourceID: "res1", GranteeKind: "mailbox", GranteeID: "mb1", Rights: "read"}},
+		},
+	}
+	mb := &mbFake{byID: map[string]*models.Mailbox{"mb1": {ID: "mb1", LocalPart: "alice", DomainID: "dom1"}}}
+	ag := &fakeAgent{}
+	r := newSRReconciler(t, ag, sr, mb, &mgFake{}, &domFake{err: errors.New("db down")})
+	r.reconcileSharedResources(context.Background())
+
+	require.Nil(t, calendarShareSet(ag),
+		"domain lookup DB error must skip the push (keep last-known state)")
+}
+
+func TestReconcileSharedResources_GroupLookupDBError_SkipsPush(t *testing.T) {
+	sr := &srFake{
+		res: []models.SharedResource{calRes("res1", "teamcal@example.org")},
+		grants: map[string][]models.SharedResourceGrant{
+			"res1": {{ResourceID: "res1", GranteeKind: "group", GranteeID: "grp1", Rights: "read"}},
+		},
+	}
+	ag := &fakeAgent{}
+	r := newSRReconciler(t, ag, sr, &mbFake{}, &mgFake{err: errors.New("db down")}, &domFake{})
+	r.reconcileSharedResources(context.Background())
+
+	require.Nil(t, calendarShareSet(ag),
+		"group lookup DB error must skip the push (keep last-known state)")
+}
+
+// A DB error on one resource must not stop a sibling resource in the same pass
+// from converging — the skip is per-resource.
+func TestReconcileSharedResources_DBError_OtherResourceStillPushed(t *testing.T) {
+	sr := &srFake{
+		res: []models.SharedResource{
+			calRes("res1", "a@example.org"), // mailbox grantee → hits the failing lookup
+			calRes("res2", "b@example.org"), // group grantee → resolves
+		},
+		grants: map[string][]models.SharedResourceGrant{
+			"res1": {{ResourceID: "res1", GranteeKind: "mailbox", GranteeID: "mb1", Rights: "read"}},
+			"res2": {{ResourceID: "res2", GranteeKind: "group", GranteeID: "grp1", Rights: "read"}},
+		},
+	}
+	mb := &mbFake{err: errors.New("db down")} // fails res1's mailbox lookup only
+	mg := &mgFake{members: map[string][]string{"grp1": {"bob@example.org"}}}
+
+	ag := &fakeAgent{}
+	r := newSRReconciler(t, ag, sr, mb, mg, &domFake{})
+	r.reconcileSharedResources(context.Background())
+
+	require.Equal(t, 1, shareSetCount(ag), "res1 push skipped on DB error; res2 still pushed")
+	require.Equal(t, "b@example.org", calendarShareSet(ag).params.(map[string]any)["owner_email"],
+		"the surviving push is the healthy sibling res2")
 }


### PR DESCRIPTION
## What

The shared-resource reconciler resolves every grant to a target email and
then pushes the whole `shareWith` map to Stalwart as an **idempotent
replace**. Inside that resolve loop, *any* grantee-lookup failure was a bare
`continue` that dropped the grantee from the map:

```go
case "mailbox":
    mb, err := r.srMailboxes.FindByID(ctx, g.GranteeID)
    if err != nil {
        continue
    }
    dom, err := r.domains.FindByID(ctx, mb.DomainID)
    if err != nil {
        continue
    }
    shares[mb.LocalPart+"@"+dom.Name] = g.Rights
```

So a **transient data-access error** on one grantee's lookup (not on
`ListGrants`, which already `return`s) silently omitted that grantee from
the pushed map, and the replace **revoked them in Stalwart** until a later
pass happened to resolve cleanly. A DB blip became a real, if temporary,
loss of access — surfaced nowhere.

This is the projection-side companion to **#1688**, which made grantee
existence explicit at write time (JAB-339 AC4). Same defect class — *never
collapse a data-access error into a silent drop* — still lived on the
reconciler side.

## Fix — fail closed, per lookup

- **mailbox / domain `FindByID`:** `errors.Is(err, repository.ErrNotFound)`
  → `continue` (the grantee is genuinely gone — e.g. deleted before its
  grants were pruned — so drop it and push the rest; **unchanged**). Any
  **other** error → log + `return` before the push.
- **group `ListMemberEmails`:** has **no** not-found case — a missing or
  empty group returns no rows + a `nil` error — so any error there is a
  data-access failure → log + `return`.

Not pushing **is** "keep last-known state": the replace is all-or-nothing,
so a map built from a partial lookup is a guess. This is exactly the rule
the `ListGrants` failure above already follows (a DB error we cannot
interpret means we do not know the true state, so we do not push one).

The skip is **per-resource** — `reconcileOneSharedResource` returns, so a
sibling resource in the same pass still converges (covered by a test).

## Revocation-direction tradeoff (called out on purpose)

Before: a lookup blip on grantee A wrongly revoked A, while a pending
revocation of grantee B (already removed from the DB grants) was still
applied. After: neither is applied until the next clean pass, so a
genuinely-revoked B keeps access **one extra interval**.

That is the correct trade, and it is not new policy: the existing
`ListGrants` failure already delays convergence — including revocations —
by one interval. This extends the same "a DB error is not evidence the
grant set changed, so don't push a guess" rule down to the per-grantee
lookups. Convergence resumes on the next clean tick.

## No wire / schema change

Reads only (`mailboxes` / `mail_groups` / `domains` via `FindByID` /
`ListMemberEmails`). The agent verb (`*.share_set`) and its payload are
unchanged — only the push / no-push decision changes. No migration, no
golden regen, no SPA change.

## Tests (reconciler package)

- **not-found stays inert** — a missing mailbox grantee, and a mailbox with
  a dangling `DomainID`, are each dropped while the push still runs for the
  rest.
- **data-access error skips the push** — one test each for the mailbox,
  domain, and group lookup, asserting no `share_set` call.
- **per-resource skip** — a DB error on one resource does not stop a healthy
  sibling in the same pass from being pushed (asserts exactly one push, for
  the sibling).

The reconciler test fakes were corrected to **mirror the real repos**: a
missing id now returns `repository.ErrNotFound`, not `(nil, nil)`. The old
fake would have nil-deref'd on a missing mailbox, so the inert path was
previously untestable — which is how the `continue`-on-everything behavior
went unnoticed.

**Five guards falsified against compiling neutralizations, each reverted:**
the three data-access `return`s (→ `continue`, each skip test RED) and the
two not-found branches (→ `false`, each inert test RED).

`gofmt` + `go vet ./...` clean; `go build ./...` clean; the reconciler
package is green under `-race`.

## No box-verify

The agent verb and payload are unchanged — only the reconciler's push /
no-push decision changes, and the fake agent exercises that decision fully
(push vs. no push, and the resulting `shares` map). A live box would run the
same unchanged `*.share_set` against Stalwart that it already runs in
production; it adds nothing the unit path does not already cover. (Reconciler
surface, so stating the rationale explicitly.)

## Not in this slice

- AC4 grantee **domain/tenant** policy — still a product decision (see
  #1688: same-domain / same-owner-tenant / any).
- Module extraction of the grant path into `sharedresourceops`.

Part of JAB-339 (shared-resource lifecycle); the parent stays open.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
