### PR TITLE
fix(malware): route quarantine restore through a shared module so the CLI enforces the reason policy and sends it to the Agent (JAB-325 AC1)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3399,7 +3399,7 @@ jabali malware quarantine restore <id> [flags]
 
 **Flags:**
 
-- `--reason` — why the file is being restored (required)
+- `--reason` — why the file is being restored (required, min 5 chars)
 
 #### `jabali malware scan`
 

--- a/panel-api/cmd/server/malware_cmd.go
+++ b/panel-api/cmd/server/malware_cmd.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/malwareops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -174,31 +176,27 @@ func newMalwareQuarantineRestoreCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if reason == "" {
-				return fmt.Errorf("--reason is required (restoring re-exposes a flagged file)")
-			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 			defer cancel()
 			repo := repository.NewMalwareQuarantineRepository(sharedDB)
-			row, err := repo.Get(ctx, args[0])
+			row, err := malwareops.RestoreQuarantine(ctx,
+				malwareops.Deps{Quarantine: repo, Agent: sharedAgent}, args[0], "cli", reason)
 			if err != nil {
-				return fmt.Errorf("quarantine entry not found: %w", err)
-			}
-			if _, err := sharedAgent.Call(ctx, "security.malware.quarantine.restore", map[string]any{
-				"quarantine_path": row.QuarantinePath,
-				"original_path":   row.OriginalPath,
-			}); err != nil {
-				return err
-			}
-			if err := repo.Restore(ctx, row.ID, "cli", reason); err != nil {
-				return fmt.Errorf("persist restore: %w", err)
+				switch {
+				case errors.Is(err, malwareops.ErrReasonTooShort):
+					return fmt.Errorf("--reason must be at least %d characters (restoring re-exposes a flagged file)", malwareops.MinRestoreReasonLen)
+				case errors.Is(err, repository.ErrNotFound):
+					return fmt.Errorf("quarantine entry not found: %s", args[0])
+				default:
+					return err
+				}
 			}
 			cliAuditOK(ctx, "malware.quarantine_restore", "malware_quarantine", row.ID, row.UserID)
 			fmt.Fprintf(cmd.OutOrStdout(), "Restored %s → %s\n", row.ID, row.OriginalPath)
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&reason, "reason", "", "why the file is being restored (required)")
+	cmd.Flags().StringVar(&reason, "reason", "", "why the file is being restored (required, min 5 chars)")
 	return cmd
 }
 

--- a/panel-api/cmd/server/malware_cmd_test.go
+++ b/panel-api/cmd/server/malware_cmd_test.go
@@ -87,3 +87,33 @@ func TestMalwareYaraDelete_RunEWiresAgentFirstThenDBRow(t *testing.T) {
 		}
 	}
 }
+
+// JAB-325 AC1: the quarantine restore command must route through the shared
+// malwareops module (one reason policy, and the reason reaches the Agent). The
+// pins are that the RunE calls malwareops.RestoreQuarantine and no longer
+// builds the agent params inline — the old inline path dropped the reason from
+// the Agent call and used a weaker reason check.
+func TestMalwareQuarantineRestore_RunERoutesThroughModule(t *testing.T) {
+	src, err := os.ReadFile("malware_cmd.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	s := string(src)
+	start := strings.Index(s, "func newMalwareQuarantineRestoreCmd")
+	if start < 0 {
+		t.Fatal("restore command not found")
+	}
+	body := s[start:]
+	if end := strings.Index(body[1:], "\nfunc "); end >= 0 {
+		body = body[:end+1]
+	}
+	if !strings.Contains(body, "malwareops.RestoreQuarantine(") {
+		t.Error("restore RunE must route through malwareops.RestoreQuarantine")
+	}
+	if strings.Contains(body, `"quarantine_path"`) {
+		t.Error("restore RunE must not build the agent params inline (quarantine_path present)")
+	}
+	if strings.Contains(body, "sharedAgent.Call(") {
+		t.Error("restore RunE must not call the agent directly")
+	}
+}

--- a/panel-api/internal/api/security_malware.go
+++ b/panel-api/internal/api/security_malware.go
@@ -20,6 +20,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/malwareops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -200,41 +201,32 @@ func (h *securityMalwareHandler) restoreQuarantine(c *gin.Context) {
 	var body struct {
 		Reason string `json:"reason"`
 	}
-	if err := c.ShouldBindJSON(&body); err != nil || len(body.Reason) < 5 {
-		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "reason_required",
-			"detail": "reason is required (min 5 chars) for audit"})
-		return
-	}
+	_ = c.ShouldBindJSON(&body) // reason policy is enforced by the module
 	ctx, cancel := context.WithTimeout(c.Request.Context(), malwareCallTimeout)
 	defer cancel()
