### PR TITLE
feat(nginx): tenant deny-paths and static-cache typed rules (GH #1624)

### DIFF
--- a/docs/site/user/domains.md
+++ b/docs/site/user/domains.md
@@ -45,7 +45,13 @@ Three extra per-domain tabs — **Domain options**, **Rewrite rules**, and **Adv
 When they are enabled you can, on your own domains:
 
 - **Domain options** — set a curated, safe set of nginx options: maximum upload size, HSTS, the common security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), and gzip. You supply values; each option renders to a fixed, vetted directive — never raw config.
-- **Rewrite rules** — add two kinds of structured rule. A `rewrite` rule whose target must be a local path (no scheme or host, so it can never become an open redirect or a proxy to another service), and a `custom_header` rule that adds one response header. Every rule is validated before it is applied. The headers the panel manages for security — `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` — can't be set here; use **Domain options** for HSTS and the security headers instead.
+- **Rewrite rules** — add structured rules that the panel turns into vetted nginx directives; you never write raw config. The kinds available to you are:
+    - `rewrite` — its target must be a local path (no scheme or host, so it can never become an open redirect or a proxy to another service).
+    - `custom_header` — adds one response header. The headers the panel manages for security — `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` — can't be set here; use **Domain options** for HSTS and the security headers instead.
+    - **Deny paths** — block all access to files by extension (for example hide `.env`, `.sql`, `.bak`, `.log`). You supply a list of bare extensions and the panel builds the matching rule; PHP files are handled by the server and can't be blocked this way.
+    - **Static cache** — set a long cache lifetime for files by extension (for example `pdf`, `mp4`). Common web assets (css, js, images, fonts) are already cached by the server, so those are declined; and PHP-family extensions are refused so a source file is never served as a static download.
+
+    Every rule is validated before it is applied.
 - **Advanced directives** — a small raw-directive box for response tuning only. Just three directives are accepted — `add_header`, `expires`, and `etag` — one statement per line, no `{ }` blocks and no backslashes. Headers the panel manages for you (HSTS, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Length`, `Transfer-Encoding`) are rejected so you can't accidentally weaken them. If a line is refused you see exactly which one. Anything that routes, reads files, or proxies is not accepted here — those stay admin-only.
 
 Under **Rewrite rules**, if your administrator has added their own raw nginx directives to your domain, they are shown to you read-only as *Administrator-managed directives* — so nothing that shapes your site's config is hidden from you, even though only an administrator can change it.

--- a/docs/site/user/domains.md
+++ b/docs/site/user/domains.md
@@ -51,7 +51,7 @@ When they are enabled you can, on your own domains:
     - **Deny paths** — block all access to files by extension (for example hide `.env`, `.sql`, `.bak`, `.log`). You supply a list of bare extensions and the panel builds the matching rule; PHP files are handled by the server and can't be blocked this way.
     - **Static cache** — set a long cache lifetime for files by extension (for example `pdf`, `mp4`). Common web assets (css, js, images, fonts) are already cached by the server, so those are declined; and PHP-family extensions are refused so a source file is never served as a static download.
 
-    Every rule is validated before it is applied.
+    Every rule is validated before it is applied. **Deny paths** and **Static cache** don't apply to a domain that is served entirely by a reverse proxy — on those, the proxy handles every request before these file rules are reached.
 - **Advanced directives** — a small raw-directive box for response tuning only. Just three directives are accepted — `add_header`, `expires`, and `etag` — one statement per line, no `{ }` blocks and no backslashes. Headers the panel manages for you (HSTS, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Length`, `Transfer-Encoding`) are rejected so you can't accidentally weaken them. If a line is refused you see exactly which one. Anything that routes, reads files, or proxies is not accepted here — those stay admin-only.
 
 Under **Rewrite rules**, if your administrator has added their own raw nginx directives to your domain, they are shown to you read-only as *Administrator-managed directives* — so nothing that shapes your site's config is hidden from you, even though only an administrator can change it.

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -2086,7 +2086,7 @@ func validatePageRedirects(prs models.PageRedirects) error {
 
 func isValidNginxRuleType(s string) bool {
 	switch s {
-	case "custom_header", "rewrite", "proxy_pass", "ip_access", "php_setting", "max_upload_size", "static_alias", "media_alias":
+	case "custom_header", "rewrite", "proxy_pass", "ip_access", "php_setting", "max_upload_size", "static_alias", "media_alias", "deny_paths", "static_cache":
 		return true
 	}
 	return false
@@ -2186,9 +2186,29 @@ func validateNginxRules(rules models.NginxRules) error {
 			if strings.ContainsAny(r.Target, " \t\n\r;{}") {
 				return fmt.Errorf("rule %d: invalid chars in %s target", i, r.Type)
 			}
+		case "deny_paths":
+			// GH #1624: block files by extension. The panel builds the regex from
+			// this list (nginxrules.extensionAlternation), so the only thing a
+			// tenant supplies is bare extensions — validateExtensionList enforces
+			// [A-Za-z0-9]+ per extension, which is the regex-injection boundary.
+			if err := validateExtensionList(r.Extensions, r.Type); err != nil {
+				return fmt.Errorf("rule %d: %v", i, err)
+			}
+		case "static_cache":
+			// GH #1624: long-cache files by extension. Same extension boundary as
+			// deny_paths, plus an nginx `expires` duration.
+			if err := validateExtensionList(r.Extensions, r.Type); err != nil {
+				return fmt.Errorf("rule %d: %v", i, err)
+			}
+			if r.Duration == "" {
+				return fmt.Errorf("rule %d: static_cache needs a duration (e.g. \"30d\", \"1h\", \"max\")", i)
+			}
+			if !isNginxExpires(r.Duration) {
+				return fmt.Errorf("rule %d: static_cache duration must be an nginx expires value (e.g. \"30d\", \"1h\", \"max\", \"off\")", i)
+			}
 		}
 		// Forbid control characters everywhere to prevent newline injection into vhost
-		allText := r.Name + r.Value + r.Pattern + r.Replacement + r.Target + r.Path + r.Size + r.ReadTimeout
+		allText := r.Name + r.Value + r.Pattern + r.Replacement + r.Target + r.Path + r.Size + r.ReadTimeout + r.Duration + strings.Join(r.Extensions, "")
 		for _, c := range allText {
 			if c < 32 && c != '\t' {
 				return fmt.Errorf("rule %d: contains invalid control chars", i)
@@ -2201,6 +2221,87 @@ func validateNginxRules(rules models.NginxRules) error {
 		}
 	}
 	return nil
+}
+
+const (
+	// maxExtensionsPerRule / maxExtensionLen bound a deny_paths / static_cache
+	// extension list. Soft abuse limits — nginx -t on the agent is the real
+	// validator — but they also keep the compiled `\.( … )$` alternation small.
+	maxExtensionsPerRule = 32
+	maxExtensionLen      = 16
+)
+
+// extensionCharRE is the extension charset for deny_paths / static_cache. Bare
+// letters/digits only — no dot, slash, or regex metacharacter. This is the
+// regex-injection boundary: nginxrules.extensionAlternation joins these verbatim
+// into `\.( … )$`, so anything but [A-Za-z0-9] could break out of the group.
+var extensionCharRE = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+
+// phpFamilyExtensionRE matches extensions nginx would otherwise hand to PHP-FPM:
+// php, php7, php8, phtml, phar, pht, phps. Rejected in BOTH new rule types.
+// static_cache: serving one of these as a static file discloses PHP source
+// (e.g. wp-config.php with DB credentials). deny_paths: the template's
+// `location ~ \.php$` (rendered earlier in the vhost) wins the first-match, so a
+// tenant deny_paths for php is a silent no-op — reject it rather than mislead.
+var phpFamilyExtensionRE = regexp.MustCompile(`^(?i:php[0-9]*|phtml|phar|pht|phps)$`)
+
+// templateCachedExtensions are the extensions the agent vhost template already
+// long-caches in its own `location ~* \.(css|js|…)$` block, which is rendered
+// BEFORE the tenant rule directives — so nginx's first-match rule means a tenant
+// static_cache for one of these never takes effect. Reject them with a clear
+// message rather than store a dead rule. Mirrors the template list in
+// panel-agent/internal/commands/domain_create.go.
+var templateCachedExtensions = map[string]struct{}{
+	"css": {}, "js": {}, "jpg": {}, "jpeg": {}, "png": {}, "gif": {},
+	"ico": {}, "svg": {}, "webp": {}, "woff": {}, "woff2": {}, "ttf": {}, "eot": {},
+}
+
+// validateExtensionList checks a deny_paths / static_cache extension list.
+// ruleType tailors the rejections (static_cache also refuses the
+// already-template-cached extensions).
+func validateExtensionList(exts []string, ruleType string) error {
+	if len(exts) == 0 {
+		return fmt.Errorf("%s needs at least one file extension", ruleType)
+	}
+	if len(exts) > maxExtensionsPerRule {
+		return fmt.Errorf("%s: too many extensions (max %d)", ruleType, maxExtensionsPerRule)
+	}
+	for _, e := range exts {
+		norm := strings.ToLower(strings.TrimSpace(e))
+		if norm == "" {
+			return fmt.Errorf("%s: empty extension", ruleType)
+		}
+		if len(norm) > maxExtensionLen {
+			return fmt.Errorf("%s: extension %q too long (max %d chars)", ruleType, e, maxExtensionLen)
+		}
+		if !extensionCharRE.MatchString(norm) {
+			return fmt.Errorf("%s: extension %q may contain only letters and digits (no dot or symbols)", ruleType, e)
+		}
+		if phpFamilyExtensionRE.MatchString(norm) {
+			if ruleType == "static_cache" {
+				return fmt.Errorf("%s: extension %q would serve PHP source as a static file — refused", ruleType, e)
+			}
+			return fmt.Errorf("%s: extension %q is handled by the PHP location and can't be blocked this way", ruleType, e)
+		}
+		if ruleType == "static_cache" {
+			if _, cached := templateCachedExtensions[norm]; cached {
+				return fmt.Errorf("static_cache: %q is already long-cached by the server; only extensions outside the default set can be tuned here", e)
+			}
+		}
+	}
+	return nil
+}
+
+// isNginxExpires reports whether s is a value the nginx `expires` directive
+// accepts: a time with an optional unit (30d, 5m, -1), the keywords epoch / max
+// / off, or the daily @HH[hMM] form, with an optional leading `modified`. Reuses
+// the same grammar as the tenant raw-directives path (tenantExpiresRe).
+func isNginxExpires(s string) bool {
+	s = strings.TrimSpace(s)
+	if rest, ok := strings.CutPrefix(s, "modified "); ok {
+		s = strings.TrimSpace(rest)
+	}
+	return tenantExpiresRe.MatchString(s)
 }
 
 // redosNestedQuantRE flags the classic catastrophic-backtracking shape: a group
@@ -2270,6 +2371,13 @@ func validateProxyPassTarget(target string) error {
 var tenantSafeNginxRuleTypes = map[string]struct{}{
 	"rewrite":       {},
 	"custom_header": {},
+	// GH #1624 typed location rules. Both are panel-rendered from a validated
+	// extension list (no tenant-supplied regex, no reverse-proxy/file-path
+	// surface), so they carry no more trust surface than the extension charset:
+	//   - deny_paths  -> location ~* \.(…)$ { deny all; }
+	//   - static_cache -> location ~* \.(…)$ { expires <dur>; }   (no add_header)
+	"deny_paths":   {},
+	"static_cache": {},
 }
 
 // tenantManagedResponseHeaders are response-header names a tenant custom_header

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -2254,6 +2254,9 @@ var phpFamilyExtensionRE = regexp.MustCompile(`^(?i:php[0-9]*|phtml|phar|pht|php
 var templateCachedExtensions = map[string]struct{}{
 	"css": {}, "js": {}, "jpg": {}, "jpeg": {}, "png": {}, "gif": {},
 	"ico": {}, "svg": {}, "webp": {}, "woff": {}, "woff2": {}, "ttf": {}, "eot": {},
+	// The template also caches HTML (`location ~* \.html?$`, 5m) in the same
+	// cache_enabled block, ahead of the tenant rules.
+	"html": {}, "htm": {},
 }
 
 // validateExtensionList checks a deny_paths / static_cache extension list.
@@ -2283,24 +2286,35 @@ func validateExtensionList(exts []string, ruleType string) error {
 			}
 			return fmt.Errorf("%s: extension %q is handled by the PHP location and can't be blocked this way", ruleType, e)
 		}
-		if ruleType == "static_cache" {
-			if _, cached := templateCachedExtensions[norm]; cached {
-				return fmt.Errorf("static_cache: %q is already long-cached by the server; only extensions outside the default set can be tuned here", e)
-			}
+		// The vhost template's own static-asset location (`location ~* \.(css|
+		// js|…|html)$`) renders BEFORE the tenant rule directives, and nginx
+		// takes the first-matching regex location — so a deny_paths OR
+		// static_cache rule for one of those extensions would never fire. Reject
+		// both rather than silently store a dead rule (a silent no-op is worst
+		// for deny_paths, where the tenant believes a file is blocked when it is
+		// not). Erring toward rejection is the safe direction; when server
+		// caching is off the template block is absent, but the validator can't
+		// see that per-domain flag, so the conservative reject stands.
+		if _, cached := templateCachedExtensions[norm]; cached {
+			return fmt.Errorf("%s: %q is served by the server's built-in static-asset handling (which is matched first), so a rule here would not take effect", ruleType, e)
 		}
 	}
 	return nil
 }
 
 // isNginxExpires reports whether s is a value the nginx `expires` directive
-// accepts: a time with an optional unit (30d, 5m, -1), the keywords epoch / max
-// / off, or the daily @HH[hMM] form, with an optional leading `modified`. Reuses
-// the same grammar as the tenant raw-directives path (tenantExpiresRe).
+// accepts: a time with an optional unit (30d, 5m, -1), or the keywords epoch /
+// max / off / the daily @HH[hMM] form. Reuses the tenant raw-directives grammar
+// (tenantExpiresRe).
+//
+// It validates the RAW string — no trimming. tenantExpiresRe is fully anchored,
+// so any surrounding whitespace (ASCII space/tab OR a Unicode space such as
+// U+00A0 NBSP that a copy-paste from a document can smuggle in) fails the match.
+// This matters because Duration is rendered VERBATIM into `expires <dur>;`
+// (unlike Extensions, which extensionAlternation re-trims at render time): a
+// value that validated-when-trimmed but rendered-raw would pass here yet break
+// `nginx -t`, and a tenant's bad vhost is torn down rather than reverted.
 func isNginxExpires(s string) bool {
-	s = strings.TrimSpace(s)
-	if rest, ok := strings.CutPrefix(s, "modified "); ok {
-		s = strings.TrimSpace(rest)
-	}
 	return tenantExpiresRe.MatchString(s)
 }
 

--- a/panel-api/internal/api/domains_typed_location_rules_test.go
+++ b/panel-api/internal/api/domains_typed_location_rules_test.go
@@ -70,7 +70,35 @@ func TestValidateNginxRules_TypedLocationRules(t *testing.T) {
 			name:      "static_cache rejects an already-template-cached extension",
 			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"css"}, Duration: "30d"}},
 			wantError: true,
-			errSubstr: "already long-cached",
+			errSubstr: "built-in static-asset",
+		},
+		{
+			name:      "deny_paths rejects a template-cached extension (shadowed, would no-op)",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{"svg"}}},
+			wantError: true,
+			errSubstr: "built-in static-asset",
+		},
+		{
+			name:      "deny_paths rejects html (template caches it too)",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{"html"}}},
+			wantError: true,
+			errSubstr: "built-in static-asset",
+		},
+		{
+			// A non-breaking space (U+00A0) can ride in on a copy-paste of "30d".
+			// It survives a TrimSpace but must NOT survive validation, because
+			// Duration is rendered verbatim into `expires <dur>;` and would then
+			// fail nginx -t (tearing down the tenant's vhost).
+			name:      "static_cache rejects a duration with a non-breaking space",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"pdf"}, Duration: " 30d"}},
+			wantError: true,
+			errSubstr: "expires value",
+		},
+		{
+			name:      "static_cache rejects a duration with a trailing space",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"pdf"}, Duration: "30d "}},
+			wantError: true,
+			errSubstr: "expires value",
 		},
 		{
 			name:      "static_cache requires a duration",

--- a/panel-api/internal/api/domains_typed_location_rules_test.go
+++ b/panel-api/internal/api/domains_typed_location_rules_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestValidateNginxRules_TypedLocationRules covers the GH #1624 deny_paths /
+// static_cache rule kinds: the accepted shapes and every rejection, with the
+// regex-injection case first (the reason the extension charset exists).
+func TestValidateNginxRules_TypedLocationRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		rules     models.NginxRules
+		wantError bool
+		errSubstr string
+	}{
+		{
+			name:      "deny_paths with plain extensions is valid",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{"env", "sql", "bak", "log"}}},
+			wantError: false,
+		},
+		{
+			name:      "static_cache with a non-default extension + duration is valid",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"pdf", "mp4"}, Duration: "30d"}},
+			wantError: false,
+		},
+		{
+			// The core boundary: a short extension carrying a regex/nginx
+			// metacharacter that would break out of the panel-built `\.( … )$`
+			// group. Kept under the length cap so the charset check is what trips.
+			name:      "deny_paths rejects a regex-injection extension",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{`env)$`}}},
+			wantError: true,
+			errSubstr: "letters and digits",
+		},
+		{
+			name:      "deny_paths rejects a dotted extension",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{".env"}}},
+			wantError: true,
+			errSubstr: "letters and digits",
+		},
+		{
+			name:      "deny_paths rejects an empty extension list",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{}}},
+			wantError: true,
+			errSubstr: "at least one",
+		},
+		{
+			name:      "deny_paths rejects php (silent no-op: php location wins)",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{"php"}}},
+			wantError: true,
+			errSubstr: "PHP location",
+		},
+		{
+			name:      "static_cache rejects php-family (source disclosure)",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"phtml"}, Duration: "1h"}},
+			wantError: true,
+			errSubstr: "PHP source",
+		},
+		{
+			name:      "static_cache rejects php7 (versioned php)",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"php7"}, Duration: "1h"}},
+			wantError: true,
+			errSubstr: "PHP source",
+		},
+		{
+			name:      "static_cache rejects an already-template-cached extension",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"css"}, Duration: "30d"}},
+			wantError: true,
+			errSubstr: "already long-cached",
+		},
+		{
+			name:      "static_cache requires a duration",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"pdf"}}},
+			wantError: true,
+			errSubstr: "needs a duration",
+		},
+		{
+			name:      "static_cache rejects a bogus duration",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"pdf"}, Duration: "forever"}},
+			wantError: true,
+			errSubstr: "expires value",
+		},
+		{
+			name:      "static_cache accepts the max keyword",
+			rules:     models.NginxRules{{Type: "static_cache", Extensions: []string{"pdf"}, Duration: "max"}},
+			wantError: false,
+		},
+		{
+			name:      "deny_paths rejects a control character in an extension",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: []string{"en\nv"}}},
+			wantError: true,
+		},
+		{
+			name:      "deny_paths rejects too many extensions",
+			rules:     models.NginxRules{{Type: "deny_paths", Extensions: manyExts(maxExtensionsPerRule + 1)}},
+			wantError: true,
+			errSubstr: "too many",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNginxRules(tc.rules)
+			if tc.wantError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.errSubstr != "" && (err == nil || !strings.Contains(err.Error(), tc.errSubstr)) {
+				t.Fatalf("expected error containing %q, got %v", tc.errSubstr, err)
+			}
+		})
+	}
+}
+
+// TestValidateTenantNginxRules_TypedLocationRules confirms both new kinds are in
+// the tenant-safe subset, while an admin-only kind (proxy_pass) still is not.
+func TestValidateTenantNginxRules_TypedLocationRules(t *testing.T) {
+	if err := validateTenantNginxRules(models.NginxRules{
+		{Type: "deny_paths", Extensions: []string{"env", "sql"}},
+		{Type: "static_cache", Extensions: []string{"pdf"}, Duration: "7d"},
+	}); err != nil {
+		t.Fatalf("tenant deny_paths+static_cache should be allowed, got %v", err)
+	}
+	err := validateTenantNginxRules(models.NginxRules{
+		{Type: "proxy_pass", Path: "/", Target: "http://127.0.0.1:8080"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not available to tenants") {
+		t.Fatalf("tenant proxy_pass should be refused, got %v", err)
+	}
+}
+
+func manyExts(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		// distinct so the count cap trips, not the dedupe in compile
+		out[i] = "ext" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26))
+	}
+	return out
+}

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -95,6 +95,19 @@ type NginxRule struct {
 
 	// max_upload_size
 	Size string `json:"size,omitempty"`
+
+	// deny_paths, static_cache (GH #1624): a list of bare file extensions
+	// (letters/digits only, no dot) the panel compiles into a single
+	// case-insensitive, end-anchored `location ~* \.(a|b)$` block. The tenant
+	// never supplies the regex — the panel builds it from this validated list,
+	// which is the regex-injection boundary.
+	Extensions []string `json:"extensions,omitempty"`
+
+	// static_cache: the cache lifetime for the matched extensions, as an nginx
+	// `expires` duration (e.g. "30d", "1h", "max"). Rendered as `expires <dur>;`
+	// only — no `add_header`, because an add_header inside a location suppresses
+	// the panel's inherited server-scope security headers (JAB-70).
+	Duration string `json:"duration,omitempty"`
 }
 
 // NginxRules implements driver.Valuer / sql.Scanner so GORM can

