### PR TITLE
feat(nginx): tenant advanced-directives editor UI (GH #1624, ADR-0169 Phase 4b)

### DIFF
--- a/panel-ui/src/components/DomainAdvancedDirectivesPanel.test.tsx
+++ b/panel-ui/src/components/DomainAdvancedDirectivesPanel.test.tsx
@@ -1,0 +1,72 @@
+// DomainAdvancedDirectivesPanel.test — GH #1624 / ADR-0169 Phase 4b. Tenant raw
+// "advanced directives" editor: loads the domain's current directives, PATCHes
+// nginx_tenant_directives on save, and — the key UX guarantee — surfaces the
+// backend's exact rejection reason (the 400 `detail` from
+// ValidateNginxDirectivesTenant) rather than a generic toast.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../apiClient", () => ({
+  apiClient: { get: vi.fn(), patch: vi.fn() },
+}));
+
+const errorToast = vi.hoisted(() => vi.fn());
+const successToast = vi.hoisted(() => vi.fn());
+vi.mock("../lib/feedback", () => ({
+  feedback: { message: { success: successToast, error: errorToast, warning: vi.fn() } },
+}));
+
+import { apiClient } from "../apiClient";
+import { DomainAdvancedDirectivesPanel } from "./DomainAdvancedDirectivesPanel";
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockPatch = apiClient.patch as ReturnType<typeof vi.fn>;
+
+function renderPanel() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DomainAdvancedDirectivesPanel domainId="d1" />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGet.mockResolvedValue({ data: { nginx_tenant_directives: "add_header X-A a;" } });
+});
+
+describe("DomainAdvancedDirectivesPanel", () => {
+  it("loads the domain's current directives into the textarea", async () => {
+    renderPanel();
+    expect(await screen.findByDisplayValue("add_header X-A a;")).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith("/domains/d1");
+  });
+
+  it("saves via PATCH /domains/:id with nginx_tenant_directives", async () => {
+    mockPatch.mockResolvedValue({ data: {} });
+    renderPanel();
+    const textarea = await screen.findByDisplayValue("add_header X-A a;");
+    fireEvent.change(textarea, { target: { value: "expires 30d;" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(mockPatch).toHaveBeenCalledWith("/domains/d1", { nginx_tenant_directives: "expires 30d;" }),
+    );
+  });
+
+  it("surfaces the API's rejection detail (not a generic toast)", async () => {
+    mockPatch.mockRejectedValue({
+      response: { data: { detail: "advanced directives: 'proxy_pass' is not allowed (only add_header, expires, etag)" } },
+    });
+    renderPanel();
+    const textarea = await screen.findByDisplayValue("add_header X-A a;");
+    fireEvent.change(textarea, { target: { value: "proxy_pass http://127.0.0.1:9000;" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(errorToast).toHaveBeenCalledWith(
+        "advanced directives: 'proxy_pass' is not allowed (only add_header, expires, etag)",
+      ),
+    );
+  });
+});

--- a/panel-ui/src/components/DomainAdvancedDirectivesPanel.tsx
+++ b/panel-ui/src/components/DomainAdvancedDirectivesPanel.tsx
@@ -1,0 +1,124 @@
+// DomainAdvancedDirectivesPanel — GH #1624 / ADR-0169 Phase 4b. Tenant-facing
+// raw "advanced directives" for a single domain, gated (like the curated safe
+// options and the rewrite rule builder) on tenant_domain_options_enabled.
+//
+// Unlike the admin-only nginx_custom_directives, the tenant field is confined by
+// a tight value-grammar on the backend (ValidateNginxDirectivesTenant): one
+// statement per line, no blocks, and only add_header / expires / etag — so it
+// cannot SSRF, disclose files, or suppress logging. The panel surfaces the
+// backend's exact rejection reason (the 400 `detail`) so a tenant sees which
+// line was refused rather than a generic error.
+import { useEffect, useState } from "react";
+import { Button, Form, Input, Typography } from "antd";
+import { feedback } from "../lib/feedback";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../apiClient";
+
+// Mirrors the API cap (tenantDirectivesMaxBytes) so the form rejects an
+// over-long blob before the round-trip.
+const MAX_BYTES = 8 * 1024;
+
+// pickDetail surfaces the backend's `detail` (the exact rejected directive from
+// ValidateNginxDirectivesTenant) instead of a generic axios message.
+const pickDetail = (err: unknown, fallback: string): string => {
+  const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+  if (detail) return detail;
+  return err instanceof Error ? err.message : fallback;
+};
+
+export interface DomainAdvancedDirectivesPanelProps {
+  domainId: string;
+  onSaved?: () => void;
+}
+
+interface Values {
+  nginx_tenant_directives?: string;
+}
+
+export const DomainAdvancedDirectivesPanel = ({ domainId, onSaved }: DomainAdvancedDirectivesPanelProps) => {
+  const qc = useQueryClient();
+  const [form] = Form.useForm<Values>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ nginx_tenant_directives?: string }>(`/domains/${domainId}`);
+        if (!cancelled) {
+          form.setFieldsValue({ nginx_tenant_directives: resp.data.nginx_tenant_directives ?? "" });
+        }
+      } catch {
+        if (!cancelled) feedback.message.error("Failed to load advanced directives");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [domainId, form]);
+
+  const onSave = async () => {
+    let values: Values;
+    try {
+      values = await form.validateFields();
+    } catch {
+      return; // antd renders the field error
+    }
+    setSaving(true);
+    try {
+      await apiClient.patch(`/domains/${domainId}`, {
+        nginx_tenant_directives: values.nginx_tenant_directives ?? "",
+      });
+      feedback.message.success("Advanced directives saved — applied on the next reconcile");
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
+      onSaved?.();
+    } catch (err) {
+      feedback.message.error(pickDetail(err, "Failed to save advanced directives"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Typography.Paragraph type="secondary">
+        Extra nginx directives for this domain, one per line. Only response and
+        caching directives are allowed — <code>add_header</code>,{" "}
+        <code>expires</code> and <code>etag</code>. Each line must be a single
+        complete statement ending in <code>;</code>. Blocks,{" "}
+        <code>proxy_pass</code>, <code>root</code> and other routing or file
+        directives stay admin-only. Panel-managed response headers (HSTS,
+        X-Frame-Options, …) can't be overridden here — use the Domain options
+        tab for those.
+      </Typography.Paragraph>
+      <Form<Values> form={form} layout="vertical" disabled={loading}>
+        <Form.Item
+          name="nginx_tenant_directives"
+          rules={[
+            {
+              validator: (_, v: string) =>
+                new TextEncoder().encode(v ?? "").length > MAX_BYTES
+                  ? Promise.reject(new Error(`Directives exceed ${Math.round(MAX_BYTES / 1024)} KB`))
+                  : Promise.resolve(),
+            },
+          ]}
+        >
+          <Input.TextArea
+            spellCheck={false}
+            autoSize={{ minRows: 6 }}
+            style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace", fontSize: 13 }}
+            placeholder={"add_header X-Robots-Tag noindex;\nexpires 30d;\netag on;"}
+          />
+        </Form.Item>
+        <Button type="primary" loading={saving} disabled={loading} onClick={onSave}>
+          Save
+        </Button>
+      </Form>
+    </div>
+  );
+};

--- a/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.test.tsx
@@ -48,6 +48,9 @@ vi.mock("../../../hooks/useServerCapabilities", () => ({
 vi.mock("../../../components/DomainNginxOptionsPanel", () => ({
   DomainNginxOptionsPanel: ({ domainId }: { domainId: string }) => <div>options-pane:{domainId}</div>,
 }));
+vi.mock("../../../components/DomainAdvancedDirectivesPanel", () => ({
+  DomainAdvancedDirectivesPanel: ({ domainId }: { domainId: string }) => <div>advanced-pane:{domainId}</div>,
+}));
 vi.mock("../../DomainSettingsButton", () => ({
   TenantNginxRulesPanel: ({ domain }: { domain: { id: string } }) => <div>rewrite-pane:{domain.id}</div>,
 }));
@@ -225,6 +228,7 @@ describe("WebDomainPage (GH #1543)", () => {
     expect(screen.getByText("Index Files")).toBeInTheDocument();
     expect(screen.queryByText("Domain options")).not.toBeInTheDocument();
     expect(screen.queryByText("Rewrite rules")).not.toBeInTheDocument();
+    expect(screen.queryByText("Advanced directives")).not.toBeInTheDocument();
     // "Document root" also labels an Overview fact, so assert the pane itself
     // (its stub marker) is absent rather than the ambiguous tab text.
     expect(screen.queryByText("docroot-pane:d1")).not.toBeInTheDocument();
@@ -236,7 +240,14 @@ describe("WebDomainPage (GH #1543)", () => {
     expect(await screen.findByText("options-pane:d1")).toBeInTheDocument();
     // The other gated tabs are present in the strip.
     expect(screen.getByText("Rewrite rules")).toBeInTheDocument();
+    expect(screen.getByText("Advanced directives")).toBeInTheDocument();
     expect(screen.getByText("Document root")).toBeInTheDocument();
+  });
+
+  it("renders the advanced-directives pane when the caps are on (GH #1624 Phase 4)", async () => {
+    caps.value = { tenant_domain_options_enabled: true, tenant_docroot_editable: false };
+    renderAt("/jabali-panel/domains/d1/advanced-directives");
+    expect(await screen.findByText("advanced-pane:d1")).toBeInTheDocument();
   });
 
   it("falls back to Overview when a URL targets a cap-gated tab that is off", async () => {

--- a/panel-ui/src/shells/user/domains/WebDomainPage.tsx
+++ b/panel-ui/src/shells/user/domains/WebDomainPage.tsx
@@ -31,6 +31,7 @@ import { DomainRedirectsPanel } from "../../DomainRedirectsPanel";
 import { DNSRecordsPanel } from "../../dns/DNSRecordsPage";
 import { DomainLogsPanel } from "../../../components/logs/DomainLogsPanel";
 import { DomainNginxOptionsPanel } from "../../../components/DomainNginxOptionsPanel";
+import { DomainAdvancedDirectivesPanel } from "../../../components/DomainAdvancedDirectivesPanel";
 import { TenantNginxRulesPanel } from "../../DomainSettingsButton";
 import { DomainDocRootPanel } from "../../../components/domains/DomainDocRootPanel";
 import { DomainPHPSettingsPanel } from "../../../components/domains/DomainPHPSettingsPanel";
@@ -123,7 +124,7 @@ export const WebDomainPage = () => {
               type="info"
               showIcon
               message="More domain controls are available on request"
-              description="When your administrator enables tenant domain options for this server, you get two extra tabs on your domains: a curated set of safe nginx options (max upload size, HSTS, security headers, gzip) and a limited rewrite / custom-response-header rule builder. Raw nginx directives stay admin-only."
+              description="When your administrator enables tenant domain options for this server, you get extra tabs on your domains: a curated set of safe nginx options (max upload size, HSTS, security headers, gzip), a limited rewrite / custom-response-header rule builder, and a small set of advanced response and caching directives (add_header, expires, etag). Routing directives like proxy_pass and root stay admin-only."
             />
           )}
         </Space>
@@ -173,6 +174,11 @@ export const WebDomainPage = () => {
             key: "rewrite-rules",
             label: "Rewrite rules",
             node: <TenantNginxRulesPanel domain={domain} />,
+          },
+          {
+            key: "advanced-directives",
+            label: "Advanced directives",
+            node: <DomainAdvancedDirectivesPanel domainId={domain.id} />,
           },
         ]
       : []),


### PR DESCRIPTION
## GH #1624 / ADR-0169 Phase 4b — tenant advanced-directives editor (UI)

The tenant-facing UI for the raw "advanced directives" field shipped in Phase 4a
(backend PR). **Merge after Phase 4a** — the field must exist first, or a tenant's
save is silently ignored (Go drops the unknown JSON field).

### What

A new **"Advanced directives"** tab on the tenant Web Domain page
(`WebDomainPage.tsx`), gated on the same `tenant_domain_options_enabled`
capability as the existing "Domain options" and "Rewrite rules" tabs — hidden
entirely when the cap is off (never a disabled stub, matching the established
rule). It renders `DomainAdvancedDirectivesPanel`: a monospace textarea bound to
`nginx_tenant_directives`, PATCHed to `/domains/{id}`.

Like the admin `RawDirectivesEditor`, it surfaces the backend's exact **400
`detail`** (the precise rejected directive from `ValidateNginxDirectivesTenant`)
so a tenant sees which line was refused, not a generic toast. The textarea
mirrors the API's 8 KB cap client-side, and the panel copy states the allowed
directives (`add_header`, `expires`, `etag`), the one-statement-per-line rule,
and that routing/file directives and panel-managed headers stay out of reach.

The Overview discoverability hint (shown when the cap is off) is updated to
mention the third tab and to stop claiming raw directives are entirely
admin-only.

### Tests

- `DomainAdvancedDirectivesPanel.test.tsx` — loads current directives, PATCHes
  `nginx_tenant_directives`, and surfaces the 400 `detail`. **Fail-first
  verified**: neutralizing `pickDetail` flips the detail-surfacing test.
- `WebDomainPage.test.tsx` — the new tab is hidden when the cap is off, present
  when on, and its pane renders at `/…/advanced-directives`.

`tsc` + `eslint` clean; affected vitest suites green (25 tests). No new i18n
(matches the sibling tenant panels' hardcoded English).

**HELD** for `MERGE_APPROVED`. Refs GH #1624.