-	row, err := h.cfg.Quarantine.Get(ctx, id)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_get_quarantine"})
-		return
-	}
-	if _, err := h.cfg.Agent.Call(ctx, "security.malware.quarantine.restore", map[string]any{
-		"quarantine_path": row.QuarantinePath,
-		"original_path":   row.OriginalPath,
-		"reason":          body.Reason,
-	}); err != nil {
-		status, errBody := translateAgentError(err)
-		c.JSON(status, errBody)
-		return
-	}
 	claims := ginctx.Claims(c)
 	restoredBy := ""
 	if claims != nil {
 		restoredBy = claims.UserID
 	}
-	if err := h.cfg.Quarantine.Restore(ctx, id, restoredBy, body.Reason); err != nil {
+	_, err := malwareops.RestoreQuarantine(ctx,
+		malwareops.Deps{Quarantine: h.cfg.Quarantine, Agent: h.cfg.Agent}, id, restoredBy, body.Reason)
+	switch {
+	case errors.Is(err, malwareops.ErrReasonTooShort):
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "reason_required",
+			"detail": "reason is required (min 5 chars) for audit"})
+	case errors.Is(err, repository.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
+	case errors.Is(err, malwareops.ErrLoadQuarantine):
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_get_quarantine"})
+	case errors.Is(err, malwareops.ErrPersistRestore):
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_restore"})
-		return
+	case err != nil:
+		status, errBody := translateAgentError(err) // agent error → same mapping as before
+		c.JSON(status, errBody)
+	default:
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "restored": true})
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok", "restored": true})
 }
 
 func (h *securityMalwareHandler) deleteQuarantine(c *gin.Context) {

--- a/panel-api/internal/api/security_malware_restore_test.go
+++ b/panel-api/internal/api/security_malware_restore_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type restoreQRepo struct {
+	repository.MalwareQuarantineRepository
+	row        *models.MalwareQuarantine
+	getErr     error
+	restoreErr error
+	restored   bool
+	gotReason  string
+}
+
+func (f *restoreQRepo) Get(context.Context, string) (*models.MalwareQuarantine, error) {
+	return f.row, f.getErr
+}
+
+func (f *restoreQRepo) Restore(_ context.Context, _, _, reason string) error {
+	f.restored = true
+	f.gotReason = reason
+	return f.restoreErr
+}
+
+type malwRestoreAgent struct {
+	called bool
+	params map[string]any
+	err    error
+}
+
+func (f *malwRestoreAgent) Call(_ context.Context, _ string, params any) (json.RawMessage, error) {
+	f.called = true
+	if p, ok := params.(map[string]any); ok {
+		f.params = p
+	}
+	return nil, f.err
+}
+
+func restoreReq(body string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: "q1"}}
+	return c, w
+}
+
+func restoreRow() *models.MalwareQuarantine {
+	return &models.MalwareQuarantine{ID: "q1", QuarantinePath: "/q/e", OriginalPath: "/home/e"}
+}
+
+func restoreHandler(q *restoreQRepo, ag *malwRestoreAgent) *securityMalwareHandler {
+	return &securityMalwareHandler{cfg: SecurityMalwareHandlerConfig{Agent: ag, Quarantine: q}}
+}
+
+// A too-short reason is rejected 400 before the agent or DB is touched.
+func TestRestoreQuarantineHTTP_ShortReason(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	q := &restoreQRepo{row: restoreRow()}
+	ag := &malwRestoreAgent{}
+	c, w := restoreReq(`{"reason":"four"}`)
+	restoreHandler(q, ag).restoreQuarantine(c)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "reason_required")
+	require.False(t, ag.called, "agent not called on invalid reason")
+	require.False(t, q.restored, "nothing persisted on invalid reason")
+}
+
+// A missing entry is 404.
+func TestRestoreQuarantineHTTP_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	q := &restoreQRepo{getErr: repository.ErrNotFound}
+	ag := &malwRestoreAgent{}
+	c, w := restoreReq(`{"reason":"valid reason"}`)
+	restoreHandler(q, ag).restoreQuarantine(c)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "not_found")
+	require.False(t, ag.called)
+}
+
+// An Agent error is mapped through translateAgentError (FailedPrecondition →
+// 409), not a generic 500 — proving the module's %w wrap keeps the
+// *agent.AgentError reachable — and the restore is NOT persisted.
+func TestRestoreQuarantineHTTP_AgentErrorTranslatedAndNotPersisted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	q := &restoreQRepo{row: restoreRow()}
+	ag := &malwRestoreAgent{err: &agent.AgentError{Code: agent.CodeFailedPrecondition, Message: "locked"}}
+	c, w := restoreReq(`{"reason":"valid reason"}`)
+	restoreHandler(q, ag).restoreQuarantine(c)
+	require.Equal(t, http.StatusConflict, w.Code, "translateAgentError mapping preserved")
+	require.False(t, q.restored, "agent failure must not advance DB truth")
+}
+
+// Happy path: 200, and the Agent receives the reason as audit evidence.
+func TestRestoreQuarantineHTTP_SendsReasonAndPersists(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	q := &restoreQRepo{row: restoreRow()}
+	ag := &malwRestoreAgent{}
+	c, w := restoreReq(`{"reason":"accidental clean-file quarantine"}`)
+	restoreHandler(q, ag).restoreQuarantine(c)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "accidental clean-file quarantine", ag.params["reason"],
+		"the Agent must receive the reason")
+	require.True(t, q.restored)
+	require.Equal(t, "accidental clean-file quarantine", q.gotReason)
+}