--- a/panel-api/internal/nginxrules/compile.go
+++ b/panel-api/internal/nginxrules/compile.go
@@ -146,6 +146,32 @@ func Compile(d *models.Domain) string {
 
 		case "max_upload_size":
 			fmt.Fprintf(&b, "    client_max_body_size %s;\n", r.Size)
+
+		case "deny_paths":
+			// Block access to files by extension (GH #1624): sensitive files a
+			// tenant migrated in — .env, .sql, .bak, .log, … The panel builds the
+			// regex from the validated extension list (validateNginxRules enforces
+			// [A-Za-z0-9]+ per extension), so there is no tenant-supplied regex to
+			// inject. End-anchored + case-insensitive so `.ENV` is caught too.
+			if alt := extensionAlternation(r.Extensions); alt != "" {
+				fmt.Fprintf(&b,
+					"    location ~* \\.(%s)$ {\n"+
+						"        deny all;\n"+
+						"    }\n", alt)
+			}
+
+		case "static_cache":
+			// Long-cache static files by extension (GH #1624). Renders `expires`
+			// ONLY: an `add_header` inside a location suppresses the server-scope
+			// security headers the panel sets (JAB-70), and `expires` already
+			// emits Cache-Control: max-age without that hazard. Same panel-built
+			// regex as deny_paths.
+			if alt := extensionAlternation(r.Extensions); alt != "" && r.Duration != "" {
+				fmt.Fprintf(&b,
+					"    location ~* \\.(%s)$ {\n"+
+						"        expires %s;\n"+
+						"    }\n", alt, r.Duration)
+			}
 		}
 	}
 	return b.String()
