### PR TITLE
fix(backups): commit tenant-card and DR-feed schedule rows + links atomically (JAB-307)

### DIFF
--- a/panel-api/cmd/server/dr_cmd.go
+++ b/panel-api/cmd/server/dr_cmd.go
@@ -282,11 +282,17 @@ func newDRFeedCmd() *cobra.Command {
 				Enabled:             true,
 				NextRunAt:           &next,
 			}
-			if err := schedRepo.Create(ctx, s); err != nil {
+			// One transaction: the row and its destination link commit together, or
+			// the whole create rolls back. A separate Create + ReplaceDestinations
+			// could leave a runnable row with zero destinations if the link write
+			// failed — and because findDRScheduleForDest matches by destination link,
+			// that orphan is invisible on retry, so the next run stacks a SECOND DR
+			// feed. A DR feed carries no explicit users, so each one fans out to every
+			// non-admin tenant plus the system backup: two of them double the whole
+			// fleet's backup load every tick (JAB-307). The empty user set is
+			// intentional (the fan-out) and is passed as nil to the atomic primitive.
+			if err := schedRepo.CreateWithMemberships(ctx, s, []string{destID}, nil); err != nil {
 				return fmt.Errorf("create DR feed schedule: %w", err)
-			}
-			if err := schedRepo.ReplaceDestinations(ctx, s.ID, []string{destID}); err != nil {
-				return fmt.Errorf("link DR feed schedule to destination: %w", err)
 			}
 			fmt.Printf("DR feed configured: schedule %s ships all tenant account backups + the system backup to %s on cron %q.\n", s.ID, dest.Name, cron)
 			fmt.Println("Pair the standby against this same destination with `jabali dr pair --destination <id>`.")

--- a/panel-api/cmd/server/dr_cmd_atomic_source_test.go
+++ b/panel-api/cmd/server/dr_cmd_atomic_source_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Source-pin: `jabali dr feed` provisions its DR feed schedule and destination
+// link through the atomic CreateWithMemberships primitive, not a bare Create
+// followed by a separate ReplaceDestinations. A link-write failure after a bare
+// Create would leave a runnable, user-less DR feed with zero destinations; because
+// findDRScheduleForDest matches by destination link, that orphan is invisible on
+// the next run and a SECOND all-tenants+system feed gets stacked (JAB-307). There
+// is no cobra harness for this command, so a body-scoped source-pin is the
+// proportionate guard for the one-line primitive swap.
+func TestDRFeed_ProvisionsScheduleAtomically_Source(t *testing.T) {
+	raw, err := os.ReadFile("dr_cmd.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	s := string(raw)
+	start := strings.Index(s, "func newDRFeedCmd(")
+	if start < 0 {
+		t.Fatal("newDRFeedCmd not found")
+	}
+	rest := s[start+len("func newDRFeedCmd("):]
+	end := strings.Index(rest, "\nfunc newDRUnfeedCmd(")
+	if end < 0 {
+		t.Fatal("could not bound newDRFeedCmd body")
+	}
+	body := rest[:end]
+
+	if !strings.Contains(body, "CreateWithMemberships(") {
+		t.Error("dr feed must provision the schedule + destination link through CreateWithMemberships")
+	}
+	// The existing-feed upgrade legitimately calls schedRepo.Update; only the
+	// create path must be atomic, so guard the two writes that were split.
+	for _, bad := range []string{"schedRepo.Create(", "schedRepo.ReplaceDestinations("} {
+		if strings.Contains(body, bad) {
+			t.Errorf("dr feed still calls %s (row + link must commit atomically)", bad)
+		}
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1974,6 +1974,15 @@ func (h *meBackupHandler) putSchedule(c *gin.Context) {
 		return
 	}
 	uid := user.ID
+	// Scope the fan-out to THIS tenant only (an empty user list would fan out to
+	// every non-admin user at tick time — never for a tenant-owned schedule), and
+	// link the chosen destination (none when disabling). Both sets are handed to
+	// the atomic primitive below so the row and its links commit together.
+	users := []string{uid}
+	dests := []string{}
+	if destID != "" {
+		dests = append(dests, destID)
+	}
 	sched := h.findMeSchedule(c.Request.Context(), user.ID)
 	if sched == nil {
 		sched = &models.BackupSchedule{
@@ -1986,7 +1995,12 @@ func (h *meBackupHandler) putSchedule(c *gin.Context) {
 		sched.Enabled = req.Enabled
 		sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly = keepDaily, keepWeekly, keepMonthly
 		sched.NextRunAt = &next
-		if err := h.cfg.Schedules.Create(c.Request.Context(), sched); err != nil {
+		// One transaction: the row plus the user and destination links commit
+		// together, or the whole create rolls back. The previous three sequential
+		// writes (Create + ReplaceUsers + ReplaceDestinations) could leave a runnable
+		// row with no or partial links if the second or third write failed (JAB-307).
+		// Same atomic primitive the admin, CLI, and multi-schedule tenant paths use.
+		if err := h.cfg.Schedules.CreateWithMemberships(c.Request.Context(), sched, dests, users); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
 			return
 		}
@@ -1997,24 +2011,15 @@ func (h *meBackupHandler) putSchedule(c *gin.Context) {
 		sched.Enabled = req.Enabled
 		sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly = keepDaily, keepWeekly, keepMonthly
 		sched.NextRunAt = &next
-		if err := h.cfg.Schedules.Update(c.Request.Context(), sched); err != nil {
+		// One transaction: the field changes plus both membership sets commit
+		// together, or the whole update rolls back. UpdateWithMemberships writes the
+		// same column set the old Update did (cron_expr, content, enabled, keep_*,
+		// next_run_at, user_id), so field persistence is unchanged — it only wraps
+		// the two membership replacements into the same transaction (JAB-307).
+		if err := h.cfg.Schedules.UpdateWithMemberships(c.Request.Context(), sched, &dests, &users); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
 			return
 		}
-	}
-	// Scope the fan-out to THIS tenant only (empty user list would fan out to
-	// every non-admin user at tick time — never for a tenant-owned schedule).
-	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), sched.ID, []string{uid}); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
-		return
-	}
-	dests := []string{}
-	if destID != "" {
-		dests = append(dests, destID)
-	}
-	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), sched.ID, dests); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
-		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/panel-api/internal/api/backups_me_putschedule_test.go
+++ b/panel-api/internal/api/backups_me_putschedule_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// The legacy single-schedule tenant card (PUT /me/backup-schedule) predates the
+// multi-schedule surface (GH #454 7B). It upserts the caller's own account
+// schedule and was the last tenant upsert door still doing three sequential
+// writes (Create/Update + ReplaceUsers + ReplaceDestinations). These tests pin it
+// to the same atomic primitives the multi-schedule create/update handlers use, so
+// a mid-sequence failure can never leave a runnable row with partial links
+// (JAB-307).
+
+// newPutSchedHandler mirrors newSchedHandler but gives the settings a valid
+// admin-owned cron: the card is cron-governed (not window-governed), so
+// putSchedule reads settings.TenantBackupCron for NextFire.
+func newPutSchedHandler(store *schedStore, dest *models.BackupDestination) *meBackupHandler {
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	h := newSchedHandler(store, users, schedTestPkg(3), dest)
+	h.cfg.Settings = &fakeSettingsRepo{s: &models.ServerSettings{ID: 1, TenantBackupCron: "0 3 * * *"}}
+	return h
+}
+
+func newPutSchedRouter(h *meBackupHandler, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: false})
+		c.Next()
+	})
+	r.PUT("/me/backup-schedule", h.putSchedule)
+	return r
+}
+
+// No existing schedule → the create branch must persist the row plus the user
+// and destination links in ONE atomic primitive, not three sequential writes.
+// Also pins the (dests, users) argument order.
+func TestMePutSchedule_CreateRoutesThroughAtomicMemberships(t *testing.T) {
+	store := newSchedStore()
+	dest := &models.BackupDestination{ID: "d1", Kind: "local", Enabled: true}
+	h := newPutSchedHandler(store, dest)
+	r := newPutSchedRouter(h, "userA")
+
+	rec := doReq(t, r, http.MethodPut, "/me/backup-schedule", `{"enabled":true,"content":"full","destination_id":"d1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.cwmCalls != 1 {
+		t.Fatalf("CreateWithMemberships calls = %d, want 1 (must route through the atomic primitive)", store.cwmCalls)
+	}
+	if store.createCalls != 0 || store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("three sequential writes not collapsed: create=%d replaceUsers=%d replaceDest=%d", store.createCalls, store.replaceUsersCalls, store.replaceDestCalls)
+	}
+	if len(store.lastCWMUsers) != 1 || store.lastCWMUsers[0] != "userA" {
+		t.Fatalf("users slot = %v, want [userA] (dests/users arg order swapped?)", store.lastCWMUsers)
+	}
+	if len(store.lastCWMDests) != 1 || store.lastCWMDests[0] != "d1" {
+		t.Fatalf("dests slot = %v, want [d1] (dests/users arg order swapped?)", store.lastCWMDests)
+	}
+}
+
+// An existing owned schedule → the update branch must persist the field changes
+// plus both membership sets in ONE atomic primitive. Also pins the (dests, users)
+// argument order.
+func TestMePutSchedule_UpdateRoutesThroughAtomicMemberships(t *testing.T) {
+	store := newSchedStore()
+	dest := &models.BackupDestination{ID: "d1", Kind: "local", Enabled: true}
+	h := newPutSchedHandler(store, dest)
+	r := newPutSchedRouter(h, "userA")
+
+	// Seed the caller's own schedule through the create branch (disabled, no
+	// destination is a legal save), then reset counters so the update assertions
+	// are unambiguous about the second PUT alone.
+	if rec := doReq(t, r, http.MethodPut, "/me/backup-schedule", `{"enabled":false,"content":"full"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed put = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.cwmCalls != 1 || len(store.rows) != 1 {
+		t.Fatalf("seed did not create exactly one row via CWM: cwm=%d rows=%d", store.cwmCalls, len(store.rows))
+	}
+	store.cwmCalls, store.uwmCalls, store.createCalls, store.updateCalls, store.replaceUsersCalls, store.replaceDestCalls = 0, 0, 0, 0, 0, 0
+
+	rec := doReq(t, r, http.MethodPut, "/me/backup-schedule", `{"enabled":true,"content":"database","destination_id":"d1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update put = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.uwmCalls != 1 {
+		t.Fatalf("UpdateWithMemberships calls = %d, want 1", store.uwmCalls)
+	}
+	if store.updateCalls != 0 || store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("three sequential writes not collapsed: update=%d replaceUsers=%d replaceDest=%d", store.updateCalls, store.replaceUsersCalls, store.replaceDestCalls)
+	}
+	if len(store.lastUWMUsers) != 1 || store.lastUWMUsers[0] != "userA" {
+		t.Fatalf("users slot = %v, want [userA] (dests/users arg order swapped?)", store.lastUWMUsers)
+	}
+	if len(store.lastUWMDests) != 1 || store.lastUWMDests[0] != "d1" {
+		t.Fatalf("dests slot = %v, want [d1] (dests/users arg order swapped?)", store.lastUWMDests)
+	}
+}
+
+// A failed atomic persist on the create branch must surface as 500 db_create,
+// leave no separate membership write around it, and store no row (JAB-307).
+func TestMePutSchedule_CreateAtomicFailReturns500(t *testing.T) {
+	store := newSchedStore()
+	h := newPutSchedHandler(store, nil)
+	r := newPutSchedRouter(h, "userA")
+
+	store.failCWM = repository.ErrConflict
+	rec := doReq(t, r, http.MethodPut, "/me/backup-schedule", `{"enabled":false,"content":"full"}`)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "db_create") {
+		t.Fatalf("atomic persist failure must 500 db_create: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.replaceUsersCalls != 0 || store.replaceDestCalls != 0 {
+		t.Fatalf("partial membership writes around a failed atomic create: replaceUsers=%d replaceDest=%d", store.replaceUsersCalls, store.replaceDestCalls)
+	}
+	if len(store.rows) != 0 {
+		t.Fatalf("failed atomic create left %d rows", len(store.rows))
+	}
+}
+
+// Source-pin: the legacy card body routes both its branches through the atomic
+// primitives and no longer hand-rolls the three separate writes. Scoped to the
+// putSchedule body so a file-wide check does not catch the sibling handlers.
+func TestMePutSchedule_RoutesThroughAtomicPrimitives_Source(t *testing.T) {
+	raw, err := os.ReadFile("backups.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	body := scheduleFuncBody(t, string(raw), "func (h *meBackupHandler) putSchedule(")
+	for _, want := range []string{"CreateWithMemberships(", "UpdateWithMemberships("} {
+		if !strings.Contains(body, want) {
+			t.Errorf("putSchedule must route through %s", want)
+		}
+	}
+	for _, bad := range []string{"Schedules.Create(", "Schedules.Update(", "ReplaceUsers(", "ReplaceDestinations("} {
+		if strings.Contains(body, bad) {
+			t.Errorf("putSchedule still calls %s (must be one atomic write per branch)", bad)
+		}
+	}
+}


### PR DESCRIPTION

## What

Two backup-schedule composers still created the schedule row and then replaced its user and destination links in **separate** writes, so a failure between them could leave a runnable row with missing or partial links — the exact "runnable partial row when join writes fail" JAB-307 calls out. This routes both through the transactional repository primitives (`CreateWithMemberships` / `UpdateWithMemberships`) the admin, CLI, and multi-schedule tenant paths already use.

## Ticket status

**JAB-307 — closes.** AC4 ("row, destination links, and user links commit atomically") was the last open criterion, and it had two remaining doors, not one:

- **Tenant card `PUT /me/backup-schedule`** (`putSchedule`) — the legacy single-schedule upsert (predates the GH #454-7B multi-schedule surface). The `#1661` slice made the multi-schedule `createSchedule`/`updateSchedule` atomic but left this one on `Create/Update` + `ReplaceUsers` + `ReplaceDestinations`.
- **`jabali dr feed`** (`newDRFeedCmd`, GH #331/#1169) — an operator CLI composer that builds a `BackupSchedule` with a bare `Create` then a separate `ReplaceDestinations`. It is a CLI door, which the ticket's scope explicitly includes; the earlier door inventory did not name it (it predates the #1642-1661 slices at 2026-08-06, so it was simply missed, not newly introduced).

The other AC4-relevant composer, `internal/backupscheduler/default_local.go`, is a **per-tick converger**, not one of the ticket's "HTTP, CLI, and tenant schedule paths": a partial link failure there is re-linked on the next tick (it already heals a missing destination), and its `ReplaceUsers(nil)` on a fresh row is a no-op. It stays as-is by design.

AC1-AC3 and AC5 are already met on `main` (verified against code, not just prior comments — details below).

## How

- **`putSchedule`** — `dests` and `users` are computed once before the create/update branch. Create → `CreateWithMemberships(sched, dests, []string{uid})` (error → `db_create`); update → `UpdateWithMemberships(sched, &dests, &users)` (error → `db_update`). The separate `ReplaceUsers` / `ReplaceDestinations` calls and their `db_link_users` / `db_link_destinations` error sub-codes are removed — `grep` found no consumer of those sub-codes in `panel-ui`, `openapi.yaml`, docs, or E2E fixtures.
- **`newDRFeedCmd`** — the `Create` + `ReplaceDestinations` pair becomes one `CreateWithMemberships(s, []string{destID}, nil)`. The empty user set (the intentional all-tenants fan-out) is passed as `nil`; `replaceUsersTx` no-ops on an empty list.

**Field persistence is unchanged.** `UpdateWithMemberships` writes the same column set the old `Update` did — `cron_expr`, `content`, `enabled`, `keep_daily/weekly/monthly`, `next_run_at`, `user_id` — confirmed by reading the repository method (it uses an explicit `Updates(map[string]any{…})`, so the admin-owned `cron_expr` still lands; no allowlist silent-drop). No DB, wire, or agent change; the only observable difference is that a mid-sequence failure now rolls the whole upsert back instead of leaving a half-linked row.

### Why the DR-feed door matters most

`findDRScheduleForDest` matches an existing feed **by destination link**. If the old `Create` succeeded but `ReplaceDestinations` failed, the row exists with zero destinations and is invisible to that lookup on retry — so the next `dr feed` run creates a **second** feed. A DR feed carries no explicit users, so each one fans out to every non-admin tenant *and* fires the system backup on the same tick: two of them double the whole fleet's backup load, indefinitely. The atomic primitive removes that failure mode. (This prevents *new* orphans; a box that already hit the old race and holds a zero-destination feed row is not swept by this change — that would be a separate one-off cleanup, and no such box is known.)

## Acceptance criteria (verified on `main`)

- **AC1 — admin accounts cannot be schedule targets:** ✅ both admin doors route through `backupscheduleops` (`Create`/`Update`), which returns `ErrAdminUser` for an admin target (REST `backup_schedules.go:188`, CLI `backup_schedule_cmd.go:335/481`). The tenant card is admin-blocked at the gate and always `Kind=account`, so the policy is N/A there.
- **AC2 — system schedules have no users and normalized include-system flags:** ✅ enforced in the `backupscheduleops` leaf (kind validation + system-kind branch).
- **AC3 — invalid cron causes no write:** ✅ `ErrInvalidCron` in the leaf → REST `invalid_cron` 400; the tenant card validates via `NextFire` before persisting.
- **AC4 — row, destination links, and user links commit atomically:** ✅ **this PR** (the two doors above; the admin/multi-schedule/CLI-leaf doors were already atomic via `#1642-1661`).
- **AC5 — disabled run-now rejected consistently:** ✅ met on both run-now doors that exist — REST `POST /admin/backup-schedules/:id/run-now` returns 409 `schedule_disabled`, and the CLI run-now guard refuses a disabled schedule. There is no tenant run-now door.

The ticket's "Proposed Module" is satisfied by the existing `internal/backupscheduleops` leaf that owns kind/user policy, cron normalization, and next-fire; the tenant card and DR feed keep their own request shapes and call the atomic repo primitives directly (as the sibling `createSchedule`/`updateSchedule` handlers already do).

## Tests / falsification

- **`putSchedule` matrix** (`backups_me_putschedule_test.go`, reusing the `#1661` instrumented `schedStore`): create routes through `CreateWithMemberships` with `(dests, users)` in the right slots and no `Create`/`ReplaceUsers`/`ReplaceDestinations`; update routes through `UpdateWithMemberships`; a failed atomic create returns 500 `db_create` and stores no row.
- **Source-pins:** the `putSchedule` body contains `CreateWithMemberships(` + `UpdateWithMemberships(` and none of `Schedules.Create(` / `Schedules.Update(` / `ReplaceUsers(` / `ReplaceDestinations(`; the `newDRFeedCmd` body contains `CreateWithMemberships(` and no `schedRepo.Create(` / `schedRepo.ReplaceDestinations(`.
- **Falsification:** each guard was reddened by neutralizing the routing back to the split writes (compiling) and confirming the failure, then reverted. Full `internal/api` and `cmd/server` suites stay green; `go vet` clean; `gofmt` clean on the touched hunks (the one pre-existing `BackupHandlerConfig` alignment diff is on `main` already and is left untouched).

## Box

**No box.** This routes two composers through repository primitives already live in production for the admin, CLI, and multi-schedule tenant paths. No new agent verb, no migration, no cert or reconciler surface; the record set and response shape are unchanged (only the two dropped `db_link_*` sub-codes, which had no consumer). Unit matrix + source-pins cover it.

https://claude.ai/code/session_01XqKfjLN9bo5poxScxSHgUA