--- a/panel-api/internal/malwareops/malwareops.go
+++ b/panel-api/internal/malwareops/malwareops.go
@@ -1,0 +1,84 @@
+// Package malwareops owns the transport-neutral Malware Artifact Lifecycle
+// policy (JAB-325). The REST handler and the operator CLI are adapters: they
+// resolve identity and shape output, while this package owns validation,
+// Agent-first ordering, and persistence so the two cannot drift.
+package malwareops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// MinRestoreReasonLen is the single minimum-length policy for a quarantine
+// restore reason, shared by every adapter. Restoring re-exposes a flagged
+// file, so the reason is mandatory audit evidence.
+const MinRestoreReasonLen = 5
+
+var (
+	// ErrReasonTooShort is returned when the restore reason is shorter than
+	// MinRestoreReasonLen.
+	ErrReasonTooShort = errors.New("malwareops: restore reason too short")
+	// ErrLoadQuarantine wraps a non-not-found failure loading the entry.
+	ErrLoadQuarantine = errors.New("malwareops: load quarantine entry")
+	// ErrPersistRestore wraps a failure recording the restore in DB truth.
+	ErrPersistRestore = errors.New("malwareops: persist restore")
+)
+
+// Caller is the narrow slice of the Agent client this package needs.
+type Caller interface {
+	Call(ctx context.Context, command string, params any) (json.RawMessage, error)
+}
+
+// QuarantineRepo is the narrow slice of the quarantine repository this package
+// needs.
+type QuarantineRepo interface {
+	Get(ctx context.Context, id string) (*models.MalwareQuarantine, error)
+	Restore(ctx context.Context, id, restoredBy, reason string) error
+}
+
+// Deps are the collaborators RestoreQuarantine requires.
+type Deps struct {
+	Quarantine QuarantineRepo
+	Agent      Caller
+}
+
+// RestoreQuarantine validates the reason, instructs the Agent to move the file
+// back to its original path, then records the restore in DB truth — in that
+// order, so an Agent failure never advances DB truth. The Agent receives the
+// reason as audit evidence (the REST adapter sent it already; the CLI adapter
+// used to drop it). On success it returns the pre-restore row so an adapter
+// can log and print it.
+//
+// Error contract: ErrReasonTooShort (validation); repository.ErrNotFound
+// (passed through unwrapped so an adapter can map it to 404); ErrLoadQuarantine
+// (other load failure); an Agent error wrapped with %w (so errors.As still
+// finds *agent.AgentError for the REST translateAgentError mapping); or
+// ErrPersistRestore (the restore write failed after the host succeeded).
+func RestoreQuarantine(ctx context.Context, d Deps, id, restoredBy, reason string) (*models.MalwareQuarantine, error) {
+	if len(reason) < MinRestoreReasonLen {
+		return nil, ErrReasonTooShort
+	}
+	row, err := d.Quarantine.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: %v", ErrLoadQuarantine, err)
+	}
+	if _, err := d.Agent.Call(ctx, "security.malware.quarantine.restore", map[string]any{
+		"quarantine_path": row.QuarantinePath,
+		"original_path":   row.OriginalPath,
+		"reason":          reason,
+	}); err != nil {
+		return nil, fmt.Errorf("restore agent: %w", err)
+	}
+	if err := d.Quarantine.Restore(ctx, id, restoredBy, reason); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrPersistRestore, err)
+	}
+	return row, nil
+}