@@ -192,6 +218,29 @@ func reverseProxyRules(d *models.Domain) []models.NginxRule {
 func rootPath(p string) bool {
 	p = strings.TrimSpace(p)
 	return p == "/" || p == ""
+}
+
+// extensionAlternation lowercases, de-duplicates (preserving first-seen order)
+// and joins a validated extension list into an nginx regex alternation body,
+// e.g. ["ENV","sql","env"] -> "env|sql". The validator (validateNginxRules)
+// guarantees each element is [A-Za-z0-9]+, so no element needs regex escaping
+// and the result can never break out of the `\.( … )$` the caller wraps it in.
+// Returns "" for an empty list so the caller emits no location block.
+func extensionAlternation(exts []string) string {
+	seen := make(map[string]struct{}, len(exts))
+	out := make([]string, 0, len(exts))
+	for _, e := range exts {
+		e = strings.ToLower(strings.TrimSpace(e))
+		if e == "" {
+			continue
+		}
+		if _, dup := seen[e]; dup {
+			continue
+		}
+		seen[e] = struct{}{}
+		out = append(out, e)
+	}
+	return strings.Join(out, "|")
 }
 
 func quoteNginxString(s string) string {

--- a/panel-api/internal/nginxrules/compile_test.go
+++ b/panel-api/internal/nginxrules/compile_test.go
@@ -7,6 +7,26 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
+// TestStaticCacheNoAddHeader pins the JAB-70 security property: static_cache
+// must render `expires` only. An `add_header` inside a location suppresses the
+// server-scope security headers (HSTS, X-Frame-Options, …) the panel sets, so a
+// static_cache that emitted one would silently weaken hardening on every cached
+// asset. Kept as its own test so a future "add Cache-Control immutable" change
+// trips here loudly.
+func TestStaticCacheNoAddHeader(t *testing.T) {
+	got := Compile(&models.Domain{
+		NginxRules: []models.NginxRule{
+			{Type: "static_cache", Extensions: []string{"pdf"}, Duration: "30d"},
+		},
+	})
+	if strings.Contains(got, "add_header") {
+		t.Fatalf("static_cache must not emit add_header (JAB-70 header suppression); got:\n%s", got)
+	}
+	if !strings.Contains(got, "expires 30d;") {
+		t.Fatalf("static_cache should emit `expires 30d;`; got:\n%s", got)
+	}
+}
+
 func TestCompile(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -39,6 +59,45 @@ func TestCompile(t *testing.T) {
 			},
 			want:     `add_header X-Custom "test-value";`,
 			wantBool: true,
+		},
+		{
+			name: "deny_paths compiles a case-insensitive extension deny block",
+			domain: &models.Domain{
+				NginxRules: []models.NginxRule{
+					{Type: "deny_paths", Extensions: []string{"env", "sql", "bak"}},
+				},
+			},
+			want:     "location ~* \\.(env|sql|bak)$ {\n        deny all;\n    }\n",
+			wantBool: true,
+		},
+		{
+			name: "deny_paths lowercases and de-duplicates extensions",
+			domain: &models.Domain{
+				NginxRules: []models.NginxRule{
+					{Type: "deny_paths", Extensions: []string{"ENV", "env", "Sql"}},
+				},
+			},
+			want:     "location ~* \\.(env|sql)$ {\n        deny all;\n    }\n",
+			wantBool: true,
+		},
+		{
+			name: "static_cache renders expires only (no add_header — JAB-70)",
+			domain: &models.Domain{
+				NginxRules: []models.NginxRule{
+					{Type: "static_cache", Extensions: []string{"pdf", "mp4"}, Duration: "30d"},
+				},
+			},
+			want:     "location ~* \\.(pdf|mp4)$ {\n        expires 30d;\n    }\n",
+			wantBool: true,
+		},
+		{
+			name: "static_cache with empty extensions emits nothing",
+			domain: &models.Domain{
+				NginxRules: []models.NginxRule{
+					{Type: "static_cache", Extensions: []string{}, Duration: "30d"},
+				},
+			},
+			want: "",
 		},
 		{
 			name: "custom_header with always flag true",

--- a/panel-ui/src/shells/DomainSettingsButton.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.tsx
@@ -62,7 +62,12 @@ export type NginxRule =
       ips: string[];
     }
   | { type: "php_setting"; name: string; value: string }
-  | { type: "max_upload_size"; size: string };
+  | { type: "max_upload_size"; size: string }
+  // GH #1624 typed location rules. The panel builds the `location ~* \.(…)$`
+  // block from `extensions` (bare, letter/digit-only tokens) — the tenant never
+  // writes the regex. deny_paths → `deny all;`, static_cache → `expires <dur>;`.
+  | { type: "deny_paths"; extensions: string[] }
+  | { type: "static_cache"; extensions: string[]; duration: string };
 
 // Minimal shape — admin and user shells have slightly different Domain
 // records but this button only cares about these fields.
@@ -140,9 +145,41 @@ const compileRules = (rules: NginxRule[]): string => {
         out.push(`    client_max_body_size ${r.size};`);
         break;
       }
+      case "deny_paths": {
+        const alt = extAlternation(r.extensions);
+        if (alt) {
+          out.push(`    location ~* \\.(${alt})$ {`);
+          out.push("        deny all;");
+          out.push("    }");
+        }
+        break;
+      }
+      case "static_cache": {
+        const alt = extAlternation(r.extensions);
+        if (alt && r.duration) {
+          out.push(`    location ~* \\.(${alt})$ {`);
+          out.push(`        expires ${r.duration};`);
+          out.push("    }");
+        }
+        break;
+      }
     }
   }
   return out.join("\n");
