### PR TITLE
fix(shared-resources): enforce the same-owner domain policy on shared-resource grants (JAB-339 AC4)

### DIFF
--- a/panel-api/cmd/server/shared_resource_cmd.go
+++ b/panel-api/cmd/server/shared_resource_cmd.go
@@ -169,15 +169,34 @@ func newSharedResourceGrantCmd() *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
-			// JAB-339 AC4: reject a grant to a non-existent grantee before any
-			// write — the shared owner with the REST handler. The inline flag
-			// checks above already caught a bad kind / empty id with a
-			// flag-specific message, so only the existence check fires here.
+			// Load the resource and its domain first: the domain's UserID is the
+			// resource owner the same-owner domain policy compares against (a bad
+			// --resource now fails "shared resource not found" instead of an
+			// empty ListGrants later).
+			repo := sharedResourceRepoFromDB()
+			sr, err := repo.FindByID(ctx, resourceID)
+			if err != nil {
+				if errors.Is(err, repository.ErrNotFound) {
+					return fmt.Errorf("shared resource not found: %s", resourceID)
+				}
+				return fmt.Errorf("load shared resource: %w", err)
+			}
+			dom, err := domainRepoFromDB().FindByID(ctx, sr.DomainID)
+			if err != nil {
+				return fmt.Errorf("load resource domain: %w", err)
+			}
+			// JAB-339 AC4: reject a grant to a non-existent grantee, and enforce
+			// the same-owner domain policy (the grantee must belong to the
+			// resource owner, dom.UserID), before any write — the shared owner
+			// with the REST handler. The inline flag checks above already caught
+			// a bad kind / empty id with a flag-specific message, so only the
+			// existence + owner-scope checks fire here.
 			grantDeps := sharedresourceops.Deps{
 				Mailboxes:  mailboxRepoFromDB(),
 				MailGroups: repository.NewMailGroupRepository(sharedDB),
+				Domains:    domainRepoFromDB(),
 			}