--- a/panel-api/internal/malwareops/malwareops_test.go
+++ b/panel-api/internal/malwareops/malwareops_test.go
@@ -1,0 +1,128 @@
+package malwareops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeQRepo struct {
+	row        *models.MalwareQuarantine
+	getErr     error
+	restoreErr error
+	restored   bool
+	gotBy      string
+	gotReason  string
+}
+
+func (f *fakeQRepo) Get(context.Context, string) (*models.MalwareQuarantine, error) {
+	return f.row, f.getErr
+}
+
+func (f *fakeQRepo) Restore(_ context.Context, _, by, reason string) error {
+	f.restored = true
+	f.gotBy, f.gotReason = by, reason
+	return f.restoreErr
+}
+
+type fakeCaller struct {
+	called bool
+	params map[string]any
+	err    error
+}
+
+func (f *fakeCaller) Call(_ context.Context, _ string, params any) (json.RawMessage, error) {
+	f.called = true
+	if p, ok := params.(map[string]any); ok {
+		f.params = p
+	}
+	return nil, f.err
+}
+
+func sampleRow() *models.MalwareQuarantine {
+	return &models.MalwareQuarantine{ID: "q1", QuarantinePath: "/q/evil", OriginalPath: "/home/u/evil"}
+}
+
+// A reason under the minimum is rejected before anything else runs.
+func TestRestoreQuarantine_ReasonTooShort(t *testing.T) {
+	q := &fakeQRepo{row: sampleRow()}
+	ag := &fakeCaller{}
+	_, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "cli", "four")
+	require.ErrorIs(t, err, ErrReasonTooShort)
+	require.False(t, ag.called, "agent must not be called on an invalid reason")
+	require.False(t, q.restored, "restore must not be persisted on an invalid reason")
+}
+
+// A reason of exactly the minimum length is accepted.
+func TestRestoreQuarantine_MinLengthAccepted(t *testing.T) {
+	q := &fakeQRepo{row: sampleRow()}
+	ag := &fakeCaller{}
+	row, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "cli", "12345")
+	require.NoError(t, err)
+	require.Equal(t, "q1", row.ID)
+}
+
+// Happy path: the Agent receives the reason as audit evidence, and the restore
+// is persisted with the caller's identity + reason.
+func TestRestoreQuarantine_SendsReasonToAgentAndPersists(t *testing.T) {
+	q := &fakeQRepo{row: sampleRow()}
+	ag := &fakeCaller{}
+	_, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "admin-7", "accidental quarantine of a clean invoice")
+	require.NoError(t, err)
+	require.True(t, ag.called)
+	require.Equal(t, "/q/evil", ag.params["quarantine_path"])
+	require.Equal(t, "/home/u/evil", ag.params["original_path"])
+	require.Equal(t, "accidental quarantine of a clean invoice", ag.params["reason"],
+		"the Agent must receive the reason (audit evidence)")
+	require.True(t, q.restored)
+	require.Equal(t, "admin-7", q.gotBy)
+	require.Equal(t, "accidental quarantine of a clean invoice", q.gotReason)
+}
+
+// A missing entry is passed through as repository.ErrNotFound so an adapter can
+// map it to 404; the Agent is never called.
+func TestRestoreQuarantine_NotFoundPassthrough(t *testing.T) {
+	q := &fakeQRepo{getErr: repository.ErrNotFound}
+	ag := &fakeCaller{}
+	_, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "cli", "valid reason")
+	require.ErrorIs(t, err, repository.ErrNotFound)
+	require.NotErrorIs(t, err, ErrLoadQuarantine)
+	require.False(t, ag.called)
+}
+
+// Any other load failure is wrapped as ErrLoadQuarantine (kept distinct from
+// not-found so the adapter returns 500, not 404).
+func TestRestoreQuarantine_LoadErrorWrapped(t *testing.T) {
+	q := &fakeQRepo{getErr: errors.New("db down")}
+	ag := &fakeCaller{}
+	_, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "cli", "valid reason")
+	require.ErrorIs(t, err, ErrLoadQuarantine)
+	require.NotErrorIs(t, err, repository.ErrNotFound)
+	require.False(t, ag.called)
+}
+
+// Agent-first ordering (AC3): an Agent failure must NOT advance DB truth.
+func TestRestoreQuarantine_AgentFailureDoesNotPersist(t *testing.T) {
+	q := &fakeQRepo{row: sampleRow()}
+	ag := &fakeCaller{err: errors.New("agent boom")}
+	_, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "cli", "valid reason")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrPersistRestore, "an agent failure is not a persist failure")
+	require.False(t, q.restored, "agent failure must not advance DB truth")
+}
+
+// A persist failure after a successful host restore is surfaced as
+// ErrPersistRestore, not swallowed.
+func TestRestoreQuarantine_PersistErrorWrapped(t *testing.T) {
+	q := &fakeQRepo{row: sampleRow(), restoreErr: errors.New("write fail")}
+	ag := &fakeCaller{}
+	_, err := RestoreQuarantine(context.Background(), Deps{Quarantine: q, Agent: ag}, "q1", "cli", "valid reason")
+	require.ErrorIs(t, err, ErrPersistRestore)
+	require.True(t, ag.called, "the host restore already ran")
+}