+};
+
+// extAlternation mirrors nginxrules.extensionAlternation (Go): lowercase,
+// de-duplicate (first-seen order), join with `|`. Keep in sync with the backend.
+const extAlternation = (exts: string[]): string => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of exts || []) {
+    const e = raw.trim().toLowerCase();
+    if (!e || seen.has(e)) continue;
+    seen.add(e);
+    out.push(e);
+  }
+  return out.join("|");
 };
 
 // Raw Directives editor component. Shows two stacked sections:
@@ -490,6 +527,88 @@ const renderMaxUploadSizeBody = (
   </>
 );
 
+// GH #1624: shared extensions editor for deny_paths / static_cache. A tags
+// Select where each tag is one bare extension (no dot). The backend validates
+// [A-Za-z0-9]+ per tag; here we just strip a leading dot and lower-case for a
+// forgiving paste ("*.env" / ".env" / "ENV" all land as "env").
+const renderExtensionsField = (
+  extensions: string[],
+  onUpdate: (field: string, value: unknown) => void,
+) => (
+  <Col span={24}>
+    <div style={{ marginBottom: 8 }}>
+      <Typography.Text>
+        File extensions <Typography.Text type="danger">*</Typography.Text>
+      </Typography.Text>
+    </div>
+    <Select
+      mode="tags"
+      style={{ width: "100%" }}
+      value={extensions}
+      placeholder="env  sql  bak"
+      tokenSeparators={[",", " "]}
+      onChange={(vals: string[]) =>
+        onUpdate(
+          "extensions",
+          vals.map((v) => v.trim().replace(/^\*?\./, "").toLowerCase()).filter(Boolean),
+        )
+      }
+      options={[]}
+    />
+    <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
+      Bare extensions, no dot — e.g. env, sql, bak. Matched case-insensitively at
+      the end of the path.
+    </Typography.Text>
+  </Col>
+);
+
+const renderDenyPathsBody = (
+  rule: Extract<NginxRule, { type: "deny_paths" }>,
+  onUpdate: (field: string, value: unknown) => void,
+) => (
+  <>
+    <Row gutter={16}>{renderExtensionsField(rule.extensions, onUpdate)}</Row>
+    <Typography.Text type="secondary" style={{ display: "block", marginTop: 8 }}>
+      Denies all access to files with these extensions (e.g. hide{" "}
+      <Typography.Text code>.env</Typography.Text>,{" "}
+      <Typography.Text code>.sql</Typography.Text>,{" "}
+      <Typography.Text code>.bak</Typography.Text>). PHP is handled separately and
+      can&apos;t be blocked here.
+    </Typography.Text>
+  </>
+);
+
+const renderStaticCacheBody = (
+  rule: Extract<NginxRule, { type: "static_cache" }>,
+  onUpdate: (field: string, value: unknown) => void,
+) => (
+  <>
+    <Row gutter={16}>{renderExtensionsField(rule.extensions, onUpdate)}</Row>
+    <Row gutter={16} style={{ marginTop: 12 }}>
+      <Col span={12}>
+        <div style={{ marginBottom: 8 }}>
+          <Typography.Text>
+            Cache duration <Typography.Text type="danger">*</Typography.Text>
+          </Typography.Text>
+        </div>
+        <Input
+          placeholder="30d"
+          value={rule.duration}
+          onChange={(e) => onUpdate("duration", e.target.value)}
+        />
+        <Typography.Text type="secondary" style={{ display: "block", marginTop: 4 }}>
+          nginx expires value — e.g. 30d, 1h, max.
+        </Typography.Text>
+      </Col>
+    </Row>
+    <Typography.Text type="secondary" style={{ display: "block", marginTop: 8 }}>
+      Sets a long cache lifetime for these files. Common web assets (css, js,
+      images, fonts) are already cached by the server and can&apos;t be re-tuned
+      here.
+    </Typography.Text>
+  </>
+);
+
 // Sortable rule card
 interface SortableRuleCardProps {
   idx: number;
@@ -526,6 +645,8 @@ const SortableRuleCard = ({
       ip_access: "IP Access",
       php_setting: "PHP Setting",
       max_upload_size: "Max Upload Size",
+      deny_paths: "Deny Paths",
+      static_cache: "Static Cache",
     };
     return labels[type];
   };
@@ -544,6 +665,10 @@ const SortableRuleCard = ({
         return `${rule.name} = ${rule.value}`;
       case "max_upload_size":
         return `Max: ${rule.size}`;
+      case "deny_paths":
+        return `deny ${(rule.extensions || []).join(", ")}`;
+      case "static_cache":
+        return `${(rule.extensions || []).join(", ")} → ${rule.duration}`;
     }
   };
 
@@ -622,6 +747,16 @@ const SortableRuleCard = ({
                 rule as Extract<NginxRule, { type: "max_upload_size" }>,
                 (field, value) => onUpdate(idx, field, value)
               )}
+            {rule.type === "deny_paths" &&
+              renderDenyPathsBody(
+                rule as Extract<NginxRule, { type: "deny_paths" }>,
+                (field, value) => onUpdate(idx, field, value)
+              )}
+            {rule.type === "static_cache" &&
+              renderStaticCacheBody(
+                rule as Extract<NginxRule, { type: "static_cache" }>,
+                (field, value) => onUpdate(idx, field, value)
+              )}
           </div>
         )}
       </Card>