-			if err := sharedresourceops.ValidateGrants(ctx, grantDeps, []models.SharedResourceGrant{
+			if err := sharedresourceops.ValidateGrants(ctx, grantDeps, dom.UserID, []models.SharedResourceGrant{
 				{ResourceID: resourceID, GranteeKind: granteeKind, GranteeID: granteeID, Rights: rights},
 			}); err != nil {
 				if errors.Is(err, sharedresourceops.ErrGranteeNotFound) {
@@ -185,7 +204,6 @@ func newSharedResourceGrantCmd() *cobra.Command {
 				}
 				return fmt.Errorf("validate grantee: %w", err)
 			}
-			repo := sharedResourceRepoFromDB()
 			grants, err := repo.ListGrants(ctx, resourceID)
 			if err != nil {
 				return fmt.Errorf("list grants: %w", err)

--- a/panel-api/internal/api/shared_resources.go
+++ b/panel-api/internal/api/shared_resources.go
@@ -195,7 +195,7 @@ func (h *sharedResourceHandler) update(c *gin.Context) {
 
 func (h *sharedResourceHandler) setGrants(c *gin.Context) {
 	claims := ginctx.Claims(c)
-	sr, _, ok := h.loadResourceWithAuth(c, c.Param("rid"), claims)
+	sr, dom, ok := h.loadResourceWithAuth(c, c.Param("rid"), claims)
 	if !ok {
 		return
 	}
@@ -219,13 +219,15 @@ func (h *sharedResourceHandler) setGrants(c *gin.Context) {
 			Rights:      g.Rights,
 		})
 	}
-	// JAB-339 AC4: validate the grantee kind + id and reject a grant to a
-	// non-existent grantee BEFORE the write — the shared owner both the REST
-	// handler and the CLI call, so they cannot drift. A dangling grantee id
-	// would otherwise persist and be silently dropped by the reconciler on
-	// every pass.
-	grantDeps := sharedresourceops.Deps{Mailboxes: h.cfg.Mailboxes, MailGroups: h.cfg.MailGroups}
-	if err := sharedresourceops.ValidateGrants(c.Request.Context(), grantDeps, grants); err != nil {
+	// JAB-339 AC4: validate the grantee kind + id, reject a grant to a
+	// non-existent grantee, and enforce the same-owner domain policy (the
+	// grantee must belong to the resource owner, dom.UserID) BEFORE the write —
+	// the shared owner both the REST handler and the CLI call, so they cannot
+	// drift. A dangling grantee id would otherwise persist and be silently
+	// dropped by the reconciler on every pass; an out-of-scope grantee is
+	// rejected as grantee_not_found (indistinguishable from missing).
+	grantDeps := sharedresourceops.Deps{Mailboxes: h.cfg.Mailboxes, MailGroups: h.cfg.MailGroups, Domains: h.cfg.Domains}
+	if err := sharedresourceops.ValidateGrants(c.Request.Context(), grantDeps, dom.UserID, grants); err != nil {
 		switch {
 		case errors.Is(err, sharedresourceops.ErrGranteeInvalidKind):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grantee_kind"})

--- a/panel-api/internal/sharedresourceops/sharedresourceops.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops.go
@@ -40,23 +40,30 @@ func ValidKind(kind string) bool { return kinds[kind] }
 type NotifyFunc func(ctx context.Context, cmd string, params any)
 
 // Deps carries the collaborators the operations need. Create and Delete use
-// Resources; ValidateGrants uses Mailboxes + MailGroups. Each operation guards
+// Resources; ValidateGrants uses Mailboxes + MailGroups + Domains (the last to
+// resolve a grantee's owner for the domain-policy check). Each operation guards
 // only the deps it needs, so an adapter wires whichever it calls.
 type Deps struct {
 	Resources  repository.SharedResourceRepository
 	Mailboxes  MailboxLookup
 	MailGroups MailGroupLookup
+	Domains    DomainLookup
 }
 
-// MailboxLookup and MailGroupLookup are the narrow existence-lookup slices of
-// the mailbox and mail-group repositories that ValidateGrants needs — declared
-// consumer-side so the fakes stay small and the module does not pull in the
-// full repository interfaces. Both concrete repositories satisfy them.
+// MailboxLookup, MailGroupLookup, and DomainLookup are the narrow lookup slices
+// of the mailbox, mail-group, and domain repositories that ValidateGrants needs
+// — declared consumer-side so the fakes stay small and the module does not pull
+// in the full repository interfaces. All three concrete repositories satisfy
+// them. A grantee row carries only a DomainID (neither Mailbox nor MailGroup
+// has an owner field), so ownership is resolved through the domain's UserID.
 type MailboxLookup interface {
 	FindByID(ctx context.Context, id string) (*models.Mailbox, error)
 }
 type MailGroupLookup interface {
 	FindByID(ctx context.Context, id string) (*models.MailGroup, error)
+}
+type DomainLookup interface {
+	FindByID(ctx context.Context, id string) (*models.Domain, error)
 }
 
 // granteeKinds is the grant GranteeKind allowlist (a grant points at a mailbox
@@ -226,17 +233,32 @@ func Delete(ctx context.Context, d Deps, in DeleteInput, notify NotifyFunc) erro
 // copies, while the CLI keeps its flag-specific messages first and lets this
 // re-check them harmlessly — so one owner governs the policy for both.
 //
-// Domain / tenant scoping of the grantee is deliberately NOT enforced here: a
-// cross-domain grant is a sharing-scope policy question, not a privilege
-// escalation (the caller can only share a resource it already owns, and the
-// grantee gains nothing on its own tenant), and which domains a grantee may
-// come from is an open product decision. When that rule lands it belongs in
-// this same validator and MUST return ErrGranteeNotFound too — a grantee that
-// exists but is out of policy must be indistinguishable from a missing one, so
-// the error can never be used to enumerate rows across a tenant boundary.
-func ValidateGrants(ctx context.Context, d Deps, grants []models.SharedResourceGrant) error {
-	if d.Mailboxes == nil || d.MailGroups == nil {
-		return fmt.Errorf("%w: mailbox + mail-group lookups required", ErrDeps)
+// Domain policy (JAB-339 AC4, the second half of "grantee existence/domain
+// policy is explicit"): the grantee must belong to the SAME OWNER as the
+// resource. ownerUserID is the resource owner (the resource's domain's UserID,
+// resolved and passed by the adapter). A grantee row carries only a DomainID,
+// so its owner is resolved through the domain's UserID and compared. A grantee
+// that exists but is out of scope returns ErrGranteeNotFound — identical to a
+// missing one — so the error can NEVER be used to enumerate mailbox / group
+// rows across an owner boundary (anti-enumeration). A grantee whose domain row
+// is itself gone is likewise unusable and returns ErrGranteeNotFound; only an
+// unexpected data-access error is ErrInternal, never collapsed into not-found.
+//
+// ownerUserID is required: an empty owner is a wiring bug (it would admit only
+// grantees whose domain has UserID == "") and fails loud as ErrDeps, alongside
+// the nil-dependency guard.
+//
+// Scope: write-time only. A pre-existing cross-owner grant already in the DB is
+// NOT swept by this check and the reconciler keeps projecting it (it never calls
+// ValidateGrants); a retroactive sweep is a separate decision, and a
+// reconciler-side filter would re-introduce the silent-Stalwart-revoke class the
+// #1690 fix just closed.
+func ValidateGrants(ctx context.Context, d Deps, ownerUserID string, grants []models.SharedResourceGrant) error {
+	if d.Mailboxes == nil || d.MailGroups == nil || d.Domains == nil {
+		return fmt.Errorf("%w: mailbox + mail-group + domain lookups required", ErrDeps)
+	}
+	if ownerUserID == "" {
+		return fmt.Errorf("%w: owner user id required", ErrDeps)
 	}
 	for _, g := range grants {
 		if !ValidGranteeKind(g.GranteeKind) {
@@ -245,21 +267,40 @@ func ValidateGrants(ctx context.Context, d Deps, grants []models.SharedResourceG
 		if g.GranteeID == "" {
 			return ErrGranteeMissingID
 		}
+		var granteeDomainID string
 		switch g.GranteeKind {
 		case "mailbox":
-			if _, err := d.Mailboxes.FindByID(ctx, g.GranteeID); err != nil {
+			mb, err := d.Mailboxes.FindByID(ctx, g.GranteeID)
+			if err != nil {
 				if errors.Is(err, repository.ErrNotFound) {
 					return fmt.Errorf("%w: mailbox %s", ErrGranteeNotFound, g.GranteeID)
 				}
 				return fmt.Errorf("%w: mailbox lookup %s: %v", ErrInternal, g.GranteeID, err)
 			}
+			granteeDomainID = mb.DomainID
 		case "group":
-			if _, err := d.MailGroups.FindByID(ctx, g.GranteeID); err != nil {
+			mg, err := d.MailGroups.FindByID(ctx, g.GranteeID)
+			if err != nil {
 				if errors.Is(err, repository.ErrNotFound) {
 					return fmt.Errorf("%w: group %s", ErrGranteeNotFound, g.GranteeID)
 				}
 				return fmt.Errorf("%w: group lookup %s: %v", ErrInternal, g.GranteeID, err)
 			}
+			granteeDomainID = mg.DomainID
+		}
+		// Same-owner domain policy. Resolve the grantee's domain owner and
+		// compare to the resource owner. Out of scope and a dangling domain
+		// both return ErrGranteeNotFound (anti-enumeration); only a real
+		// data-access failure is ErrInternal.
+		dom, err := d.Domains.FindByID(ctx, granteeDomainID)
+		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				return fmt.Errorf("%w: grantee %s domain", ErrGranteeNotFound, g.GranteeID)
+			}
+			return fmt.Errorf("%w: grantee %s domain lookup: %v", ErrInternal, g.GranteeID, err)
+		}
+		if dom.UserID != ownerUserID {
+			return fmt.Errorf("%w: grantee %s out of owner scope", ErrGranteeNotFound, g.GranteeID)
 		}
 	}
 	return nil

--- a/panel-api/internal/sharedresourceops/sharedresourceops_test.go
+++ b/panel-api/internal/sharedresourceops/sharedresourceops_test.go
@@ -275,10 +275,11 @@ func TestDelete_NilDepsReturnsErrDeps(t *testing.T) {
 }
 
 // lookMb / lookMg are the narrow MailboxLookup / MailGroupLookup fakes. A seeded
-// id resolves; anything else is repository.ErrNotFound; a non-nil err short-
-// circuits every lookup (to exercise the fail-closed path).
+// id resolves to a row carrying its DomainID (so the domain-policy check can
+// resolve the grantee's owner); anything else is repository.ErrNotFound; a
+// non-nil err short-circuits every lookup (to exercise the fail-closed path).
 type lookMb struct {
-	ids map[string]bool
+	ids map[string]string // id -> domainID
 	err error
 }
 
@@ -286,14 +287,14 @@ func (l *lookMb) FindByID(_ context.Context, id string) (*models.Mailbox, error)
 	if l.err != nil {
 		return nil, l.err
 	}
-	if l.ids[id] {
-		return &models.Mailbox{ID: id}, nil
+	if dom, ok := l.ids[id]; ok {
+		return &models.Mailbox{ID: id, DomainID: dom}, nil
 	}
 	return nil, repository.ErrNotFound
 }
 
 type lookMg struct {
-	ids map[string]bool
+	ids map[string]string // id -> domainID
 	err error
 }
 
@@ -301,8 +302,26 @@ func (l *lookMg) FindByID(_ context.Context, id string) (*models.MailGroup, erro
 	if l.err != nil {
 		return nil, l.err
 	}
-	if l.ids[id] {
-		return &models.MailGroup{ID: id}, nil
+	if dom, ok := l.ids[id]; ok {
+		return &models.MailGroup{ID: id, DomainID: dom}, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// lookDom is the narrow DomainLookup fake. A seeded domain id resolves to a
+// domain owned by the mapped UserID; anything else is repository.ErrNotFound; a
+// non-nil err short-circuits (to exercise the owner-lookup fail-closed path).
+type lookDom struct {
+	owners map[string]string // domainID -> owner UserID
+	err    error
+}
+
+func (l *lookDom) FindByID(_ context.Context, id string) (*models.Domain, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	if uid, ok := l.owners[id]; ok {
+		return &models.Domain{UserID: uid}, nil
 	}
 	return nil, repository.ErrNotFound
 }
@@ -311,33 +330,49 @@ func grant(kind, id string) []models.SharedResourceGrant {
 	return []models.SharedResourceGrant{{GranteeKind: kind, GranteeID: id, Rights: "read"}}
 }
 
-// TestValidateGrants is the JAB-339 AC4 gate table: an existing grantee passes;
-// a missing mailbox / group id, a bad kind, an empty id, and missing deps each
-// fail with their own sentinel. Message content is not asserted — only the
-// nil / sentinel outcome — so the adapters own their transport wording.
+// TestValidateGrants is the JAB-339 AC4 gate table covering BOTH halves of
+// "grantee existence/domain policy is explicit": an existing same-owner grantee
+// passes (including one in a DIFFERENT domain of the same owner); a missing id,
+// a CROSS-OWNER grantee, and a grantee whose domain row is gone all fail as
+// ErrGranteeNotFound (the out-of-scope case indistinguishable from missing, so
+// the error cannot enumerate another owner's rows); a bad kind, an empty id,
+// missing deps, and an empty owner fail with their own sentinel. Message content
+// is not asserted — only the nil / sentinel outcome — so the adapters own their
+// transport wording.
+//
+// Fixture: owner1 owns dom1 + dom3; owner2 owns dom2. mb1/grp1 live in dom1,
+// mb2/grp2 in dom2, mb3 in dom3, and mbGone points at a domain with no row.
 func TestValidateGrants(t *testing.T) {
 	d := Deps{
-		Mailboxes:  &lookMb{ids: map[string]bool{"mb1": true}},
-		MailGroups: &lookMg{ids: map[string]bool{"grp1": true}},
+		Mailboxes:  &lookMb{ids: map[string]string{"mb1": "dom1", "mb2": "dom2", "mb3": "dom3", "mbGone": "domGone"}},
+		MailGroups: &lookMg{ids: map[string]string{"grp1": "dom1", "grp2": "dom2"}},
+		Domains:    &lookDom{owners: map[string]string{"dom1": "owner1", "dom2": "owner2", "dom3": "owner1"}},
 	}
+	const owner = "owner1"
 	cases := []struct {
 		name    string
 		grants  []models.SharedResourceGrant
 		deps    Deps
+		owner   string
 		wantErr error // nil = must pass
 	}{
-		{"mailbox exists", grant("mailbox", "mb1"), d, nil},
-		{"group exists", grant("group", "grp1"), d, nil},
-		{"mailbox missing", grant("mailbox", "ghost"), d, ErrGranteeNotFound},
-		{"group missing", grant("group", "ghost"), d, ErrGranteeNotFound},
-		{"bad kind", grant("user", "mb1"), d, ErrGranteeInvalidKind},
-		{"empty id", grant("mailbox", ""), d, ErrGranteeMissingID},
-		{"no deps", grant("mailbox", "mb1"), Deps{}, ErrDeps},
-		{"empty set passes", nil, d, nil},
+		{"mailbox same owner", grant("mailbox", "mb1"), d, owner, nil},
+		{"group same owner", grant("group", "grp1"), d, owner, nil},
+		{"mailbox same owner other domain", grant("mailbox", "mb3"), d, owner, nil},
+		{"mailbox missing", grant("mailbox", "ghost"), d, owner, ErrGranteeNotFound},
+		{"group missing", grant("group", "ghost"), d, owner, ErrGranteeNotFound},
+		{"mailbox cross owner", grant("mailbox", "mb2"), d, owner, ErrGranteeNotFound},
+		{"group cross owner", grant("group", "grp2"), d, owner, ErrGranteeNotFound},
+		{"grantee dangling domain", grant("mailbox", "mbGone"), d, owner, ErrGranteeNotFound},
+		{"bad kind", grant("user", "mb1"), d, owner, ErrGranteeInvalidKind},
+		{"empty id", grant("mailbox", ""), d, owner, ErrGranteeMissingID},
+		{"no deps", grant("mailbox", "mb1"), Deps{}, owner, ErrDeps},
+		{"empty owner", grant("mailbox", "mb1"), d, "", ErrDeps},
+		{"empty set passes", nil, d, owner, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateGrants(context.Background(), tc.deps, tc.grants)
+			err := ValidateGrants(context.Background(), tc.deps, tc.owner, tc.grants)
 			if tc.wantErr == nil {
 				if err != nil {
 					t.Fatalf("want nil, got %v", err)
@@ -356,16 +391,21 @@ func TestValidateGrants(t *testing.T) {
 // — collapsing would let a grant through on a transient DB blip (fail open).
 func TestValidateGrants_LookupErrorFailsClosed(t *testing.T) {
 	dbErr := errors.New("db down")
+	okDom := &lookDom{owners: map[string]string{"dom1": "owner1"}}
 	for _, tc := range []struct {
 		name  string
 		deps  Deps
 		grant []models.SharedResourceGrant
 	}{
-		{"mailbox lookup error", Deps{Mailboxes: &lookMb{err: dbErr}, MailGroups: &lookMg{}}, grant("mailbox", "mb1")},
-		{"group lookup error", Deps{Mailboxes: &lookMb{}, MailGroups: &lookMg{err: dbErr}}, grant("group", "grp1")},
+		{"mailbox lookup error", Deps{Mailboxes: &lookMb{err: dbErr}, MailGroups: &lookMg{}, Domains: okDom}, grant("mailbox", "mb1")},
+		{"group lookup error", Deps{Mailboxes: &lookMb{}, MailGroups: &lookMg{err: dbErr}, Domains: okDom}, grant("group", "grp1")},
+		// The domain (owner) lookup fails closed too: a DB blip resolving the
+		// grantee's owner must surface as ErrInternal, never collapse into
+		// ErrGranteeNotFound (which would let an out-of-scope grant through).
+		{"domain lookup error", Deps{Mailboxes: &lookMb{ids: map[string]string{"mb1": "dom1"}}, MailGroups: &lookMg{}, Domains: &lookDom{err: dbErr}}, grant("mailbox", "mb1")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateGrants(context.Background(), tc.deps, tc.grant)
+			err := ValidateGrants(context.Background(), tc.deps, "owner1", tc.grant)
 			if !errors.Is(err, ErrInternal) {
 				t.Fatalf("want ErrInternal (fail closed), got %v", err)
 			}


### PR DESCRIPTION
## What

Enforce a **same-owner domain policy** on shared-resource grants. This is the second half of JAB-339 AC4 ("Grantee existence/domain policy is explicit"): #1688 shipped the existence half (reject a grant to a non-existent grantee); this PR adds the domain policy — a grantee must belong to the **same owner** as the resource it is granted on, so a tenant cannot share their resource with another owner's mailbox or mail-group.

## Why

`ValidateGrants` already confirmed a grantee row exists, but nothing bounded *which* grantee. A tenant could name any existing mailbox/group ID — including one owned by a different tenant — and the grant would validate and then project into Stalwart. AC4 asks for the policy to be explicit; "any existing grantee" is not a policy.

## How

`sharedresourceops.ValidateGrants` gains the resource owner (`ownerUserID string`) and a `Domains` lookup in `Deps`. For each grant, after confirming the grantee exists, it resolves the grantee's owner through its domain (a `Mailbox`/`MailGroup` carries only a `DomainID`; neither has an owner field, so ownership is the domain's `UserID`) and compares it to the resource owner.

Error mapping (unchanged surface — every failure maps to the same `400 grantee_not_found` the existence check already returned):
- grantee exists but out of owner scope → `ErrGranteeNotFound` (identical to missing — anti-enumeration: the error can never be used to probe mailbox/group rows across an owner boundary)
- grantee's domain row itself gone → `ErrGranteeNotFound`
- unexpected data-access error on the owner lookup → `ErrInternal`, never collapsed into not-found
- empty `ownerUserID` → `ErrDeps` (a wiring bug; an empty owner would admit only grantees whose domain has `UserID == ""`, so it fails loud alongside the existing nil-dependency guard)

**Policy choice — "same owner", not "same domain".** Owner = the resource's domain's `UserID`. A tenant may share across their *own* domains (same `UserID`, different domain); they may not share with another owner. "Same domain" was considered and rejected as too tight for multi-domain tenants.

**Admin callers are bound too.** `dom.UserID` is the resource owner regardless of who calls. A REST admin and the CLI (admin-by-construction) both get `grantee_not_found` on a cross-owner grant — there is no override. This is deliberate for this slice; flag it if an admin cross-tenant share is a real requirement.

Adapters resolve and pass the owner:
- **REST `setGrants`** already loaded the resource's domain via `loadResourceWithAuth` and discarded it; it now passes `dom.UserID` and wires `h.cfg.Domains`.
- **CLI `grant`** loads the resource and its domain before validating (a bad `--resource` now fails `shared resource not found` instead of an empty `ListGrants` later) and wires `domainRepoFromDB()`.

## Scope / known gaps

- **Write-time only.** A pre-existing cross-owner grant already in the DB is **not** swept by this check, and the reconciler keeps projecting it — the reconciler never calls `ValidateGrants`. A retroactive sweep is a separate decision; a reconciler-side filter would re-introduce the silent-Stalwart-revoke class the #1690 fix just closed.
- **REST validates the full replacement set; CLI `grant` validates only the delta.** New operational consequence: a resource that already holds a cross-owner grant (admin-created via CLI, or any pre-#1688 grant) becomes **un-editable via REST** — every `PUT .../grants` fails `400 grantee_not_found`, and the anti-enumeration design means the error does not name which grantee or why. The CLI can still add to such a resource. This is the remaining **JAB-339 AC3** gap ("equivalent CLI/HTTP inputs persist identical state"), not a defect in this slice; it is tracked there. Rare in practice (the UI picker scopes to the tenant's own mailboxes), but a tenant who hits it gets an opaque wall.

## Tests

- `sharedresourceops`: the gate table now covers both halves — same-owner mailbox/group (including a different domain of the same owner) pass; a cross-owner mailbox/group, a missing grantee, and a grantee whose domain row is gone all fail as `ErrGranteeNotFound`; a bad kind, empty id, missing deps, and empty owner fail with their own sentinel; the empty set passes. The fail-closed test adds a domain-lookup DB-error case proving the owner lookup surfaces `ErrInternal`, never collapsed.
- The CLI source-pin (ValidateGrants runs before ReplaceGrants) still holds.
- Three guards falsified against compiling neutralizations, each reverted: the owner comparison (cross-owner grants then pass), the empty-owner guard (empty owner then slips past `ErrDeps`), and the owner-lookup fail-closed classification (a domain DB error then collapses into `ErrGranteeNotFound`).
- `gofmt` + `go vet` clean; `go build ./...` clean; `internal/sharedresourceops`, `internal/api`, and `cmd/server` packages green (full-package runs: api 5.928s, cmd/server 0.510s).

**REST wiring coverage:** the `setGrants` handler test exists but its domain fake returns a single fixed domain, so there is no handler-level cross-owner characterization. The REST path passing `dom.UserID` (not the caller's id) is covered by compile + the module test; for a tenant caller the two are equal, and the CLI path exercises the same `ValidateGrants` contract directly.

No box: panel-side write-time validation only — no new agent verb, no reconciler change (the projection path is untouched), no migration, no cert. The decision is fully exercised by the module test and the adapter wiring compiles against the real repositories.

Part of JAB-339 (shared-resource lifecycle); the parent stays open (module extraction + any retroactive-sweep decision remain).

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