### PR DESCRIPTION
fix(malware): route quarantine restore through a shared module so the CLI enforces the reason policy and sends it to the Agent (JAB-325 AC1)

## Why

JAB-325 AC1: "Restore uses one minimum reason policy and sends the reason to the Agent."

The operator CLI `malware quarantine restore` had drifted from the REST handler on the restore reason — which is the mandatory audit evidence for why a flagged file was re-exposed:

- it accepted any **non-empty** reason, while REST requires **≥ 5 chars**; and
- it **omitted the reason** from the `security.malware.quarantine.restore` Agent call entirely, while REST sends it.

So a CLI restore could pass a 1-char reason, and on that path the host never recorded why the file was un-quarantined. Two adapters, one policy, diverging — the exact drift this ticket exists to close.

## Approach — a module, not a second copy

Rather than copy the literal and the param map into the CLI (which is how the drift happened in the first place), I extracted a small transport-neutral package `internal/malwareops`, and both adapters call it. This mirrors the 18 sibling `*ops` leaves (`userops`, `domainops`, `sharedresourceops`, …) — the established seam for "one policy, many doors."

`malwareops.RestoreQuarantine` owns the policy and the ordering:

1. validate the reason (`MinRestoreReasonLen = 5`, one source of truth)
2. load the entry
3. `Agent.Call` **with the reason**
4. persist