@@ -682,6 +817,12 @@ const RuleBuilder = ({
       case "max_upload_size":
         newRule = { type: "max_upload_size", size: "" };
         break;
+      case "deny_paths":
+        newRule = { type: "deny_paths", extensions: [] };
+        break;
+      case "static_cache":
+        newRule = { type: "static_cache", extensions: [], duration: "30d" };
+        break;
     }
 
     const newRules = [...rules, newRule];
@@ -707,6 +848,8 @@ const RuleBuilder = ({
     { key: "ip_access", label: "IP Access", icon: <PlusOutlined /> },
     { key: "php_setting", label: "PHP Setting", icon: <PlusOutlined /> },
     { key: "max_upload_size", label: "Max Upload Size", icon: <PlusOutlined /> },
+    { key: "deny_paths", label: "Deny Paths", icon: <PlusOutlined /> },
+    { key: "static_cache", label: "Static Cache", icon: <PlusOutlined /> },
   ].filter(
     (it) => !allowedTypes || allowedTypes.includes(it.key as NginxRule["type"]),
   );
@@ -1344,7 +1487,7 @@ export const TenantNginxRulesPanel = ({
         must point to a local path on your own site (no external URLs or
         proxying).
       </Typography.Paragraph>
-      <RuleBuilder rules={rules} onRulesChange={setRules} allowedTypes={["rewrite", "custom_header"]} />
+      <RuleBuilder rules={rules} onRulesChange={setRules} allowedTypes={["rewrite", "custom_header", "deny_paths", "static_cache"]} />
       <div style={{ marginTop: 16 }}>
         <Button type="primary" loading={saving} onClick={handleSave}>
           Save

--- a/panel-ui/src/shells/DomainSettingsButton.typedlocation.test.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.typedlocation.test.tsx
@@ -1,0 +1,56 @@
+// DomainSettingsButton.typedlocation.test.tsx — GH #1624 typed location rules.
+//
+// The tenant Rule Builder must offer the two new panel-rendered kinds
+// (Deny Paths, Static Cache) and must NOT offer the admin-only kinds
+// (Proxy Pass, IP Access, PHP Setting) — the UI mirror of the backend
+// tenantSafeNginxRuleTypes subset.
+//
+// Only apiClient is mocked; the real AntD widgets + in-file RuleBuilder render.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TenantNginxRulesPanel,
+  type DomainSettingsTarget,
+} from "./DomainSettingsButton";
+
+vi.mock("../apiClient", () => ({ apiClient: { patch: vi.fn() } }));
+
+import { apiClient } from "../apiClient";
+
+const mocked = apiClient as unknown as { patch: ReturnType<typeof vi.fn> };
+
+function renderTenant(domain: DomainSettingsTarget) {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <TenantNginxRulesPanel domain={domain} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+const domain: DomainSettingsTarget = { id: "d1", name: "example.com", nginx_rules: [] };
+
+describe("GH #1624 — tenant Rule Builder typed location rules", () => {
+  beforeEach(() => {
+    mocked.patch.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  it("offers Deny Paths and Static Cache but not the admin-only kinds", async () => {
+    renderTenant(domain);
+    // antd Dropdown opens on hover of the trigger button.
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /Add Rule/i }));
+    await waitFor(() => expect(screen.getByText("Deny Paths")).toBeInTheDocument());
+    expect(screen.getByText("Static Cache")).toBeInTheDocument();
+    expect(screen.getByText("Custom Header")).toBeInTheDocument();
+    expect(screen.getByText("Rewrite")).toBeInTheDocument();
+    // Admin-only kinds must never appear in the tenant subset.
+    expect(screen.queryByText("Proxy Pass")).not.toBeInTheDocument();
+    expect(screen.queryByText("IP Access")).not.toBeInTheDocument();
+    expect(screen.queryByText("PHP Setting")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds two panel-rendered Rule Builder kinds to the **tenant-safe subset**, so a non-admin owner (when `TenantDomainOptionsEnabled` is on) can express the two most common "Advanced Directives" use cases from #1624 **without a raw `location` block**:

- **`deny_paths`** → `location ~* \.(env|sql|bak)$ { deny all; }` — block sensitive files by extension (a real gap: `ip_access` is IP-based and admin-only, and the stock vhost ships no dotfile/`.env`/`.sql` deny).
- **`static_cache`** → `location ~* \.(pdf|mp4)$ { expires 30d; }` — long-cache files by extension.

The tenant supplies **only a list of bare, letter/digit-only extensions** (plus an nginx `expires` duration for `static_cache`); the panel builds the regex alternation from that validated list. **That extension charset (`^[A-Za-z0-9]+$`) is the entire trust boundary** — there is no tenant-authored regex or config.

This is the "expand the subset via typed rules, not a wider raw whitelist" path agreed in the #1624 thread (raw `location`/`return` stay excluded).

### Security model
- Extensions must match `^[A-Za-z0-9]+$` (no dot/slash/metacharacter), count- and length-capped. The validated value and the rendered value are both pure functions of the same list (validator and `extensionAlternation` apply identical trim+lowercase), so they can't diverge.
- **`static_cache` renders `expires` only, never `add_header`** — an `add_header` inside a `location` suppresses the panel's inherited server-scope security headers (HSTS/XFO/nosniff/Referrer-Policy — JAB-70). A dedicated compile test pins this.
- **`static_cache` refuses the PHP family** (`php`, `php7`, `phtml`, `phar`, …) so a source file is never served as a static download; **`deny_paths` refuses it too** (the template's `~ \.php$` handler wins first-match, so it'd be a silent no-op).
- Both refuse the extensions the vhost template already handles in its `location ~* \.(css|js|…|html)$` block (rendered first → first-match wins), rather than store a dead rule.
- `static_cache` duration is validated on the **raw** value (anchored `tenantExpiresRe`), rejecting any surrounding whitespace including a copy-pasted NBSP that would otherwise render verbatim and fail `nginx -t`.

Rendering goes through the existing `nginxrules.Compile` → `rule_directives` the reconciler already assembles, so it **inherits the per-vhost `nginx -t` + revert containment — no agent change**.

### Adversarial security review
Ran `ecc:security-reviewer` on the first commit; it confirmed the injection boundary, JAB-70, PHP-family and ReDoS surfaces are safe as designed, and surfaced two MEDIUM + two LOW issues, all fixed in the second commit (raw-duration/NBSP, `deny_paths` shadow guard, `html`/`htm`, reverse-proxy docs note).

**Pre-existing risk noted, out of scope:** the agent's `writeVhost` deletes a failing vhost on `nginx -t` failure rather than restoring the last-good config, so *any* bad directive (admin raw included) is an outage, not a no-op. This diff removes the tenant-reachable trigger; the restore-on-fail hardening is a separate follow-up.

### Tests
- Go: `TestValidateNginxRules_TypedLocationRules` (accept + every rejection, regex-injection first), `TestValidateTenantNginxRules_TypedLocationRules` (subset: both allowed, proxy_pass refused), `TestCompile` cases + `TestStaticCacheNoAddHeader` (JAB-70). Fail-first verified for the charset guard, the JAB-70 no-add_header guard, and the raw-duration guard.
- UI: `DomainSettingsButton.typedlocation.test.tsx` (tenant menu offers Deny Paths + Static Cache, not the admin-only kinds).
- `go build`/`vet` clean; `tsc`/`eslint` clean; vitest green.

Held for `MERGE_APPROVED`. First of two — the follow-up (nginx-snippet import) will stack on this.

https://claude.ai/code/session_01UprR4Xcvq7htpiRioPaGP5
