### PR TITLE
feat(domains): surface raw nginx directives read-only across both stores (GH #1624 / ADR-0169 Phase 5)

### DIFF
--- a/panel-ui/src/components/domains/types.ts
+++ b/panel-ui/src/components/domains/types.ts
@@ -79,6 +79,10 @@ export type Domain = {
   temp_url?: string | null;
   bot_challenge_include?: boolean;
   nginx_custom_directives: string;
+  // GH #1624 / ADR-0169 Phase 4a: tenant-authored raw "advanced directives".
+  // Optional — absent (omitempty) until the Phase 4a backend column (#1691)
+  // lands; the admin Nginx section surfaces it read-only in Phase 5.
+  nginx_tenant_directives?: string | null;
   redirect_all_to?: string | null;
   redirect_all_type?: string | null;
   page_redirects?:

--- a/panel-ui/src/shells/DomainSettingsButton.phase5.test.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.phase5.test.tsx
@@ -1,0 +1,120 @@
+// DomainSettingsButton.phase5.test.tsx — GH #1624 / ADR-0169 Phase 5.
+//
+// Phase 5 unifies the two config stores by making the typed Rule Builder the
+// rendered source of truth while keeping raw directives *visible, not silently
+// ignored*:
+//   - Tenant view (TenantNginxRulesPanel): admin-authored raw directives
+//     (nginx_custom_directives) are shown read-only under the builder, never
+//     reverse-parsed into editable rules.
+//   - Admin mirror (DomainNginxSection): the owner's tenant "advanced
+//     directives" (nginx_tenant_directives, Phase 4a) are shown read-only with
+//     a Clear action, because disabling the opt-in does not deactivate an
+//     already-stored snippet.
+//
+// Only apiClient is mocked; the real AntD widgets and the in-file RuleBuilder
+// render.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TenantNginxRulesPanel,
+  DomainNginxSection,
+  type DomainSettingsTarget,
+} from "./DomainSettingsButton";
+
+vi.mock("../apiClient", () => ({ apiClient: { patch: vi.fn() } }));
+
+import { apiClient } from "../apiClient";
+
+const mocked = apiClient as unknown as { patch: ReturnType<typeof vi.fn> };
+
+function renderTenant(domain: DomainSettingsTarget) {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <TenantNginxRulesPanel domain={domain} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+function renderAdmin(domain: DomainSettingsTarget) {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <DomainNginxSection domain={domain} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ADR-0169 Phase 5 — tenant view surfaces admin raw directives", () => {
+  beforeEach(() => {
+    mocked.patch.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  it("surfaces admin raw directives read-only under the builder", () => {
+    renderTenant({
+      id: "d1",
+      name: "x.com",
+      nginx_custom_directives: "add_header X-Admin one;\nexpires 1h;",
+      nginx_rules: [],
+    });
+    // Nothing that shapes the vhost is invisible to the owner.
+    expect(screen.getByText("Administrator-managed directives")).toBeTruthy();
+    // getByDisplayValue normalises whitespace (newlines -> spaces), so match a
+    // single-line substring of the surfaced directives.
+    const ta = screen.getByDisplayValue(
+      /add_header X-Admin one;/,
+    ) as HTMLTextAreaElement;
+    // Surfaced, but NOT editable and NOT reverse-parsed into rules — read-only.
+    expect(ta.readOnly).toBe(true);
+  });
+
+  it("hides the admin-directives block when the admin has set none", () => {
+    renderTenant({
+      id: "d1",
+      name: "x.com",
+      nginx_custom_directives: "",
+      nginx_rules: [],
+    });
+    expect(screen.queryByText("Administrator-managed directives")).toBeNull();
+  });
+});
+
+describe("ADR-0169 Phase 5 — admin mirror of tenant advanced directives", () => {
+  beforeEach(() => {
+    mocked.patch.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  it("shows the owner's directives read-only and clears them with an empty string", async () => {
+    renderAdmin({
+      id: "d1",
+      name: "x.com",
+      nginx_tenant_directives: "add_header X-Robots-Tag noindex;",
+      nginx_rules: [],
+    });
+    expect(screen.getByText("Tenant advanced directives")).toBeTruthy();
+    const ta = screen.getByDisplayValue(
+      "add_header X-Robots-Tag noindex;",
+    ) as HTMLTextAreaElement;
+    expect(ta.readOnly).toBe(true);
+
+    fireEvent.click(screen.getByText("Clear tenant directives"));
+    await waitFor(() => expect(mocked.patch).toHaveBeenCalled());
+    const [url, body] = mocked.patch.mock.calls[0];
+    expect(url).toBe("/domains/d1");
+    // Must be "" (not null): a Go *string can't tell JSON null from an omitted
+    // field, so null would read as "no change" and the snippet would persist.
+    expect(body).toEqual({ nginx_tenant_directives: "" });
+  });
+
+  it("hides the tenant-directives mirror when the owner has set none", () => {
+    renderAdmin({ id: "d1", name: "x.com", nginx_rules: [] });
+    expect(screen.queryByText("Tenant advanced directives")).toBeNull();
+  });
+});

--- a/panel-ui/src/shells/DomainSettingsButton.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.tsx
@@ -72,6 +72,11 @@ export type DomainSettingsTarget = {
   user_id?: string;
   php_pool_id?: string | null;
   nginx_custom_directives?: string | null;
+  // GH #1624 / ADR-0169 Phase 5: the tenant-authored raw "advanced directives"
+  // field. Surfaced read-only (with a Clear action) in the admin Nginx section
+  // so an admin can see and remove an owner's snippet — undefined until the
+  // Phase 4a backend column (#1691) lands, so the mirror stays hidden till then.
+  nginx_tenant_directives?: string | null;
   nginx_rules?: NginxRule[] | null;
 };
 
@@ -1136,6 +1141,7 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
   );
   const [rules, setRules] = useState<NginxRule[]>(domain.nginx_rules ?? []);
   const [isSaving, setIsSaving] = useState(false);
+  const [clearingTenant, setClearingTenant] = useState(false);
   const qc = useQueryClient();
 
   // Re-sync from prop when the domain reloads (e.g. after a save
@@ -1164,6 +1170,29 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
       feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  // GH #1624 / ADR-0169 Phase 5: disabling the tenant opt-in does NOT deactivate
+  // already-stored tenant directives (the reconciler still renders the column),
+  // so an admin killing an abusive owner snippet needs a way to null it. Sends
+  // "" (not null) — a Go *string can't tell JSON null from an omitted field, so
+  // null would read as "no change" and the snippet would persist (cf. #717).
+  const handleClearTenant = async () => {
+    setClearingTenant(true);
+    try {
+      await apiClient.patch(`/domains/${domain.id}`, { nginx_tenant_directives: "" });
+      feedback.message.success("Tenant advanced directives cleared");
+      qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
+    } catch (err) {
+      const e = err as {
+        response?: { data?: { detail?: string } };
+        message?: string;
+      };
+      feedback.message.error(`Failed to clear: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
+    } finally {
+      setClearingTenant(false);
     }
   };
 
@@ -1231,6 +1260,32 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
           Save
         </Button>
       </div>
+      {/* GH #1624 / ADR-0169 Phase 5 (admin mirror): show the owner's raw
+          "advanced directives" (add_header / expires / etag, Phase 4a) so an
+          admin can see what the tenant added and clear it. Hidden until the
+          #1691 column lands (field undefined) and when the owner has set none. */}
+      {domain.nginx_tenant_directives && domain.nginx_tenant_directives.trim() !== "" && (
+        <div style={{ marginTop: 24, paddingTop: 16, borderTop: "1px solid rgba(0,0,0,0.06)" }}>
+          <div style={{ marginBottom: 8 }}>
+            <Typography.Text strong>Tenant advanced directives</Typography.Text>
+          </div>
+          <Input.TextArea
+            rows={Math.min(12, Math.max(3, domain.nginx_tenant_directives.split("\n").length))}
+            value={domain.nginx_tenant_directives}
+            readOnly
+            style={{ fontFamily: "monospace", background: "rgba(0,0,0,0.03)" }}
+          />
+          <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
+            Authored by the domain owner (add_header / expires / etag only). Clear
+            to remove them from the vhost.
+          </Typography.Text>
+          <div style={{ marginTop: 8 }}>
+            <Button danger loading={clearingTenant} onClick={handleClearTenant}>
+              Clear tenant directives
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -1295,6 +1350,28 @@ export const TenantNginxRulesPanel = ({
           Save
         </Button>
       </div>
+      {/* GH #1624 / ADR-0169 Phase 5: the typed Rule Builder above is the
+          rendered source of truth, but an admin may also have added raw
+          directives to this domain. Surface them read-only here ("visible, not
+          silently ignored") so nothing that shapes the vhost is invisible to
+          the owner. Not reverse-parsed into editable rules — deliberately just
+          shown. Hidden when the admin has set none. */}
+      {domain.nginx_custom_directives && domain.nginx_custom_directives.trim() !== "" && (
+        <div style={{ marginTop: 24, paddingTop: 16, borderTop: "1px solid rgba(0,0,0,0.06)" }}>
+          <div style={{ marginBottom: 8 }}>
+            <Typography.Text strong>Administrator-managed directives</Typography.Text>
+          </div>
+          <Input.TextArea
+            rows={Math.min(12, Math.max(3, domain.nginx_custom_directives.split("\n").length))}
+            value={domain.nginx_custom_directives}
+            readOnly
+            style={{ fontFamily: "monospace", background: "rgba(0,0,0,0.03)" }}
+          />
+          <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
+            Applied to this domain. Only an administrator can change these.
+          </Typography.Text>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## GH #1624 / ADR-0169 Phase 5 — unify the two config stores (read-only surfacing)

The final ADR-0169 phase. It makes the typed Rule Builder the **rendered source
of truth** while keeping raw directives **visible, not silently ignored**. Neither
store is reverse-parsed into the other — both are simply shown in the one view
that was missing them. This is UI only: no migration, no Go, no render-pipeline
change (both stores already render).

### Why surfacing, not a round-trip

ADR-0169 Phase 5 (verbatim): *"Make the typed Rule Builder the rendered source of
truth. Admin raw directives remain the escape hatch and are surfaced read-only in
the builder view ('visible, not silently ignored') rather than reverse-parsed."*
The rejected Alternative C was a full bidirectional builder↔raw round-trip. An
arbitrary admin paste is not round-trippable into structured, editable rules, so
Phase 5 shows it read-only instead of pretending otherwise.

### Tenant view — surface the admin's raw directives

`TenantNginxRulesPanel` (the tenant Rewrite-rules builder) now shows the
admin-authored `nginx_custom_directives` **read-only** beneath the builder, when
non-empty. These already reached the tenant in the domain JSON
(`enrichDomainResponse` embeds the full domain) but were never displayed — so
config that shapes the owner's vhost was invisible to them. Rendered with the
same read-only monospace widget the Raw-Directives tab already uses for its
"From Rule Builder (read-only)" preview; never a typed-back input.

`TenantNginxRulesPanel` is rendered in two places — the WebDomainPage "Rewrite
rules" tab and the domain-list row-menu Modal (`TenantNginxRulesButton` delegates
to it) — so the admin-directives block appears in both, which is intended.
`nginx_custom_directives` is in the shared wire section of the tenant `Domain`
type, so both surfaces already have the data.

### Admin mirror — surface (and clear) the tenant's directives

`DomainNginxSection` (admin DomainEdit "Nginx" tab) now shows the owner's tenant
`nginx_tenant_directives` (Phase 4a) **read-only with a Clear button**. This
closes the operational gap the Phase 4a security review flagged: **disabling the
tenant opt-in does not deactivate an already-stored snippet** — the reconciler
still renders the column — so an admin killing an abusive owner directive needs a
way to null it, and there was previously no admin surface for the field at all.

Clear sends `""`, **not** `null`: a Go `*string` cannot distinguish JSON null from
an omitted field, so null reads as "no change" and the snippet would persist
(the exact #717 regression). It reuses the Phase 4a PATCH gate, which already
accepts an admin write to this field.

`DomainNginxSection` already reads and PATCHes `nginx_custom_directives` off the
same `domain` object, so once #1691 lands the sibling `nginx_tenant_directives`
arrives on the same wire — no admin-specific projection needed. A post-#1691
browser check confirms the block renders with real data.

### Gating / degradation

- The tenant block lives inside the already-gated Rewrite-rules tab, so it is
  invisible when `tenant_domain_options_enabled` is off — consistent with "in the
  builder view."
- Both blocks are hidden when their field is empty.
- The admin mirror also stays hidden until the Phase 4a backend column (#1691)
  lands: the field is `undefined` until then, so this degrades gracefully if
  merged before #1691 (though the intended order is P5 after #1691).

### Scope notes

- **Render pipeline unchanged.** Precedence between typed rules and raw directives
  is not specified by the ADR and is out of scope.
- **Pre-existing observation (not addressed here):** admin raw directives are
  already exposed to the owner via `GET /domains/:id` today, independent of this
  change. A snippet could carry a secret (e.g. `proxy_set_header Authorization`).
  Surfacing in the UI does not widen exposure — it only stops hiding what the
  owner already receives. Redacting would be an API change that contradicts the
  ADR's visibility goal; flagged for the maintainer, not acted on.

### Tests

`DomainSettingsButton.phase5.test.tsx`:
- tenant view surfaces the admin directives read-only (present + `readOnly`), and
  hides the block when the admin has set none;
- admin mirror shows the owner directives read-only and Clear PATCHes
  `{nginx_tenant_directives: ""}`, and hides the block when the owner has none.

**Fail-first verified**: gating the tenant render behind `false` flips the
surfacing test; changing Clear's body from `""` to `null` flips the clear test.
`tsc` + `eslint` clean; the suite is green (4 tests).

### Docs

User docs for Phase 4 (advanced directives) + Phase 5 (admin-managed read-only)
are rolled into a single follow-up docs PR after P5, together with the three
stale ADR nits and the Phase 4 exclusions note.

**HELD** for `MERGE_APPROVED`. Refs GH #1624.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5