Agent-first, so an Agent failure never advances DB truth (AC3 — already true on both sides; this pins it rather than closing it).

### Error contract

Typed sentinels let each adapter map without re-deriving policy:

- `ErrReasonTooShort` (validation)
- `repository.ErrNotFound` — passed through unwrapped so an adapter maps it to 404
- `ErrLoadQuarantine` — other load failure
- the Agent error **wrapped with `%w`** so the REST handler's `errors.As`/`translateAgentError` mapping still resolves `*agent.AgentError` (FailedPrecondition → 409, etc.). The 409 HTTP test is the proof: a generic 500 there would mean the wrap broke `errors.As`.
- `ErrPersistRestore` — the restore write failed after the host succeeded

## Adapters

- **REST** `restoreQuarantine` now calls the module and maps the sentinels to the **same responses it returned before**: 400 `reason_required`, 404 `not_found`, 500 `db_get_quarantine` / `db_restore`, `translateAgentError` for an Agent error, 200. Identity (`claims.UserID`) stays in the handler.
  - One path changed shape internally (same wire result): the handler now does `_ = c.ShouldBindJSON(&body)` and lets the module's reason check fire, instead of returning 400 on a bind error first. A malformed/empty body still returns **400 `reason_required`** (an unbound body has an empty reason, which is < 5). Same status, same code — flagging it because the `_ =` on a bind is visible in the diff.
- **CLI** `restore` RunE calls the module with `"cli"` as the actor: `ErrReasonTooShort` → "--reason must be at least 5 characters…", `ErrNotFound` → a friendly not-found. The `--reason` help now states the minimum.
  - Test fake is named `malwRestoreAgent` because `restoreAgent` was already taken by `backups_restore_async_test.go`.

## CLI behavior change (the point of the slice, not collateral)

- a reason under 5 chars is now **rejected** (was: any non-empty reason accepted);
- the reason now **reaches the Agent** (was: dropped).

No REST wire/schema change — same routes, same response shapes, all existing codes preserved.

CLI reference golden regenerated; the diff is exactly one line — the `--reason` help: "why the file is being restored (required, min 5 chars)".

## Tests

- **`malwareops`**: reason-too-short (no agent, no persist); min-length accepted; happy path asserts the Agent receives the reason and the row is persisted with actor + reason; not-found passthrough; other load error wrapped as `ErrLoadQuarantine` (distinct from not-found); agent failure does not persist (AC3); persist failure surfaced as `ErrPersistRestore`.
- **REST** (real handler + fakes): 400 short reason, 404 not-found, Agent error translated to 409 (proving the `%w` wrap keeps `*agent.AgentError` reachable) with no persist, 200 happy path asserting the Agent got the reason.
- **CLI source-pin**: the restore RunE routes through `malwareops.RestoreQuarantine` and no longer builds the Agent params inline.

Four guards falsified against compiling neutralizations, each reverted: the reason validator, the reason param in the Agent call, the Agent-before-persist ordering, and the CLI routing pin. `gofmt` + `go vet ./...` clean; `go build ./...` clean; `malwareops`, `api`, and `cmd/server` packages green (`api` and `cmd/server` under `-race`).

## No box-verify

The Agent verb is unchanged and REST already sends the reason in production, so the CLI now sends exactly what REST sends. The decision and the params are fully exercised by the module test and the handler fakes — there is no new live surface to observe.

## Not in this slice

Quarantine delete and YARA upload/toggle/delete are untouched (YARA delete DB-truth already shipped; the agent-side `os.Remove` ENOENT-heal remains a separate follow-up). AC3 is pinned here for restore only — delete/YARA still need it. Part of JAB-325; the parent stays open.

Part of JAB-325 (malware artifact lifecycle).

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA