### PR TITLE
refactor(reconciler): route periodic email-enable convergence through domainmailops (JAB-286 AC4/AC5, JAB-288 AC5)

### DIFF
--- a/panel-api/internal/domainmailops/domainmailops.go
+++ b/panel-api/internal/domainmailops/domainmailops.go
@@ -23,12 +23,16 @@
 // operator CLI both drove: agent domain.email_dkim_rotate → persist the new
 // public key → wipe + republish the M6-managed DNS.
 //
-// Not yet routed through here: the reconciler's per-tick provisioning
-// (internal/reconciler/panel_primary_dkim.go — ensurePanelPrimaryDKIM /
-// ensureTenantEmailEnabled + its own managed-DNS convergence), which carries
-// its own reserved-TLD and already-provisioned guards and a distinct panel-cert
-// lineage. JAB-288 and JAB-286 stay module-parents until that fourth caller is
-// migrated.
+// The reconciler's per-tick enable convergence now routes through Enable as
+// well (internal/reconciler/panel_primary_dkim.go — ensurePanelPrimaryDKIM /
+// ensureTenantEmailEnabled), so all four callers (REST, domain-create, CLI,
+// reconciler) share this one implementation of the agent→persist→DNS ordering
+// (JAB-288 AC5 / JAB-286 AC4). The reconciler keeps its own reserved-TLD and
+// already-provisioned guards at the call site and omits SSL scheduling —
+// ReconcileSSLSANDrift converges mail SANs on its own tick, so the periodic
+// path flips no cert row (preserving its pre-extraction behavior). It still
+// owns ensureTenantDKIMRecords, a pure DNS back-fill with no agent call that
+// sits outside the enable lifecycle this module owns.
 package domainmailops
 
 import (

--- a/panel-api/internal/reconciler/panel_primary_dkim.go
+++ b/panel-api/internal/reconciler/panel_primary_dkim.go
@@ -16,17 +16,36 @@ package reconciler
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/domainmailops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-const panelPrimaryEmailAgentTimeout = 30 * time.Second
+// mailOpsDeps builds the shared Domain Mail Lifecycle dependency set
+// (internal/domainmailops) for the reconciler's periodic enable convergence.
+//
+// SSLCerts and SSLReconciler are intentionally omitted. The reconciler
+// converges mail SANs through ReconcileSSLSANDrift on its own tick; the
+// per-tick enable path has never flipped a cert row, so wiring SSL scheduling
+// through Enable here would introduce a cert-row mutation the periodic path
+// never performed. JAB-288 requires the extraction to preserve current
+// Agent-first behavior, so SSL stays with the drift reconciler.
+//
+// Call is the agent method value — every caller guards r.agent != nil before
+// invoking Enable, so the method value is never built on a nil interface.
+func (r *Reconciler) mailOpsDeps() domainmailops.Deps {
+	return domainmailops.Deps{
+		Domains:        r.domains,
+		DNSZones:       r.dnsZones,
+		DNSRecords:     r.dnsRecords,
+		ServerSettings: r.serverSettings,
+		Call:           r.agent.Call,
+	}
+}
 
 // ensurePanelPrimaryDKIM is a reconciler-scoped mirror of the HTTP
 // email-enable handler's EnableDomainEmailInline flow. No-op if DKIM
@@ -57,69 +76,27 @@ func (r *Reconciler) ensurePanelPrimaryDKIM(ctx context.Context, domain *models.
 		return
 	}
 
-	agentCtx, cancel := context.WithTimeout(ctx, panelPrimaryEmailAgentTimeout)
-	defer cancel()
-	raw, err := r.agent.Call(agentCtx, "domain.email_enable", map[string]any{
-		"domain_id":   domain.ID,
-		"domain_name": domain.Name,
-	})
+	// JAB-286 AC4 / JAB-288 AC5: the periodic enable convergence routes through
+	// the shared domainmailops.Enable implementation — Agent provisioning
+	// (domain.email_enable → Ed25519 DKIM keypair + Stalwart add), state
+	// persistence (UpdateEmailState), and managed-only M6 DNS writes in one
+	// declared order — instead of copying the Agent→database→DNS ordering here.
+	// Enable validates a complete DKIM response and never persists on an
+	// incomplete one, so on error nothing is written and the next tick retries
+	// (email_enabled stays 1, DkimSelector stays null). Enable mutates the
+	// passed domain in place on success, so subsequent per-tick code on this
+	// pass sees the new state without a reload. SSL deps are omitted — see
+	// mailOpsDeps.
+	selector, _, warnings, err := domainmailops.Enable(ctx, r.mailOpsDeps(), domain)
 	if err != nil {
-		r.log.Error("panel-primary DKIM: agent domain.email_enable failed",
+		r.log.Error("panel-primary DKIM: enable convergence failed",
 			"domain", domain.Name, "err", err)
 		return
 	}
-
-	var resp struct {
-		Ok            bool   `json:"ok"`
-		DKIMSelector  string `json:"dkim_selector"`
-		DKIMPublicKey string `json:"dkim_public_key"`
-	}
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		r.log.Error("panel-primary DKIM: agent response unmarshal",
-			"domain", domain.Name, "err", err)
-		return
-	}
-	if !resp.Ok || resp.DKIMSelector == "" || resp.DKIMPublicKey == "" {
-		r.log.Error("panel-primary DKIM: agent returned incomplete response",
-			"domain", domain.Name,
-			"ok", resp.Ok,
-			"selector", resp.DKIMSelector,
-			"pubkey_len", len(resp.DKIMPublicKey))
-		return
-	}
-
-	selector := resp.DKIMSelector
-	pubKey := resp.DKIMPublicKey
-	now := time.Now().UTC()
-	if err := r.domains.UpdateEmailState(ctx, domain.ID, repository.DomainEmailState{
-		Enabled:        true,
-		DkimSelector:   &selector,
-		DkimPublicKey:  &pubKey,
-		EmailEnabledAt: &now,
-	}); err != nil {
-		r.log.Error("panel-primary DKIM: UpdateEmailState failed",
-			"domain", domain.Name, "err", err)
-		// The agent-side keypair + Stalwart entry already exist; next
-		// tick will retry the DB write. No rollback needed — a panel-
-		// primary-only re-enable is idempotent on the agent side.
-		return
-	}
-
-	// Mutate the caller's struct so subsequent per-tick code (e.g.
-	// reconcileWebmailVhosts on the same pass) sees the up-to-date
-	// state without a reload.
-	domain.DkimSelector = &selector
-	domain.DkimPublicKey = &pubKey
-	domain.EmailEnabledAt = &now
+	logManagedDNSWarnings(r, "panel-primary DKIM", domain.Name, warnings)
 
 	r.log.Info("panel-primary DKIM: provisioned",
 		"domain", domain.Name, "selector", selector)
-
-	// Best-effort DNS sync. The apex zone was already created by
-	// bootstrap_pdns_self_zone at install time; syncPanelPrimaryEmailDNS
-	// adds MX/SPF/DKIM/DMARC inside that zone. Warnings are logged; DB
-	// state is already committed.
-	r.syncPanelPrimaryEmailDNS(ctx, domain.ID, selector, pubKey)
 }
 
 // ensureTenantEmailEnabled is the tenant-domain counterpart of
@@ -144,59 +121,33 @@ func (r *Reconciler) ensureTenantEmailEnabled(ctx context.Context, domain *model
 		return
 	}
 
-	agentCtx, cancel := context.WithTimeout(ctx, panelPrimaryEmailAgentTimeout)
-	defer cancel()
-	raw, err := r.agent.Call(agentCtx, "domain.email_enable", map[string]any{
-		"domain_id":   domain.ID,
-		"domain_name": domain.Name,
-	})
+	// JAB-286 AC4 / JAB-288 AC5: route the periodic enable convergence through
+	// the shared domainmailops.Enable (Agent provisioning → state persistence →
+	// managed DNS, one declared order; incomplete Agent responses never persist).
+	// See ensurePanelPrimaryDKIM and mailOpsDeps for the SSL-nil rationale.
+	selector, _, warnings, err := domainmailops.Enable(ctx, r.mailOpsDeps(), domain)
 	if err != nil {
-		r.log.Error("tenant email enable: agent domain.email_enable failed",
+		r.log.Error("tenant email enable: enable convergence failed",
 			"domain", domain.Name, "err", err)
 		return
 	}
-
-	var resp struct {
-		Ok            bool   `json:"ok"`
-		DKIMSelector  string `json:"dkim_selector"`
-		DKIMPublicKey string `json:"dkim_public_key"`
-	}
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		r.log.Error("tenant email enable: agent response unmarshal",
-			"domain", domain.Name, "err", err)
-		return
-	}
-	if !resp.Ok || resp.DKIMSelector == "" || resp.DKIMPublicKey == "" {
-		r.log.Error("tenant email enable: agent returned incomplete response",
-			"domain", domain.Name,
-			"ok", resp.Ok,
-			"selector", resp.DKIMSelector,
-			"pubkey_len", len(resp.DKIMPublicKey))
-		return
-	}
-
-	selector := resp.DKIMSelector
-	pubKey := resp.DKIMPublicKey
-	now := time.Now().UTC()
-	if err := r.domains.UpdateEmailState(ctx, domain.ID, repository.DomainEmailState{
-		Enabled:        true,
-		DkimSelector:   &selector,
-		DkimPublicKey:  &pubKey,
-		EmailEnabledAt: &now,
-	}); err != nil {
-		r.log.Error("tenant email enable: UpdateEmailState failed",
-			"domain", domain.Name, "err", err)
-		return
-	}
-
-	domain.DkimSelector = &selector
-	domain.DkimPublicKey = &pubKey
-	domain.EmailEnabledAt = &now
+	logManagedDNSWarnings(r, "tenant email enable", domain.Name, warnings)
 
 	r.log.Info("tenant email enable: provisioned",
 		"domain", domain.Name, "selector", selector)
+}
 
-	r.syncPanelPrimaryEmailDNS(ctx, domain.ID, selector, pubKey)
+// logManagedDNSWarnings emits domainmailops.Enable's best-effort managed-DNS
+// warnings at Debug. The pre-extraction reconciler logged a user-edited M6
+// record conflict at Debug deliberately — it is the expected steady state and
+// would otherwise spam ~60 lines/hr per edited record. Enable returns that same
+// conflict as a warning string (no internal log), so logging at Debug preserves
+// the anti-spam level; genuine hard failures (missing zone, create error) are
+// already surfaced at Error from inside domainmailops.SyncManagedDNSOnEnable.
+func logManagedDNSWarnings(r *Reconciler, prefix, domainName string, warnings []string) {
+	for _, w := range warnings {
+		r.log.Debug(prefix+": managed-DNS warning", "domain", domainName, "warning", w)
+	}
 }
 
 // ensureTenantDKIMRecords back-fills the M6 DNS records (jabali._domainkey

--- a/panel-api/internal/reconciler/panel_primary_dkim_mailops_test.go
+++ b/panel-api/internal/reconciler/panel_primary_dkim_mailops_test.go
@@ -1,0 +1,174 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-286 AC5 / JAB-288 AC5: the reconciler's periodic enable convergence
+// (ensurePanelPrimaryDKIM / ensureTenantEmailEnabled) is the fourth caller of
+// the shared domainmailops.Enable lifecycle. These contract tests exercise the
+// same failure matrix the REST and CLI adapters do — happy, agent-failure, and
+// incomplete-Agent-response (fail-closed, never persist) — proving the periodic
+// path routes through the Module rather than copying the Agent→database→DNS
+// ordering (JAB-286 AC4).
+
+// fakeMailEnableAgent answers domain.email_enable with a configurable response
+// so the failure matrix can drive the ok / incomplete / error branches.
+type fakeMailEnableAgent struct {
+	calls      int
+	returnErr  bool
+	incomplete bool // ok=true but empty public key
+}
+
+func (f *fakeMailEnableAgent) Call(_ context.Context, command string, _ any) (json.RawMessage, error) {
+	if command != "domain.email_enable" {
+		return nil, nil
+	}
+	f.calls++
+	if f.returnErr {
+		return nil, errors.New("simulated agent failure")
+	}
+	if f.incomplete {
+		// ok=true but no public key — the Agent half-answered; Enable must
+		// never persist this (it would overwrite the last usable state).
+		return json.RawMessage(`{"ok":true,"dkim_selector":"jabali","dkim_public_key":""}`), nil
+	}
+	return json.RawMessage(`{"ok":true,"dkim_selector":"jabali","dkim_public_key":"MIIBdummykey"}`), nil
+}
+
+// mailOpsTestReconciler wires the fakes the enable convergence reaches through
+// mailOpsDeps: domains (UpdateEmailState), dnsZones + dnsRecords (managed DNS),
+// serverSettings, and the agent. SSL repos are left nil exactly as the
+// reconciler omits them.
+func mailOpsTestReconciler(agent *fakeMailEnableAgent, dom *models.Domain) (*Reconciler, *fakeDNSRecordRepo) {
+	domainRepo := &fakeDomainRepo{domains: map[string]*models.Domain{dom.ID: dom}}
+	zoneRepo := &fakeDNSZoneRepo{zones: map[string]*models.DNSZone{
+		"zone1": {ID: "zone1", Name: dom.Name, DomainID: dom.ID},
+	}}
+	recordRepo := &fakeDNSRecordRepo{records: map[string]*models.DNSRecord{}}
+	r := &Reconciler{
+		domains:        domainRepo,
+		dnsZones:       zoneRepo,
+		dnsRecords:     recordRepo,
+		serverSettings: &fakeSettingsRepo{srv: &models.ServerSettings{}},
+		agent:          agent,
+		log:            slog.New(slog.DiscardHandler),
+	}
+	return r, recordRepo
+}
+
+func mailOpsTestDomain(isPanelPrimary bool) *models.Domain {
+	return &models.Domain{
+		ID:             "dom1",
+		Name:           "tenant.example.com", // TLD "com" → mail-routable
+		EmailEnabled:   true,
+		IsPanelPrimary: isPanelPrimary,
+		// DkimSelector nil → not yet provisioned → convergence fires.
+	}
+}
+
+// runEnableMatrix drives one of the two periodic-enable entry points through
+// the shared failure matrix and asserts the Module's fail-closed contract.
+func runEnableMatrix(t *testing.T, isPanelPrimary bool, invoke func(r *Reconciler, ctx context.Context, d *models.Domain)) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("happy: agent ok → persists pair and publishes managed DNS", func(t *testing.T) {
+		agent := &fakeMailEnableAgent{}
+		dom := mailOpsTestDomain(isPanelPrimary)
+		r, records := mailOpsTestReconciler(agent, dom)
+
+		invoke(r, ctx, dom)
+
+		if agent.calls != 1 {
+			t.Fatalf("expected exactly 1 agent call, got %d", agent.calls)
+		}
+		if dom.DkimSelector == nil || *dom.DkimSelector != "jabali" {
+			t.Fatalf("expected DkimSelector persisted as jabali, got %v", dom.DkimSelector)
+		}
+		if dom.DkimPublicKey == nil || *dom.DkimPublicKey == "" {
+			t.Fatalf("expected DkimPublicKey persisted, got %v", dom.DkimPublicKey)
+		}
+		// Managed-DNS writes run only after a successful persist (the declared
+		// order inside Enable). Records present ⇒ the whole agent→db→DNS
+		// ordering ran through the Module.
+		if len(records.records) == 0 {
+			t.Fatalf("expected managed DNS records published, got none")
+		}
+	})
+
+	t.Run("agent error → nothing persisted, no DNS", func(t *testing.T) {
+		agent := &fakeMailEnableAgent{returnErr: true}
+		dom := mailOpsTestDomain(isPanelPrimary)
+		r, records := mailOpsTestReconciler(agent, dom)
+
+		invoke(r, ctx, dom)
+
+		if dom.DkimSelector != nil {
+			t.Fatalf("agent failure must not persist a selector, got %v", *dom.DkimSelector)
+		}
+		if len(records.records) != 0 {
+			t.Fatalf("agent failure must not publish DNS, got %d records", len(records.records))
+		}
+	})
+
+	t.Run("incomplete agent response → fail-closed, never overwrite state", func(t *testing.T) {
+		agent := &fakeMailEnableAgent{incomplete: true}
+		dom := mailOpsTestDomain(isPanelPrimary)
+		r, records := mailOpsTestReconciler(agent, dom)
+
+		invoke(r, ctx, dom)
+
+		if dom.DkimSelector != nil {
+			t.Fatalf("incomplete response must not persist a selector, got %v", *dom.DkimSelector)
+		}
+		if dom.DkimPublicKey != nil {
+			t.Fatalf("incomplete response must not persist a public key, got %v", *dom.DkimPublicKey)
+		}
+		if len(records.records) != 0 {
+			t.Fatalf("incomplete response must not publish DNS, got %d records", len(records.records))
+		}
+	})
+}
+
+func TestEnsurePanelPrimaryDKIM_RoutesThroughMailOps(t *testing.T) {
+	runEnableMatrix(t, true, func(r *Reconciler, ctx context.Context, d *models.Domain) {
+		r.ensurePanelPrimaryDKIM(ctx, d)
+	})
+}
+
+func TestEnsureTenantEmailEnabled_RoutesThroughMailOps(t *testing.T) {
+	runEnableMatrix(t, false, func(r *Reconciler, ctx context.Context, d *models.Domain) {
+		r.ensureTenantEmailEnabled(ctx, d)
+	})
+}
+
+// TestPanelPrimaryDKIM_SourceRoutesThroughModule source-pins the routing: both
+// entry points must call the shared domainmailops.Enable via mailOpsDeps, and
+// the direct agent command literal must no longer live in this file (it now
+// lives inside domainmailops). If someone re-inlines the agent→persist→DNS
+// ordering here, this fails — the behavioral matrix above would keep passing on
+// a re-inlined copy that still fail-closes, so this pin is what actually holds
+// AC4/AC5's "invokes the shared Implementation" requirement.
+func TestPanelPrimaryDKIM_SourceRoutesThroughModule(t *testing.T) {
+	src, err := os.ReadFile("panel_primary_dkim.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	s := string(src)
+	if n := strings.Count(s, "domainmailops.Enable(ctx, r.mailOpsDeps(), domain)"); n != 2 {
+		t.Fatalf("expected both entry points to route through domainmailops.Enable (found %d call sites)", n)
+	}
+	if strings.Contains(s, `"domain.email_enable"`) {
+		t.Fatalf("panel_primary_dkim.go still issues domain.email_enable directly; " +
+			"the agent call must route through domainmailops.Enable")
+	}
+}


### PR DESCRIPTION
## What

Route the reconciler's per-tick email-enable convergence — `ensurePanelPrimaryDKIM` and `ensureTenantEmailEnabled` in `internal/reconciler/panel_primary_dkim.go` — through the shared `internal/domainmailops.Enable` lifecycle. This was the **fourth** independent copy of the `agent(domain.email_enable)` → `UpdateEmailState` → managed-DNS ordering, alongside the REST handler, domain-create, and the operator CLI (those three were consolidated in #1509).

## Ticket status

**JAB-288 — closes.** #1509 shipped AC1–AC4; its AC5 was explicitly "3 of 4 — the reconciler is the fourth caller." This adds the fourth, so all four callers share one implementation and the parity matrix now spans REST + create + CLI + reconciler.

**JAB-286 — stays open on AC3.**
- AC1 / AC2 ✅ (#1510, `RotateDKIM`).
- **AC4 ✅ (this PR):** periodic convergence invokes the shared implementation instead of copying the agent→database→DNS ordering.
- **AC5 ✅ (this PR):** the reconciler contract test completes the REST/CLI/reconciler failure-matrix trio.
- **AC3 remains partial:** DNS conflict / missing-zone are still `[]string` warnings, not typed results — a deliberate choice in #1510 (a DNS hiccup must not fail an enable whose key already persisted). Promoting those two to typed results vs accepting strings-as-contract is a standalone decision, not touched here.

## How

`mailOpsDeps()` builds `domainmailops.Deps{Domains, DNSZones, DNSRecords, ServerSettings, Call: r.agent.Call}`. Both entry points keep their caller-side guards, then collapse the agent-call / unmarshal / fail-close / `UpdateEmailState` / struct-mutate / DNS-sync block into one `Enable` call.

Behavior is preserved:
- **Guards unchanged** — nil domain, `is_panel_primary`, `email_enabled`, RFC-6761 reserved-TLD skip, already-provisioned idempotency, agent-unconfigured.
- **Managed-DNS record set byte-identical** — `Enable`'s `SyncManagedDNSOnEnable` and the reconciler's `syncPanelPrimaryEmailDNS` both build from the same `dnscompile.BuildEmailRecords`, with the same `hasExistingM6Record` / `findConflict` (`managed_by="m6"`) skip semantics.
- **Fail-closed unchanged** — `Enable` validates a complete DKIM response and never persists on an incomplete one (exactly what the inline code did), so an agent failure leaves `email_enabled=1` / `dkim_selector=NULL` for the next tick to retry.

**SSL deps are deliberately nil** (not a gap). The periodic enable path has never flipped a cert row; `ReconcileSSLSANDrift` converges mail SANs on its own tick from `row.EmailEnabled`. The JAB-288 investigation note already established this is "a latency difference, not a correctness gap." Wiring `triggerSSLSANExpansion` into the reconciler here would add a cert-row mutation the reconciler never performed, which JAB-288's "preserve current Agent-first behavior during extraction" forbids.

`ensureTenantDKIMRecords` keeps the reconciler-local `syncPanelPrimaryEmailDNS` helper: it is a pure DNS back-fill with no agent call, outside the enable lifecycle the module owns.

## Log-level deltas (only observable runtime change — no DB/wire/agent change)

- Managed-DNS warnings from `Enable` are logged at **Debug**, preserving the pre-extraction DNS-conflict level (a user-edited M6 record is the expected steady state and would otherwise spam ~60 lines/hr per edited record).
- A hard DNS failure (list/create error) was `Warn` inline; the module logs it at **Error** internally → more visible, not less.
- A missing DNS zone at provision was `Warn` inline; the module returns it as a warning string with no internal log → now **Debug** (arguably right for an external-DNS domain, but a visibility reduction — flagged).
- `Enable` calls `triggerSSLSANExpansion` unconditionally; with `SSLCerts` nil it emits one Info line (`SSL reconciliation skipped (SSLCerts not wired)`) **per provisioned domain**. The operator CLI already emits this same line; it is new only in that the reconciler can now reach it (once per domain at first provision, not per tick). Happy to demote it to Debug in the module in a follow-up if the volume is unwelcome on a large first-provision pass.

## Tests / falsification

- **Contract test** (`panel_primary_dkim_mailops_test.go`) drives both entry points through the same **enable** failure matrix the REST/CLI adapters use: happy (persists pair + publishes managed DNS), agent-error (nothing persisted, no DNS), incomplete-response (fail-closed, never overwrite state). Persist-fail is *not* in the enable matrix — it exists only for `RotateDKIM`, which has no reconciler path.
- **Source-pin** asserts both entry points route through `domainmailops.Enable` and that the literal `"domain.email_enable"` no longer lives in the reconciler (re-inlining would fail this, where the behavioral matrix alone would still pass on a re-inlined fail-closed copy).
- **Falsification:** neutralized `ensurePanelPrimaryDKIM`'s routing (no-op, compiling) → the happy test ("got 0 agent calls") and the source-pin ("found 1 call sites") both went RED; reverted.
- The rest of the reconciler suite stays green as a no-regression check; parity of these two paths rests on code equivalence (same `BuildEmailRecords`, same guards, same order, same fail-close) plus the matrix above.

## Box

**No box.** This routes the reconciler through `domainmailops.Enable`, already the live production enable path for the REST, domain-create, and CLI callers (box-considered in #1509/#1510). The record set is byte-identical, SSL is untouched (no cert surface), there is no new agent verb and no migration — the only runtime deltas are the log levels above. Unit parity + the new matrix + the source-pin cover it. Can run the .60 drill on request.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA
